### PR TITLE
fix(infra): correct fck-nat AMI filter + undersized instance type

### DIFF
--- a/openbank-infra/aws/modules/network/main.tf
+++ b/openbank-infra/aws/modules/network/main.tf
@@ -99,8 +99,14 @@ data "aws_ami" "fck_nat" {
   owners      = ["568608671756"] # fck-nat publisher account
 
   filter {
+    # Publisher's naming convention now inserts hvm-<fck-nat version>-<build date>
+    # between "al2023" and "arm64" (e.g. fck-nat-al2023-hvm-1.4.0-20260701-arm64-ebs).
+    # The old "fck-nat-al2023-arm64-*" pattern stopped matching anything, which
+    # broke every tofu plan/apply for this module ("query returned no results").
+    # This pattern is deliberately anchored right after "al2023" so it does NOT
+    # also match the "fck-nat-nat64-al2023-hvm-*" NAT64 variant.
     name   = "name"
-    values = ["fck-nat-al2023-arm64-*"]
+    values = ["fck-nat-al2023-hvm-*-arm64-*"]
   }
 
   filter {
@@ -140,9 +146,11 @@ resource "aws_security_group" "fck_nat" {
 }
 
 resource "aws_instance" "fck_nat" {
-  count         = var.egress_mode == "fck_nat" ? 1 : 0
-  ami           = data.aws_ami.fck_nat[0].id
-  instance_type = "t4g.nano"
+  count = var.egress_mode == "fck_nat" ? 1 : 0
+  ami   = data.aws_ami.fck_nat[0].id
+  # t4g.nano/micro hit InsufficientInstanceCapacity in eu-north-1a; t4g.small
+  # is reliably available and still comfortably sized for NAT-instance traffic.
+  instance_type = "t4g.small"
 
   subnet_id = aws_subnet.public[0].id
   # tfsec/infracost EC2.9/EC2.25: public IP is intentional — this IS the NAT.


### PR DESCRIPTION
## Summary

Found while test-planning the `hashicorp/aws` 5→6 provider bump PRs (#50-63):
`tofu plan` for `sandbox-substrate` fails — confirmed via a control-branch test
that this is **unrelated to the provider bump**, it already fails on unmodified
`main`.

- **AMI filter** (`modules/network/main.tf`): the publisher's naming convention
  now inserts `hvm-<version>-<date>` between `al2023` and `arm64`
  (`fck-nat-al2023-hvm-1.4.0-20260701-arm64-ebs`). The old
  `fck-nat-al2023-arm64-*` pattern matches zero AMIs, so every plan/apply for
  this module fails with `query returned no results`. New pattern verified
  against live AWS (`aws ec2 describe-images`) and anchored so it does not also
  match the `fck-nat-nat64-*` variant.
- **Instance type**: `t4g.nano`/`micro` hit `InsufficientInstanceCapacity` in
  `eu-north-1a`; `t4g.small` is reliably available. Fixing only the AMI filter
  without this would risk the same capacity error on the next replacement.

## Verification

`tofu plan` (`AWS_PROFILE=openbank`) now completes cleanly — exit 0, was exit 1
before this fix. Only `aws_instance.fck_nat` + its EIP association need
replacement (AMI + instance-type change); the other ~45 in-place changes in
the plan are pre-existing drift unaffected by this PR (present identically on
unmodified `main`).

**Not applied.** Replacing the live `fck-nat` instance briefly interrupts NAT
egress for the sandbox cluster — apply at a chosen low-traffic window.

## Linked issues

N/A — infra bug fix (blocks `tofu plan`/`apply` for this env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)