### PR TITLE
security(product-catalog): sanitize fee-waiver diagnostics before logging

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/application/ProductCatalogService.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/application/ProductCatalogService.kt
@@ -262,6 +262,11 @@ data class ProductRequest(
  * "free text vs. executable rule" gap is visible on real data rather than silent.
  * No money is moved here — runtime fee posting is a deferred money-path phase.
  */
+// CodeQL java/log-injection: product.code/fee.name/fee.waiveCondition are admin-supplied
+// catalog config, logged verbatim below. Strip CR/LF so they can't forge additional log lines
+// (log forging, CWE-117).
+private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
 private fun validateFeeWaivers(product: Product, log: Logger) {
     product.fees.filter { it.waivable }.forEach { fee ->
         require(!fee.waiveCondition.isNullOrBlank()) {
@@ -270,8 +275,9 @@ private fun validateFeeWaivers(product: Product, log: Logger) {
         val predicate = WaiveConditionParser.parse(fee.waiveCondition)
         if (predicate is WaivePredicate.Unparseable) {
             log.warning(
-                "Product '${product.code}' fee '${fee.name}' has a non-evaluable waiver condition " +
-                    "(${predicate.reason}): \"${fee.waiveCondition}\" — fee will not be auto-waived (ADR-0138)",
+                "Product '${product.code.sanitizeForLog()}' fee '${fee.name.sanitizeForLog()}' has a " +
+                    "non-evaluable waiver condition (${predicate.reason.sanitizeForLog()}): " +
+                    "\"${fee.waiveCondition.sanitizeForLog()}\" — fee will not be auto-waived (ADR-0138)",
             )
         }
     }


### PR DESCRIPTION
## Summary
Fixes 1 open CodeQL `java/log-injection` alert in `ProductCatalogService.kt` (`validateFeeWaivers`).

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for an open CodeQL finding.

## Changes
`product.code`/`fee.name`/`fee.waiveCondition`/the waiver-parser's rejection reason (admin-supplied catalog config) were interpolated verbatim into a log line. Added a local `sanitizeForLog()` (strips CR/LF).

## Definition of Done
- [x] Unit tests pass unmodified (logging-only change).
- [x] `./gradlew :openbank-product-catalog:compileKotlin :openbank-product-catalog:test :openbank-product-catalog:detekt :openbank-product-catalog:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact
- [x] None (logging-only change)

## Rollout / Rollback
- Deployment strategy: rolling (standard release via release-please).
- Rollback plan: revert this PR.
- Data migration reversible: N/A