### PR TITLE
feat(libs-runtime): centralize structured JSON log format

### DIFF
--- a/openbank-libs-runtime/src/main/resources/META-INF/microprofile-config.properties
+++ b/openbank-libs-runtime/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Shared defaults for all openbank-*-service modules that depend on openbank-libs-runtime.
+# Service-specific application.yaml entries take precedence over these values.
+
+# Structured JSON log format — correlates with OTel traces (traceId/spanId injected by
+# quarkus-opentelemetry) and HTTP correlation headers (correlationId/requestId injected by
+# CorrelationIdRequestFilter in openbank-libs-runtime).
+quarkus.log.console.format={"timestamp":"%d{yyyy-MM-dd HH:mm:ss.SSS}","level":"%p","logger":"%c{3.}","message":"%s","traceId":"%X{traceId}","spanId":"%X{spanId}","correlationId":"%X{correlationId}","requestId":"%X{requestId}"}%n
+
+# Plain text for local development — override at service level to customise further.
+%dev.quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId} corrId=%X{correlationId} [%c{2.}] %s%e%n


### PR DESCRIPTION
## Summary

- Adds `openbank-libs-runtime/src/main/resources/META-INF/microprofile-config.properties` with a shared default JSON log format
- SmallRye Config loads library-jar properties at lower priority than service `application.yaml`, so the ~29 services without any log format get structured JSON logging automatically
- The 4 services that already define a custom format (`account`, `psd2`, `sca`, `agent`) keep their own value — no behaviour change for them
- JSON fields: `timestamp`, `level`, `logger`, `message`, `traceId`, `spanId` (OTel), `correlationId`, `requestId` (CorrelationIdRequestFilter)
- Dev-profile override included: plain text format for local development

## Test plan

- [ ] `./gradlew :openbank-libs-runtime:build` passes (no code change, just a resource file)
- [ ] Spot-check: a service without its own log format (e.g. `openbank-kyc-service`) emits JSON on startup after this lands
- [ ] Existing account/psd2/sca log format unchanged (their `application.yaml` overrides the library default)

## Linked issues

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)