### PR TITLE
ci: offload light non-credentialed jobs to ubuntu-latest

### DIFF
--- a/.github/workflows/adr-registry.yml
+++ b/.github/workflows/adr-registry.yml
@@ -41,7 +41,8 @@ concurrency:
 jobs:
   adr-registry:
     name: adr-registry
-    runs-on: openbank-build
+    # Pure bash over docs/adr/, no Gradle/Docker — trivially portable off the self-hosted pool.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -30,7 +30,8 @@ concurrency:
 jobs:
   issue-hygiene:
     name: issue-hygiene
-    runs-on: openbank-build
+    # actions/github-script only — no self-hosted-pool dependency.
+    runs-on: ubuntu-latest
     steps:
       - name: Lint PR "Linked issues"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -28,14 +28,10 @@ concurrency:
 jobs:
   sync:
     name: Sync labels
-    # Sandbox maintenance pool, same as the scans (ADR-0027 phase 0 / ADR-0040). This job
-    # deliberately depends on only ONE host binary — `curl` — which is present on every host
-    # in the pool. The earlier `gh`-based design was abandoned: `gh` is NOT uniformly
-    # available across the heterogeneous (darwin/linux x amd64/arm64) self-hosted fleet — it
-    # is absent on the Linux sandbox hosts and, on the macOS hosts, lives on a Homebrew PATH
-    # the runner service does not expose. So we talk to the GitHub REST API directly with
-    # `curl` and parse the manifest with a version-pinned `yq` fetched into RUNNER_TEMP.
-    runs-on: openbank-batch
+    # Only depends on `curl` (present everywhere, incl. ubuntu-latest) and a version-pinned
+    # `yq` fetched into RUNNER_TEMP — no self-hosted-pool-specific tooling. Public repo =
+    # free GitHub-hosted minutes, so this comes off the Hetzner/ARC pool.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -32,7 +32,8 @@ concurrency:
 jobs:
   verify:
     name: build + verify bundle, check ConfigMap sync
-    runs-on: openbank-build
+    # Installs OPA to $HOME/bin itself (no sudo needed) — no self-hosted-pool dependency.
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,11 +23,10 @@
 # token-gated: until the SCORECARD_TOKEN secret exists, the analysis is SKIPPED (the
 # job stays green with a notice) — it auto-activates once the secret is added.
 #
-# Runs on the self-hosted pool, pinned to Linux x86. GitHub-hosted runners
-# (ubuntu-latest) are blocked by the Actions-minutes budget on this repo — which is
-# the whole point of the Hetzner/ARC fleet (ADR-0040 / ADR-0053). The scorecard
-# binary is linux/amd64 and the `openbank-build` label also spans the Mac ARM host,
-# so runs-on pins `Linux` + `X64` to land on a Hetzner/ARC x86 runner, never the Mac.
+# Runs on ubuntu-latest: the repo went public, so GitHub-hosted Actions minutes are
+# free/unlimited — the Actions-minutes-budget constraint that used to pin this to the
+# Hetzner/ARC x86 pool (ADR-0040 / ADR-0053) no longer applies. ubuntu-latest is also
+# linux/amd64, matching what the scorecard binary needs.
 # -----------------------------------------------------------------------------
 name: OpenSSF Scorecard
 
@@ -51,7 +50,7 @@ concurrency:
 jobs:
   analysis:
     name: scorecard
-    runs-on: [openbank-build, Linux, X64]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,6 +82,14 @@ jobs:
     # pool lacking those toolchains). Public repo = free GitHub-hosted minutes.
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # The java-kotlin leg's autobuild shells out to its own `./gradlew testClasses`
+    # (whole-fleet dependency resolution, ~30 modules + quarkus-bom) without picking up
+    # any GRADLE_OPTS we'd set in a step — it needs the env var at the job level. Without
+    # this, Gradle's auto-detected 3 GiB default heap OOMs on that resolution (first seen
+    # moving this job off the 16 GB Hetzner host to ubuntu-latest). Same fix pattern as
+    # fleet-lint.yml's GRADLE_OPTS.
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,9 @@ jobs:
   # dependency-affecting file changed; schedule/manual always run (audit posture).
   detect-deps:
     name: Detect dependency changes
-    runs-on: openbank-batch
+    # Pure checkout + git diff, no self-hosted-specific tooling. The repo is public, so
+    # GitHub-hosted minutes are free/unlimited — offload this off the Hetzner/ARC pool.
+    runs-on: ubuntu-latest
     outputs:
       run_sbom: ${{ steps.f.outputs.run_sbom }}
     steps:
@@ -75,7 +77,10 @@ jobs:
     # cover vulnerable-dependency detection. (Aside: the CodeQL CLI also does not
     # support linux/arm64, so it could not run on the arm64 sandbox runner anyway.)
     if: github.event.repository.private == false
-    runs-on: openbank-batch
+    # Standard github/codeql-action usage targets ubuntu-latest; no self-hosted-specific
+    # dependency here (setup-java/setup-node are already used to work around the Hetzner
+    # pool lacking those toolchains). Public repo = free GitHub-hosted minutes.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -180,7 +185,8 @@ jobs:
   # ---------------------------------------------------------------------------
   sbom:
     name: SBOM (repo-wide)
-    runs-on: openbank-batch
+    # anchore/sbom-action is a container action with no self-hosted-pool dependency.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     # Runs on schedule/manual, and on main pushes only when dependencies changed
     # (see detect-deps). Never on PRs. The authoritative, signed, release-attached


### PR DESCRIPTION
## Summary

The repo is now public, so GitHub-hosted Actions minutes are free/unlimited on `ubuntu-latest`. This moves stateless, credential-free CI jobs off the Hetzner/ARC self-hosted pool to free up capacity there, without touching any job that needs self-hosted-specific tooling or cloud credentials.

## Type of change

- [x] chore (build / tooling)

## Linked issues

N/A — FinOps/capacity experiment on CI runner routing, not tied to a tracked issue.

## Changes

- `security.yml`: `detect-deps`, `codeql`, and `sbom` (repo-wide) → `ubuntu-latest`.
- `labels.yml`, `opa-policy.yml`, `adr-registry.yml`, `issue-hygiene.yml` → `ubuntu-latest`.
- `scorecard.yml` → `ubuntu-latest`; also removed a stale comment that pinned it to the self-hosted pool specifically to dodge the *private*-repo Actions-minutes budget (moot now that we're public).

Deliberately **left on self-hosted** (openbank-build/openbank-batch):
- `trivy` and `gitleaks` (secret-scan.yml) — both invoke a host-installed CLI binary (via brew) rather than a self-installing action; would fail as `command not found` on `ubuntu-latest` without adding an install step first. `gitleaks` also gates every PR, so I didn't want to risk it without testing.
- `fleet-lint.yml` and `sbom-per-service` (security.yml) — fleet-wide Gradle builds across ~30 services that benefit from the Hetzner persistent Gradle cache; not "light" jobs despite initially being scoped in.

## Definition of Done

- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (N/A — no Gradle-module changes; workflow-only YAML, validated with `python3 -c "import yaml; yaml.safe_load(...)"`.)
- [x] No new lint warnings.
- [x] Docs updated (README, ADR if architectural). (N/A — no architectural change.)

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: n/a (CI config only, takes effect on next workflow run on this branch/PR).
- Rollback plan: revert this PR; `runs-on` reverts to the self-hosted labels.
- Data migration reversible: N/A

## Reviewer notes

Follow-up (not in this PR, flagging separately): `scorecard.yml` still has other private-repo-era conditionals (`publish_results: false`, gated SARIF upload, `SCORECARD_TOKEN` gating) that are candidates to flip now that the repo is public — left untouched here to keep this PR to routing only.