### PR TITLE
fix(infra): sdd-service — first-ever build/push/sign, replace placeholder tag

### DIFF
--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sdd-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sdd-service:sandbox-placeholder
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sdd-service:sandbox-be701531
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

`sdd-service` (SEPA Direct Debit mandate lifecycle, ADR-0036) never had an
ECR repository at all — its Deployment referenced `:sandbox-placeholder`
since scaffolding, and Kyverno rejected every deploy attempt because the
tag was never built.

## Fix

- Created the ECR repository (`openbank-sdd-service`, MUTABLE tags,
  AES256 encryption — matching every existing per-service repo; there's
  no `aws_ecr_repository` Terraform resource managing per-service repos
  in this account, so this follows the same out-of-band creation pattern
  every other service repo already used).
- Built + pushed + cosign-signed `sandbox-be701531` via
  `openbank-infra/scripts/build-push-service.sh`.

## Risk

Not money-path per `rules.yaml`; plain `Deployment` (no canary
complexity); first-ever deployment for this service (0 pods running
previously, so no live traffic affected).

## Type of change

- [x] fix

## Linked issues

N/A — infra drift fix surfaced by today's ArgoCD sync-outage investigation; no tracked backlog issue.

## Changes

- `openbank-infra/gitops/components/sdd/sdd-service.yaml`: image tag
  `sandbox-placeholder` → `sandbox-be701531`.

## Definition of Done

- [x] YAML validated.
- [x] ECR repository created.
- [x] Image built, pushed, and cosign-signed successfully.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.