### PR TITLE
fix(ci): remove osxkeychain credsStore before ECR login on Mac mini runner

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -137,6 +137,19 @@ jobs:
           # docker logout clears ~/.docker/config.json but leaves the osxkeychain entry;
           # the subsequent docker login then fails with "already exists in the keychain".
           security delete-internet-password -s "$ECR_REGISTRY" 2>/dev/null || true
+          # Remove credsStore=osxkeychain from Docker config so amazon-ecr-login stores
+          # credentials in the config file rather than the macOS Keychain. The Keychain
+          # requires interactive unlocking (-25308: errSecInteractionNotAllowed) which
+          # fails in non-interactive CI sessions. File-based credentials are safe here:
+          # the runner is ephemeral per-job and ECR tokens expire in 12 h anyway.
+          python3 -c "
+import json, os, pathlib
+cfg = pathlib.Path.home() / '.docker' / 'config.json'
+data = json.loads(cfg.read_text()) if cfg.exists() else {}
+data.pop('credsStore', None)
+cfg.parent.mkdir(parents=True, exist_ok=True)
+cfg.write_text(json.dumps(data))
+"
 
       - name: ECR login
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -142,14 +142,7 @@ jobs:
           # requires interactive unlocking (-25308: errSecInteractionNotAllowed) which
           # fails in non-interactive CI sessions. File-based credentials are safe here:
           # the runner is ephemeral per-job and ECR tokens expire in 12 h anyway.
-          python3 -c "
-import json, os, pathlib
-cfg = pathlib.Path.home() / '.docker' / 'config.json'
-data = json.loads(cfg.read_text()) if cfg.exists() else {}
-data.pop('credsStore', None)
-cfg.parent.mkdir(parents=True, exist_ok=True)
-cfg.write_text(json.dumps(data))
-"
+          python3 -c "import json,pathlib; p=pathlib.Path.home()/'.docker'/'config.json'; d=json.loads(p.read_text()) if p.exists() else {}; d.pop('credsStore',None); p.parent.mkdir(parents=True,exist_ok=True); p.write_text(json.dumps(d))"
 
       - name: ECR login
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6


### PR DESCRIPTION
## Summary

- Adds a `python3` one-liner to strip `credsStore` from `~/.docker/config.json` in the macOS-only "Clear stale ECR credentials" step before the ECR login action
- Prevents `errSecInteractionNotAllowed (-25308)` when `amazon-ecr-login` tries to store the ECR token in the locked macOS Keychain on the Mac mini runner
- ECR tokens are 12 h; runner home is per-job — file-based credential storage is safe

## Root cause

`admin-ui-deploy` workflow run 28491161835 failed at ECR login: Docker's default `osxkeychain` credential store requires interactive Keychain unlock, which is unavailable in non-interactive CI sessions.

## Test plan

- [ ] Next `admin-ui-deploy.yml` run on Mac mini runner completes ECR login successfully

## Linked issues

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)