### PR TITLE
docs(adr): delivery notes — ADR-0077 Phase 3 shipped, ADR-0122 Phase 2 in progress

### DIFF
--- a/docs/adr/0077-observability-three-pillar-strategy.md
+++ b/docs/adr/0077-observability-three-pillar-strategy.md
@@ -18,6 +18,18 @@
 > - ADR-0087 (Correlation & Profiling Layer) and ADR-0088 (Extension: on-call, SLO-as-code, durable
 >   retention, mobile RUM) extend this ADR for the operational edges not covered here.
 
+> **Amendment 2026-07-01 — Phase 3 structured logging shipped.**
+>
+> - **Phase 3 (structured JSON logs):** ✅ Shipped — `META-INF/microprofile-config.properties`
+>   added to `openbank-libs-runtime` (PR #31) with shared JSON log format; fields: `traceId`,
+>   `spanId` (OTel), `correlationId`, `requestId` (CorrelationIdRequestFilter). SmallRye Config
+>   picks this up from the library JAR at lower priority than service-level `application.yaml`,
+>   so the ~29 services without any log format automatically get structured JSON logging; the 4
+>   services with a custom format (`account`, `psd2`, `sca`, `agent`) keep their own value.
+>   Dev-profile override (plain text) also centralised in the same file.
+> - **Remaining:** Phase 4 alerting (Alertmanager already wired per ADR-0088 D1); money-path
+>   domain metrics (issue #787, 2-approval gate).
+
 ---
 
 ## Context

--- a/docs/adr/0122-split-openbank-libs-into-domain-and-runtime.md
+++ b/docs/adr/0122-split-openbank-libs-into-domain-and-runtime.md
@@ -5,12 +5,14 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): jiri.raska
 
-**Delivery note (updated 2026-06-30):**
+**Delivery note (updated 2026-07-01):**
 - **Phase 0** — ✅ Shipped (PR #2821 predecessor, dead `libs/temporal/` skeleton removed).
 - **Phase 1** — ✅ Shipped (PR #2821 `refactor(libs)`: `openbank-libs-domain` and
   `openbank-libs-runtime` modules created; packages moved per-file; composite build updated).
-- **Phase 2** — Fleet sweep pending: each service's `build.gradle.kts` still depends on the
-  monolithic `openbank-libs` wrapper rather than the split modules. One PR per service.
+- **Phase 2** — 🔄 In progress (issue #32): non-money-path batch (22 services + simulation, PR #33)
+  open; money-path batch (12 services, PR #34) open, awaiting 2 approvals per ADR-0030. The
+  monolithic `openbank-libs` acts as a backward-compat umbrella (`api()` re-export) until
+  both batches merge.
 - **Phase 3** — Not started (evaluate publish-versioned; separate ADR revision of ADR-0014).
 
 ## Context


### PR DESCRIPTION
## Summary

- **ADR-0077** (observability strategy): adds 2026-07-01 amendment noting Phase 3 (structured JSON logging) shipped via PR #31; documents remaining gaps (money-path metrics issue #787)
- **ADR-0122** (libs split): updates Phase 2 status from "pending" to "in progress"; references issue #32, PR #33 (non-money-path), PR #34 (money-path, 2 approvals pending)

Delivery-Status values unchanged for both (both remain Partial) — `gen-index.sh` re-run not needed.

## Linked issues

N/A — delivery-note-only docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)