### PR TITLE
fix(admin-ui): pin postcss to 8.5.16 (CVE-2026-41305)

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -11082,34 +11082,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -11736,7 +11708,6 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -50,7 +50,8 @@
     "zod": "4.4.3"
   },
   "overrides": {
-    "glob": "10.5.0"
+    "glob": "10.5.0",
+    "postcss": "8.5.16"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",


### PR DESCRIPTION
## Summary

- Dependabot alert flagged `postcss@8.4.31` (transitive via `next@16.2.9`) as vulnerable to
  [CVE-2026-41305](https://github.com/advisories) — XSS via unescaped `</style>` in CSS
  stringify output.
- Dependabot couldn't auto-fix: `vite`/`vitest` require `postcss@^8.5.15` while `next` pins
  `8.4.31` — no single version satisfies both requirement sets without an override.
- Added `postcss: 8.5.16` to `package.json` `overrides` (npm's resolutions mechanism), forcing
  a single deduped `postcss@8.5.16` across the whole dependency tree.
- Verified: clean `npm install` (0 vulnerabilities), `tsc --noEmit` passes.

## Linked issues

N/A — dependency security fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)