### PR TITLE
security(ci): restore restrictive top-level permissions default (take 2)

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -53,6 +53,11 @@ on:
         required: false
         default: "manual"
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block); the build-push job below declares its own override for the access it needs.
+permissions:
+  contents: read
+
 concurrency:
   # One admin-ui deploy at a time — a second push while a deploy PR is open would
   # produce conflicting image tags. Cancel the in-flight run; the newer commit wins.

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: ""
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block); each job below declares its own override for the access it needs.
+permissions:
+  contents: read
+
 concurrency:
   # One deploy pipeline at a time — a second push while a deploy PR is open would
   # update the same gitops lines, causing a merge conflict. Cancel the in-flight run

--- a/.github/workflows/backfill-release-evidence.yml
+++ b/.github/workflows/backfill-release-evidence.yml
@@ -19,6 +19,11 @@ on:
         required: true
         type: string
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block); the backfill job below declares its own override for the write access it needs.
+permissions:
+  contents: read
+
 jobs:
   backfill:
     name: Backfill ${{ inputs.tag }}

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: 'false'
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block); the prune job below declares its own override for the write access it needs.
+permissions:
+  contents: read
+
 jobs:
   prune-stale-branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,6 +21,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block); the auto-merge job below declares its own override for the write access it needs.
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     name: Auto-merge patch/minor Dependabot PRs

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: "openbank-ledger-service openbank-balance-service openbank-account-service openbank-transaction-service openbank-fx-service"
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block); the pitest job below already declares contents: read too, belt-and-suspenders.
+permissions:
+  contents: read
+
 jobs:
   pitest:
     name: pitest / ${{ matrix.service }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,13 @@ on:
   push:
     branches: [main]
 
+# Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
+# block, not just job-level grants — otherwise a job without its own override would fall
+# back to the repo's default token permissions, which this workflow can't see/control).
+# Jobs below that need more (contents/pull-requests write) declare their own override.
+permissions:
+  contents: read
+
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
PR #106 removed workflow-level `permissions:` entirely in favor of job-level scoping, which triggered a new Scorecard finding: "no topLevel permission defined" (#276-280). Restores a minimal top-level `permissions: contents: read` default on 7 files, keeping the job-level overrides from #106 unchanged.

## Type of change
- [x] security (private until disclosed)

## Linked issues
N/A — direct fix for open Scorecard findings.

## Changes
Added `permissions: { contents: read }` at the workflow level on: `release-please.yml`, `dependabot-auto-merge.yml`, `branch-cleanup.yml`, `backfill-release-evidence.yml`, `auto-deploy.yml`, `admin-ui-deploy.yml`, `pitest.yml`. Jobs that need write access keep their existing job-level override from #106.

## Definition of Done
- [x] All changed files validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [x] No behavior change — purely adds a top-level restriction that jobs already override where needed.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact
- [x] None

## Rollout / Rollback
- Deployment strategy: n/a (CI config only).
- Rollback plan: revert this PR.
- Data migration reversible: N/A