### PR TITLE
fix(infra): flip AUTHZ_ENFORCE=true on 11 remaining money-path services (ADR-0034 Phase 5)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -107,6 +107,11 @@ spec:
                 secretKeyRef:
                   name: account-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             # Balance-service in-cluster URL (default is localhost:8103 which fails in k8s).
             - name: BALANCE_SERVICE_URL
               value: http://balance-service.balances.svc:8103

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -109,6 +109,11 @@ spec:
                 secretKeyRef:
                   name: balance-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -82,6 +82,11 @@ spec:
                   name: fx-service-oidc
                   key: OIDC_CLIENT_SECRET
                   optional: true
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -100,6 +100,11 @@ spec:
                 secretKeyRef:
                   name: ledger-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             # isn't flooded with connection-refused retries.
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -99,6 +99,11 @@ spec:
                 secretKeyRef:
                   name: transaction-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             # ADR-0137 image-independent convergence: load the scheme-accepted
             # group.id / DLQ-topic override (transaction-service-msg-override
             # ConfigMap, mounted below) as an external Quarkus config source so
@@ -349,6 +354,11 @@ spec:
                 secretKeyRef:
                   name: sepa-payment-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             # createPayment dedupes on the Idempotency-Key header via Redis (in-namespace, see
             # redis.yaml) and screens via sanctions/aml — all defaulted to localhost, so the REST
             # path 500'd. Wire them to the in-cluster services (mirrors domestic-payment below).
@@ -594,6 +604,11 @@ spec:
                 secretKeyRef:
                   name: domestic-payment-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             # createPayment dedupes on the Idempotency-Key header via Redis (in-namespace, see
             # redis.yaml) and screens via sanctions/aml — all defaulted to localhost, so the REST
             # path 500'd / held in RECEIVED. Wire them to the in-cluster services.
@@ -823,6 +838,11 @@ spec:
                 secretKeyRef:
                   name: sepa-instant-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
@@ -1037,6 +1057,11 @@ spec:
                 secretKeyRef:
                   name: clearing-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
@@ -1778,6 +1803,11 @@ spec:
                 secretKeyRef:
                   name: swift-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -81,6 +81,11 @@ spec:
                 secretKeyRef:
                   name: sca-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # OPA sidecar is deployed (ADR-0034). AUTHZ_ENFORCE=true enables the
+            # money-path enforcement fleet rollout (Phase 5) — deployed behind the
+            # existing canary Rollout, which aborts automatically on elevated error rate.
+            - name: AUTHZ_ENFORCE
+              value: "true"
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.sca.svc:6379
             - name: QUARKUS_FLYWAY_REPAIR_AT_START


### PR DESCRIPTION
## Summary

Continues the pilot (`consent-service`, `fraud-service`, #90 — validated
successfully, canary promoted to 100%, both stable Healthy) to the
remaining 11 money-path services whose `application.yaml` already has a
complete `opa:`/`authz:` config block: `ledger-service`,
`transaction-service`, `account-service`, `balance-service`,
`sepa-payment`, `sepa-instant`, `domestic-payment`, `clearing-service`,
`swift-service`, `fx-service`, `sca-service`.

All 11 already run as Argo Rollouts canary with the
`openbank-money-path-canary` AnalysisTemplate (10%→5m pause→30%→5m
pause→100%, auto-abort on error rate ≥ 5%) — the same safety net that
validated today's pilot.

## NOT included in this batch

- **`lending-service`**: `application.yaml` has no `opa:`/`authz:` block
  at all (confirmed by direct inspection) — needs that added in a
  service-repo PR + a rebuilt image before a gitops flip does anything.
  Separate follow-up.
- **`billing-service`**: zero `@Authorize` annotations anywhere in its
  source — OPA was never wired into its REST resources. Needs real
  endpoint-level authorization code, not a config change. Separate,
  larger follow-up.

## Authorization

Maintainer explicitly reviewed and authorized proceeding through this
item today (chat approval, 2026-07-02), continuing the pattern from the
successful consent/fraud pilot merged earlier today (#90).

## Type of change

- [x] fix
- [x] breaking change (candidate — authorization enforcement can now
      reject a previously-allowed request; that's the intent)

## Linked issues

N/A — infra rollout of an already-Accepted ADR (ADR-0034 Phase 5); no tracked backlog issue.

## Changes

- 6 gitops manifests, 11 services: add `AUTHZ_ENFORCE=true`.

## Definition of Done

- [x] YAML validated (multi-document) on every touched file.
- [x] Each anchor match verified unique before insertion (no duplicate/
      misplaced blocks — caught and fixed one `optional: true` ordering
      issue in fx-service.yaml during review).
- [ ] Canaries watched through promotion after merge.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] Auth/crypto/payment code changed → tagging `security-review-required`.