### PR TITLE
fix(infra): anacredit-service — replace unbuilt placeholder tag with a signed image

### DIFF
--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: anacredit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-placeholder
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-be701531
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

Same class of bug as lending-service (#96): `anacredit-service`'s
Deployment referenced `:sandbox-placeholder`, which was never built, so
Kyverno correctly rejected every deploy. The only image previously pushed
for this repo (`sandbox-ba90e1bd`, 2026-06-09) was also never signed, so
it would have failed the same check even with a correct tag.

## Fix

Built a fresh image from current `main` via
`openbank-infra/scripts/build-push-service.sh`, which pushed
`sandbox-be701531` and signed it with cosign v2
(`key=awskms:///alias/openbank-cosign-signing`, Rekor tlog entry
recorded).

## Risk

Not money-path (AnaCredit regulatory reporting, not a payment-execution
path per `rules.yaml: money_path_services`); plain `Deployment` (no canary
complexity); first-ever deployment for this service (0 pods running
previously, so no live traffic affected).

## Type of change

- [x] fix

## Linked issues

N/A — infra drift fix surfaced by today's ArgoCD sync-outage investigation; no tracked backlog issue.

## Changes

- `openbank-infra/gitops/components/anacredit/anacredit-service.yaml`:
  image tag `sandbox-placeholder` → `sandbox-be701531`.

## Definition of Done

- [x] YAML validated.
- [x] Image built, pushed, and cosign-signed successfully (verified in build log).

## Security checklist

- [x] No secrets, tokens, passwords, or PII.