### PR TITLE
security(libs-domain): harden XXE defenses in ISO20022 XML parsing

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Iso20022Validator.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Iso20022Validator.kt
@@ -23,6 +23,10 @@ import javax.xml.validation.SchemaFactory
  * Uses only the JDK's built-in JAXP ([SchemaFactory] / W3C XML Schema), so the library carries
  * no XML-binding dependency. Schemas are loaded once from the classpath and cached — [Schema] is
  * thread-safe, so a single validator instance is safe to share.
+ *
+ * [validate] parses XML that arrives over the wire, so both the [SchemaFactory] ([forSchema]) and
+ * the per-call [javax.xml.validation.Validator] ([validate]) have external DTD/schema access
+ * disabled — XXE-hardened, mirroring [Pacs008Reader]/[Pacs004Reader].
  */
 class Iso20022Validator(private val schema: Schema) {
     /**
@@ -35,6 +39,11 @@ class Iso20022Validator(private val schema: Schema) {
     fun validate(xml: String): Iso20022ValidationResult {
         val errors = mutableListOf<String>()
         val validator = schema.newValidator()
+        // XXE hardening: xml is untrusted wire input. Disabling external DTD/schema access on the
+        // Validator itself (not just the SchemaFactory that built schema) is the belt-and-suspenders
+        // fix — it is the object CodeQL's java/xxe sink actually flags (validate() below).
+        validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+        validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
         validator.errorHandler = object : ErrorHandler {
             override fun warning(exception: SAXParseException) = Unit
             override fun error(exception: SAXParseException) {
@@ -72,6 +81,10 @@ class Iso20022Validator(private val schema: Schema) {
             val url = Iso20022Validator::class.java.classLoader.getResource(path)
                 ?: error("ISO 20022 schema not found on classpath: $path")
             val factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+            // XXE hardening: no vendored schema uses xs:import/xs:include, so external
+            // resolution is never legitimately needed — disable it outright.
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
             val schema = try {
                 factory.newSchema(url)
             } catch (e: org.xml.sax.SAXException) {

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs004Reader.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs004Reader.kt
@@ -23,12 +23,13 @@ class Pacs004ParseException(message: String) : RuntimeException(message)
  */
 class Pacs004Reader {
     fun read(xml: String): PaymentReturn {
-        val factory = DocumentBuilderFactory.newInstance().apply {
-            isNamespaceAware = true
-            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
-        }
+        // XXE hardening as plain imperative calls (not `.apply {}`) so static analysis can trace
+        // the sanitizing calls straight to the factory that builds the parser below.
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.isNamespaceAware = true
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
         // Wrap the XML parse: the document comes off the wire, so malformed input
         // (SAXParseException, IOException) must surface as the reader's own
         // Pacs004ParseException rather than leaking a raw parser exception to callers.

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs008Reader.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs008Reader.kt
@@ -37,12 +37,13 @@ class Pacs008ParseException(message: String) : RuntimeException(message)
  */
 class Pacs008Reader {
     fun read(xml: String): ReceivedCreditTransfer {
-        val factory = DocumentBuilderFactory.newInstance().apply {
-            isNamespaceAware = true
-            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
-            setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
-        }
+        // XXE hardening as plain imperative calls (not `.apply {}`) so static analysis can trace
+        // the sanitizing calls straight to the factory that builds the parser below.
+        val factory = DocumentBuilderFactory.newInstance()
+        factory.isNamespaceAware = true
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
         val doc = factory.newDocumentBuilder()
             .parse(ByteArrayInputStream(xml.toByteArray(Charsets.UTF_8)))
         doc.documentElement.normalize()


### PR DESCRIPTION
## Summary

Fixes 3 open CodeQL `java/xxe` alerts (#33, #34, #35) in `openbank-libs-domain`'s ISO20022 XML handling — closes the gap in `Iso20022Validator` and strengthens the two readers against a likely static-analysis false-positive.

## Type of change

- [x] security (private until disclosed)

## Linked issues

N/A — direct fix for open CodeQL code-scanning alerts, not a tracked issue.

## Changes

- `Iso20022Validator.kt`: the `SchemaFactory`/`Validator` that parses untrusted wire XML had no external DTD/schema restriction — a real gap, now closed (`ACCESS_EXTERNAL_DTD`/`ACCESS_EXTERNAL_SCHEMA` set to `""` on both the factory and the per-call validator).
- `Pacs008Reader.kt` / `Pacs004Reader.kt`: already had `disallow-doctype-decl=true` (the OWASP primary XXE defense) plus the same external-access restrictions — already secure. Refactored the `DocumentBuilderFactory` setup out of a Kotlin `.apply {}` block into plain statements so CodeQL's dataflow can trace the sanitizer to the parser (suspected false-positive cause for alerts #34/#35). No behavior change — verified with `Pacs008ReaderTest`/`Pacs004ReaderTest`.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — unchanged, this module already has none.
- [x] Unit tests added/updated. (Existing `Pacs008ReaderTest`/`Pacs004ReaderTest` pass unmodified; no dedicated `Iso20022ValidatorTest` exists yet — behavior is unchanged, only parser hardening added.)
- [x] `./gradlew :openbank-libs-domain:detekt ktlintCheck :openbank-libs-domain:test :openbank-libs-domain:compileKotlin` passes locally.
- [x] No new lint warnings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency (JDK-only JAXP).
- [x] Auth / crypto / payment code changed? → this touches payment-message (pacs.008/pacs.004) parsing — flagging `security-review-required` per the checklist, though this module is **not** on the `money_path_services` list in `rules.yaml` (only `default_approvals: 1` applies).

## Compliance impact

- [x] None (parser hardening only, no behavior/schema change)

## Rollout / Rollback

- Deployment strategy: rolling (standard service release via release-please once merged).
- Rollback plan: revert this PR; the prior parser config, while functionally equivalent for the two readers, had the real gap in `Iso20022Validator`.
- Data migration reversible: N/A

## Reviewer notes

Not self-merging — intentionally left for human review despite `openbank-libs-domain` not being on the money-path list, since it's shared payment-message parsing code used by multiple services.