### PR TITLE
security(ci): pin remaining unpinned GitHub Actions and script installs

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -374,7 +374,9 @@ jobs:
           if command -v trivy >/dev/null 2>&1; then
             echo "Using pre-baked trivy: $(trivy --version 2>/dev/null | head -1)"; exit 0
           fi
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+          # Pinned to the v0.63.0 tag (not `main`) so the installer script itself is
+          # immutable, matching the trivy version it installs.
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.63.0/contrib/install.sh \
             | sh -s -- -b /usr/local/bin v0.63.0
 
       - name: Prune Docker build cache before scan

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
   prune-stale-branches:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           OPENBANK_REPO_ROOT: "${{ github.workspace }}"
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-report
@@ -250,10 +250,10 @@ jobs:
       # (pip/pip3 not in PATH). Fall back to checking if pyyaml is already present.
       - name: gen-network-policies drift gate (ADR-0081, issue #854)
         run: |
-          python3 -m pip install --quiet pyyaml --break-system-packages 2>/dev/null \
-            || python3 -m pip install --quiet pyyaml 2>/dev/null \
-            || pip3 install --quiet pyyaml --break-system-packages 2>/dev/null \
-            || pip3 install --quiet pyyaml 2>/dev/null \
+          python3 -m pip install --quiet "pyyaml==6.0.2" --break-system-packages 2>/dev/null \
+            || python3 -m pip install --quiet "pyyaml==6.0.2" 2>/dev/null \
+            || pip3 install --quiet "pyyaml==6.0.2" --break-system-packages 2>/dev/null \
+            || pip3 install --quiet "pyyaml==6.0.2" 2>/dev/null \
             || python3 -c "import yaml" 2>/dev/null \
             || { echo "::error::pyyaml unavailable — add it to the runner base image"; exit 1; }
           python3 openbank-infra/scripts/gen-network-policies.py

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           java-version: "25"
           distribution: temurin
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload pitest XML report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pitest-${{ matrix.service }}
           path: ${{ matrix.service }}/build/reports/pitest/


### PR DESCRIPTION
## Summary

Fixes the workflow-level subset of Scorecard's Pinned-Dependencies findings (repo already SHA-pins nearly everything; these 6 stragglers missed it).

## Type of change

- [x] security (private until disclosed)
- [x] chore (build / tooling)

## Linked issues

N/A — direct fix for open Scorecard findings.

## Changes

- `pitest.yml`: `actions/setup-java@v5` → SHA-pinned; both `actions/upload-artifact@v7` → SHA-pinned.
- `branch-cleanup.yml`: `actions/checkout@v7` → SHA-pinned.
- `ci.yml`: `actions/upload-artifact@v7` (Playwright report) → SHA-pinned; `pip install pyyaml` → version-pinned (`==6.0.2`).
- `auto-deploy.yml`: trivy `contrib/install.sh` fetched from `main` (floating) while installing the pinned `v0.63.0` release — now fetched from the `v0.63.0` tag.

All action SHAs reused from identical pins already present elsewhere in the repo, for consistency.

## Definition of Done

- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (N/A — workflow YAML only, validated with `python3 -c "import yaml; yaml.safe_load(...)"`.)
- [x] No new lint warnings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: n/a (CI config only).
- Rollback plan: revert this PR.
- Data migration reversible: N/A