### PR TITLE
fix(infra): tpp-registry-service — first-ever build/push/sign, replace placeholder tag

### DIFF
--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: tpp-registry-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-tpp-registry-service:sandbox-placeholder
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-tpp-registry-service:sandbox-be701531
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

`tpp-registry-service` never had an ECR repository — its Deployment
referenced `:sandbox-placeholder` since scaffolding, and Kyverno rejected
every deploy attempt.

## Fix

- Created the ECR repository (`openbank-tpp-registry-service`, MUTABLE
  tags, AES256 encryption — same out-of-band convention as every existing
  per-service repo).
- Built + pushed + cosign-signed `sandbox-be701531` via
  `openbank-infra/scripts/build-push-service.sh`.

## Risk

Not money-path per `rules.yaml`; plain `Deployment` (no canary
complexity); first-ever deployment for this service (0 pods running
previously, so no live traffic affected).

## Type of change

- [x] fix

## Linked issues

N/A — infra drift fix surfaced by today's ArgoCD sync-outage investigation; no tracked backlog issue.

## Changes

- `openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml`:
  image tag `sandbox-placeholder` → `sandbox-be701531`.

## Definition of Done

- [x] YAML validated.
- [x] ECR repository created.
- [x] Image built, pushed, and cosign-signed successfully.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.