### PR TITLE
chore(gitops): auto-deploy services @ 363b7b454820304d8997c5e6ffa2251fa197c96b

### DIFF
--- a/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
+++ b/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: devops-agent
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-devops-agent:sandbox-463681ed
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-devops-agent:sandbox-363b7b45
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 363b7b454820304d8997c5e6ffa2251fa197c96b.

**Changed services:** ["openbank-devops-agent"]

Each image tag was updated to `sandbox-363b7b454820304d8997c5e6ffa2251fa197c96b` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.