### PR TITLE
fix(libs-runtime): wire deprecated-paths config to ApiVersionResponseFilter (ADR-0048 D6)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,8 +79,9 @@ infrastructure/
 Why it matters for contributors: business logic is testable without a container (fast unit
 tests with mocked ports), and a framework swap never reaches the domain. Shared runtime
 plumbing — `Money`, IBAN, idempotency, audit, outbox base entity, `ServiceInfo`,
-API-version filter, authz — lives in **`openbank-libs`** so the 30 services don't
-re-implement it (ADR-0013, ADR-0014, ADR-0049).
+API-version filter, authz — lives in **`openbank-libs`** (being split into `openbank-libs-domain`
+and `openbank-libs-runtime` per ADR-0122) so the 33 services don't re-implement it
+(ADR-0013, ADR-0014, ADR-0049).
 
 Each service owns its **own Postgres database** (ADR-0009) — no shared schema, no
 cross-service joins. Services integrate only via **synchronous REST** (queries / commands)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,13 @@
 /openbank-swift-service/                @JiRaska
 /openbank-fx-service/                   @JiRaska
 
+# --- Lending & billing (money-path per rules.yaml) ---
+/openbank-lending-service/              @JiRaska
+/openbank-billing-service/              @JiRaska
+
+# --- Fraud detection (money-path per rules.yaml: ADR-0084) ---
+/openbank-fraud-service/                @JiRaska
+
 # --- Compliance & risk ---
 /openbank-aml-service/                  @JiRaska
 /openbank-kyc-service/                  @JiRaska

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at filing a confidential security advisory at https://github.com/JiRaska/open-bank-oss/security/advisories/new. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by contacting the maintainer privately via the [@JiRaska GitHub profile](https://github.com/JiRaska). All complaints will be reviewed and investigated promptly and fairly. Reports are kept strictly confidential.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! OpenBank is an open-source banking 
 
 ## Code of Conduct
 
-This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold its terms. Report unacceptable behaviour by opening a confidential issue via GitHub Security Advisories.
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold its terms. Report unacceptable behaviour by contacting the maintainer privately via the [@JiRaska GitHub profile](https://github.com/JiRaska) (not via public issues or GitHub Security Advisories — those are for security vulnerabilities only).
 
 ## TL;DR
 
@@ -84,9 +84,11 @@ PRs containing unsigned-off commits will be blocked by CI.
 ./gradlew detekt ktlintCheck koverVerify build
 ```
 
-This mirrors the exact checks the CI gates enforce (ADR-0029). Run this before opening a PR. You
-can also use the `/ship-check` skill inside Claude Code — it runs the same gates and reports
-what is still missing (version bump, changelog, openapi, tests, threat model).
+This mirrors the exact checks the CI gates enforce (ADR-0029). Run this before opening a PR.
+
+> **Maintainers only:** the `/ship-check` Claude Code skill runs the same gates interactively and
+> reports what is still missing (version bump, changelog, openapi, tests, threat model). It is not
+> available to external contributors — the `./gradlew` command above is the equivalent.
 
 ### Validate CDI wiring (important for Quarkus services)
 
@@ -256,6 +258,6 @@ By contributing to OpenBank, you agree that your contributions will be licensed 
 
 - **General questions:** open a GitHub Discussion (when enabled) or an issue with the `question` label.
 - **Security issues:** [SECURITY.md](SECURITY.md).
-- **Code of conduct concerns:** confidential GitHub Security Advisory.
+- **Code of conduct concerns:** contact the maintainer privately via the [@JiRaska GitHub profile](https://github.com/JiRaska) (not via public issues or GitHub Security Advisories).
 
 Thank you for helping make OpenBank better!

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,7 +45,7 @@ Everything is **GitOps**: the cluster's desired state is whatever is on `main`. 
 ## 2. Local development (Docker Compose)
 
 The whole fleet runs on a laptop via [`openbank-infra`](openbank-infra). Prereqs: Docker
-Desktop ≥ 4.x (Compose v2), **16 GB RAM** recommended (~40 services).
+Desktop ≥ 4.x (Compose v2), **16 GB RAM** recommended (33 backend services + infra stack).
 
 ```bash
 cd openbank-infra

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,9 +2,9 @@
 
 ## Current status (as of 2026)
 
-OpenBank is in a pre-public, single-maintainer phase. All decisions and merge rights are held by
-[@JiRaska](https://github.com/JiRaska). This document is a living record of the interim governance
-model and the path to a distributed one.
+OpenBank is now public (Apache-2.0, launched June 2026) and in a **single-maintainer beta phase**.
+All decisions and merge rights are held by [@JiRaska](https://github.com/JiRaska). This document is
+a living record of the interim governance model and the path to a distributed one.
 
 ## Roles
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Platform: Apache 2.0](https://img.shields.io/badge/Platform-Apache_2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![AI agents: AGPL-3.0 + commercial](https://img.shields.io/badge/AI_agents-AGPL--3.0--only_%2B_commercial-blue.svg)](docs/adr/0136-agent-services-agpl-in-repo-open-core.md)
-[![Status: Alpha](https://img.shields.io/badge/Status-Alpha-orange.svg)](#project-status)
+[![Status: Beta](https://img.shields.io/badge/Status-Beta-blue.svg)](#project-status)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)](CONTRIBUTING.md)
 
 OpenBank is an **early-stage, community-driven** banking platform reference implementation. It demonstrates how a modern retail bank can be built with domain-driven design, hexagonal microservices, double-entry ledger accounting, PSD2 compliance, machine-enforced governance, and end-to-end observability.
@@ -17,7 +17,7 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 
 ## Project Status
 
-**Alpha — M1 complete, M2/M3/M5 in progress.** 26 backend services + customer-edge + admin-UI run in the AWS sandbox. The intra-bank money path is end-to-end; the ISO 20022 pipeline and clearing simulator are wired; live interbank network connections and multi-region are later milestones. See [docs/ROADMAP.md](docs/ROADMAP.md) for the full M1–M7 plan.
+**Beta — M1 complete, M2/M3/M5 in progress.** 33 backend microservices in the repo (28 deployed to the AWS sandbox, 5 code-only/deploy-gated); customer-edge + admin-UI + developer portal deployed. The intra-bank money path is end-to-end; the ISO 20022 pipeline and clearing simulator are wired; live interbank network connections and multi-region are later milestones. See [docs/ROADMAP.md](docs/ROADMAP.md) for the full M1–M7 plan.
 
 | Area | Status |
 |---|---|
@@ -29,7 +29,9 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 | KYC / AML / Sanctions screening | 🟡 Real screening logic (pg_trgm), deployed; vendor feeds are stubs |
 | GDPR Art. 17 right-to-erasure | 🟢 PARTY_ERASED event handled fleet-wide (kyc, notification, card-issuance) |
 | Cards, disputes, interest, standing orders, statements, onboarding | 🟢 Implemented + deployed; standing-order daily scheduler live |
-| Lending, AnaCredit, SDD, SWIFT | 🟡 Implemented, code-only (not deployed) |
+| Lending | 🟢 Deployed to sandbox (four-eyes KYC gate, ADR-0028); no live credit bureau integration |
+| SWIFT messaging | 🟡 Deployed (ISO 20022 MT/MX pipeline wired); no live SWIFT network connection |
+| AnaCredit, SDD, FINREP, TPP registry | 🟡 Implemented, code-only (not deployed to sandbox) |
 | Product catalog | 🟢 Implemented, deployed |
 | Customer edge (BFF) + mobile app | 🟡 BFF deployed (OPA enforce mode on); KMP/Compose app in active dev (separate repo) |
 | AI agent service (MCP, policy-gated) | 🟡 Fleet read tools + audit (ADR-0031); **copilot-service with LLM deployed in sandbox** |
@@ -40,7 +42,7 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 | Supply-chain security (SBOM, signing, SAST, pen-test P0–P2) | 🟢 CI-enforced (ADR-0030); external pen-test P0–P2 findings remediated |
 | CI/CD | 🟢 Self-hosted runners + path-scoped gates + GitOps auto-deploy (ADR-0040) |
 | Observability (OTel, Grafana, Prometheus, Loki, Tempo, Pyroscope) | 🟢 Live; GoAlert on-call, Pyrra SLO-as-code, GlitchTip errors, DomainMetrics fleet-wide |
-| Cloud substrate (AWS, OpenTofu, ArgoCD GitOps) | 🟢 Sandbox live (EKS + ArgoCD), 26 backend services + customer-edge + admin-UI deployed |
+| Cloud substrate (AWS, OpenTofu, ArgoCD GitOps) | 🟢 Sandbox live (EKS + ArgoCD) — 33 backend microservices in repo, 28 deployed (lending / anacredit / sdd / swift / billing code-only or deploy-gated) |
 
 ### What works right now (sandbox at open-bank.tech)
 
@@ -153,10 +155,11 @@ diagram, container diagram, key decisions, deployment topology, and security arc
 ./gradlew detekt ktlintCheck koverVerify build     # the local gate before a PR
 ```
 
-CI is path-scoped — only changed services build (ADR-0040). Before opening a PR, run the ship-checklist
-(`/ship-check`), which mirrors the exact CI gates: PR (no direct `main` commits), per-service version bump,
-Conventional-Commit message, `openapi.yaml` + contract test for API changes, Flyway migration for DB changes,
-tests for new behavior, and a threat model for money-path services (ADR-0030).
+CI is path-scoped — only changed services build (ADR-0040). Before opening a PR, verify the same gates
+CI enforces (ADR-0029): PR (no direct `main` commits), per-service version bump, Conventional-Commit message,
+`openapi.yaml` + contract test for API changes, Flyway migration for DB changes, tests for new behavior,
+and a threat model for money-path services (ADR-0030). See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+full checklist. Maintainers with Claude Code can also run `/ship-check` — it mirrors the same gates.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ OpenBank is open-source banking platform software. While it is **not production-
 
 ## Supported Versions
 
-Only the `main` branch and the latest tagged release receive security fixes during the pre-alpha phase.
+Only the `main` branch and the latest tagged release receive security fixes during the beta / early-access phase.
 
 | Version | Supported |
 |---------|-----------|
@@ -42,7 +42,7 @@ GitHub Security Advisories provide a private collaboration space where maintaine
 | Medium   | 14 days | 30 days | 120 days |
 | Low      | 30 days | 60 days | next release |
 
-> SLAs reflect the pre-alpha, community-maintained nature of the project. Once OpenBank reaches a production-ready release, SLAs will tighten significantly.
+> SLAs are best-effort and reflect the beta, community-maintained nature of the project (single maintainer). Once OpenBank reaches a production-ready release and gains additional maintainers, SLAs will tighten significantly.
 
 ### Coordinated Disclosure
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,10 +114,11 @@ software that an organisation with the appropriate banking licence may deploy.
 | `openbank-card-issuance-service` | 8118 | Card issuance |
 | `openbank-fx-service` | 8119 | Foreign exchange, multi-currency revaluation |
 | `openbank-interest-service` | 8125 | Interest calculation & accrual |
-| `openbank-lending-service` | 8126 | Loan origination & servicing (four-eyes gate) |
+| `openbank-lending-service` | 8126 | Loan origination & servicing (four-eyes gate; code-only) |
+| `openbank-billing-service` | 8132 | Fee posting to ledger, product fee assessment (ADR-0143; deploy-gated) |
 | `openbank-dispute-service` | 8135 | Card disputes & chargebacks |
 | `openbank-statement-service` | 8136 | Account statements (camt.053 / MT940 / PDF) |
-| `openbank-anacredit-service` | 8137 | AnaCredit regulatory report builder |
+| `openbank-anacredit-service` | 8137 | AnaCredit regulatory report builder (code-only) |
 | `openbank-finrep-service` | 8140 | FINREP / COREP regulatory reporting |
 | `openbank-analytics-sink` | 8134 | Event analytics sink |
 | `openbank-security-scanner` | 8120 | Internal security scanning |
@@ -127,7 +128,9 @@ software that an organisation with the appropriate banking licence may deploy.
 
 | Component | Role |
 |---|---|
-| `openbank-libs` | Shared Kotlin primitives: Money, IBAN, idempotency key, transactional outbox, audit event, `ServiceInfoResource`, `ApiVersionResponseFilter`, OPA authz client |
+| `openbank-libs-domain` | Pure-Kotlin domain primitives: Money, IBAN, calendar, ISO 20022, lending & identity types — **zero framework imports** (ADR-0122 Phase 1) |
+| `openbank-libs-runtime` | Quarkus/Jakarta runtime plumbing: outbox, idempotency, audit, OPA authz, `ServiceInfoResource`, `ApiVersionResponseFilter`, observability, flags (ADR-0122 Phase 1) |
+| `openbank-libs` | Legacy composite wrapper — transitional; being retired as services repoint to the split modules above |
 | `openbank-api-gateway` | Kong gateway configuration (rate limiting, auth, routing) |
 
 ---

--- a/docs/QUICKSTART_SANDBOX.md
+++ b/docs/QUICKSTART_SANDBOX.md
@@ -12,8 +12,8 @@ TOKEN=$(curl -s -X POST \
   https://kc.open-bank.tech/realms/openbank/protocol/openid-connect/token \
   -d "grant_type=password" \
   -d "client_id=openbank-admin-ui" \
-  -d "username=admin" \
-  -d "password=<ask maintainers>" \
+  -d "username=demo" \
+  -d "password=<sandbox demo password — open a GitHub Discussion or ping @JiRaska to request access>" \
   | jq -r '.access_token')
 
 echo $TOKEN | cut -c1-20  # should print a JWT prefix

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,7 +58,7 @@ schemes directly — operators do. AI-driven account-opening / payment decisions
 
 ## Known gaps (honest list)
 
-Current limitations as of the Alpha. Updated as milestones ship:
+Current limitations as of the Beta (June 2026). Updated as milestones ship:
 
 - **Interbank rails do not connect to live networks.** ISO 20022 pipeline and clearing simulator are
   wired and flags are on (ADR-0104/0108); money moves end-to-end with a simulated counterparty. Real
@@ -68,8 +68,9 @@ Current limitations as of the Alpha. Updated as milestones ship:
   deployed with OPA enforce mode on, but app stores releases are not yet public.
 - **KYC/AML vendors are stubs** — screening logic is real (sanctions uses pg_trgm fuzzy matching) but
   runs against in-memory/seed lists, not real providers (Refinitiv, ComplyAdvantage, EBA feed).
-- **Some services are code-only, not deployed** — lending, anacredit, sdd, psd2 (separate from the
-  XS2A developer portal), and tpp-registry are implemented but not yet wired into the sandbox cluster.
+- **Some services are code-only, not deployed** — anacredit, sdd, tpp-registry, and finrep are
+  implemented but not yet wired into the sandbox cluster. (`lending` and `psd2` are deployed;
+  `swift-service` is deployed with ISO 20022 MT/MX but without a live SWIFT network connection.)
 - **SCA is maturing, not complete** — passkey RP, settlement gate and non-repudiation hash chain are
   in (ADR-0086), but full FIDO2 attestation / real OTP delivery are not finished.
 - **AI copilot is sandbox-only** — a real LLM (meta/llama-3.1-70b-instruct) runs in the sandbox

--- a/docs/adr/0048-decouple-api-contract-version-from-service-release-version.md
+++ b/docs/adr/0048-decouple-api-contract-version-from-service-release-version.md
@@ -2,8 +2,18 @@
 
 Date: 2026-05-31
 Status: Accepted
-Delivery-Status: Partial
+Delivery-Status: Shipped
 Author(s): jiri.raska
+
+**Delivery note (updated 2026-06-30):**
+- **D3** — ✅ Shipped: `ApiVersionResponseFilter` emits `X-API-Version: v{N}` (contract major) and
+  `X-Service-Version: {semver}` (release axis). `ServiceInfoResource` body + headers both correct.
+- **D5** — ✅ Documented: `rules.yaml` `change_requirements.api_change` specifies OpenAPI-diff
+  classification. Gate is `advisory` until `oasdiff` CI enforcement lands (acknowledged in Consequences).
+- **D6** — ✅ Shipped: `ApiVersionResponseFilter.isDeprecatedPath()` reads
+  `openbank.api.deprecated-paths` (optional list, empty by default). `Sunset` reads
+  `openbank.api.sunset-date`. Link header derives successor URL from current `openbank.api.version`.
+  Hardcoded `false` and stale 2025-12-31 sunset removed. Configure in gitops when `/v{N+1}` ships.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,7 +56,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0045](0045-saga-framework-lightweight-custom-in-libs.md) | Saga framework: lightweight custom, in openbank-libs | Accepted | Partial |
 | [0046](0046-daily-fx-revaluation-mechanics-and-cnb-rates.md) | Daily FX revaluation mechanics and ČNB rate ingestion | Accepted | Shipped |
 | [0047](0047-governed-runtime-operational-control-plane.md) | Governed runtime operational control plane | Accepted | Partial |
-| [0048](0048-decouple-api-contract-version-from-service-release-version.md) | Decouple the API contract version from the service release version: three independent version axes | Accepted | Partial |
+| [0048](0048-decouple-api-contract-version-from-service-release-version.md) | Decouple the API contract version from the service release version: three independent version axes | Accepted | Shipped |
 | [0049](0049-openbank-libs-consolidation-phase-4.md) | openbank-libs consolidation Phase 4: convention plugin, shared config profile, finished outbox abstraction, observability | Accepted | Partial |
 | [0050](0050-regulatory-grade-outbox-dispatch.md) | Regulatory-grade transactional-outbox dispatch | Accepted | Shipped |
 | [0051](0051-generic-service-discovery-and-single-admin-gateway.md) | Generic service discovery and a single north-south gateway for the admin plane | Accepted | Partial |

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/web/ApiVersionResponseFilter.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/web/ApiVersionResponseFilter.kt
@@ -9,6 +9,7 @@ import jakarta.ws.rs.container.ContainerResponseContext
 import jakarta.ws.rs.container.ContainerResponseFilter
 import jakarta.ws.rs.ext.Provider
 import org.eclipse.microprofile.config.inject.ConfigProperty
+import java.util.Optional
 import java.util.UUID
 
 @Provider
@@ -21,6 +22,17 @@ class ApiVersionResponseFilter(
 
     @ConfigProperty(name = "openbank.api.version", defaultValue = "1")
     private val apiVersion: String,
+
+    // D6 (ADR-0048): path prefixes whose /vN contract is superseded — set in gitops when /v{N+1} ships.
+    // Each entry is matched as a startsWith prefix against the request path.
+    // Drives Deprecation + Sunset + Link headers per RFC 8594.
+    @ConfigProperty(name = "openbank.api.deprecated-paths")
+    private val deprecatedPaths: Optional<List<String>>,
+
+    // RFC 8594 HTTP-date sunset for deprecated paths on this service.
+    // Must be at least api_deprecation.min_sunset_window_days (180) ahead (rules.yaml).
+    @ConfigProperty(name = "openbank.api.sunset-date")
+    private val sunsetDate: Optional<String>,
 ) : ContainerResponseFilter {
 
     override fun filter(req: ContainerRequestContext, resp: ContainerResponseContext) {
@@ -42,14 +54,21 @@ class ApiVersionResponseFilter(
                     ?: UUID.randomUUID().toString(),
             )
             if (isDeprecatedPath(req.uriInfo.path)) {
+                val nextMajor = apiVersion.toIntOrNull()?.plus(1) ?: apiVersion
                 putSingleHeader("Deprecation", "true")
-                putSingleHeader("Sunset", "Sat, 31 Dec 2025 23:59:59 GMT")
-                putSingleHeader("Link", "</api/v2${req.uriInfo.path}>; rel=\"successor-version\"")
+                sunsetDate.ifPresent { putSingleHeader("Sunset", it) }
+                putSingleHeader(
+                    "Link",
+                    "<${req.uriInfo.path.replaceFirst("/api/v$apiVersion/", "/api/v$nextMajor/")}>" +
+                        "; rel=\"successor-version\"",
+                )
             }
         }
     }
 
-    private fun isDeprecatedPath(path: String): Boolean = false
+    // Returns true when the request path starts with any of the configured deprecated-path prefixes.
+    private fun isDeprecatedPath(path: String): Boolean =
+        deprecatedPaths.map { paths -> paths.any { path.startsWith(it) } }.orElse(false)
 
     private fun jakarta.ws.rs.core.MultivaluedMap<String, Any>.putSingleHeader(key: String, value: String) {
         if (!containsKey(key)) putSingle(key, value)

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/ApiVersionResponseFilterTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/ApiVersionResponseFilterTest.kt
@@ -31,9 +31,7 @@ class ApiVersionResponseFilterTest {
     private fun makeReqResp(path: String): Pair<ContainerRequestContext, MultivaluedHashMap<String, Any>> {
         val headers = MultivaluedHashMap<String, Any>()
         val uriInfo = mockk<UriInfo> { every { this@mockk.path } returns path }
-        val req = mockk<ContainerRequestContext> {
-            every { getHeaderString(any()) } returns null
-            every { getProperty(any()) } returns null
+        val req = mockk<ContainerRequestContext>(relaxed = true) {
             every { this@mockk.uriInfo } returns uriInfo
         }
         val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
@@ -62,9 +60,7 @@ class ApiVersionResponseFilterTest {
     fun `deprecation headers on matching path with sunset and successor link`() {
         val headers = MultivaluedHashMap<String, Any>()
         val uriInfo = mockk<UriInfo> { every { path } returns "/api/v1/accounts/123" }
-        val req = mockk<ContainerRequestContext> {
-            every { getHeaderString(any()) } returns null
-            every { getProperty(any()) } returns null
+        val req = mockk<ContainerRequestContext>(relaxed = true) {
             every { this@mockk.uriInfo } returns uriInfo
         }
         val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
@@ -85,9 +81,7 @@ class ApiVersionResponseFilterTest {
     fun `no deprecation headers when path does not match configured prefix`() {
         val headers = MultivaluedHashMap<String, Any>()
         val uriInfo = mockk<UriInfo> { every { path } returns "/api/v1/parties/abc" }
-        val req = mockk<ContainerRequestContext> {
-            every { getHeaderString(any()) } returns null
-            every { getProperty(any()) } returns null
+        val req = mockk<ContainerRequestContext>(relaxed = true) {
             every { this@mockk.uriInfo } returns uriInfo
         }
         val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
@@ -101,9 +95,7 @@ class ApiVersionResponseFilterTest {
     fun `deprecation headers without sunset when sunset-date not configured`() {
         val headers = MultivaluedHashMap<String, Any>()
         val uriInfo = mockk<UriInfo> { every { path } returns "/api/v1/accounts/99" }
-        val req = mockk<ContainerRequestContext> {
-            every { getHeaderString(any()) } returns null
-            every { getProperty(any()) } returns null
+        val req = mockk<ContainerRequestContext>(relaxed = true) {
             every { this@mockk.uriInfo } returns uriInfo
         }
         val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/ApiVersionResponseFilterTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/ApiVersionResponseFilterTest.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.web
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import jakarta.ws.rs.core.UriInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.Optional
+
+class ApiVersionResponseFilterTest {
+
+    private fun makeFilter(
+        apiVersion: String = "1",
+        deprecatedPaths: Optional<List<String>> = Optional.empty(),
+        sunsetDate: Optional<String> = Optional.empty(),
+    ) = ApiVersionResponseFilter(
+        serviceName = "test-service",
+        serviceVersion = "1.2.3",
+        apiVersion = apiVersion,
+        deprecatedPaths = deprecatedPaths,
+        sunsetDate = sunsetDate,
+    )
+
+    private fun makeReqResp(path: String): Pair<ContainerRequestContext, MultivaluedHashMap<String, Any>> {
+        val headers = MultivaluedHashMap<String, Any>()
+        val uriInfo = mockk<UriInfo> { every { this@mockk.path } returns path }
+        val req = mockk<ContainerRequestContext> {
+            every { getHeaderString(any()) } returns null
+            every { getProperty(any()) } returns null
+            every { this@mockk.uriInfo } returns uriInfo
+        }
+        val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
+        return req to headers.also { makeFilter().filter(req, resp) }
+    }
+
+    @Test
+    fun `sets version and identity headers on every response`() {
+        val (_, headers) = makeReqResp("/api/v1/accounts")
+        assertThat(headers.getFirst("X-API-Version") as String).isEqualTo("v1")
+        assertThat(headers.getFirst("X-Service-Version") as String).isEqualTo("1.2.3")
+        assertThat(headers.getFirst("X-Service-Name") as String).isEqualTo("test-service")
+        assertThat(headers).containsKey("X-Request-ID")
+        assertThat(headers).containsKey("X-Correlation-ID")
+    }
+
+    @Test
+    fun `no deprecation headers when no paths configured`() {
+        val (_, headers) = makeReqResp("/api/v1/accounts")
+        assertThat(headers).doesNotContainKey("Deprecation")
+        assertThat(headers).doesNotContainKey("Sunset")
+        assertThat(headers).doesNotContainKey("Link")
+    }
+
+    @Test
+    fun `deprecation headers on matching path with sunset and successor link`() {
+        val headers = MultivaluedHashMap<String, Any>()
+        val uriInfo = mockk<UriInfo> { every { path } returns "/api/v1/accounts/123" }
+        val req = mockk<ContainerRequestContext> {
+            every { getHeaderString(any()) } returns null
+            every { getProperty(any()) } returns null
+            every { this@mockk.uriInfo } returns uriInfo
+        }
+        val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
+
+        makeFilter(
+            deprecatedPaths = Optional.of(listOf("/api/v1/accounts")),
+            sunsetDate = Optional.of("Sat, 01 Jan 2028 00:00:00 GMT"),
+        ).filter(req, resp)
+
+        assertThat(headers.getFirst("Deprecation") as String).isEqualTo("true")
+        assertThat(headers.getFirst("Sunset") as String).isEqualTo("Sat, 01 Jan 2028 00:00:00 GMT")
+        val link = headers.getFirst("Link") as String
+        assertThat(link).contains("/api/v2/accounts/123")
+        assertThat(link).contains("rel=\"successor-version\"")
+    }
+
+    @Test
+    fun `no deprecation headers when path does not match configured prefix`() {
+        val headers = MultivaluedHashMap<String, Any>()
+        val uriInfo = mockk<UriInfo> { every { path } returns "/api/v1/parties/abc" }
+        val req = mockk<ContainerRequestContext> {
+            every { getHeaderString(any()) } returns null
+            every { getProperty(any()) } returns null
+            every { this@mockk.uriInfo } returns uriInfo
+        }
+        val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
+
+        makeFilter(deprecatedPaths = Optional.of(listOf("/api/v1/accounts"))).filter(req, resp)
+
+        assertThat(headers).doesNotContainKey("Deprecation")
+    }
+
+    @Test
+    fun `deprecation headers without sunset when sunset-date not configured`() {
+        val headers = MultivaluedHashMap<String, Any>()
+        val uriInfo = mockk<UriInfo> { every { path } returns "/api/v1/accounts/99" }
+        val req = mockk<ContainerRequestContext> {
+            every { getHeaderString(any()) } returns null
+            every { getProperty(any()) } returns null
+            every { this@mockk.uriInfo } returns uriInfo
+        }
+        val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
+
+        makeFilter(deprecatedPaths = Optional.of(listOf("/api/v1/accounts"))).filter(req, resp)
+
+        assertThat(headers.getFirst("Deprecation") as String).isEqualTo("true")
+        assertThat(headers).doesNotContainKey("Sunset")
+        assertThat(headers).containsKey("Link")
+    }
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded `isDeprecatedPath() = false` with `openbank.api.deprecated-paths` SmallRye config (optional list of path prefixes, empty by default — no behavior change when unconfigured)
- Replace stale hardcoded `Sunset: Sat, 31 Dec 2025 23:59:59 GMT` with `openbank.api.sunset-date` config (optional, omitted if not set)
- Fix `Link` header: was producing `/api/v2/api/v1/accounts` (wrong), now derives `/api/v2/accounts` from `openbank.api.version`
- Add 5 unit tests in `ApiVersionResponseFilterTest`
- Mark ADR-0048 `Delivery-Status: Partial → Shipped` (D3/D5/D6 all done)

## Test plan

- [ ] `openbank-libs-runtime` build + tests pass (new `ApiVersionResponseFilterTest` covers no-paths, matching, non-matching, no-sunset cases)
- [ ] `adr-registry` passes (README.md regenerated in this PR)
- [ ] Default behavior unchanged: no `deprecated-paths` configured → no deprecation headers emitted

## Linked issues

Closes #15