### PR TITLE
docs(governance): propose ADR-0144–0152 — governance/security/compliance follow-ups

### DIFF
--- a/docs/adr/0144-gate-graduation-advisory-rules-carry-an-enforcement-deadline.md
+++ b/docs/adr/0144-gate-graduation-advisory-rules-carry-an-enforcement-deadline.md
@@ -1,0 +1,105 @@
+# ADR-0144 — Gate graduation — advisory rules carry an enforcement deadline
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+`openbank-libs/governance/rules.yaml` carries an `enforced` flag per rule
+(`block` | `advisory` | `planned`), by design (ADR-0029 D7: a gate flips to
+`block` only once its producing layer exists). That design is correct — but
+it has no matching *exit* condition. Today the majority of rules sit at
+`advisory`, including some whose producing layer has been "Shipped" for
+months (e.g. `authz.enforce` is still `false` on every money-path service
+per ADR-0034, even though the OPA sidecar, the `@Authorize` interceptor, and
+the policy bundle are all live). An advisory rule with no deadline can stay
+advisory forever without anyone deciding that on purpose — it just never
+comes up again once the PR that shipped the producer merges.
+
+The failure mode is specific: a rule can be *technically enforceable* and
+*organizationally never enforced*, and nothing in the repo distinguishes
+that state from "genuinely still blocked on a missing producer." An external
+reviewer (or a regulator) reading `rules.yaml` today cannot tell the two
+apart without cross-referencing every linked ADR's delivery status by hand.
+
+## Decision
+
+We will require every rule with `enforced: advisory` or `enforced: planned`
+in `rules.yaml` to carry a `target_enforce_date` (ISO date) and a
+`blocked_on` field naming the specific missing producer (an ADR id, a PR, or
+a script path). A new CI check
+(`.github/scripts/check-gate-graduation.sh`) fails the build when
+`target_enforce_date` has passed and the rule is still not `block` — unless
+the same PR that would otherwise fail also moves the date forward with a
+one-line reason in the commit body. A rule may not be added to `rules.yaml`
+without a `target_enforce_date`.
+
+This does not change what any rule currently blocks. It changes what happens
+when a producer ships and nobody flips the switch: today, nothing; after
+this ADR, CI.
+
+## Alternatives considered
+
+- **Flip everything currently advisory to `block` immediately.** Rejected —
+  several advisory rules (e.g. `api-contract` pending `oasdiff` wiring,
+  `provenance` pending fleet-wide SBOM re-attestation per ADR-0030 D4) do not
+  yet have a working producer; flipping them would break every open PR for a
+  reason unrelated to the PR's content.
+- **Leave it to periodic manual audit (e.g. quarterly governance review).**
+  Rejected — this is the status quo, and it is exactly why 14 money-path
+  services have sat at `authz.enforce: false` after their producer shipped.
+  A rule without a forcing function decays to permanently advisory.
+- **Track graduation dates in a separate tracking issue instead of in
+  `rules.yaml`.** Rejected — `rules.yaml` is the declared single source of
+  truth (rule #7, "derived data is never hand-edited" / "nothing computable
+  is typed twice"); a parallel tracking issue would itself rot the way the
+  governance manifest used to before ADR-0071.
+
+## Consequences
+
+**Positive**
+- Advisory-vs-blocked-on-purpose becomes machine-checkable instead of
+  requiring a human to read every linked ADR.
+- Creates a forcing function for the highest-value backlog item this review
+  surfaced: OPA enforcement on money-path services has no other trigger to
+  ever happen.
+- The escape hatch (move the date, state why, in the commit) is intentionally
+  visible in `git log` rather than a silent config edit — anyone can audit
+  how many times a deadline was pushed and why.
+
+**Negative**
+- Adds a new required CI check; a rule with a passed deadline and a
+  legitimately-still-missing producer will fail CI until someone moves the
+  date, which is friction by design but is still friction.
+- The `blocked_on` field is free text validated only for presence, not for
+  truthfulness — a rule can claim to be blocked on something that shipped
+  weeks ago. The check catches *deadline* drift, not *justification* drift.
+
+**Neutral**
+- Does not change the `block` / `advisory` / `planned` vocabulary itself,
+  only adds required metadata to the latter two states.
+
+## Compliance impact
+
+- PCI DSS: not applicable directly — indirectly strengthens evidence that
+  Req. 6.2–6.3 controls (SSDLC gates) are not merely declared.
+- DORA: Art. 6 (ICT risk management framework must be *effective*, not
+  merely documented) — this closes the gap between "rule exists" and "rule
+  runs."
+- GDPR: not applicable.
+- PSD2: not applicable directly.
+- CNB: not applicable directly.
+
+## References
+
+- ADR-0029 (versioning, release and governance as code) — D7 phasing; this
+  ADR adds the missing graduation half of that phasing.
+- ADR-0030 (supply-chain security and SSDLC hardening) — several D-items
+  cited here as still-advisory examples.
+- ADR-0034 (unified OPA authorization) — Phase 5 enforcement, the concrete
+  case that motivated this ADR: 14 money-path services still
+  `authz.enforce: false`.
+- `openbank-libs/governance/rules.yaml` — the file this ADR amends the
+  schema of.

--- a/docs/adr/0145-api-deprecation-and-sunset-policy.md
+++ b/docs/adr/0145-api-deprecation-and-sunset-policy.md
@@ -1,0 +1,116 @@
+# ADR-0145 — API deprecation and sunset policy
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+ADR-0048 D6 already ships the *mechanism*: `ApiVersionResponseFilter`
+reads `openbank.api.deprecated-paths` and `openbank.api.sunset-date` and
+emits `Deprecation` / `Sunset` / `Link: rel=successor-version` headers;
+`rules.yaml: api_deprecation.min_sunset_window_days: 180` is a real,
+already-declared constant. What is missing is not plumbing — it is the
+*policy* that decides when to populate `deprecated_paths`, who decides a
+change is breaking enough to require a new major, and how TPP/partner
+consumers (PSD2 XS2A per ADR-0090) are notified outside of an HTTP header
+they may never read (e.g. a developer-portal changelog, a webhook per
+ADR-0059). None of that is decided; `deprecated_paths` is an empty list
+today, and it is undocumented whether it stays empty because nothing has
+ever been deprecated, or because nobody has decided the process for
+deprecating something.
+
+This matters more for OpenBank than for an average API: a breaking change
+to `/api/v1/*` propagates to real TPPs under a PSD2 authorization, and
+ADR-0090's Berlin Group NextGenPSD2 profile is itself a moving external
+standard OpenBank must track.
+
+## Decision
+
+We will adopt the following as policy, on top of the existing D6 mechanism:
+
+1. **What requires a major bump.** Removing a field, tightening a
+   validation, changing a status-code contract, or removing an endpoint are
+   breaking; adding an optional field or a new endpoint is not. This
+   classification is derived the same way ADR-0048 already derives it —
+   from the `oasdiff` diff of `openapi.yaml`, not from commit type — and a
+   breaking diff without a corresponding major bump fails CI (the
+   `api-contract` gate; see ADR-0144 for its graduation from advisory to
+   block).
+2. **Minimum sunset window stays 180 days** (already declared) for any
+   externally-reachable path (PSD2 XS2A surfaces, developer-portal-listed
+   endpoints); internal-only service-to-service paths may declare a shorter
+   window per-path.
+3. **Notification is two-channel, not header-only**: the existing
+   `Deprecation`/`Sunset` headers (machine channel) plus an entry in the
+   developer-portal changelog and an outbound webhook via the ADR-0059
+   oversight-webhook mechanism (human/operational channel), fired the day
+   `deprecated_paths` gains a new entry.
+4. **Sunset requires evidence of zero live traffic**, not just elapsed time:
+   the gate additionally checks Tier-B HTTP metrics (ADR-0077) show zero
+   requests to the path over the preceding 30 days before the path may be
+   removed from the router, even after the 180-day window elapses.
+
+## Alternatives considered
+
+- **Never break anything (permanent path aliasing).** Rejected — PSD2's own
+  Berlin Group profile evolves under external control; OpenBank cannot
+  promise an infinite-lifetime contract for a standard it does not own.
+- **Per-endpoint versioning instead of per-major-URL versioning.** Rejected
+  — contradicts ADR-0048's existing decision that `openapi.yaml:info.version`
+  major tracks the URL major fleet-wide; per-endpoint versioning would
+  fragment that invariant service by service.
+- **Rely on the HTTP headers alone, no separate notification channel.**
+  Rejected — a TPP's automated client reads headers; a TPP's human
+  integrator, who has to schedule the migration, does not poll HTTP headers.
+  ADR-0059's webhook channel already exists for exactly this kind of
+  operational signal.
+
+## Consequences
+
+**Positive**
+- Closes the last undecided piece of the API-contract version axis
+  (ADR-0048); `deprecated_paths` staying empty becomes a verifiable fact
+  ("nothing has been deprecated yet") rather than an ambiguous one.
+- Gives PSD2 TPP integrators a concrete, written commitment (180 days,
+  two-channel notice) instead of an implicit one.
+
+**Negative**
+- The zero-traffic-before-sunset check (item 4) can indefinitely delay a
+  path's removal if even one stale client keeps polling it — intentional
+  (never break a live consumer), but it means "deprecated" is not the same
+  as "will definitely be gone in 180 days."
+- Requires the `api-contract` gate to move from advisory to block (tracked
+  under ADR-0144) before item 1 has real teeth; until then this ADR is
+  policy without enforcement.
+
+**Neutral**
+- Does not change anything about internal (non-`openapi.yaml`) contracts;
+  Kafka/AsyncAPI event versioning is out of scope (see ADR-0006).
+
+## Compliance impact
+
+- PCI DSS: not applicable directly.
+- DORA: Art. 9 (ICT change-management controls covering externally-facing
+  interfaces).
+- GDPR: not applicable.
+- PSD2: RTS on SCA & CSC, Art. 30(4) — TPPs must receive advance notice of
+  interface changes; this ADR is the concrete implementation of that
+  obligation for OpenBank's XS2A surface (ADR-0090).
+- CNB: aligns with ČNB supervisory expectation of a documented, stable TPP
+  interface lifecycle.
+
+## References
+
+- ADR-0048 (decouple API contract version from release version) — D6 ships
+  the mechanism this ADR turns into policy.
+- ADR-0090 (PSD2 XS2A Berlin Group base + ČOBS profile) — the primary
+  external consumer this policy protects.
+- ADR-0059 (outbound oversight webhooks) — reused as the notification
+  channel.
+- ADR-0077 (observability three-pillar strategy) — Tier-B HTTP metrics used
+  as the zero-traffic sunset evidence.
+- ADR-0144 (gate graduation) — governs when `api-contract` moves from
+  advisory to block.
+- `openbank-libs/governance/rules.yaml: api_deprecation`.

--- a/docs/adr/0146-incident-response-and-security-operations-framework.md
+++ b/docs/adr/0146-incident-response-and-security-operations-framework.md
@@ -1,0 +1,123 @@
+# ADR-0146 — Incident response and security-operations framework
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+`docs/runbooks/` holds per-system operational procedures (Vault/OpenBao,
+Postgres, Kafka, Loki, per-service runbooks) and ADR-0134 sets BCP/DR
+targets (RTO/RPO per tier, DR test cadence) with an ICT-risk-management
+mapping to DORA. What sits between the two is missing: a runbook says *how*
+to recover one system; ADR-0134 says *how fast* recovery must be for the
+platform. Neither says *who declares an incident, at what severity, who is
+paged, in what order, and when the clock in ADR-0134's RTO actually starts
+running*. Without a severity/escalation decision, "detection" (Falco, Trivy,
+CodeQL findings, Alertmanager) and "response" (the runbooks) are connected
+only by tribal knowledge — which does not survive a bus-factor-1 project
+(see `GOVERNANCE.md`) and does not produce the audit trail DORA's major-ICT-
+incident reporting (Art. 19–20) requires: a reportable incident needs a
+recorded classification decision and a timeline, not just a fixed runbook
+followed at some point.
+
+## Decision
+
+We will adopt a four-tier incident severity model with a recorded
+escalation path, and treat every declared incident as a first-class,
+auditable record:
+
+- **P1** — money-path service down, authentication/authorization bypass,
+  confirmed data exposure, active exploitation. Declare within 15 minutes
+  of detection; initial response target 30 minutes.
+- **P2** — high-severity vulnerability with no confirmed exploitation,
+  non-money-path service down, degraded money-path service. Response target
+  4 hours.
+- **P3** — medium-severity finding, non-customer-facing degradation.
+  Response target 24 hours.
+- **P4** — informational, low-severity finding, no user impact. Async,
+  tracked as a normal issue (ADR-0052).
+
+Every P1/P2 incident opens an entry in the ICT incident register (the same
+register ADR-0134 already requires for DORA reporting and ADR-0061 already
+plans to source MTTR from); the register entry, not the runbook, is what
+starts and stops the RTO clock. Declaration and resolution both go through
+the audit chain (ADR-0086/0133) with an actor identity — human or, per
+ADR-0031, an AI agent's charter identity when an agent is first to detect.
+Key-handling procedures (OpenBao unseal, cosign KMS key rotation, Keycloak
+realm signing-key renewal, cert-manager PKI rotation) are written down as
+runbooks under `docs/runbooks/key-ceremonies/` with an annual dry-run
+requirement, since they are the one class of procedure that is rehearsed
+least and needed most under actual incident pressure.
+
+## Alternatives considered
+
+- **Leave severity classification implicit / ad hoc per incident.**
+  Rejected — this is the status quo; it produces inconsistent response times
+  and, more importantly, no defensible record for a DORA major-incident
+  report, which has its own regulator-facing deadline once an incident is
+  classified as major.
+- **Adopt a third-party IR platform/process (e.g. a commercial on-call SaaS
+  runbook product) wholesale.** Rejected — GoAlert (already in the
+  observability stack per ADR-0088) already provides the paging primitive;
+  the missing piece is the severity/escalation *decision*, not another tool.
+- **Fold this into ADR-0134 as an addendum rather than a new ADR.**
+  Rejected — ADR-0134 is about business-continuity *targets*; this ADR is
+  about the *operational decision process* that hits those targets. Keeping
+  them separate lets each evolve independently (targets change on a
+  regulatory cadence; escalation mechanics change on an operational one).
+
+## Consequences
+
+**Positive**
+- Gives DORA Art. 17/19–20 major-incident reporting a concrete trigger
+  (P1/P2 declaration) and a concrete evidence trail (the ICT register entry
+  + audit chain), instead of relying on someone remembering to write it up
+  after the fact.
+- Directly feeds ADR-0061's DORA-metrics roadmap: MTTR needs incident-
+  register sourcing (its Phase 3, currently deferred) — this ADR is the
+  decision that Phase 3 has been waiting on.
+- Key-ceremony documentation reduces bus-factor risk on the single highest-
+  consequence class of manual procedure in the platform.
+
+**Negative**
+- At a single-maintainer bus factor, a formal escalation tree is partly
+  aspirational — the honest version of this ADR states that today's
+  secondary/tertiary escalation contacts are unfilled, rather than
+  fabricating an on-call rotation that does not exist. That gap is itself
+  visible and trackable once written down, which is the point.
+- Adds process overhead (register entry, severity call) to every P1/P2,
+  which is friction during an actual incident if not rehearsed.
+
+**Neutral**
+- Does not replace or duplicate any existing runbook; runbooks remain the
+  system-level "how," this ADR is the incident-level "who/when/how fast."
+
+## Compliance impact
+
+- PCI DSS: Req. 12.10 (incident response plan, roles, and testing).
+- DORA: Art. 10 (ICT incident detection), Art. 17 (ICT-related incident
+  management process), Art. 19–20 (major incident classification and
+  reporting).
+- GDPR: Art. 33–34 (breach notification) share the same declaration/
+  classification trigger for incidents involving personal data.
+- PSD2: RTS on incident reporting for payment service providers — the same
+  classification event this ADR introduces is the trigger for the PSD2
+  major-incident notification obligation.
+- CNB: aligns with ČNB's expected incident-management and reporting
+  practice for regulated entities.
+
+## References
+
+- ADR-0134 (business continuity and DORA ICTRM) — RTO/RPO targets and the
+  ICT incident register this ADR operationalizes.
+- ADR-0061 (DORA metrics from in-house sources) — MTTR Phase 3 sourcing,
+  unblocked by the register this ADR requires.
+- ADR-0086 / ADR-0133 (non-repudiation, tamper-evident audit chain) — the
+  audit mechanism incident declarations are recorded through.
+- ADR-0031 (AI agent governance) — how an agent-detected incident is
+  attributed.
+- ADR-0088 (observability extension: on-call, SLO-as-code) — GoAlert paging
+  primitive reused here.
+- `GOVERNANCE.md` — bus-factor context for the escalation-tree honesty note.

--- a/docs/adr/0147-cross-repo-governance-delivery-status-beyond-the-monorepo.md
+++ b/docs/adr/0147-cross-repo-governance-delivery-status-beyond-the-monorepo.md
@@ -1,0 +1,112 @@
+# ADR-0147 — Cross-repo governance — delivery status beyond the monorepo
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+Not every ADR's delivery lives in this monorepo. ADR-0095 (QRlessPay BLE
+proximity payments) is explicit about this: the BLE peripheral/central
+client work ships in `openbank-app` (a separate Apache-2.0 repo, referenced
+by its own ADR numbering — "ADR-0087 in `openbank-app`" — independent of
+this repo's sequence), with only the wire-format spec and threat model
+living here. `openbank-app` also carries the customer-facing Kotlin
+Multiplatform client for ADR-0064/0066/0073, and ADR-0031 D8 anticipated a
+possible separate agent-runtime repo.
+
+Nothing in `catalog.json`, the governance manifest, or `gen-index.sh`
+currently records that an ADR's delivery status is partly or wholly
+external. A reviewer — human or an AI agent doing exactly the kind of
+audit this ADR sweep came out of — reading only this repo will conclude an
+externally-delivered feature is "paper only," which is a false negative:
+it happened to this review for ADR-0095 specifically. As the platform grows
+more satellite repos (customer app, and potentially the agent-runtime
+carve-out from ADR-0136), this failure mode gets more common, not less.
+
+## Decision
+
+We will add an explicit, minimal cross-repo delivery field rather than
+build a cross-repo CI system: any ADR whose delivery is partly or wholly
+outside this monorepo declares `Delivery-Repos: <repo-name>[, <repo-name>]`
+in its front-matter (alongside the existing `Decision-Status` /
+`Delivery-Status` two-axis header), and its Delivery note names the specific
+artifact in that repo (a tag, a release, or that repo's own ADR id, the way
+ADR-0095 already informally does). `gen-index.sh` is extended to render this
+field in the index table so `Delivery-Status: Partial` next to an empty
+`Delivery-Repos` reads differently from `Delivery-Status: Partial` with
+`Delivery-Repos: openbank-app` — the latter is a pointer, not a gap.
+`.github/scripts/check-adr-registry.sh` gets one new check: a declared
+`Delivery-Repos` value must be a name present in a small
+`docs/adr/known-repos.txt` allowlist (to catch a typo'd repo name, not to
+validate the remote repo's actual state, which is out of scope).
+
+## Alternatives considered
+
+- **Merge `openbank-app` (and any future satellite repo) into this
+  monorepo.** Rejected — different release cadence (mobile app-store
+  review cycles vs. this repo's continuous per-service release-please),
+  different toolchain (Kotlin Multiplatform/Compose vs. Quarkus/Next.js),
+  and different secret surface (App Store credentials). Merging would trade
+  a documentation gap for a much larger operational one.
+- **Build automated cross-repo status sync (e.g. a scheduled job that reads
+  `openbank-app`'s tags/releases and writes them back into this repo's
+  `catalog.json`).** Rejected for now — this is the eventual correct
+  answer once there are enough satellite repos to justify the automation
+  cost, but for one satellite repo today it is solving a problem that does
+  not yet exist at scale. The frontmatter-field version is cheap and can be
+  upgraded to automation later without a breaking change to the schema.
+- **Do nothing; rely on ADR authors remembering to mention the other repo
+  in prose, as ADR-0095 already does.** Rejected — it worked for ADR-0095
+  because its author happened to write it clearly; it is not a system,
+  it is one author's diligence, and it just produced a wrong finding in an
+  external review that had no way to discover the prose convention.
+
+## Consequences
+
+**Positive**
+- Removes a specific, demonstrated false-negative failure mode ("this ADR
+  looks unimplemented") for any audit, review, or AI agent reading only
+  this repo.
+- Cheap: one frontmatter field, one allowlist file, one small addition to
+  an existing script — no new infrastructure, consistent with not
+  over-building before the problem is large.
+- Extends naturally if `openbank-app` or a future agent-runtime repo grows
+  its own governance-as-code (`rules.yaml`-equivalent) — this ADR's field
+  is a pointer other tooling can key off later.
+
+**Negative**
+- `Delivery-Repos` truthfulness is not verified against the target repo
+  automatically (see rejected alternative #2) — it is only checked for
+  "is this a known repo name," not "is the claimed artifact actually
+  there." A stale or wrong pointer is possible until automation is added.
+- Requires a one-time sweep of existing ADRs that already have undeclared
+  external delivery (starting with ADR-0095) to backfill the new field.
+
+**Neutral**
+- Does not change `Decision-Status`/`Delivery-Status` semantics for
+  monorepo-only ADRs, which remain the overwhelming majority.
+
+## Compliance impact
+
+- PCI DSS: not applicable directly.
+- DORA: Art. 8 (complete and accurate ICT asset inventory — the client app
+  is an ICT asset whose delivery state should be discoverable from the
+  same governance surface as everything else).
+- GDPR: not applicable directly.
+- PSD2: not applicable directly.
+- CNB: not applicable directly.
+
+## References
+
+- ADR-0095 (QRlessPay BLE proximity SPAYD payments) — the concrete example
+  that motivated this ADR; its client delivery in `openbank-app` is
+  correctly documented in prose but invisible to tooling.
+- ADR-0064 (customer app Kotlin Multiplatform) — the other major
+  `openbank-app` delivery surface.
+- ADR-0136 (agent services AGPL open-core) — D8's contemplated future
+  agent-runtime repo, the next likely case this ADR needs to cover.
+- ADR-0071 (governance manifest as derived data) — the principle this ADR
+  extends across a repo boundary.
+- `docs/adr/gen-index.sh`, `.github/scripts/check-adr-registry.sh`.

--- a/docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md
+++ b/docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md
@@ -1,0 +1,139 @@
+# ADR-0148 — AI assurance — prompt registry, evals gate, and EU AI Act mapping
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+ADR-0031 shipped agent identity, policy-gated MCP, human-in-the-loop
+approval, and AI-attributed audit — every `AuditEvent` for an agent action
+already carries `model_id`, `model_version`, and `prompt_hash`. What that
+audit trail cannot yet do is answer "what did the prompt behind this hash
+actually say, and has this agent's behavior been validated before this
+model/prompt combination went live." There is no registry mapping
+`prompt_hash` to prompt content, no evals suite gating a model or prompt
+change before deployment, and no single document mapping the `agents.yaml`
+charters (`compliance-officer`, `ledger-domain-engineer`, `ui-assistant`,
+`rca-investigator`, `customer-copilot`, `finops-agent`, `devops-agent`) to
+EU AI Act obligations. This last gap gets materially worse the moment
+ADR-0142 (credit decisioning) moves past "Proposed" — creditworthiness
+assessment is Annex III(5)(b) high-risk under the AI Act, which brings
+mandatory obligations (Art. 9–15: risk management, data governance,
+technical documentation, human oversight, accuracy/robustness) that the
+current governance substrate satisfies in spirit (HITL, audit, kill-switch)
+but has never mapped article-by-article.
+
+This ADR deliberately does **not** re-decide agent governance
+(ADR-0031), model provenance (ADR-0141), or the ML decisioning platform
+(ADR-0139/0140/0142). It is the assurance layer sitting on top of all four:
+the thing that makes a past agent decision reproducible and a future model/
+prompt change measurable, before it ships.
+
+## Decision
+
+We will add three concrete artifacts, none of which require a new
+governance primitive — they consume what ADR-0031/0141 already produce:
+
+1. **Prompt registry.** Every system prompt used by an agent or the
+   copilot lives as a versioned file under
+   `openbank-libs/governance/prompts/<agent>/<version>.md`; `prompt_hash`
+   in the audit event is the content hash of this file. A CI check rejects
+   any agent/copilot deploy referencing a `prompt_hash` not present in the
+   registry — an unregistered prompt cannot go live.
+2. **Evals gate.** Each charter in `agents.yaml` declares a small set of
+   scenario-based success criteria (e.g., for `finops-agent`: "flags a
+   synthetic NAT-egress-spike fixture within its detection window";
+   for `customer-copilot`: "never proposes a payment above the declared
+   dynamic-linking scope"). A new model or prompt version must pass the
+   existing eval suite before promotion; a regression against the prior
+   version's pass rate blocks deploy the same way a coverage-ratchet
+   regression blocks a service release (ADR-0020's pattern, applied to
+   agents instead of code coverage).
+3. **EU AI Act mapping.** `docs/compliance/eu-ai-act.md`, generated (not
+   hand-maintained, per rule #7) from `agents.yaml`: for each charter, its
+   Annex III risk classification, and which Art. 9–15 obligation each
+   existing control (HITL queue, kill-switch, audit trail, OPA policy gate,
+   SPIFFE identity) already satisfies versus which remains open. This
+   becomes the concrete precondition ADR-0142 (credit decisioning) must
+   reference before it can move past "Proposed."
+
+## Alternatives considered
+
+- **Store prompts in Langfuse (the SaaS observability tool declared in
+  `agents.yaml` but not yet deployed) instead of in-repo.** Rejected for
+  money-path-adjacent agents — a prompt controlling a `propose_payment`
+  tool-call belongs inside the same audit chain and git history as the
+  code it governs, not in a third-party system outside the ADR-0086
+  tamper-evident chain. Non-money-path agents may still use Langfuse for
+  tracing; the registry is specifically about the immutable versioned
+  content, not the observability layer.
+- **Defer evals until real (non-mock) models are wired up for
+  finops-agent/devops-agent.** Rejected — an eval suite written after the
+  first real model ships tends never to get written, because nothing forces
+  it. Writing the gate now, against the mock provider, means the first real
+  model swap is the first thing the gate has ever exercised, not an
+  untested leap.
+- **Fold the EU AI Act mapping into ADR-0031 as an amendment.** Rejected —
+  ADR-0031 is already broad (agents-as-code, MCP, HITL, audit); appending a
+  regulatory mapping to it every time a new agent charter is added would
+  make it grow without bound. A generated, separate document that is
+  regenerated whenever `agents.yaml` changes is more honest about being
+  derived data.
+
+## Consequences
+
+**Positive**
+- Makes a past agent decision reproducible: `prompt_hash` in an audit
+  record now resolves to actual content, closing a real gap this platform
+  review found in the audit chain.
+- Gives ADR-0142 (credit decisioning) a concrete, checkable precondition
+  instead of an implicit expectation that "the governance framework covers
+  it."
+- The evals gate is the first thing that would have caught a bad prompt
+  change before it reached a `customer-copilot` deploy, rather than after.
+
+**Negative**
+- Writing meaningful eval scenarios per charter is real work, not
+  boilerplate — a shallow eval suite (e.g. one trivial fixture) would
+  satisfy the gate's letter without its purpose. This ADR does not by
+  itself guarantee eval quality, only that a gate exists.
+- Adds a new required directory/registry that must be kept in sync with
+  `agents.yaml`; a charter added without a corresponding prompt-registry
+  entry needs its own guard (tracked as an implementation detail, not a
+  new decision).
+
+**Neutral**
+- Does not change any charter's `tools.allow`/`data_scope`/`requires_human`
+  semantics — purely additive assurance around the existing model.
+
+## Compliance impact
+
+- PCI DSS: not applicable directly.
+- DORA: Art. 9 (ICT risk management applied to AI-driven change).
+- GDPR: Art. 22 (automated individual decision-making) — directly relevant
+  once ADR-0142 lands; this ADR is a precondition for that ADR's own
+  compliance-impact section to be honest.
+- PSD2: not applicable directly.
+- CNB: not applicable directly. Additionally: EU AI Act (Regulation (EU)
+  2024/1689) Art. 6/9–15 and Annex III(5)(b) — the primary regulation this
+  ADR maps against; `docs/compliance/eu-ai-act.md` is the artifact of
+  record.
+
+## References
+
+- ADR-0031 (AI agent governance and operations) — the primitives (charter
+  registry, OPA gate, HITL, audit) this ADR adds assurance on top of.
+- ADR-0141 (model registry & provenance) — the ML-model-card equivalent for
+  trained models; this ADR's prompt registry is the analogous artifact for
+  prompts.
+- ADR-0142 (credit decisioning engine) — the concrete future ADR this one
+  is a precondition for.
+- ADR-0089 (customer-facing AI assistant) — `customer-copilot` charter,
+  cited as an evals example.
+- ADR-0112 / ADR-0119 (FinOps agent / DevOps agent) — cited as evals
+  examples.
+- ADR-0020 (code coverage regression floor) — the ratchet pattern this ADR
+  reuses for eval pass rates.
+- `openbank-libs/governance/agents.yaml`.

--- a/docs/adr/0149-digital-accessibility-standard-wcag-2-2-aa-en-301-549.md
+++ b/docs/adr/0149-digital-accessibility-standard-wcag-2-2-aa-en-301-549.md
@@ -1,0 +1,110 @@
+# ADR-0149 — Digital accessibility standard (WCAG 2.2 AA / EN 301 549)
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+The European Accessibility Act (Directive (EU) 2019/882) has been
+applicable to consumer banking services since 28 June 2025; retail banking
+is explicitly in scope (Annex I). `openbank-admin-ui` has a mature,
+CI-enforced quality-guard pattern (graceful-error states, bilingual
+strings, app-shell rules, all backed by guard tests under `src/test/`), but
+none of those guards check accessibility, and no ADR has decided a
+conformance target for either the admin UI or, more importantly, the
+customer-facing `openbank-app` (ADR-0064/0066/0073), which is the surface
+actually in the EAA's regulatory scope — the admin UI is an internal
+operator tool, not a consumer-facing service. Retrofitting accessibility
+after a UI is built is materially more expensive than building to a
+standard from the start (component selection, color-contrast tokens,
+focus-order, and screen-reader semantics are easiest to get right at
+initial construction), which is the argument for deciding this now rather
+than after `openbank-app` reaches a wider release.
+
+## Decision
+
+We will adopt WCAG 2.2 level AA, aligned with EN 301 549, as the
+conformance target for customer-facing surfaces (`openbank-app`, the PSD2
+developer portal per ADR-0093), and as a best-effort (not gated) target for
+the internal admin UI, given the latter is not in the EAA's regulatory
+scope and the existing guard-test investment there is already high. For
+`openbank-admin-ui`, we add one new guard test in the same family as the
+existing graceful-state/i18n/shell guards: an `axe-core` automated check
+run against key pages in CI, non-blocking initially (advisory, per
+ADR-0144's graduation model, with a target enforce date) so it surfaces
+regressions without immediately blocking every existing PR. For
+`openbank-app`, the equivalent decision (specific tooling, since it is
+Kotlin Multiplatform/Compose rather than React) is deferred to an ADR in
+that repository, cross-referenced here per ADR-0147.
+
+## Alternatives considered
+
+- **WCAG 2.2 AAA.** Rejected — AAA includes success criteria (e.g. sign
+  language interpretation, extended audio description) that are
+  disproportionate for a banking control-plane/consumer-app pair at this
+  stage; AA is the standard EN 301 549 itself references and is the
+  de facto regulatory baseline.
+- **Defer until after public launch / after `openbank-app` reaches GA.**
+  Rejected — the EAA is already in force for the regulated surface
+  (consumer banking), and retrofitting is the more expensive path; a
+  reference implementation claiming banking-grade quality should not ship
+  a launch-blocking compliance gap.
+- **Apply the same enforced (blocking) gate to `openbank-admin-ui` as to
+  `openbank-app`.** Rejected — the admin UI is an internal operator tool
+  outside EAA scope; making its accessibility gate blocking today would add
+  friction disproportionate to the actual regulatory requirement. Advisory
+  with a stated target date (per ADR-0144) is the appropriate weight.
+
+## Consequences
+
+**Positive**
+- Closes a genuine, previously undecided regulatory gap for the actual
+  in-scope surface (`openbank-app`).
+- Reuses the existing, proven CI-guard-test pattern in `openbank-admin-ui`
+  rather than inventing a new enforcement mechanism.
+- Deciding a target now, before `openbank-app` accretes more screens, is
+  cheaper than a retrofit later.
+
+**Negative**
+- `axe-core` and similar automated tools catch a meaningful but incomplete
+  subset of WCAG success criteria (color contrast, missing labels, ARIA
+  misuse); full AA conformance additionally requires manual review
+  (keyboard-only navigation, screen-reader walkthroughs) that this ADR does
+  not itself schedule.
+- The `openbank-app` decision is explicitly deferred to that repo, which
+  means this ADR alone does not close the regulatory gap — it only commits
+  to closing it and names the mechanism (ADR-0147 cross-reference).
+
+**Neutral**
+- Does not require replacing the admin UI's existing component choices
+  (Radix UI is already a reasonably accessible-by-default headless
+  component base).
+
+## Compliance impact
+
+- PCI DSS: not applicable.
+- DORA: not applicable directly.
+- GDPR: not applicable directly.
+- PSD2: relevant to the developer portal (ADR-0093), which should meet the
+  same target as other public-facing surfaces.
+- CNB: not applicable directly. Additionally: European Accessibility Act
+  (Directive (EU) 2019/882) and EN 301 549 — the primary regulations this
+  ADR targets.
+
+## References
+
+- ADR-0064 (customer app Kotlin Multiplatform) — the primary in-scope
+  surface; the `openbank-app`-side ADR is tracked via ADR-0147.
+- ADR-0066 (passwordless customer authentication) — a customer-app flow
+  where accessible design (e.g. biometric fallback affordances) matters
+  directly.
+- ADR-0093 (public developer portal for PSD2 XS2A) — the other externally
+  reachable surface in scope.
+- ADR-0076 (admin-ui integration and e2e testing) — the existing guard-test
+  pattern this ADR extends.
+- ADR-0144 (gate graduation) — governs the admin-ui `axe-core` check's path
+  from advisory to enforced.
+- ADR-0147 (cross-repo governance) — the mechanism for tracking the
+  `openbank-app`-side accessibility ADR from this repo.

--- a/docs/adr/0150-internationalization-and-language-support-strategy.md
+++ b/docs/adr/0150-internationalization-and-language-support-strategy.md
@@ -1,0 +1,104 @@
+# ADR-0150 — Internationalization and language-support strategy
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+`openbank-admin-ui` is bilingual (Czech/English) via a custom `useLanguage()`
+hook and a `t('Česky', 'English')` call-site pattern, enforced by a CI guard
+test that scans every `page.tsx` for un-wrapped strings. This works well at
+exactly two locales, but it does not scale to a third without a rewrite:
+every call site is a hardcoded pair, not a lookup against a locale-keyed
+catalog. No ADR has decided whether OpenBank ever needs a third language —
+customer-facing notification templates, statement PDFs (ADR-0035), and the
+`customer-copilot` (ADR-0089, which itself flags "Czech-language quality of
+self-hosted models" as its headline risk) all currently assume Czech is the
+customer's language without that being a recorded decision either.
+
+Left undecided, the risk runs in both directions: someone eventually
+"upgrades" the admin UI to `i18next`/ICU catalogs for no concrete reason
+(churn without a customer need), or a real third-language requirement shows
+up (e.g. English-only branch, a non-Czech-speaking operator) and there is no
+plan for how the current pattern would need to change.
+
+## Decision
+
+We will declare Czech and English as the supported locale set for the
+current phase, and treat `t('Česky', 'English')` as an intentional design
+choice — not tech debt — for as long as the locale count stays at two: it
+is the cheapest correct implementation of a two-locale system, and the
+existing CI guard already prevents the alternative failure mode
+(un-translated strings). We define the concrete trigger for migration: the
+moment a third locale is required for any customer-facing or admin surface,
+the admin-ui `t()` call sites migrate to an ICU-message-format catalog
+keyed by locale, in the same PR that adds the third language (not before).
+Customer-facing backend text (notifications, statement templates per
+ADR-0035, dispute/complaint correspondence per ADR-0117) is locale-derived
+from the party's declared preference at the point of generation, defaulting
+to Czech, with English as the only other currently-supported value —
+mirroring the admin-ui decision rather than diverging from it.
+
+## Alternatives considered
+
+- **Migrate to `i18next`/ICU catalogs now, pre-emptively.** Rejected — no
+  concrete third-language requirement exists today; this would be exactly
+  the kind of premature abstraction the platform's own engineering
+  conventions warn against, trading a working, guarded two-locale pattern
+  for generic infrastructure serving a hypothetical need.
+- **Leave the locale question fully undecided (status quo).** Rejected —
+  this is the gap the review surfaced: without a recorded decision, the
+  current pattern reads as an oversight rather than a choice, and there is
+  no documented trigger for when to revisit it.
+- **Support English as the default/primary language instead of Czech.**
+  Rejected — the regulatory profile (ČOBS, ČNB, AnaCredit, Czech AML law)
+  and the primary customer base are Czech; English is the secondary
+  language for both admin operators and any non-Czech-speaking customers,
+  consistent with how the platform already treats it.
+
+## Consequences
+
+**Positive**
+- Converts an implicit assumption into an explicit, reviewable decision;
+  the existing admin-ui pattern stops being an unstated risk and becomes a
+  documented choice with a stated expiry condition.
+- Gives `customer-copilot` (ADR-0089) and any future customer-facing text
+  generation a clear locale contract to build against, rather than an
+  assumption to infer from code.
+
+**Negative**
+- If a third language does become a real requirement, the migration cost
+  (rewriting every `t()` call site) is paid all at once rather than
+  amortized — this is a known, accepted trade-off for keeping the current
+  pattern simple while it serves exactly two locales.
+
+**Neutral**
+- Does not affect the ISO 20022 message layer (ADR-0104) or other
+  machine-readable interchange formats, which are not natural-language
+  surfaces.
+
+## Compliance impact
+
+- PCI DSS: not applicable.
+- DORA: not applicable.
+- GDPR: not applicable directly (data-subject communication language is a
+  fairness/transparency consideration under Art. 12 "concise, transparent,
+  intelligible" — satisfied by defaulting to the customer's own language).
+- PSD2: not applicable directly.
+- CNB: not applicable directly — consumer-protection expectation that
+  contractual/statement documentation be available in Czech is already met
+  by the declared default.
+
+## References
+
+- ADR-0035 (multi-currency account statements) — a locale-dependent
+  customer-facing document surface.
+- ADR-0089 (customer-facing AI assistant) — flags Czech-language model
+  quality as its headline risk; this ADR gives that risk a locale contract
+  to be measured against.
+- ADR-0117 (dispute and complaint lifecycle) — another locale-dependent
+  customer-correspondence surface.
+- ADR-0076 (admin-ui integration and e2e testing) — the existing bilingual
+  guard-test pattern this ADR ratifies.

--- a/docs/adr/0151-chaos-engineering-and-infrastructure-failure-injection-policy.md
+++ b/docs/adr/0151-chaos-engineering-and-infrastructure-failure-injection-policy.md
@@ -1,0 +1,113 @@
+# ADR-0151 — Chaos engineering and infrastructure failure-injection policy
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): jiri.raska
+
+## Context
+
+The deterministic simulation testing harness (ADR-0100/0115) validates
+money-path *code* under injected faults — stuck sagas, compensation gaps,
+double-credit — inside a deterministic, replayable JVM process. It does not
+and cannot validate the *infrastructure* underneath that code: a CNPG
+primary failover, a Kafka broker loss, an EKS node eviction mid-transaction,
+or a Temporal server restart. ADR-0011 (testing pyramid) names chaos testing
+as a future layer ("M4 onwards" for staging, "M7 onwards" for production-
+grade) but sets no policy — no tooling choice, no blast-radius rule, no
+approval gate, no link to the evidence DORA's resilience-testing
+requirement (Art. 24–26) expects. Today, whatever infrastructure resilience
+the platform has is the accidental byproduct of Karpenter's normal node
+consolidation churn, not a deliberately tested property.
+
+This is explicitly a complement to DST, not a substitute: DST proves the
+code handles a fault correctly when the fault happens; chaos engineering
+proves the fault actually gets triggered and observed correctly by the real
+infrastructure DST does not model (NetworkPolicy behavior under partition,
+PodDisruptionBudget honoring, actual failover timing).
+
+## Decision
+
+We will adopt Chaos Mesh (CNCF, Kubernetes-native, fits the existing
+cloud-agnostic in-cluster substrate per ADR-0027) as the chaos-engineering
+tool, with the following policy:
+
+- **Sandbox-only to start.** Production chaos experiments are explicitly
+  out of scope until ADR-0011's M7 milestone and a separate approval gate
+  this ADR does not itself grant.
+- **Every experiment declares a hypothesis and an abort condition** before
+  it runs (e.g. "ledger-service survives a CNPG primary failover with < 30s
+  of write unavailability; abort if error rate exceeds 50% for > 2
+  minutes") — an experiment without a stated hypothesis is not run.
+- **Scheduled, not continuous**: a monthly chaos run against a declared
+  rotation of failure classes (pod kill, node drain, network delay/
+  partition, CNPG failover, Kafka broker loss), starting only after the
+  Temporal migration (ADR-0101/0120) reaches its target end state — running
+  chaos against a topology mid-migration would test a shape of the system
+  that is about to change, wasting the exercise.
+- **Every run's result is recorded in the ICT incident/resilience-testing
+  register** (the same register ADR-0146 introduces), which is what turns
+  these runs into DORA Art. 24–26 evidence rather than ad hoc exercises.
+
+## Alternatives considered
+
+- **LitmusChaos instead of Chaos Mesh.** Rejected as the default choice —
+  both are viable CNCF options; Chaos Mesh's dashboard and CRD model fit
+  the existing ArgoCD/GitOps-declarative pattern slightly more naturally,
+  and this is an implementation detail, not a decision with lasting
+  consequences either way.
+- **Rely on DST alone and treat infrastructure resilience as adequately
+  covered by Karpenter's natural node churn.** Rejected — natural churn is
+  uncontrolled (no hypothesis, no fixed blast radius, no scheduled
+  cadence) and does not exercise network-partition or stateful-failover
+  scenarios DST cannot reach either.
+- **Start chaos experiments in production immediately (fail-fast
+  philosophy).** Rejected — appropriate for a company with mature
+  incident response and a large blast-radius budget; OpenBank does not yet
+  have the incident-response framework (ADR-0146) or bus-factor resilience
+  to safely absorb a production chaos experiment gone wrong today.
+
+## Consequences
+
+**Positive**
+- Turns "infrastructure resilience" from an assumed property into a
+  measured, scheduled, evidenced one — directly closing a DORA testing-
+  programme gap this review found.
+- The hypothesis/abort-condition discipline (borrowed from the general
+  chaos-engineering practice, e.g. Netflix's original formulation) prevents
+  chaos runs from becoming unstructured production-adjacent risk-taking.
+
+**Negative**
+- Explicitly deferring to after the Temporal migration and to sandbox-only
+  means real infrastructure-resilience evidence is not available
+  immediately — this is a deliberate sequencing choice, not a gap this ADR
+  closes today.
+- Chaos Mesh itself is another operational component to run, monitor, and
+  keep patched (its own supply-chain surface under ADR-0030).
+
+**Neutral**
+- Does not change DST's scope or ownership (ADR-0100/0115 remain the
+  code-level fault-injection layer).
+
+## Compliance impact
+
+- PCI DSS: not applicable directly.
+- DORA: Art. 24–26 (digital operational resilience testing programme) —
+  the primary regulation this ADR is written to satisfy.
+- GDPR: not applicable.
+- PSD2: not applicable directly.
+- CNB: aligns with ČNB supervisory expectation of demonstrated operational
+  resilience testing.
+
+## References
+
+- ADR-0100 / ADR-0115 (deterministic simulation testing / harness) — the
+  code-level complement this ADR does not duplicate.
+- ADR-0011 (testing pyramid) — names chaos as a future layer without policy;
+  this ADR supplies that policy.
+- ADR-0101 / ADR-0120 (Temporal durable execution / migration) — the
+  topology this ADR's scheduled runs wait to stabilize against.
+- ADR-0027 (cloud-agnostic in-cluster substrate) — why Chaos Mesh fits the
+  existing GitOps model.
+- ADR-0146 (incident response and security-operations framework) — the
+  register chaos-run results are recorded into.

--- a/docs/adr/0152-single-tenancy-boundary-statement.md
+++ b/docs/adr/0152-single-tenancy-boundary-statement.md
@@ -1,0 +1,101 @@
+# ADR-0152 — Single-tenancy boundary statement
+
+Date: 2026-07-02
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: N/A — decision-only
+Author(s): jiri.raska
+
+## Context
+
+Every deployment of OpenBank today implicitly assumes one bank per
+deployment: Postgres-per-service (ADR-0009), the money-path OPA policies
+(ADR-0034), and the ledger-as-golden-source model (ADR-0039) all reason
+about "the bank," singular, with no tenant dimension anywhere in the
+schema, the domain model, or the authorization model. This has never been
+decided — it has only ever been assumed, which is precisely the condition
+under which a well-meaning future change (e.g. "let's add a `tenant_id`
+column so we could support a second brand on this cluster someday") gets
+made piecemeal, in one service at a time, without ever resolving whether
+multi-tenancy is actually a goal. A tenant dimension threaded halfway
+through the domain layer — present in some entities, absent in others — is
+worse than either a clean single-tenant model or a deliberately designed
+multi-tenant one.
+
+## Decision
+
+We will declare single-tenant-per-deployment as an architectural invariant:
+one OpenBank deployment (one cluster, one GitOps environment, one set of
+Postgres instances) serves exactly one regulated banking entity. A second
+bank wanting to run OpenBank runs its own deployment, from the same
+codebase, via the existing GitOps templating (ADR-0027) — this is the
+"multi-tenancy" the platform supports, at the *operator* layer, not inside
+the domain. No service's domain model, database schema, or OPA policy may
+introduce a tenant-scoping dimension; a genuine future need for
+single-cluster multi-tenancy (multiple regulated entities sharing one
+deployment) requires a new ADR that explicitly supersedes this one, because
+it changes load-bearing assumptions in the ledger, authorization, and data-
+residency model simultaneously and cannot be introduced as an incremental
+patch to any single service.
+
+## Alternatives considered
+
+- **Design multi-tenancy now, before any tenant exists.** Rejected — this
+  is speculative complexity with no current customer driving the
+  requirement; it would touch the ledger's golden-source model
+  (ADR-0039), every service's Postgres schema (ADR-0009), and the OPA
+  policy model (ADR-0034) simultaneously, for a need that does not exist
+  today and may never.
+- **Say nothing and let single-tenancy remain an unstated assumption.**
+  Rejected — this is the status quo, and it is exactly the condition that
+  invites an incremental, undecided drift toward partial multi-tenancy,
+  which is architecturally worse than either clean alternative.
+- **Declare multi-tenancy support via schema-per-tenant within a shared
+  deployment (a middle ground).** Rejected — even this "lighter" form
+  still requires deciding tenant-scoping in the ledger and OPA policy
+  layers; if a genuine need arises it deserves a full ADR weighing this
+  option properly, not a default reached by omission here.
+
+## Consequences
+
+**Positive**
+- Removes ambiguity that could otherwise lead to inconsistent, partial
+  tenant-scoping creeping into individual services over time.
+- Gives a clear, high bar for the alternative (a full superseding ADR) if a
+  genuine multi-tenant requirement ever appears, rather than allowing it to
+  be decided implicitly by whichever service touches it first.
+- Simplifies data-residency and GDPR controllership reasoning: one
+  deployment, one controller, one regulator relationship — no ambiguity
+  about which tenant's data a given record belongs to.
+
+**Negative**
+- Every additional bank that wants to run OpenBank pays the operational
+  cost of a full separate deployment rather than joining a shared,
+  amortized cluster — an explicit, accepted trade-off in exchange for
+  architectural simplicity and regulatory clarity.
+
+**Neutral**
+- Does not affect internal multi-currency/multi-pocket modeling
+  (ADR-0024/0109/0110), which is a per-customer, not per-tenant, dimension
+  and is unaffected by this decision.
+
+## Compliance impact
+
+- PCI DSS: not applicable directly.
+- DORA: not applicable directly.
+- GDPR: Art. 28 (clear controller/processor boundary) — a single-tenant
+  deployment gives an unambiguous data controller per deployment, which is
+  a compliance-positive simplification rather than a burden.
+- PSD2: not applicable directly.
+- CNB: not applicable directly — one deployment per regulated entity aligns
+  cleanly with the standard model of one banking license per legal entity.
+
+## References
+
+- ADR-0009 (Postgres per service) — the schema-isolation model this ADR
+  declares tenant-free.
+- ADR-0034 (unified OPA authorization) — the policy model this ADR declares
+  tenant-free.
+- ADR-0039 (ledger as golden source) — the ledger model most sensitive to
+  an incremental tenant-scoping change.
+- ADR-0027 (cloud-agnostic in-cluster substrate) — the GitOps templating
+  mechanism that is the actual answer to "a second bank wants to run this."

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -146,3 +146,12 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0141](0141-model-registry-provenance.md) | Model registry and provenance for ML decisioning | Proposed | Planned |
 | [0142](0142-credit-decisioning-engine.md) | Credit decisioning engine on the ML decisioning platform | Proposed | Planned |
 | [0143](0143-runtime-product-fee-posting-via-a-dedicated-billing-service.md) | Runtime product fee posting via a dedicated billing service | Accepted | Partial |
+| [0144](0144-gate-graduation-advisory-rules-carry-an-enforcement-deadline.md) | Gate graduation — advisory rules carry an enforcement deadline | Proposed | Planned |
+| [0145](0145-api-deprecation-and-sunset-policy.md) | API deprecation and sunset policy | Proposed | Planned |
+| [0146](0146-incident-response-and-security-operations-framework.md) | Incident response and security-operations framework | Proposed | Planned |
+| [0147](0147-cross-repo-governance-delivery-status-beyond-the-monorepo.md) | Cross-repo governance — delivery status beyond the monorepo | Proposed | Planned |
+| [0148](0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md) | AI assurance — prompt registry, evals gate, and EU AI Act mapping | Proposed | Planned |
+| [0149](0149-digital-accessibility-standard-wcag-2-2-aa-en-301-549.md) | Digital accessibility standard (WCAG 2.2 AA / EN 301 549) | Proposed | Planned |
+| [0150](0150-internationalization-and-language-support-strategy.md) | Internationalization and language-support strategy | Proposed | Planned |
+| [0151](0151-chaos-engineering-and-infrastructure-failure-injection-policy.md) | Chaos engineering and infrastructure failure-injection policy | Proposed | Planned |
+| [0152](0152-single-tenancy-boundary-statement.md) | Single-tenancy boundary statement | Proposed | N/A — decision-only |


### PR DESCRIPTION
## Summary

Nine new **Proposed** ADRs (0144–0152) closing decision gaps surfaced by a
critical cross-cutting review of ADR practice, security/regulatory posture,
DevOps/FinOps, architecture, and AI-readiness. None are self-accepted —
each needs human review and an explicit Accepted/Rejected call.

| ADR | Title | Why it's needed |
|---|---|---|
| [0144](docs/adr/0144-gate-graduation-advisory-rules-carry-an-enforcement-deadline.md) | Gate graduation | Most `rules.yaml` rules sit at `advisory` with no exit condition — this gives every advisory/planned rule a `target_enforce_date` + CI check. Unblocks OPA enforce on money-path (ADR-0034 Phase 5). |
| [0145](docs/adr/0145-api-deprecation-and-sunset-policy.md) | API deprecation & sunset policy | ADR-0048 D6 shipped the *mechanism* (`min_sunset_window_days: 180` already in `rules.yaml`); this decides the *policy* — what's breaking, how TPPs are notified. |
| [0146](docs/adr/0146-incident-response-and-security-operations-framework.md) | Incident response framework | Severity tiers (P1–P4), escalation, and key-ceremony docs — the piece between "detection" and "runbooks" that DORA Art. 17/19–20 major-incident reporting needs. |
| [0147](docs/adr/0147-cross-repo-governance-delivery-status-beyond-the-monorepo.md) | Cross-repo governance | `openbank-app` delivers parts of ADR-0095/0064; nothing records that in this repo's catalog, which produces false "unimplemented" findings on external review. |
| [0148](docs/adr/0148-ai-assurance-prompt-registry-evals-gate-and-eu-ai-act-mapping.md) | AI assurance | Prompt registry (resolve `prompt_hash` to content), an evals gate per agent charter, and a generated EU AI Act mapping — precondition for ADR-0142 (credit decisioning). |
| [0149](docs/adr/0149-digital-accessibility-standard-wcag-2-2-aa-en-301-549.md) | Accessibility standard | WCAG 2.2 AA for customer-facing surfaces — European Accessibility Act has applied to consumer banking since 2025-06-28. |
| [0150](docs/adr/0150-internationalization-and-language-support-strategy.md) | i18n strategy | Ratifies cs/en as the deliberate two-locale design (not debt) with an explicit trigger for a third language. |
| [0151](docs/adr/0151-chaos-engineering-and-infrastructure-failure-injection-policy.md) | Chaos engineering policy | Infrastructure-level fault injection to complement DST (ADR-0100/0115), which only covers code-path faults. Sandbox-only, sequenced after the Temporal migration. |
| [0152](docs/adr/0152-single-tenancy-boundary-statement.md) | Single-tenancy boundary | Declares single-tenant-per-deployment as an explicit invariant before an undecided assumption drifts into a half-implemented tenant dimension. |

Deliberately **not** included: delivery gaps on ADRs that are already
Accepted (e.g. flipping `authz.enforce` on money-path services per
ADR-0034, the fck-nat cutover per ADR-0058, Pact fleet rollout per
ADR-0063). Those are execution debt, not undecided architecture — they
belong in tracking issues referencing the existing ADR, not new ADRs.

## Type of change

- [x] docs

## Linked issues

N/A — this PR is itself the record; no tracked backlog item preceded it (new ADRs proposed for review, per ADR-0052 these are decision records, not actionable-backlog items).

## Changes

- Add ADR-0144 through ADR-0152 (all `Decision-Status: Proposed`).
- Regenerate `docs/adr/README.md` via `docs/adr/gen-index.sh`.

## Definition of Done

- [x] `bash docs/adr/gen-index.sh && bash .github/scripts/check-adr-registry.sh` passes locally.
- [x] Docs updated (this PR is docs-only).
- [ ] Human review: each ADR needs an explicit Accepted/Rejected/Superseded call — not a rubber stamp.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in any of the 9 ADRs.