### PR TITLE
security(customer-edge): validate URL via regex before URI.create (SSRF fix take 2)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -73,17 +73,29 @@ class UpstreamClient {
     )
     var allowedHostSuffixes: String = ".svc,127.0.0.1,localhost"
 
-    /** Parses [url] and rejects it unless the host matches [allowedHostSuffixes] (SSRF guard). */
+    /**
+     * Rejects [url] unless it matches [allowedHostSuffixes], via a regex match against the raw
+     * string — CodeQL's java/ssrf query specifically recognizes a regex check as a sanitizing
+     * barrier (unlike a host check performed after URI.create()). URI.create() only runs once
+     * validation has already passed. A leading "." in an entry (e.g. ".svc") matches any host
+     * ending in that domain suffix; anything else (e.g. "127.0.0.1", "localhost") must match the
+     * whole host exactly.
+     */
     private fun validatedUri(url: String): URI {
-        val uri = URI.create(url)
-        val host = uri.host
-        val suffixes = allowedHostSuffixes.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-        val allowed = host != null && suffixes.any { host == it || host.endsWith(it) }
-        require(allowed) {
-            "refusing upstream call to disallowed host '$host' " +
+        val entries = allowedHostSuffixes.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        val alternatives = entries.joinToString("|") { entry ->
+            if (entry.startsWith(".")) {
+                "[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*" + Regex.escape(entry)
+            } else {
+                Regex.escape(entry)
+            }
+        }
+        val pattern = Regex("^https?://(?:$alternatives)(?::\\d+)?(?:/.*)?$")
+        require(pattern.matches(url)) {
+            "refusing upstream call to disallowed host in url " +
                 "(configure openbank.upstream.allowed-host-suffixes to permit it)"
         }
-        return uri
+        return URI.create(url)
     }
 
     companion object {


### PR DESCRIPTION
## Summary
Follow-up to #100 — the previous SSRF fix validated the URI's `.host` **after** `URI.create(url)` had already run, which CodeQL's `java/ssrf` query doesn't recognize as a sanitizing barrier (alerts #239/#240/#241 stayed open after #100 merged). This rewrites the check to validate the raw string via a regex match — a documented, recognized sanitizer for this query — **before** `URI.create()` is ever called.

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for open CodeQL findings that survived a prior attempted fix.

## Changes
`validatedUri()` now builds a `Regex` from `allowedHostSuffixes` and matches it against the untrusted `url` string first (`require()` throws before anything else runs); `URI.create(url)` only executes after the match succeeds. Also tightened semantics: a `.`-prefixed entry (`.svc`) matches any host ending in that domain suffix; a bare entry (`127.0.0.1`, `localhost`) must match the whole host exactly — the previous `endsWith()` check could technically match e.g. `evil127.0.0.1`.

## Definition of Done
- [x] Unit tests pass — `UpstreamClientTest`'s loopback allowlist entry still resolves correctly under the new exact-match semantics.
- [x] `./gradlew :openbank-customer-edge:compileKotlin :openbank-customer-edge:test --tests "*UpstreamClientTest*" :openbank-customer-edge:detekt :openbank-customer-edge:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact
- [x] None

## Rollout / Rollback
- Deployment strategy: rolling (standard release via release-please).
- Rollback plan: revert this PR.
- Data migration reversible: N/A

## Reviewer notes

Will verify against a real CodeQL scan on this PR before considering it actually resolved this time (learned from #100 not being verified against a fresh scan before merging).