### PR TITLE
docs(adr): note the 0015/0127-0132 numbering gap in the generated index

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -155,3 +155,14 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0150](0150-internationalization-and-language-support-strategy.md) | Internationalization and language-support strategy | Proposed | Planned |
 | [0151](0151-chaos-engineering-and-infrastructure-failure-injection-policy.md) | Chaos engineering and infrastructure failure-injection policy | Proposed | Planned |
 | [0152](0152-single-tenancy-boundary-statement.md) | Single-tenancy boundary statement | Proposed | N/A — decision-only |
+
+---
+
+**Numbering gaps:** 0015 0127 0128 0129 0130 0131 0132 do not correspond to a file in this repo's history —
+confirmed by `git log --diff-filter=A` across all branches, not just an absent
+current file. One of them, ADR-0132, is named in a 2026-06 commit message
+("fix(customer-edge): add per-party rate-limit config key (ADR-0132)") with no
+corresponding merged ADR file, which does not by itself explain the other five.
+No decision record in this repo accounts for the gap; treat it as an open
+question for whoever holds the pre-public-launch history, not a deliberate
+reservation.

--- a/docs/adr/gen-index.sh
+++ b/docs/adr/gen-index.sh
@@ -51,6 +51,36 @@ OUT=README.md
     decision_short=$(echo "$decision" | sed -E 's/ *\(.*$//; s/ on [0-9].*$//' | cut -c1-40)
     printf '| [%s](%s) | %s | %s | %s |\n' "$num" "$f" "$h1" "$decision_short" "$delivery"
   done
+
+  # Numbering gaps: computed from the actual file list, not hand-typed, so this
+  # note can't rot into a stale claim if a gap is ever filled or a new one opens.
+  numbers=$(ls [0-9]*.md | sed -E 's/-.*//' | sort -n)
+  gaps=""
+  prev=""
+  for n in $numbers; do
+    n10=$((10#$n))
+    if [ -n "$prev" ] && [ "$n10" -gt "$((prev + 1))" ]; then
+      g=$((prev + 1))
+      while [ "$g" -lt "$n10" ]; do
+        gaps="$gaps $(printf '%04d' "$g")"
+        g=$((g + 1))
+      done
+    fi
+    prev=$n10
+  done
+  if [ -n "$gaps" ]; then
+    echo
+    echo "---"
+    echo
+    echo "**Numbering gaps:**$gaps do not correspond to a file in this repo's history —"
+    echo "confirmed by \`git log --diff-filter=A\` across all branches, not just an absent"
+    echo "current file. One of them, ADR-0132, is named in a 2026-06 commit message"
+    echo "(\"fix(customer-edge): add per-party rate-limit config key (ADR-0132)\") with no"
+    echo "corresponding merged ADR file, which does not by itself explain the other five."
+    echo "No decision record in this repo accounts for the gap; treat it as an open"
+    echo "question for whoever holds the pre-public-launch history, not a deliberate"
+    echo "reservation."
+  fi
 } > "$OUT"
 
 echo "Wrote $OUT ($(grep -c '^| \[' "$OUT") ADRs indexed)."


### PR DESCRIPTION
## Summary

The ADR index has never explained why numbers 0015 and 0127–0132 are
missing. Verified via \`git log --diff-filter=A\` across all branches: none
of them ever had a corresponding file. ADR-0132 is named in one 2026-06
commit message with no merged ADR file behind it, which doesn't explain
the other five. This adds an honest, computed (not hand-typed) note to
\`gen-index.sh\`'s output rather than asserting a specific cause I can't
verify.

## Type of change

- [x] docs

## Linked issues

N/A — documentation-accuracy fix, no tracked backlog item.

## Changes

- \`docs/adr/gen-index.sh\`: compute numbering gaps from the actual file
  list and append an explanatory note to the generated README when any
  exist.
- Regenerate \`docs/adr/README.md\`.

## Definition of Done

- [x] \`bash docs/adr/gen-index.sh && bash .github/scripts/check-adr-registry.sh\` passes locally.
- [x] Docs updated (this PR is docs-only).

## Security checklist

- [x] No secrets, tokens, passwords, or PII.