### PR TITLE
security(analytics-sink): sanitize caller-supplied values before logging

### DIFF
--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/ErasureService.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/ErasureService.kt
@@ -48,6 +48,11 @@ class ErasureService {
 
     private val log = Logger.getLogger(ErasureService::class.java)
 
+    // CodeQL java/log-injection: aggregateType/aggregateId/requestedBy are caller-supplied and
+    // flow straight into log lines below. Strip CR/LF so an attacker can't forge additional
+    // log lines (log forging, CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     suspend fun erase(aggregateType: String, aggregateId: String, requestedBy: String): ErasureDecision {
         val category = RetentionPolicies.categoryForAggregateType(aggregateType)
         val policy = RetentionPolicies.of(category)
@@ -56,11 +61,11 @@ class ErasureService {
         if (!policy.erasable) {
             log.infof(
                 "erasure REFUSED %s/%s category=%s basis=%s by=%s",
-                aggregateType,
-                aggregateId,
+                aggregateType.sanitizeForLog(),
+                aggregateId.sanitizeForLog(),
                 category,
                 policy.basis,
-                requestedBy,
+                requestedBy.sanitizeForLog(),
             )
             return ErasureDecision(
                 aggregateType = aggregateType,
@@ -79,11 +84,11 @@ class ErasureService {
         val rows = cryptoErasure.erase(AggregateKey(aggregateType, aggregateId))
         log.infof(
             "erasure PERFORMED %s/%s category=%s rows=%d by=%s",
-            aggregateType,
-            aggregateId,
+            aggregateType.sanitizeForLog(),
+            aggregateId.sanitizeForLog(),
             category,
             rows,
-            requestedBy,
+            requestedBy.sanitizeForLog(),
         )
         return ErasureDecision(
             aggregateType = aggregateType,

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/SensitiveReloadService.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/application/SensitiveReloadService.kt
@@ -38,6 +38,11 @@ class SensitiveReloadService {
 
     private val log = Logger.getLogger(SensitiveReloadService::class.java)
 
+    // CodeQL java/log-injection: source/requestedBy/reason/checker are operator-supplied
+    // strings that flow straight into log lines below. Strip CR/LF so an attacker (or a
+    // careless operator) can't forge additional audit-trail log lines (log forging, CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     suspend fun propose(request: BackfillRequest): Proposal<BackfillRequest> {
         val proposal = Proposal(
             id = UUID.randomUUID().toString(),
@@ -49,9 +54,9 @@ class SensitiveReloadService {
         log.infof(
             "reload proposed id=%s source=%s by=%s reason=%s",
             proposal.id,
-            request.source,
-            request.requestedBy,
-            request.reason,
+            request.source, // IngestSource enum — fixed values, no sanitization needed
+            request.requestedBy.sanitizeForLog(),
+            request.reason.sanitizeForLog(),
         )
         return proposal
     }
@@ -60,14 +65,19 @@ class SensitiveReloadService {
         val proposal = require(id)
         val approved = proposal.approve(checker, Instant.now(clock), reason)
         store.save(approved)
-        log.infof("reload approved id=%s by=%s (proposer=%s)", id, checker, proposal.proposedBy)
+        log.infof(
+            "reload approved id=%s by=%s (proposer=%s)",
+            id.sanitizeForLog(),
+            checker.sanitizeForLog(),
+            proposal.proposedBy.sanitizeForLog(),
+        )
         return approved
     }
 
     suspend fun reject(id: String, checker: String, reason: String?): Proposal<BackfillRequest> {
         val rejected = require(id).reject(checker, Instant.now(clock), reason)
         store.save(rejected)
-        log.infof("reload rejected id=%s by=%s", id, checker)
+        log.infof("reload rejected id=%s by=%s", id.sanitizeForLog(), checker.sanitizeForLog())
         return rejected
     }
 
@@ -81,7 +91,12 @@ class SensitiveReloadService {
         val executing = proposal.markExecuted(Instant.now(clock))
         val report = backfill.run(proposal.action)
         store.save(executing)
-        log.infof("reload executed id=%s batchId=%s ingested=%d", id, report.batchId, report.ingested)
+        log.infof(
+            "reload executed id=%s batchId=%s ingested=%d",
+            id.sanitizeForLog(),
+            report.batchId.sanitizeForLog(),
+            report.ingested,
+        )
         return report
     }
 

--- a/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/erasure/NoOpCryptoErasure.kt
+++ b/openbank-analytics-sink/src/main/kotlin/com/openbank/analytics/infrastructure/erasure/NoOpCryptoErasure.kt
@@ -20,10 +20,15 @@ class NoOpCryptoErasure : CryptoErasure {
 
     private val log = Logger.getLogger(NoOpCryptoErasure::class.java)
 
+    // CodeQL java/log-injection: key.aggregateType/aggregateId are caller-supplied. Strip CR/LF
+    // so an attacker can't forge additional log lines (log forging, CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     override suspend fun erase(key: AggregateKey): Long {
         log.warnf(
             "CryptoErasure no-op: would crypto-shred analytics data for %s/%s. Bind the KMS adapter in production (ADR-0023 F6).",
-            key.aggregateType, key.aggregateId
+            key.aggregateType.sanitizeForLog(),
+            key.aggregateId.sanitizeForLog(),
         )
         return 0
     }


### PR DESCRIPTION
## Summary
Fixes 8 of the 32 open CodeQL `java/log-injection` alerts across `SensitiveReloadService.kt`, `ErasureService.kt`, `NoOpCryptoErasure.kt`.

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for open CodeQL findings.

## Changes
Operator-supplied identifiers (proposal id, source, requestedBy, reason, checker, aggregateType, aggregateId) were logged verbatim in the maker-checker and GDPR-erasure audit trail. Added a local `sanitizeForLog()` (strips CR/LF) at every flagged log call site. Left `request.source` (an enum, not free text) alone.

## Definition of Done
- [x] Unit tests pass unmodified (logging-only change).
- [x] `./gradlew :openbank-analytics-sink:compileKotlin :openbank-analytics-sink:test :openbank-analytics-sink:detekt :openbank-analytics-sink:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact
- [x] None (logging-only change)

## Rollout / Rollback
- Deployment strategy: rolling (standard release via release-please).
- Rollback plan: revert this PR.
- Data migration reversible: N/A