### PR TITLE
fix(infra): flip AUTHZ_ENFORCE=true on consent-service and fraud-service (ADR-0034 Phase 5 pilot)

### DIFF
--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -83,6 +83,11 @@ spec:
                 secretKeyRef:
                   name: consent-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement pilot (Phase 5) — deployed behind the existing
+            # canary Rollout below, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.consent.svc:6379
             - name: QUARKUS_HTTP_PORT

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -77,6 +77,11 @@ spec:
                   name: fraud-service-oidc
                   key: OIDC_CLIENT_SECRET
                   optional: true
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement pilot (Phase 5) — deployed behind the existing
+            # canary Rollout below, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG


### PR DESCRIPTION
## Summary

Starts ADR-0034 Phase 5 (money-path OPA enforcement) with a two-service
pilot instead of a fleet-wide flip. All 15 money-path services
(`rules.yaml: money_path_services`) are confirmed still advisory today —
verified directly against `application.yaml` defaults and the absence of
`AUTHZ_ENFORCE` in their gitops manifests, not inferred from an ADR's
delivery note.

**Why consent-service + fraud-service first:** both already run as Argo
Rollouts canary (`kind: Rollout`, `openbank-money-path-canary`
AnalysisTemplate — 10%→5m pause→30%→5m pause→100%, auto-abort on error
rate ≥ 5% or unhealthy pods within 10 min), and neither is itself a
payment-execution or payment-blocking path: consent-service does
scope/expiry checks, fraud-service produces a scoring signal (the
synchronous blocking gate is the separate AML/sanctions check in
ADR-0032). A bad OPA policy denial here surfaces as elevated canary error
rate and reverts automatically before reaching 100% traffic — but it will
still visibly degrade consent grants / fraud scoring while the canary
runs.

## ⚠️ This is a live-deploy change, and I have not merged it

Two things make this different from a docs-only PR:

1. **ArgoCD auto-syncs `openbank-infra/gitops/` to the sandbox cluster.**
   Merging this is not "propose a change" — it deploys `AUTHZ_ENFORCE=true`
   to live consent-service and fraud-service pods (behind the canary) as
   soon as ArgoCD reconciles.
2. **`rules.yaml` requires 2 approvals + a current threat-model reference**
   for a money-path change. I can verify the threat models exist and are
   recent (`docs/threat-models/consent-service.md`,
   `docs/threat-models/fraud-service.md`, both last touched 2026-06-27),
   but I cannot provide the second human approval, and green CI here only
   checks YAML validity and repo hygiene — not whether the OPA policy
   bundle is actually correct for live consent/fraud traffic. That
   judgment needs a human watching the canary in Grafana/Argo Rollouts
   dashboard as it rolls out.

**Recommended next steps if you approve/merge:** watch the canary through
at least the 30% step before assuming it's clean; if it aborts, the
Rollout auto-reverts and nothing further is needed. The remaining 12–13
money-path services (excluding lending-service and billing-service, which
lack an `authz:` config block entirely and need that added first) are
follow-up PRs after this pilot validates — not bundled here.

## Type of change

- [x] fix
- [x] breaking change (candidate — authorization enforcement can now reject
      a previously-allowed request; that's the intent, but flagging per
      the PR template)

## Linked issues

N/A — infra pilot PR delivering an already-Accepted ADR (ADR-0034 Phase 5); no tracked backlog issue exists for this specific rollout step.

## Changes

- `openbank-infra/gitops/components/consent/consent-service.yaml`: add
  `AUTHZ_ENFORCE=true`.
- `openbank-infra/gitops/components/fraud-service/fraud-service.yaml`: add
  `AUTHZ_ENFORCE=true`.

## Definition of Done

- [x] YAML validated (`python3 -c "yaml.safe_load_all(...)"` on both files).
- [ ] Threat models re-confirmed current by a human reviewer before merge.
- [ ] Canary watched through at least the 30% step after merge.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] Auth/crypto/payment code changed → tagging `security-review-required`.