### PR TITLE
fix(ci): split Trivy SARIF upload by category (fixes every run since public launch)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -155,12 +155,25 @@ jobs:
       # it can only run once the repo is public — same gate as the CodeQL job. The
       # fs/config scans above already gate the job; this step is purely for the
       # code-scanning UI, so skipping it while private loses no enforcement.
-      - name: Upload Trivy SARIF
+      #
+      # Two separate uploads, one per file: `sarif_file: .` picked up BOTH
+      # trivy-fs.sarif and trivy-config.sarif under the single category "trivy",
+      # which GitHub's SARIF ingestion now rejects outright ("does not support
+      # uploading multiple SARIF runs with the same category" — every run since
+      # this repo went public failed here). Distinct categories per file fixes it.
+      - name: Upload Trivy fs SARIF
         if: always() && github.event.repository.private == false
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
-          sarif_file: .
-          category: trivy
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+      - name: Upload Trivy config SARIF
+        if: always() && github.event.repository.private == false
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
 
   # ---------------------------------------------------------------------------
   # SBOM (CycloneDX) — repo-wide via Syft (filesystem scan)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cd openbank-infra
 cp .env.example .env
 $EDITOR .env
 
-# 2. Start infrastructure (Postgres, Kafka, Apicurio, Keycloak, Vault, Valkey, OPA, observability)
+# 2. Start infrastructure (Postgres, Kafka, Apicurio, Keycloak, OpenBao, Valkey, OPA, observability)
 make up-infra
 
 # 3. Build and start all application services + Admin UI
@@ -105,7 +105,7 @@ Key endpoints:
 | OPA (policy decision point) | http://localhost:8181 |
 | Grafana | http://localhost:3001 |
 | Prometheus | http://localhost:9090 |
-| Vault | http://localhost:8200 |
+| OpenBao | http://localhost:8200 |
 
 Credentials for local dev are read from your `.env` file — see [`openbank-infra/.env.example`](openbank-infra/.env.example).
 
@@ -246,7 +246,7 @@ OpenBank stands on the shoulders of giants:
 - [Apache Fineract](https://github.com/apache/fineract) — pioneering open-source core banking
 - [Apache Mifos](https://mifos.org/) — community-driven banking platform
 - [Open Bank Project](https://www.openbankproject.com/) — open banking API standard
-- All maintainers of Kotlin, Quarkus, Next.js, Kafka, PostgreSQL, Keycloak, Vault, and OPA
+- All maintainers of Kotlin, Quarkus, Next.js, Kafka, PostgreSQL, Keycloak, OpenBao, and OPA
 
 ---
 


### PR DESCRIPTION
## Summary

- Traced a Trivy check failure recurring across multiple unrelated PRs (#48, #66, #75)
  to the actual error, not runner flakiness: `The CodeQL Action does not support
  uploading multiple SARIF runs with the same category.`
- Root cause: the Trivy job writes two SARIF files (`trivy-fs.sarif`,
  `trivy-config.sarif`), but the upload step used `sarif_file: .` (whole directory) +
  a single `category: trivy` — GitHub's SARIF ingestion rejects multiple runs under one
  category (policy change since 2025-07-21). This has failed on **every single run**
  since the repo went public and the upload step's private-repo gate opened.
- Fix: split into two `upload-sarif` steps with distinct categories (`trivy-fs`,
  `trivy-config`).
- Bonus: fixed 3 stale "Vault" references in README left over from the local-dev
  Vault → OpenBao fix (#74) — a `make up-infra` comment, the local endpoints table, and
  the acknowledgements list.

## Linked issues

N/A — CI config fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)