### PR TITLE
security(settlement): sanitize idempotencyKey before logging

### DIFF
--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
@@ -48,6 +48,10 @@ class SettlementService(
 
     private val log = Logger.getLogger(SettlementService::class.java)
 
+    // CodeQL java/log-injection: idempotencyKey is caller-supplied and flows straight into the
+    // log line below. Strip CR/LF so an attacker can't forge additional log lines (CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     override suspend fun originate(command: OriginateSettlementCommand): Settlement {
         // Idempotency: derive the settlement id deterministically from the caller's key, so a
         // retried request resolves to the same row (the UUID primary key is the hard duplicate
@@ -90,7 +94,7 @@ class SettlementService(
             settlementRepository.findById(id)?.also {
                 log.infof(
                     "Concurrent create for idempotencyKey '%s' (%s); using the winner's row",
-                    command.idempotencyKey,
+                    command.idempotencyKey.sanitizeForLog(),
                     id,
                 )
             } ?: throw ex


### PR DESCRIPTION
## Summary
Fixes 1 open CodeQL `java/log-injection` alert in `SettlementService.kt`.

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for an open CodeQL finding.

## Changes
`command.idempotencyKey` (caller-supplied) was logged verbatim on the concurrent-create race path. Added a local `sanitizeForLog()` (strips CR/LF).

## Definition of Done
- [x] Unit tests pass unmodified (logging-only change).
- [x] `./gradlew :openbank-settlement-service:compileKotlin :openbank-settlement-service:test :openbank-settlement-service:detekt :openbank-settlement-service:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact
- [x] None (logging-only change)

## Rollout / Rollback
- Deployment strategy: rolling (standard release via release-please).
- Rollback plan: revert this PR.
- Data migration reversible: N/A