### PR TITLE
chore(infra): add tfplan-* to gitignore to catch custom plan file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ kubeconfig
 *.tfstate
 *.tfstate.*
 # Plan files contain the full plaintext resource diff, including secret attribute values.
+tfplan-*
 *.tfplan
 tfplan
 *.tfvars


### PR DESCRIPTION
## Summary

- Adds `tfplan-*` pattern to `.gitignore` alongside existing `*.tfplan` and `tfplan`
- Fixes a gap where custom-named plan files (e.g. `tfplan-oss`) were untracked and could be accidentally staged with `git add -A`
- Identified in pre-public security audit (2026-06-30)

## Test plan

- [ ] Confirm `git check-ignore -v tfplan-oss` returns the `.gitignore` rule after merge

## Linked issues

N/A — small gitignore hardening, no issue needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)