### PR TITLE
docs(adr): delivery-status notes sweep 3 — 9 Partial ADRs (0006–0051)

### DIFF
--- a/docs/adr/0006-asyncapi-for-kafka-topics.md
+++ b/docs/adr/0006-asyncapi-for-kafka-topics.md
@@ -4,6 +4,12 @@ Date: 2026-05-26
 Status: Accepted
 Delivery-Status: Partial
 
+**Delivery note (updated 2026-07-01):**
+- **CI linting gate** — ✅ Shipped: AsyncAPI specs linted in CI; missing or malformed specs block release.
+- **Per-service specs** (`openbank-contracts/<service>/asyncapi.yaml`) — ⬜ Pending: specs exist for documented topics; full fleet coverage is the outstanding work.
+- **Schema Registry** (Apicurio or Confluent, runtime enforcement) — ⬜ Pending: not yet deployed; consumer-driven contract tests (ADR-0063) provide schema compatibility checks in the interim.
+- **Consumer SDK generation** from specs — ⬜ Pending.
+
 ## Context
 
 Kafka topics in a microservices system become an implicit API — services produce and consume events without a formal contract. The result:

--- a/docs/adr/0007-vault-for-secrets-management.md
+++ b/docs/adr/0007-vault-for-secrets-management.md
@@ -4,6 +4,12 @@ Date: 2026-05-26
 Status: Accepted
 Delivery-Status: Partial
 
+**Delivery note (updated 2026-07-01):**
+- **Vault infrastructure** — ✅ Shipped: Vault deployed via `openbank-infra/` with ArgoCD; auto-unseal via cloud KMS; External Secrets Operator reads secrets into K8s Secrets for steady-state service operation.
+- **Dynamic database credentials** (per-pod Postgres, TTL ≤ 24h) — ⬜ Pending: services consume static credentials provisioned via External Secrets; Vault database secrets engine not yet wired.
+- **cert-manager PKI integration** — ⬜ Pending: cert-manager installed; Vault PKI engine integration deferred.
+- **HSM (FIPS 140-3)** for eIDAS QSeal and regulated signing keys — ⬜ Pending: deferred until the eIDAS signing use case (ADR-0094) activates in production.
+
 ## Context
 
 A banking platform handles a lot of secrets: database credentials, Kafka SASL passwords, eIDAS QSeal private keys, JWT signing keys, third-party API tokens. Mishandling any of these is a regulatory and security catastrophe.

--- a/docs/adr/0014-openbank-libs-centralization-roadmap.md
+++ b/docs/adr/0014-openbank-libs-centralization-roadmap.md
@@ -5,6 +5,14 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): jiri.raska
 
+**Delivery note (updated 2026-07-01):**
+- **Phase 1 (house cleaning)** — ✅ Shipped: unified dependency declaration; 12 byte-identical `InfoResource.kt` deleted; Jandex plugin added to libs; `RedisIdempotencyStore` consolidated.
+- **Phase 2 (domain primitives + error contract)** — ✅ Shipped: `libs.persistence.outbox` shared entities; typesafe identifiers (`AccountId`, `TransactionId`, `PartyId`, etc. with JPA converters); `CommonExceptionMappers` returning canonical `ApiError`.
+- **Phase 3 (security + audit foundation)** — ✅ Shipped: `PiiMask`/`@MaskSensitive`; canonical `Roles.*` constants; `AuditEvent`/`AuditEventPublisher`; `ServiceTokenProvider`/`BearerTokenClientHeadersFactory` for S2S auth.
+- **Phase 4 (Gradle convention plugin)** — ✅ Shipped: `openbank.quarkus-service` convention plugin (ADR-0049) eliminates ~900 lines of duplicated build script.
+- **Phase 5 (Quarkus platform extension)** — ⬜ Deferred: revisit once libs API is stable across 2–3 minor versions.
+- **Service migration** (opportunistic) — Partial: services adopt libs primitives when touched; full fleet bespoke-code removal is ongoing.
+
 ## Context
 
 A cross-service audit (2026-05-28) measured significant duplication across the

--- a/docs/adr/0017-secrets-via-vault.md
+++ b/docs/adr/0017-secrets-via-vault.md
@@ -5,6 +5,13 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): jiri.raska
 
+**Delivery note (updated 2026-07-01):**
+- **`BootstrapVerifier` in `openbank-libs`** — ✅ Shipped: fails-fast at startup if any property literally equals a local-dev placeholder outside the `%dev` profile; prevents prod regression.
+- **Dev `docker-compose.yml` Vault container + `vault-seed.sh`** — ✅ Shipped: `make up` seeds KV paths; new contributors get a working dev stack with no unseal ceremony.
+- **Per-service `application.yaml` migration** (28 services) — Partial: account, transaction, ledger, and sepa-payment migrated first; remaining services migrate opportunistically when touched.
+- **CI vault-seed step** for integration tests — ⬜ Pending.
+- **Prod AppRole provisioning runbook** in `docs/strategy/` — ⬜ Pending.
+
 ## Context
 
 K1 from the 2026-05-28 audit:

--- a/docs/adr/0019-docs-as-service.md
+++ b/docs/adr/0019-docs-as-service.md
@@ -6,6 +6,10 @@ Delivery-Status: Partial
 Supersedes: nothing (additive)
 Implements: openbank-libs `com.openbank.libs.docs`
 
+**Delivery note (updated 2026-07-01):**
+- **Phases 1–3 + 5b** — ✅ Shipped: `DocsResource`/`DocsCatalog`/`ClasspathMarkdownLoader` in `openbank-libs`; account-service and balance-service pilot (7 sections × 2 languages + diagrams); admin-ui server-rendered docs page with i18n cookie, version chip, and Mermaid diagram viewer; `DiagramsCatalog` + `_diagrams/{slug}` endpoint.
+- **Phase 4 (fleet rollout)** — ⬜ Pending: per-service documentation content authoring for the remaining ~30 services; each service needs `src/main/resources/docs/*.md` files populated.
+
 ## Context
 
 Per-service documentation lived as Markdown files in each service repo,

--- a/docs/adr/0028-lending-bounded-context.md
+++ b/docs/adr/0028-lending-bounded-context.md
@@ -4,6 +4,11 @@ Date: 2026-05-30
 Status: Accepted
 Delivery-Status: Partial
 
+**Delivery note (updated 2026-07-01):**
+- **Phase 0 (domain primitives in libs)** — ✅ Shipped: `Amortization` (three methods: annuity, equal-principal, bullet), `Ifrs9` (three-stage ECL), `Delinquency` (DPD, CRR Art. 178 90-day trigger), typesafe identifiers (`LoanApplicationId`, `LoanId`, `CollateralId`); `LendingPrimitivesTest` green.
+- **Phase 2 (service + ledger integration)** — ✅ Shipped: `openbank-lending-service` with origination four-eyes flow (maker/checker/disburser), `RestLedgerPostingAdapter`, scheduled servicing posting, interest accrual scheduler, and write-off (`WriteOffLoanUseCase`).
+- **Phase 3 (provisioning + AnaCredit/FINREP feeds)** — ⬜ Pending: IFRS 9 staging read-model, ECL batch, AnaCredit/FINREP F-18/F-12 field-level mapping; deferred until a live loan book exists (tracked in ADR-0097).
+
 ## Context
 
 OpenBank models deposits, payments, cards, FX and the supporting compliance domains, but it has **no

--- a/docs/adr/0030-supply-chain-security-and-ssdlc-hardening.md
+++ b/docs/adr/0030-supply-chain-security-and-ssdlc-hardening.md
@@ -5,6 +5,13 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): jiri.raska
 
+**Delivery note (updated 2026-07-01):**
+- **D2 (threat-model CI gate)** — ✅ Shipped: `check-threat-models.py` runs as a required check in `Validate manifests`; all 13 money-path services have STRIDE/DFD threat models at `docs/threat-models/<service>.md`; adding a money-path service without a threat model blocks merge. Diff-aware rule (trust-boundary changes) ⬜ pending.
+- **D4 (Kyverno admission control)** — Partial: Kyverno deployed (`gitops/apps/kyverno.yaml`); `verify-openbank-image-signatures` ClusterPolicy in **Audit** mode emitting PolicyReports; flip to **Enforce** blocked on: (1) choosing Cosign trust root (keyless OIDC or AWS KMS), (2) signing images in CI, (3) setting real attestor identity.
+- **D1 (VEX + vulnerability-management lifecycle)** — ⬜ Pending: CycloneDX/OpenVEX documents not yet published alongside SBOMs; SLA-tracked triage workflow not yet implemented.
+- **D3 (mutation testing + DAST)** — ⬜ Pending: pitest configured for `openbank-lending-service` domain; DAST (OWASP ZAP baseline) not yet deployed.
+- **D5 (runtime SBOM drift detection)** — ⬜ Pending.
+
 > **Accepted (2026-06-11).** Status raised from Proposed to reflect established practice:
 > this ADR is partially implemented and load-bearing — the money-path threat-model gate
 > (`check-threat-models.py`, D2) runs as a required CI check with all money-path services

--- a/docs/adr/0041-serverless-tier-scale-to-zero-on-existing-cluster.md
+++ b/docs/adr/0041-serverless-tier-scale-to-zero-on-existing-cluster.md
@@ -5,6 +5,12 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): Jiri Raska
 
+**Delivery note (updated 2026-07-01):**
+- **Tier 1 pilot (CronJob)** — ✅ Shipped: interest accrual and reconciliation batch jobs converted to `CronJob`/`Job`; scale-to-zero with zero new control plane.
+- **Tier 2 pilot (KEDA)** — ✅ Shipped: KEDA 2.x deployed cluster-wide; notifications and FX-refresh scaled on Kafka consumer-lag trigger; idle→0 confirmed working.
+- **Tier 3 (Knative, spiky onboarding HTTP)** — ⬜ Deferred: cold-start on JVM (no native image yet) makes the saving small; floor stays at 1 until native-image work ships. HTTP trigger pilot tracked in ADR-0083.
+- **Evidence-driven flip rule** (D3) — ⬜ Pending: idle-ratio and cold-start p99 metrics instrumented; formal evaluation for additional Tier 2/3 candidates not yet run.
+
 ## Context
 
 We are sizing for millions of customers. A fair share of the ~30-service fleet is

--- a/docs/adr/0051-generic-service-discovery-and-single-admin-gateway.md
+++ b/docs/adr/0051-generic-service-discovery-and-single-admin-gateway.md
@@ -5,6 +5,11 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): Platform
 
+**Delivery note (updated 2026-07-01):**
+- **Phase 1 (K8s-API discovery)** — ✅ Shipped: `/api/services/discovery` BFF route queries Kubernetes API for labeled Deployments in domain namespaces; returns `{ source: "k8s", services: [...] }` with `ready`/`desired`/`healthy`; System Health screen fixed ("0 healthy" defect resolved). `openbank-discovery-reader` ClusterRole + per-namespace `RoleBinding`s deployed via `gitops/components/admin-ui/rbac.yaml` (7 namespaces). Static fallback for dev (no in-cluster SA token).
+- **Phase 2 (Kong north-south gateway)** — ⬜ Deferred: Kong Ingress Controller not yet deployed; services still reachable via existing Ingress objects and BFF proxy; 28-entry `SERVICE_MAP` not yet deleted.
+- **Phase 3 (gateway authn/z + rate-limiting)** — ⬜ Pending: blocked on Phase 2.
+
 ## Context
 
 The admin UI currently reaches the ~30 `openbank-*` services through three **hardcoded**


### PR DESCRIPTION
## Summary

Third and final sweep over Partial ADRs lacking a `**Delivery note**` block.
Covers early ADRs (0006–0019) and mid-range ones (0028, 0030, 0041, 0051)
not reached in sweeps 1–2.

- **0006 AsyncAPI** — CI linting live; Schema Registry + fleet specs pending
- **0007 Vault** — infrastructure + External Secrets Operator live; dynamic creds/PKI/HSM pending
- **0014 openbank-libs** — Phases 1–4 live (house cleaning → convention plugin); Quarkus extension deferred
- **0017 Secrets via Vault** — BootstrapVerifier + dev Vault live; 28-service yaml migration ongoing
- **0019 Docs-as-Service** — Phases 1–3 + 5b live; fleet content authoring (Phase 4) pending
- **0028 Lending** — domain primitives + service (origination/servicing/write-off) live; IFRS 9 provisioning + AnaCredit feeds pending
- **0030 Supply-chain security** — D2 threat-model CI gate live (13 services); D4 Kyverno audit mode; D1/D3/D5 pending
- **0041 Serverless** — Tier 1 CronJob + Tier 2 KEDA live; Tier 3 Knative deferred (JVM cold-start)
- **0051 Discovery** — Phase 1 K8s-API discovery live (fixed "0 healthy" defect); Kong gateway deferred

No code or configuration changed — documentation only.

## Linked issues

N/A — documentation-only sweep.

## Test plan

- [ ] All 9 modified ADRs contain a `**Delivery note**` block
- [ ] `docs/adr/README.md` unchanged (Delivery-Status values unchanged)
- [ ] No secrets, hostnames, or private operational details in diff

🤖 Generated with [Claude Code](https://claude.ai/claude-code)