### PR TITLE
chore(gitops): auto-deploy services @ 71e6211d37f5823285aba0c1235fd703a9f9fdb4

### DIFF
--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -25,7 +25,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: psd2-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-psd2-service:sandbox-6967ebd3
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-psd2-service:sandbox-71e6211d
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8107}


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 71e6211d37f5823285aba0c1235fd703a9f9fdb4.

**Changed services:** ["openbank-psd2-service"]

Each image tag was updated to `sandbox-71e6211d37f5823285aba0c1235fd703a9f9fdb4` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.