### PR TITLE
security(ci): fix script injection + scope GITHUB_TOKEN permissions per job

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -53,12 +53,6 @@ on:
         required: false
         default: "manual"
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write  # GitHub OIDC → openbank-arc-build-runner
-  actions: read    # gh run list / gh run download for SBOM staging
-
 concurrency:
   # One admin-ui deploy at a time — a second push while a deploy PR is open would
   # produce conflicting image tags. Cancel the in-flight run; the newer commit wins.
@@ -73,6 +67,11 @@ jobs:
     # touches cluster-topology.json / infra-lifecycle.json which match the path filter.
     if: "!startsWith(github.event.head_commit.message, 'chore(admin-ui): deploy')"
     runs-on: openbank-build
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # GitHub OIDC → openbank-arc-build-runner
+      actions: read    # gh run list / gh run download for SBOM staging
     timeout-minutes: 30
     env:
       ECR_REGISTRY: "265175468565.dkr.ecr.eu-north-1.amazonaws.com"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -42,11 +42,6 @@ on:
         required: false
         default: ""
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write  # GitHub OIDC → assume the build runner role (webhook-independent AWS auth)
-
 concurrency:
   # One deploy pipeline at a time — a second push while a deploy PR is open would
   # update the same gitops lines, causing a merge conflict. Cancel the in-flight run
@@ -59,6 +54,10 @@ jobs:
   changes:
     name: Detect changed services
     runs-on: openbank-build
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # GitHub OIDC → assume the build runner role (webhook-independent AWS auth)
     timeout-minutes: 5
     outputs:
       services: ${{ steps.detect.outputs.services }}
@@ -154,6 +153,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.any == 'true'
     runs-on: openbank-build
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # GitHub OIDC → assume the build runner role (webhook-independent AWS auth)
     timeout-minutes: 90
     env:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"
@@ -490,6 +493,10 @@ jobs:
     needs: [changes, build-push]
     if: needs.changes.outputs.any == 'true'
     runs-on: openbank-build
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # GitHub OIDC → assume the build runner role (webhook-independent AWS auth)
     timeout-minutes: 10
     env:
       PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}
@@ -585,6 +592,10 @@ jobs:
     needs: [changes, build-push, can-i-deploy]
     if: needs.changes.outputs.any == 'true'
     runs-on: openbank-build
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # GitHub OIDC → assume the build runner role (webhook-independent AWS auth)
     timeout-minutes: 10
     env:
       ECR_REGISTRY: "265175468565.dkr.ecr.eu-north-1.amazonaws.com"

--- a/.github/workflows/backfill-release-evidence.yml
+++ b/.github/workflows/backfill-release-evidence.yml
@@ -19,14 +19,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write   # upload release assets
-  id-token: write   # OIDC → assume the build-runner role for KMS cosign
-
 jobs:
   backfill:
     name: Backfill ${{ inputs.tag }}
     runs-on: openbank-batch
+    permissions:
+      contents: write   # upload release assets
+      id-token: write   # OIDC → assume the build-runner role for KMS cosign
     timeout-minutes: 30
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -15,12 +15,11 @@ on:
         required: false
         default: 'false'
 
-permissions:
-  contents: write
-
 jobs:
   prune-stale-branches:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,15 +21,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge:
     name: Auto-merge patch/minor Dependabot PRs
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Fetch Dependabot metadata
@@ -50,5 +49,10 @@ jobs:
 
       - name: Skip — major update (requires human review)
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        # PR_TITLE via env, not `${{ }}` interpolated straight into the script: the title is
+        # attacker-influenceable and direct interpolation is a script-injection vector
+        # (Scorecard Dangerous-Workflow). Env-var passing is not subject to shell expansion.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "::notice title=Major update::${{ github.event.pull_request.title }} is a major bump — skipping auto-merge, human review required."
+          echo "::notice title=Major update::${PR_TITLE} is a major bump — skipping auto-merge, human review required."

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -19,6 +19,8 @@ jobs:
   pitest:
     name: pitest / ${{ matrix.service }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,10 +14,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false
@@ -26,6 +22,9 @@ jobs:
   release-please:
     name: Release Please
     runs-on: [self-hosted, openbank-sandbox]
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 10
     outputs:
       releases_created: ${{ steps.rp.outputs.releases_created }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 # Cancel superseded runs on the same ref so Dependabot/PR pushes don't stack up
 # expensive CodeQL/Trivy/SBOM runs and drain the Free-tier minute budget.
@@ -81,6 +80,9 @@ jobs:
     # dependency here (setup-java/setup-node are already used to work around the Hetzner
     # pool lacking those toolchains). Public repo = free GitHub-hosted minutes.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload-sarif
     timeout-minutes: 30
     # The java-kotlin leg's autobuild shells out to its own `./gradlew testClasses`
     # (whole-fleet dependency resolution, ~30 modules + quarkus-bom) without picking up
@@ -141,6 +143,9 @@ jobs:
   trivy:
     name: Trivy
     runs-on: openbank-batch
+    permissions:
+      contents: read
+      security-events: write # upload-sarif
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Fixes Scorecard's Dangerous-Workflow (script injection) finding and all 9 Token-Permissions findings across `.github/workflows/`.

## Type of change

- [x] security (private until disclosed)

## Linked issues

N/A — direct fix for open Scorecard findings.

## Changes

- **Dangerous-Workflow**: `dependabot-auto-merge.yml` interpolated `${{ github.event.pull_request.title }}` (attacker-influenceable) directly into a `run:` shell script. Fixed by passing it through `env:` instead.
- **Token-Permissions** (9 findings across 8 files): moved `permissions:` from workflow-level to job-level everywhere. `security.yml` got a real narrowing (only `codeql`/`trivy` get `security-events: write`, others default to `contents: read`); `pitest.yml` had no block at all (added `contents: read`); the rest are conservative "same scope, moved down a level" changes — I did **not** attempt to guess a narrower per-job scope for `auto-deploy.yml`/`admin-ui-deploy.yml` (multi-job production deploy pipelines I can't fully exercise locally), to avoid risking under-provisioning a live release path.

## Definition of Done

- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (N/A — workflow YAML only, validated with `python3 -c "import yaml; yaml.safe_load(...)"` on every changed file.)
- [x] No new lint warnings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: n/a (CI config only).
- Rollback plan: revert this PR.
- Data migration reversible: N/A

## Reviewer notes

`auto-deploy.yml`/`admin-ui-deploy.yml` job-level blocks are intentionally NOT narrowed below the current workflow-level scope — worth a follow-up pass with someone who can watch a real deploy run if you want tighter per-job scoping there.