### PR TITLE
security(devops-agent): sanitize finding id before logging

### DIFF
--- a/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/usecase/DevOpsService.kt
+++ b/openbank-devops-agent/src/main/kotlin/com/openbank/devops/application/usecase/DevOpsService.kt
@@ -31,6 +31,10 @@ class DevOpsService(
 
     private val log = Logger.getLogger(DevOpsService::class.java)
 
+    // CodeQL java/log-injection: id is caller-supplied and flows straight into the log line
+    // below. Strip CR/LF so an attacker can't forge additional log lines (CWE-117).
+    private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')
+
     override suspend fun run(trigger: RunTrigger): DevOpsRunReport {
         log.infof("Starting DevOps analysis workflow (trigger=%s)", trigger)
         val options = WorkflowOptions.newBuilder()
@@ -51,7 +55,7 @@ class DevOpsService(
 
     private suspend fun transition(id: String, status: FindingStatus): DevOpsFinding? {
         val finding = findingRepository.findById(id) ?: return null
-        log.infof("HITL %s on finding %s by operator", status, id)
+        log.infof("HITL %s on finding %s by operator", status, id.sanitizeForLog())
         return findingRepository.update(finding.copy(status = status))
     }
 }


### PR DESCRIPTION
## Summary
Fixes 1 open CodeQL `java/log-injection` alert in `DevOpsService.kt` (HITL approve/reject transition).

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for an open CodeQL finding.

## Changes
The finding `id` (caller-supplied) was logged verbatim. Added a local `sanitizeForLog()` (strips CR/LF).

## Definition of Done
- [x] Unit tests pass unmodified (logging-only change).
- [x] `./gradlew :openbank-devops-agent:compileKotlin :openbank-devops-agent:test :openbank-devops-agent:detekt :openbank-devops-agent:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact
- [x] None (logging-only change)

## Rollout / Rollback
- Deployment strategy: rolling (standard release via release-please).
- Rollback plan: revert this PR.
- Data migration reversible: N/A