### PR TITLE
docs(adr): add delivery-status note to ADR-0118 (GDPR data lifecycle)

### DIFF
--- a/docs/adr/0118-gdpr-data-lifecycle-and-retention.md
+++ b/docs/adr/0118-gdpr-data-lifecycle-and-retention.md
@@ -5,6 +5,11 @@ Author: Claude (paired with Jiří Raška)
 Status: Accepted
 Delivery-Status: Partial
 
+**Delivery note (updated 2026-07-01):**
+- **Art. 17 erasure cascade** — ✅ Shipped: `party-service` anonymises in-place + deletes binary documents; `kyc-service` deletes documents and anonymises check results (`PartyEventConsumer.handleErased`); `notification-service` deletes preferences and history (`PartyErasureConsumer`); `card-issuance-service` anonymises `cardholderName`, `embossedName`, `deliveryAddress` (`PartyEventConsumer`). `audit-service`, `ledger-service`, `transaction-service` correctly retain data (AML/accounting override, Art. 17(3)(b)).
+- **Art. 15 data export** — ✅ Partial: `GET /api/v1/parties/{id}/gdpr-export` in `party-service` covers direct PII. kyc-service (sensitive PII) and card-issuance-service (card PII) contributions are ⬜ pending.
+- **Automated retention enforcement** — ⬜ Pending: TTL-based cleanup for session logs (90 d), KYC documents (5 y), and card PII after card expiry is policy intent only — no scheduler or batch job exists yet.
+
 ## Context
 
 GDPR Art. 17 (Right to Erasure) is partially implemented in `party-service`: `DELETE /api/v1/parties/{id}`


### PR DESCRIPTION
## Summary

- Adds the missing `**Delivery note**` block to ADR-0118 (GDPR data lifecycle — PII classification, retention periods, erasure model), the last Partial ADR without one after sweeps 1–3.
- Documents what shipped: Art. 17 erasure cascade across all five services (party, kyc, notification, card-issuance, and the three correctly-retaining services); `GET /api/v1/parties/{id}/gdpr-export` for Art. 15.
- Documents what remains pending: Art. 15 export for kyc-service and card-issuance-service; automated retention enforcement (TTL cleanup for session logs, KYC docs, card PII).

No code or configuration changed — documentation only.

## Linked issues

N/A — finalises the ADR delivery-note sweep; no separate issue tracker entry.

## Test plan

- [ ] ADR-0118 contains a `**Delivery note**` block with accurate shipped/pending breakdown
- [ ] No secrets, hostnames, or private operational detail in diff