### PR TITLE
security(psd2): sanitize request-derived values before logging

### DIFF
--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/client/StubClients.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/client/StubClients.kt
@@ -24,12 +24,16 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
+// CodeQL java/log-injection: several IDs logged below ultimately trace back to caller/request
+// input. Strip CR/LF so an attacker can't forge additional log lines (log forging, CWE-117).
+private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
 @ApplicationScoped
 class StubAccountServiceClient(private val clock: Clock) : AccountServiceClient {
     private val log = Logger.getLogger(StubAccountServiceClient::class.java)
 
     override suspend fun getAccountsByParty(partyId: String): List<ObAccount> {
-        log.infof("getAccountsByParty partyId=%s", partyId)
+        log.infof("getAccountsByParty partyId=%s", partyId.sanitizeForLog())
         return listOf(
             ObAccount("acc-001", "CZ6508000000192000145399", "CZK", "Jan Novák", "Běžný účet", "CURRENT", "CACC"),
         )
@@ -87,12 +91,12 @@ class StubConsentServiceClient : ConsentServiceClient {
     override suspend fun getConsentStatus(consentId: String): String = "ACTIVE"
 
     override suspend fun validateConsent(consentId: String, granteeId: String, scope: String, iban: String?): Boolean {
-        log.infof("validateConsent consentId=%s scope=%s", consentId, scope)
+        log.infof("validateConsent consentId=%s scope=%s", consentId.sanitizeForLog(), scope.sanitizeForLog())
         return true
     }
 
     override suspend fun revokeConsent(consentId: String, granteeId: String) {
-        log.infof("revokeConsent consentId=%s granteeId=%s", consentId, granteeId)
+        log.infof("revokeConsent consentId=%s granteeId=%s", consentId.sanitizeForLog(), granteeId.sanitizeForLog())
     }
 }
 
@@ -113,8 +117,8 @@ class StubTransactionServiceClient : TransactionServiceClient {
         val id = UUID.randomUUID().toString()
         log.debugf(
             "initiatePayment debtor=****%s creditor=****%s id=%s",
-            debtorIban.takeLast(4),
-            creditorIban.takeLast(4),
+            debtorIban.takeLast(4).sanitizeForLog(),
+            creditorIban.takeLast(4).sanitizeForLog(),
             id,
         )
         return id

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/filter/EidasMtlsFilter.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/filter/EidasMtlsFilter.kt
@@ -20,6 +20,11 @@ class EidasMtlsFilter(private val tppAuthorizationGuard: TppAuthorizationGuard) 
 
     private val log = Logger.getLogger(EidasMtlsFilter::class.java)
 
+    // CodeQL java/log-injection: path and tppId come straight off the request (URI segment /
+    // X-TPP-ID / SSL-CLIENT-S-DN header) and are logged verbatim below. Strip CR/LF so an
+    // attacker can't forge additional log lines (log forging, CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     @Suppress("LongMethod")
     override fun filter(ctx: ContainerRequestContext) {
         val path = ctx.uriInfo.path
@@ -33,7 +38,7 @@ class EidasMtlsFilter(private val tppAuthorizationGuard: TppAuthorizationGuard) 
             ?: ctx.getHeaderString("SSL-CLIENT-S-DN")
 
         if (tppId.isNullOrBlank()) {
-            log.warnf("Missing TPP identification on path: %s", path)
+            log.warnf("Missing TPP identification on path: %s", path.sanitizeForLog())
             ctx.abortWith(
                 Response.status(401)
                     .entity(
@@ -59,17 +64,27 @@ class EidasMtlsFilter(private val tppAuthorizationGuard: TppAuthorizationGuard) 
         val authorization = try {
             tppAuthorizationGuard.requireAuthorized(tppId, requiredRole)
         } catch (e: CircuitBreakerOpenException) {
-            log.errorf("TPP registry circuit open for tppId=%s path=%s", tppId, path)
+            log.errorf("TPP registry circuit open for tppId=%s path=%s", tppId.sanitizeForLog(), path.sanitizeForLog())
             ctx.abortWith(serviceUnavailable())
             return
         } catch (e: Exception) {
-            log.errorf(e, "TPP registry authorization failed for tppId=%s path=%s", tppId, path)
+            log.errorf(
+                e,
+                "TPP registry authorization failed for tppId=%s path=%s",
+                tppId.sanitizeForLog(),
+                path.sanitizeForLog(),
+            )
             ctx.abortWith(serviceUnavailable())
             return
         }
 
         if (!authorization.authorized) {
-            log.warnf("TPP %s rejected for role=%s path=%s", tppId, requiredRole, path)
+            log.warnf(
+                "TPP %s rejected for role=%s path=%s",
+                tppId.sanitizeForLog(),
+                requiredRole,
+                path.sanitizeForLog(),
+            )
             ctx.abortWith(
                 Response.status(401)
                     .entity(

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/filter/QsealSignatureFilter.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/filter/QsealSignatureFilter.kt
@@ -36,6 +36,10 @@ class QsealSignatureFilter(
 
     private val log = Logger.getLogger(QsealSignatureFilter::class.java)
 
+    // CodeQL java/log-injection: path is a raw request URI segment, logged verbatim below.
+    // Strip CR/LF so an attacker can't forge additional log lines (log forging, CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     override fun filter(ctx: ContainerRequestContext) {
         val path = ctx.uriInfo.path
         // Only the Berlin write surface carries a body to sign; reads rely on QWAC transport auth.
@@ -49,13 +53,13 @@ class QsealSignatureFilter(
         if (outcome == Outcome.VALID) return
 
         if (enforce) {
-            log.warnf("QSEAL %s on %s — rejecting (enforce)", outcome, path)
+            log.warnf("QSEAL %s on %s — rejecting (enforce)", outcome, path.sanitizeForLog())
             val err = mapOf(
                 "tppMessages" to listOf(mapOf("category" to "ERROR", "code" to "SIGNATURE_INVALID")),
             )
             ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).entity(err).build())
         } else {
-            log.debugf("QSEAL %s on %s — allowing (advisory)", outcome, path)
+            log.debugf("QSEAL %s on %s — allowing (advisory)", outcome, path.sanitizeForLog())
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes 14 of the 32 open CodeQL `java/log-injection` alerts — the full `openbank-psd2-service` cluster (`EidasMtlsFilter.kt`, `QsealSignatureFilter.kt`, `StubClients.kt`).

## Type of change

- [x] security (private until disclosed)

## Linked issues

N/A — direct fix for open CodeQL findings.

## Changes

Request-derived values (X-TPP-ID / SSL-CLIENT-S-DN headers, request URI path, stub-client IDs) were logged verbatim via `log.warnf`/`errorf`/`debugf`/`infof` — an attacker could inject `\r\n` to forge additional log lines (CWE-117). Added a local `sanitizeForLog()` (strips CR/LF) applied at every flagged log call site.

## Definition of Done

- [x] Unit tests added/updated. (Existing tests pass unmodified — pure logging change, no behavior difference.)
- [x] `./gradlew :openbank-psd2-service:compileKotlin :openbank-psd2-service:test :openbank-psd2-service:detekt :openbank-psd2-service:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None (logging-only change)

## Rollout / Rollback

- Deployment strategy: rolling (standard service release via release-please once merged).
- Rollback plan: revert this PR.
- Data migration reversible: N/A

## Reviewer notes

18 more Log Injection findings remain open across `openbank-agent-service`, `openbank-analytics-sink`, `openbank-settlement-service`, `openbank-sca-service`, `openbank-product-catalog`, `openbank-devops-agent` — follow-up PRs, not included here to keep this scoped to one service.