### PR TITLE
security(notification): clarify DER-parsing operator precedence with explicit parens

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/push/PushCrypto.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/push/PushCrypto.kt
@@ -55,10 +55,10 @@ internal object PushCrypto {
     internal fun derToP1363(der: ByteArray, partLen: Int): ByteArray {
         // SEQUENCE
         var offset = 0
-        require(der[offset++].toInt() and 0xff == 0x30) { "Invalid DER: not a SEQUENCE" }
+        require((der[offset++].toInt() and 0xff) == 0x30) { "Invalid DER: not a SEQUENCE" }
         // length (skip; may be short or long form)
         var len = der[offset++].toInt() and 0xff
-        if (len and 0x80 != 0) {
+        if ((len and 0x80) != 0) {
             val numBytes = len and 0x7f
             len = 0
             repeat(numBytes) { len = (len shl 8) or (der[offset++].toInt() and 0xff) }
@@ -73,7 +73,7 @@ internal object PushCrypto {
 
     private fun readDerInteger(der: ByteArray, start: Int): Pair<ByteArray, Int> {
         var offset = start
-        require(der[offset++].toInt() and 0xff == 0x02) { "Invalid DER: not an INTEGER" }
+        require((der[offset++].toInt() and 0xff) == 0x02) { "Invalid DER: not an INTEGER" }
         val length = der[offset++].toInt() and 0xff
         val value = der.copyOfRange(offset, offset + length)
         return value to (offset + length)


### PR DESCRIPTION
## Summary

Fixes CodeQL's "Whitespace contradicts operator precedence" finding (3 alerts) in `PushCrypto.kt`'s DER signature parsing.

## Type of change

- [x] security (private until disclosed)

## Linked issues

N/A — direct fix for open CodeQL findings.

## Changes

`X and Y == Z` visually reads as `X and (Y == Z)`, but Kotlin's infix-function precedence binds `and` tighter than `==`/`!=`, so the code already evaluated as intended (`(X and Y) == Z`). Added explicit parens for clarity — no behavior change.

## Definition of Done

- [x] Unit tests added/updated. (Existing `PushCrypto` tests pass unmodified.)
- [x] `./gradlew :openbank-notification-service:compileKotlin :openbank-notification-service:test --tests "*PushCrypto*"` passes locally.
- [x] No new lint warnings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None (clarity-only change, no behavior difference)

## Rollout / Rollback

- Deployment strategy: rolling (standard service release via release-please once merged).
- Rollback plan: revert this PR.
- Data migration reversible: N/A