### PR TITLE
security(libs-domain): full OWASP XXE hardening + DOM-based validation (take 2)

### DIFF
--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Iso20022Validator.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Iso20022Validator.kt
@@ -8,7 +8,8 @@ import org.xml.sax.ErrorHandler
 import org.xml.sax.SAXParseException
 import java.io.ByteArrayInputStream
 import javax.xml.XMLConstants
-import javax.xml.transform.stream.StreamSource
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.dom.DOMSource
 import javax.xml.validation.Schema
 import javax.xml.validation.SchemaFactory
 
@@ -24,9 +25,13 @@ import javax.xml.validation.SchemaFactory
  * no XML-binding dependency. Schemas are loaded once from the classpath and cached — [Schema] is
  * thread-safe, so a single validator instance is safe to share.
  *
- * [validate] parses XML that arrives over the wire, so both the [SchemaFactory] ([forSchema]) and
- * the per-call [javax.xml.validation.Validator] ([validate]) have external DTD/schema access
- * disabled — XXE-hardened, mirroring [Pacs008Reader]/[Pacs004Reader].
+ * [validate] parses XML that arrives over the wire. Rather than handing the raw untrusted bytes
+ * to [javax.xml.validation.Validator.validate] directly (a [SchemaFactory]/[Schema]-based sink
+ * CodeQL's java/xxe query does not reliably recognize as sanitized even with external-access
+ * properties disabled), [validate] first parses with the same XXE-hardened
+ * [DocumentBuilderFactory] (`disallow-doctype-decl`) used by [Pacs008Reader]/[Pacs004Reader], then
+ * validates the already-parsed, entity-free DOM tree. The Validator itself additionally has
+ * external DTD/schema access disabled too, belt-and-suspenders.
  */
 class Iso20022Validator(private val schema: Schema) {
     /**
@@ -39,9 +44,6 @@ class Iso20022Validator(private val schema: Schema) {
     fun validate(xml: String): Iso20022ValidationResult {
         val errors = mutableListOf<String>()
         val validator = schema.newValidator()
-        // XXE hardening: xml is untrusted wire input. Disabling external DTD/schema access on the
-        // Validator itself (not just the SchemaFactory that built schema) is the belt-and-suspenders
-        // fix — it is the object CodeQL's java/xxe sink actually flags (validate() below).
         validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "")
         validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
         validator.errorHandler = object : ErrorHandler {
@@ -54,7 +56,22 @@ class Iso20022Validator(private val schema: Schema) {
             }
         }
         return try {
-            validator.validate(StreamSource(ByteArrayInputStream(xml.toByteArray(Charsets.UTF_8))))
+            // XXE hardening: xml is untrusted wire input. Parse it with a locked-down
+            // DocumentBuilder (no DOCTYPE at all — the OWASP-recommended primary XXE defense)
+            // before the Validator ever sees it.
+            val docFactory = DocumentBuilderFactory.newInstance()
+            docFactory.isNamespaceAware = true
+            docFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            docFactory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+            docFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            docFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            docFactory.isXIncludeAware = false
+            docFactory.isExpandEntityReferences = false
+            docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+            docFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+            val doc = docFactory.newDocumentBuilder()
+                .parse(ByteArrayInputStream(xml.toByteArray(Charsets.UTF_8)))
+            validator.validate(DOMSource(doc))
             if (errors.isEmpty()) {
                 Iso20022ValidationResult.Valid
             } else {

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs004Reader.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs004Reader.kt
@@ -28,6 +28,11 @@ class Pacs004Reader {
         val factory = DocumentBuilderFactory.newInstance()
         factory.isNamespaceAware = true
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        factory.isXIncludeAware = false
+        factory.isExpandEntityReferences = false
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
         // Wrap the XML parse: the document comes off the wire, so malformed input

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs008Reader.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs008Reader.kt
@@ -42,6 +42,11 @@ class Pacs008Reader {
         val factory = DocumentBuilderFactory.newInstance()
         factory.isNamespaceAware = true
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        factory.isXIncludeAware = false
+        factory.isExpandEntityReferences = false
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
         val doc = factory.newDocumentBuilder()


### PR DESCRIPTION
## Summary
Follow-up to #99 — that PR applied the OWASP-recommended XXE mitigation but alerts #33/#34/#35 stayed open (a documented CodeQL false-negative-on-fix pattern for this exact idiom, see github/codeql#13383). This adds the full OWASP checklist and, for `Iso20022Validator`, restructures validation to go through an already-hardened DOM parse instead of feeding raw bytes to `SchemaFactory`/`Validator` directly.

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for open CodeQL findings that survived a prior attempted fix.

## Changes
- `Iso20022Validator.validate()`: parses with the hardened `DocumentBuilderFactory` first, then validates the resulting DOM tree via `DOMSource` — the `Validator` never sees raw untrusted bytes directly.
- All three files: added the full OWASP XML Entity Prevention Cheat Sheet checklist (`external-general-entities`, `external-parameter-entities`, `nonvalidating/load-external-dtd`, XInclude, entity-reference-expansion) on top of the existing `disallow-doctype-decl` + `ACCESS_EXTERNAL_*`.

## Definition of Done
- [x] Unit tests pass (existing `Pacs008ReaderTest`/`Pacs004ReaderTest` unmodified).
- [x] `./gradlew :openbank-libs-domain:compileKotlin :openbank-libs-domain:test :openbank-libs-domain:detekt :openbank-libs-domain:ktlintCheck` passes locally.
- [x] No new lint warnings.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency (JDK-only JAXP).

## Compliance impact
- [x] None (parser hardening + validation-path restructure only, no schema/behavior change)

## Rollout / Rollback
- Deployment strategy: rolling (standard release via release-please).
- Rollback plan: revert this PR.
- Data migration reversible: N/A

## Reviewer notes

Will verify against a real CodeQL scan on this PR before considering it actually resolved — #99 wasn't verified this way and the alerts didn't actually close.