### PR TITLE
fix(admin-ui): resolve all 32 open CodeQL findings

### DIFF
--- a/openbank-admin-ui/next.config.mjs
+++ b/openbank-admin-ui/next.config.mjs
@@ -14,7 +14,6 @@ const securityHeaders = [
 const nextConfig = {
   poweredByHeader: false,
   output: process.env.NEXT_STANDALONE === 'true' ? 'standalone' : undefined,
-  poweredByHeader: false,
   // `pg` (node-postgres) uses dynamic requires (pg-native, connection-string).
   // If webpack bundles it into a route, those requires break in the standalone
   // image and the route module fails to load — Next then serves a bare 404 for

--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -22,6 +22,7 @@
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "date-fns": "4.4.0",
+        "dompurify": "^3.4.11",
         "lucide-react": "1.23.0",
         "mermaid": "^11.16.0",
         "next": "16.2.9",

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -30,6 +30,7 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "date-fns": "4.4.0",
+    "dompurify": "^3.4.11",
     "lucide-react": "1.23.0",
     "mermaid": "^11.16.0",
     "next": "16.2.9",

--- a/openbank-admin-ui/scripts/generate-catalog.mjs
+++ b/openbank-admin-ui/scripts/generate-catalog.mjs
@@ -22,7 +22,7 @@
 // Usage: node scripts/generate-catalog.mjs [--repo <path>] [--out <file>]
 // Defaults: repo = parent of admin-ui, out = ./catalog.json
 
-import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from 'fs'
+import { readdirSync, statSync, readFileSync, writeFileSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { parse as parseYaml } from 'yaml'
@@ -84,7 +84,6 @@ const entries = readdirSync(REPO)
 const services = []
 for (const name of entries) {
   const dir = path.join(REPO, name)
-  const hasVersionTxt = existsSync(path.join(dir, 'version.txt'))
   // admin-ui's release version lives in package.json; everything else in version.txt.
   let releaseVersion = readText(path.join(dir, 'version.txt'))?.trim() || null
   if (!releaseVersion && name === 'openbank-admin-ui') {

--- a/openbank-admin-ui/scripts/generate-infra-lifecycle.mjs
+++ b/openbank-admin-ui/scripts/generate-infra-lifecycle.mjs
@@ -79,6 +79,10 @@ async function fetchEol(product) {
   for (let attempt = 0; attempt < 4; attempt++) {
     if (attempt > 0) await sleep(400 * attempt)
     try {
+      // `product` traces back to the statically-committed component registry
+      // JSON (openbank.eolProduct), not attacker input — a fixed catalog string
+      // like "node" or "postgresql" sent to a public, read-only lookup API.
+      // codeql[js/file-access-to-http]
       const res = await fetch(`https://endoflife.date/api/${product}.json`, {
         headers: { Accept: 'application/json' },
         signal: AbortSignal.timeout(15000),

--- a/openbank-admin-ui/src/app/api/infra/lifecycle/route.ts
+++ b/openbank-admin-ui/src/app/api/infra/lifecycle/route.ts
@@ -157,7 +157,7 @@ export async function GET() {
   const components = await Promise.all(snap.components.map(async c => {
     // 1. running version
     let running: string | null = null
-    let versionSource: string = c.versionSource
+    let versionSource: string
     if (c.versionSource === 'gitops') {
       running = c.gitopsVersion
       versionSource = 'gitops-image-tag'

--- a/openbank-admin-ui/src/app/api/services/[name]/sbom/route.ts
+++ b/openbank-admin-ui/src/app/api/services/[name]/sbom/route.ts
@@ -190,8 +190,10 @@ async function loadSbom(name: string): Promise<{ raw: string; parsed: CycloneDxS
   ]
   for (const file of candidates) {
     try {
-      const stat = await fs.stat(file)
-      if (!stat.isFile()) continue
+      // Read directly rather than stat-then-read: a separate existence/type
+      // check followed by a read is a TOCTOU race (the path could be replaced
+      // between the two calls). readFile fails the same way on ENOENT/EISDIR,
+      // so the fallback-to-next-candidate behavior is unchanged.
       const raw = await fs.readFile(file, 'utf-8')
       return { raw, parsed: JSON.parse(raw) as CycloneDxSbom }
     } catch {

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -5,7 +5,7 @@
 'use client'
 import { useState, useEffect } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { CreditCard, Plus, Search, Filter, RefreshCw, CheckCircle2, XCircle, Clock, Shield, Zap } from 'lucide-react'
+import { CreditCard, Plus, Search, RefreshCw, CheckCircle2, XCircle, Clock } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 
 interface Card {

--- a/openbank-admin-ui/src/app/dashboard/page.tsx
+++ b/openbank-admin-ui/src/app/dashboard/page.tsx
@@ -7,10 +7,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CreditCard, ArrowLeftRight, Users, Activity, TrendingUp, TrendingDown,
-  ShieldCheck, AlertTriangle, CheckCircle2, XCircle, RefreshCw, Zap,
-  DollarSign, Globe, Lock, BarChart3, Clock, Server, HardDrive } from 'lucide-react'
+  ShieldCheck, AlertTriangle, RefreshCw, Zap,
+  DollarSign, Globe, BarChart3, Clock, Server, HardDrive } from 'lucide-react'
 import Link from 'next/link'
-import { useAuth } from '@/lib/auth/useAuth'
 
 // Tri-state per fleet member. `deployed=false` is NEUTRAL (planned, not an outage) —
 // it must never be counted as an error, or the 23 not-yet-deployed services in the
@@ -39,7 +38,6 @@ const GROUP_COLORS: Record<string, string> = {
 }
 
 export default function DashboardPage() {
-  const { user, roles } = useAuth()
   const { t } = useLanguage()
   const [statuses, setStatuses] = useState<SvcStatus[]>([])
   const [loading, setLoading] = useState(true)

--- a/openbank-admin-ui/src/app/docs/cluster/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cluster/page.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   Boxes, Box, Lock, Network, Cpu, Globe, Shield, Key, CheckCircle2, CircleDashed, Circle,
-  ChevronRight, RefreshCw, Layers, FileText, BadgeCheck, AlertTriangle, Building2, Server,
+  ChevronRight, RefreshCw, FileText, BadgeCheck, AlertTriangle, Building2, Server,
 } from 'lucide-react'
 
 type Status = 'live' | 'partial' | 'planned'

--- a/openbank-admin-ui/src/app/docs/page.tsx
+++ b/openbank-admin-ui/src/app/docs/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 import Link from 'next/link'
-import { Map, GitBranch, BookOpen, Network, FileCode, Shield, ShieldAlert, Cloud, ScrollText, ShieldCheck, LayoutGrid, Smartphone, Bluetooth, Fingerprint } from 'lucide-react'
+import { GitBranch, BookOpen, Network, FileCode, Shield, ShieldAlert, Cloud, ScrollText, ShieldCheck, LayoutGrid, Smartphone, Bluetooth, Fingerprint } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 // Each section's title/desc is a [cs, en] tuple, spread into t(...) at render.

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 import { useState, useEffect } from 'react'
-import { Network, Info, RefreshCw, CheckCircle2, XCircle, HelpCircle, Database, GitBranch, ArrowRight, ArrowLeft, Layers, BookOpen } from 'lucide-react'
+import { Network, RefreshCw, CheckCircle2, XCircle, HelpCircle, Database, ArrowRight, ArrowLeft, Layers, BookOpen } from 'lucide-react'
 import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 import { svcUrl } from '@/lib/services/bff'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'

--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -100,23 +100,6 @@ function CurrencyCell({ code, meta }: { code: string; meta?: CurrencyMetaType })
   )
 }
 
-function BuySellCell({ buy, sell, symbol }: { buy: number; sell: number; symbol?: string }) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
-        <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--success-text)', background: 'var(--success-bg)', border: '1px solid var(--success-border)', borderRadius: '3px', padding: '0 4px', letterSpacing: '0.05em' }}>BUY</span>
-        {symbol && <span style={{ fontSize: '9px', color: 'var(--text-tertiary)' }}>{symbol}</span>}
-        <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', fontWeight: 700, color: 'var(--success-text)' }}>{buy.toFixed(4)}</span>
-      </div>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: '4px' }}>
-        <span style={{ fontSize: '9px', fontWeight: 700, color: 'var(--danger-text)', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)', borderRadius: '3px', padding: '0 4px', letterSpacing: '0.05em' }}>SELL</span>
-        {symbol && <span style={{ fontSize: '9px', color: 'var(--text-tertiary)' }}>{symbol}</span>}
-        <span style={{ fontFamily: 'var(--font-mono)', fontSize: '12px', fontWeight: 700, color: 'var(--danger-text)' }}>{sell.toFixed(4)}</span>
-      </div>
-    </div>
-  )
-}
-
 function MidCell({ mid, symbol }: { mid: number; symbol?: string }) {
   return (
     <div style={{ display: 'flex', alignItems: 'baseline', gap: '3px' }}>

--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -91,17 +91,15 @@ export default function InfrastructurePage() {
   const [kafkaCluster, setKafkaCluster] = useState<string>('')
   const [kafkaUnavailable, setKafkaUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [lifecycle, setLifecycle] = useState<Record<string, CompLifecycle>>({})
-  const [lcMeta, setLcMeta] = useState<{ lifecycleGeneratedAt: string | null; vulnScannedAt: string | null } | null>(null)
 
   const loadLifecycle = useCallback(async () => {
     try {
       const res = await fetch('/api/infra/lifecycle', { cache: 'no-store' })
       if (!res.ok) return
-      const data = await res.json() as { components: CompLifecycle[]; lifecycleGeneratedAt: string | null; vulnScannedAt: string | null }
+      const data = await res.json() as { components: CompLifecycle[] }
       const map: Record<string, CompLifecycle> = {}
       for (const c of data.components ?? []) map[c.id] = c
       setLifecycle(map)
-      setLcMeta({ lifecycleGeneratedAt: data.lifecycleGeneratedAt, vulnScannedAt: data.vulnScannedAt })
     } catch { /* lifecycle is additive; health view stands without it */ }
   }, [])
 

--- a/openbank-admin-ui/src/app/observability/page.tsx
+++ b/openbank-admin-ui/src/app/observability/page.tsx
@@ -7,7 +7,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { Activity, AlertTriangle, RefreshCw, Zap, Server, Clock, Database, XCircle, GitBranch, Globe } from 'lucide-react'
-import { useAuth } from '@/lib/auth/useAuth'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 import { AuthGuard } from '@/components/auth/AuthGuard'
@@ -28,7 +27,6 @@ interface MetricsData {
 }
 
 export default function ObservabilityPage() {
-  const { user } = useAuth()
   const { t } = useLanguage()
   const [metrics, setMetrics] = useState<MetricsData | null>(null)
   const [loading, setLoading] = useState(true)

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -9,7 +9,7 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   Banknote, Search, RefreshCw, Plus, Zap, Globe, CheckCircle2, XCircle,
-  Clock, AlertTriangle, Timer, ChevronDown, ChevronRight, Users, ShieldCheck, AlertCircle
+  Clock, AlertTriangle, Timer, ShieldCheck, AlertCircle
 } from 'lucide-react'
 
 // ADR-0080 P1 (pentest FIND-S3-03/04): all backend access goes through same-origin BFF
@@ -228,7 +228,6 @@ function PaymentsContent() {
   const [typeFilter, setTypeFilter] = useState<'ALL' | 'SEPA' | 'DOMESTIC'>('ALL')
 
   const [showCreate, setShowCreate] = useState<'payment-type' | 'domestic-form' | 'sepa-form' | null>(null)
-  const [createType, setCreateType] = useState<CreateType | null>(null)
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
   const [createSuccess, setCreateSuccess] = useState<string | null>(null)
@@ -266,7 +265,7 @@ function PaymentsContent() {
   const loadSct = useCallback(async () => {
     setSctLoading(true)
     try {
-      const [health, data] = await Promise.all([
+      await Promise.all([
         fetch(`${SEPA_INSTANT_API}/q/health/ready`).then(r => setSctServiceUp(r.ok)).catch(() => setSctServiceUp(false)),
         fetch(`${SEPA_INSTANT_API}/api/v1/sepa-instant`).then(r => r.json())
           .then(d => setSctPayments(Array.isArray(d) ? d : d.payments ?? []))
@@ -280,7 +279,6 @@ function PaymentsContent() {
   useEffect(() => { if (activeTab === 'sct-inst') loadSct() }, [activeTab, loadSct])
 
   const selectPaymentType = (t: CreateType) => {
-    setCreateType(t)
     setCreateError(null)
     setCreateSuccess(null)
     if (t === 'domestic-standard' || t === 'domestic-instant') {

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import {
   Package, Search, RefreshCw, AlertCircle, Edit, Play, Square, Plus, X,
-  ChevronDown, ChevronUp, Eye, EyeOff, CreditCard, Globe, TrendingDown,
+  Eye, EyeOff, CreditCard, Globe, TrendingDown,
   Clock, FileText, Tag, Users, ExternalLink, History, CheckCircle2,
   Layers, Banknote, Shield,
 } from 'lucide-react'
@@ -67,8 +67,8 @@ async function apiFetch(path: string, opts?: RequestInit) {
   const res = await fetch(`${PROXY}${path}`, { cache: 'no-store', signal: AbortSignal.timeout(8000), ...opts })
   if (!res.ok) {
     const text = await res.text().catch(() => '')
-    let msg = res.statusText
-    try { msg = JSON.parse(text)?.message ?? JSON.parse(text)?.error ?? text } catch { msg = text || res.statusText }
+    let msg: string
+    try { const parsed = JSON.parse(text); msg = parsed?.message ?? parsed?.error ?? text } catch { msg = text || res.statusText }
     throw new Error(`${res.status} ${msg}`)
   }
   return res.json()

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -42,8 +42,6 @@ export default function SwiftPage() {
     m.messageType?.includes(search.toUpperCase())
   )
 
-  const totalAmount = messages.reduce((s, m) => s + (m.amount ?? 0), 0)
-
   return (
     <AuthGuard>
       <div style={{ padding: '28px 32px', maxWidth: '1400px', animation: 'fadeIn 0.2s ease-out' }}>

--- a/openbank-admin-ui/src/app/system/inventory/page.tsx
+++ b/openbank-admin-ui/src/app/system/inventory/page.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { fetchAllServiceSnapshots } from '@/lib/api'
 import type { ServiceSnapshot, ServiceStack } from '@/types'
-import { Package, RefreshCw, CheckCircle2, AlertTriangle, XCircle, Clock, Download, ShieldAlert } from 'lucide-react'
+import { Package, RefreshCw, CheckCircle2, AlertTriangle, XCircle, Clock, ShieldAlert } from 'lucide-react'
 import { SbomViewer } from '@/components/sbom/SbomViewer'
 
 const POLL = 30_000

--- a/openbank-admin-ui/src/app/technical-accounts/page.tsx
+++ b/openbank-admin-ui/src/app/technical-accounts/page.tsx
@@ -4,8 +4,8 @@
 
 'use client'
 
-import { useEffect, useState } from 'react'
-import { Building2, RefreshCw, TrendingUp, TrendingDown } from 'lucide-react'
+import { useState } from 'react'
+import { Building2, TrendingUp, TrendingDown } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 interface TechnicalAccount {
@@ -67,8 +67,6 @@ export default function TechnicalAccountsPage() {
 
   const groups = ['all', ...Array.from(new Set(accounts.map(a => a.accountType)))]
   const filtered = filter === 'all' ? accounts : accounts.filter(a => a.accountType === filter)
-
-  const totalBalance = accounts.reduce((sum, a) => sum + (a.normalBalance === 'CREDIT' ? a.balance : -a.balance), 0)
 
   return (
     <div>

--- a/openbank-admin-ui/src/components/docs/MermaidEnhancer.tsx
+++ b/openbank-admin-ui/src/components/docs/MermaidEnhancer.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import DOMPurify from 'dompurify'
 
 // Tiny client-side enhancer. Wraps server-rendered markdown content and,
 // after mount, scans for the `<pre data-mermaid>` placeholders the
@@ -60,7 +61,11 @@ export function MermaidEnhancer({ children, contentKey }: { children: React.Reac
             const { svg } = await m.render(id, src)
             const wrap = document.createElement('div')
             wrap.className = 'mermaid-svg'
-            wrap.innerHTML = svg
+            // Mermaid's flowchart htmlLabels:true lets diagram source embed raw
+            // HTML in node labels, which ends up in the rendered `svg` string —
+            // sanitize before innerHTML so a crafted diagram source can't smuggle
+            // a <script>/event-handler payload into the page.
+            wrap.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })
             block.replaceWith(wrap)
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err)

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -13,7 +13,7 @@ import {
   HeartPulse, SlidersHorizontal, Bot, Users, ShieldCheck, Banknote,
   ScrollText, Bell, Map, FileCode, Shield, Library, Building2, FileText, Flag,
   DollarSign, Globe, Repeat, Zap, AlertOctagon, ScanLine,
-  Layers, TrendingUp, MessageSquareWarning, Package, Receipt, HardDrive, Server, ShieldAlert, FlaskConical, Cloud,
+  Layers, TrendingUp, MessageSquareWarning, Package, Receipt, Server, ShieldAlert, FlaskConical, Cloud,
   PiggyBank, GitBranch, Lock, ClipboardList, Scale, Smartphone,
   ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint,
 } from 'lucide-react'

--- a/openbank-admin-ui/src/lib/agent/svidMint.ts
+++ b/openbank-admin-ui/src/lib/agent/svidMint.ts
@@ -29,6 +29,10 @@ const ISSUE_PATH = process.env.OPENBAO_PKI_ISSUE_PATH ?? 'pki-agent/issue/agent-
 
 async function loginToken(): Promise<string> {
   const jwt = readFileSync(SA_TOKEN_PATH, 'utf-8').trim()
+  // The projected SA token is the intended Kubernetes-auth JWT for OpenBao's
+  // own /auth/kubernetes/login — OpenBao validates it against the K8s API via
+  // TokenReview. Not a leak — this is the designed in-cluster auth flow.
+  // codeql[js/file-access-to-http]
   const res = await fetch(`${BAO_ADDR}/v1/auth/kubernetes/login`, {
     method: 'POST',
     body: JSON.stringify({ role: BAO_ROLE, jwt }),

--- a/openbank-admin-ui/src/lib/discovery.ts
+++ b/openbank-admin-ui/src/lib/discovery.ts
@@ -117,6 +117,11 @@ function k8sGet<T>(path: string): Promise<T> {
     '443'
 
   return new Promise<T>((resolve, reject) => {
+    // The projected ServiceAccount token is meant to travel exactly here: it
+    // authenticates this in-cluster request to the Kubernetes API server
+    // itself (host/port from the standard KUBERNETES_SERVICE_* env, verified
+    // against the same pod's CA bundle) — not a leak, the intended auth flow.
+    // codeql[js/file-access-to-http]
     const req = https.request(
       {
         host,

--- a/openbank-admin-ui/test-edit.tsx
+++ b/openbank-admin-ui/test-edit.tsx
@@ -1,9 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
-// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
-
-'use client'
-import { useEffect, useState, useCallback } from 'react'
-import { FileCode, ExternalLink, RefreshCw, CheckCircle2, XCircle, ChevronDown, ChevronRight, Info } from 'lucide-react'
-
-// ...


### PR DESCRIPTION
## Summary

Resolves every open CodeQL code-scanning alert (32 total) on the repo.

**High:**
- `js/xss-through-dom` (`MermaidEnhancer.tsx`) — mermaid's `htmlLabels:true` lets
  diagram source embed raw HTML in the rendered SVG, which was written via
  `innerHTML` unsanitized. Added `DOMPurify.sanitize()` (SVG profile) before
  assignment.
- `js/file-system-race` (`sbom/route.ts`) — `stat()` then `readFile()` on the
  same path is a TOCTOU race. Read directly and let `readFile`'s own
  ENOENT/EISDIR errors drive the existing fallback-to-next-candidate logic.

**Medium (dismissed as false positive with inline `codeql[]` suppression):**
- `js/file-access-to-http` ×3 — two are the intended Kubernetes/OpenBao
  in-cluster auth flow (the ServiceAccount token is sent to the exact trusted
  endpoint it authenticates to, not leaked); the third sends a static,
  repo-committed registry string (not attacker input) to a public read-only
  lookup API.

**Warning:**
- `js/duplicate-property` — `poweredByHeader` set twice in `next.config.mjs`.
- `js/useless-assignment-to-local` ×2 — initial value always overwritten
  before being read.

**Note (`js/unused-local-variable` ×24):** dead imports, dead state, one fully
dead component (`fx` page's `BuySellCell`), across ~15 files. Also deleted
`test-edit.tsx` — a stray scratch file at the package root with no purpose.

Verified: `tsc --noEmit` clean, `eslint` 0 errors (14 pre-existing warnings
unrelated to these changes), `next build` succeeds.

## Linked issues

N/A — security/code-quality cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)