### PR TITLE
fix(infra): lending-service — replace unbuilt placeholder tag with a signed image

### DIFF
--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -41,7 +41,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: lending-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-lending-service:sandbox-placeholder
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-lending-service:sandbox-7b588386
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

`lending-service`'s Rollout has referenced `:sandbox-placeholder` since it
was scaffolded — a tag that was never built, so Kyverno's
`verify-openbank-image-signatures` policy correctly rejects every deploy
attempt (`MANIFEST_UNKNOWN: image tag not found`). Confirmed live: the
Rollout has been `Degraded`/`RolloutAborted` since 2026-06-28 with **zero
running pods**. This went undetected because the ArgoCD `root` app
couldn't sync at all (separate fix, already merged today) to surface the
drift clearly.

## Fix

Points at `sandbox-7b588386` (pushed 2026-06-30T10:02, digest
`9108061694ee...`) — the newest `lending-service` build that actually has
a matching cosign signature + SBOM attestation in ECR. Verified directly
against the registry: `sha256-9108061694ee....sig` and `.att` both exist
for that digest. The two builds after it (`sandbox-6f24b9f8`,
`sandbox-9db3618a`) were never signed — their CI signing step apparently
didn't complete — so they'd fail the identical Kyverno check; not used
here.

## Why flagged, not self-merged

This is the service's **first real deployment** — 0 pods running today,
so no live traffic is affected by this change itself. But it's still a
money-path service per `rules.yaml`, so: worth a human confirming the
2026-06-30 build is an acceptable version to bring live, and watching the
canary once ArgoCD applies it.

## Type of change

- [x] fix

## Linked issues

N/A — infra drift fix surfaced by today's ArgoCD sync-outage investigation; no tracked backlog issue.

## Changes

- `openbank-infra/gitops/components/lending/lending-service.yaml`: image
  tag `sandbox-placeholder` → `sandbox-7b588386`.

## Definition of Done

- [x] YAML validated (multi-document).
- [x] Target tag confirmed to have a matching cosign `.sig` + `.att` in ECR.
- [ ] Human confirms the 06-30 build is acceptable to deploy.
- [ ] Canary watched once ArgoCD applies it.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] Auth/crypto/payment code changed → tagging `security-review-required`.