### PR TITLE
chore(gitops): auto-deploy services @ fc2f02622497fc15403dacab542765ec19629290

### DIFF
--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sca-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sca-service:sandbox-3838f2f3
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sca-service:sandbox-fc2f0262
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit fc2f02622497fc15403dacab542765ec19629290.

**Changed services:** ["openbank-sca-service"]

Each image tag was updated to `sandbox-fc2f02622497fc15403dacab542765ec19629290` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.