### PR TITLE
fix(security): pin remaining unpinned dependencies fleet-wide (Scorecard)

### DIFF
--- a/.github/workflows/Dockerfile.deploy
+++ b/.github/workflows/Dockerfile.deploy
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank

--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -71,6 +71,11 @@ jobs:
         run: |
           set -euo pipefail
           # Pinned: v3 CLI flags are load-bearing below (v4 renamed them).
+          # Not hash-pinned (Scorecard Pinned-Dependencies: pipCommand, accepted gap):
+          # schemathesis carries ~20 direct + a much larger transitive dependency tree,
+          # so `pip install --require-hashes` would need a maintained full lockfile
+          # (pip-tools/poetry), not a hand-written --hash list — unlike pyyaml/yamllint
+          # elsewhere in this fleet, which are dependency-free leaf packages.
           python3 -m pip install --user --quiet "schemathesis==3.39.16"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -383,9 +383,11 @@ jobs:
             echo "Using pre-baked trivy: $(trivy --version 2>/dev/null | head -1)"; exit 0
           fi
           # Pinned to the v0.63.0 tag (not `main`) so the installer script itself is
-          # immutable, matching the trivy version it installs.
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.63.0/contrib/install.sh \
-            | sh -s -- -b /usr/local/bin v0.63.0
+          # immutable, matching the trivy version it installs. Hash-verified before
+          # execution (OpenSSF Scorecard Pinned-Dependencies: downloadThenRun).
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/v0.63.0/contrib/install.sh -o /tmp/trivy-install.sh
+          echo "2304dcc0c1883e802d376eae1b514c923b7427a7d88091dfcaf83967e6f55a7c  /tmp/trivy-install.sh" | sha256sum -c -
+          sh /tmp/trivy-install.sh -b /usr/local/bin v0.63.0
 
       - name: Prune Docker build cache before scan
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,69 @@ jobs:
       # (pip/pip3 not in PATH). Fall back to checking if pyyaml is already present.
       - name: gen-network-policies drift gate (ADR-0081, issue #854)
         run: |
-          python3 -m pip install --quiet "pyyaml==6.0.2" --break-system-packages 2>/dev/null \
-            || python3 -m pip install --quiet "pyyaml==6.0.2" 2>/dev/null \
-            || pip3 install --quiet "pyyaml==6.0.2" --break-system-packages 2>/dev/null \
-            || pip3 install --quiet "pyyaml==6.0.2" 2>/dev/null \
+          # Hash-pinned (OpenSSF Scorecard Pinned-Dependencies: pipCommand). pyyaml has no
+          # runtime deps, so a full wheel+sdist hash set is tractable and covers every
+          # platform in the mixed macOS/Linux openbank-build pool.
+          cat > /tmp/pyyaml-requirements.txt <<'REQEOF'
+          pyyaml==6.0.2 \
+              --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
+              --hash=sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf \
+              --hash=sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237 \
+              --hash=sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b \
+              --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+              --hash=sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180 \
+              --hash=sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68 \
+              --hash=sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99 \
+              --hash=sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e \
+              --hash=sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774 \
+              --hash=sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee \
+              --hash=sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c \
+              --hash=sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317 \
+              --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+              --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4 \
+              --hash=sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e \
+              --hash=sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5 \
+              --hash=sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44 \
+              --hash=sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab \
+              --hash=sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725 \
+              --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5 \
+              --hash=sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425 \
+              --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+              --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
+              --hash=sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b \
+              --hash=sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4 \
+              --hash=sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8 \
+              --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
+              --hash=sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1 \
+              --hash=sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133 \
+              --hash=sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484 \
+              --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
+              --hash=sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc \
+              --hash=sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652 \
+              --hash=sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183 \
+              --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
+              --hash=sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a \
+              --hash=sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5 \
+              --hash=sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d \
+              --hash=sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083 \
+              --hash=sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706 \
+              --hash=sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a \
+              --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
+              --hash=sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d \
+              --hash=sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f \
+              --hash=sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290 \
+              --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
+              --hash=sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19 \
+              --hash=sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e \
+              --hash=sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725 \
+              --hash=sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631 \
+              --hash=sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8 \
+              --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+          REQEOF
+          python3 -m pip install --quiet --require-hashes -r /tmp/pyyaml-requirements.txt --break-system-packages 2>/dev/null \
+            || python3 -m pip install --quiet --require-hashes -r /tmp/pyyaml-requirements.txt 2>/dev/null \
+            || pip3 install --quiet --require-hashes -r /tmp/pyyaml-requirements.txt --break-system-packages 2>/dev/null \
+            || pip3 install --quiet --require-hashes -r /tmp/pyyaml-requirements.txt 2>/dev/null \
             || python3 -c "import yaml" 2>/dev/null \
             || { echo "::error::pyyaml unavailable — add it to the runner base image"; exit 1; }
           python3 openbank-infra/scripts/gen-network-policies.py

--- a/Dockerfile.scanner
+++ b/Dockerfile.scanner
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank

--- a/openbank-infra/aws/modules/runner/user-data.sh.tftpl
+++ b/openbank-infra/aws/modules/runner/user-data.sh.tftpl
@@ -49,7 +49,72 @@ docker compose version
 #                 GitHub-hosted ubuntu once the repo is public).
 # ---------------------------------------------------------------------------
 dnf -y install python3-pip xz
-pip3 install --quiet yamllint
+# Pinned + hash-verified (OpenSSF Scorecard Pinned-Dependencies: pipCommand), including
+# yamllint's own transitive deps (pathspec, pyyaml) since --require-hashes mode needs
+# every resolved package pinned, not just the top-level one.
+cat > /tmp/yamllint-requirements.txt <<'EOF'
+yamllint==1.35.1 \
+    --hash=sha256:2e16e504bb129ff515b37823b472750b36b6de07963bd74b307341ef5ad8bdc3 \
+    --hash=sha256:7a003809f88324fd2c877734f2d575ee7881dd9043360657cc8049c809eba6cd
+pathspec==1.1.1 \
+    --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189 \
+    --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a
+pyyaml==6.0.2 \
+    --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 \
+    --hash=sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf \
+    --hash=sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237 \
+    --hash=sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b \
+    --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed \
+    --hash=sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180 \
+    --hash=sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68 \
+    --hash=sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99 \
+    --hash=sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e \
+    --hash=sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774 \
+    --hash=sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee \
+    --hash=sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c \
+    --hash=sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317 \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4 \
+    --hash=sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e \
+    --hash=sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5 \
+    --hash=sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44 \
+    --hash=sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab \
+    --hash=sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725 \
+    --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5 \
+    --hash=sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 \
+    --hash=sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b \
+    --hash=sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4 \
+    --hash=sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8 \
+    --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba \
+    --hash=sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1 \
+    --hash=sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133 \
+    --hash=sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484 \
+    --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 \
+    --hash=sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc \
+    --hash=sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652 \
+    --hash=sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183 \
+    --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
+    --hash=sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a \
+    --hash=sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5 \
+    --hash=sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d \
+    --hash=sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083 \
+    --hash=sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706 \
+    --hash=sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a \
+    --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff \
+    --hash=sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d \
+    --hash=sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f \
+    --hash=sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290 \
+    --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
+    --hash=sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19 \
+    --hash=sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e \
+    --hash=sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725 \
+    --hash=sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631 \
+    --hash=sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+EOF
+pip3 install --quiet --require-hashes -r /tmp/yamllint-requirements.txt
 
 GITLEAKS_VERSION="$(curl -fsSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r '.tag_name' | sed 's/^v//')"
 curl -fsSL -o /tmp/gitleaks.tar.gz \
@@ -71,9 +136,12 @@ shellcheck --version
 
 # Trivy: container/filesystem vuln scanning AND SBOM generation (the security
 # workflow runs `trivy fs` and emits a CycloneDX SBOM, so this one binary covers
-# both the Trivy and SBOM jobs). Official install script auto-detects the arch.
-curl -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-  | sh -s -- -b /usr/local/bin
+# both the Trivy and SBOM jobs). Pinned to the v0.63.0 tag (not `main`, matching
+# auto-deploy.yml's Install Trivy step) and hash-verified before execution
+# (OpenSSF Scorecard Pinned-Dependencies: downloadThenRun).
+curl -fsSL https://raw.githubusercontent.com/aquasecurity/trivy/v0.63.0/contrib/install.sh -o /tmp/trivy-install.sh
+echo "2304dcc0c1883e802d376eae1b514c923b7427a7d88091dfcaf83967e6f55a7c  /tmp/trivy-install.sh" | sha256sum -c -
+sh /tmp/trivy-install.sh -b /usr/local/bin
 trivy --version
 
 id -u "$RUNNER_USER" &>/dev/null || useradd -m -s /bin/bash "$RUNNER_USER"

--- a/openbank-infra/docker/keycloak/Dockerfile
+++ b/openbank-infra/docker/keycloak/Dockerfile
@@ -27,7 +27,7 @@
 
 ARG KEYCLOAK_VERSION=26.6.3
 
-FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} AS builder
+FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}@sha256:9b0330756022422149aa6502eb2def8cd47c6e1b000c7c65cdb13e7c0133e992 AS builder
 ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
@@ -35,7 +35,7 @@ ENV KC_CACHE=local
 ENV KC_FEATURES=token-exchange,admin-fine-grained-authz:v1
 RUN /opt/keycloak/bin/kc.sh build
 
-FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
+FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}@sha256:9b0330756022422149aa6502eb2def8cd47c6e1b000c7c65cdb13e7c0133e992
 # The augmented server (and its baked persisted-config) is the whole /opt/keycloak
 # tree — copy it wholesale, the approach Keycloak's own optimized-image docs use.
 COPY --from=builder /opt/keycloak/ /opt/keycloak/

--- a/openbank-infra/docker/kong/Dockerfile
+++ b/openbank-infra/docker/kong/Dockerfile
@@ -1,4 +1,4 @@
-FROM kong:3.9.3
+FROM kong:3.9.3@sha256:62721edc9669e2a96fe9d188ab8950b9105e69abb033129624a72d3e10da6777
 
 COPY docker/kong/kong.yml /etc/kong/kong.yml
 USER kong

--- a/openbank-infra/docker/pyroscope-agent/Dockerfile
+++ b/openbank-infra/docker/pyroscope-agent/Dockerfile
@@ -16,7 +16,7 @@
 #   openbank-infra/scripts/build-push-pyroscope-agent.sh
 
 # ── Stage 1: fetch + verify the pinned agent jar (build-time only) ────────────
-FROM alpine:3.24 AS fetch
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS fetch
 ARG PYROSCOPE_VERSION=2.5.4
 ARG PYROSCOPE_SHA256=ea53924454a65af9ecd3c683350b113c397eace7a35f2c165e129a312db2e0ad
 RUN apk add --no-cache curl \
@@ -27,7 +27,7 @@ RUN apk add --no-cache curl \
 # ── Stage 2: minimal carrier. The init container runs `cp` out of this image ──
 # busybox provides /bin/cp; the jar is arch-agnostic (async-profiler natives for
 # both linux-x86-64 and linux-arm64 are bundled and self-extract at attach time).
-FROM busybox:1.38
+FROM busybox:1.38@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
 COPY --from=fetch /pyroscope.jar /pyroscope.jar
 # Documented, no entrypoint needed: the init container overrides command with
 #   ["/bin/cp", "/pyroscope.jar", "/opt/pyroscope/pyroscope.jar"]

--- a/openbank-infra/docker/services/root-service.Dockerfile
+++ b/openbank-infra/docker/services/root-service.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:20-jdk AS build
+FROM eclipse-temurin:20-jdk@sha256:a8010918241007417c8c0ce7d203cf110f8c945b56da01a13eb55af7eb3d3175 AS build
 ARG SERVICE_DIR
 
 WORKDIR /workspace
@@ -17,7 +17,7 @@ RUN chmod +x gradlew && \
     done; \
     exit 1
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-alpine@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
 WORKDIR /app
 
 RUN addgroup -S openbank && adduser -S openbank -G openbank

--- a/openbank-infra/docker/services/standalone-service.Dockerfile
+++ b/openbank-infra/docker/services/standalone-service.Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jdk AS build
+FROM eclipse-temurin:25-jdk@sha256:68868d04fa9cfd5f5c6abec0b5cef86d8de2bf9c62c37c7d3e4f0f80f5cfd7ff AS build
 ARG SERVICE_DIR
 
 WORKDIR /workspace
@@ -24,7 +24,7 @@ RUN chmod +x gradlew && \
       --console=plain && \
     cp /workspace/${SERVICE_DIR}/build/*-runner.jar /workspace/quarkus-run.jar
 
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 
 RUN addgroup -S openbank && adduser -S openbank -G openbank

--- a/openbank-notification-service/Dockerfile.runtime
+++ b/openbank-notification-service/Dockerfile.runtime
@@ -10,7 +10,7 @@
 # (which `include(...)`s every service) and breaks under Gradle 9.5.1, which no
 # longer tolerates configuring an absent project dir. Fixing that for in-Docker
 # builds is a separate follow-up; this runtime image unblocks the pilot now.
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 # Explicit numeric UID/GID so a pod with runAsNonRoot can verify non-root without
 # a runAsUser override (kubelet cannot resolve a named user from the image).


### PR DESCRIPTION
## Summary
- Pins 8 Docker `FROM` images (eclipse-temurin, alpine, busybox, kong, keycloak) to the exact `@sha256:` digest reported by Scorecard's own remediation tip.
- Hash-verifies both `curl | sh` Trivy installer downloads before execution (`auto-deploy.yml`, `user-data.sh.tftpl`), and fixes `user-data.sh.tftpl`'s installer to pin the `v0.63.0` tag instead of `main`.
- Hash-locks `pyyaml` (ci.yml, 4 fallback invocations) and `yamllint` + its `pathspec`/`pyyaml` deps (`user-data.sh.tftpl`) via `pip install --require-hashes` — verified locally end-to-end in a throwaway venv.
- Leaves `schemathesis` (api-fuzz.yml) unpinned with a documented rationale: it has a ~60-entry transitive dependency tree, so hash-pinning it by hand isn't tractable without adopting a real lockfile tool (pip-tools/poetry) — unlike pyyaml/yamllint, which are small enough to enumerate.

Closes the remaining 21 open `PinnedDependenciesID` code-scanning alerts from the fleet audit (the earlier sweep in #102/#103 covered 37 Dockerfiles + GH Actions but missed these).

## Test plan
- [x] YAML syntax validated for all 3 edited workflow files (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `pip install --require-hashes` for both the pyyaml and the yamllint+pathspec+pyyaml requirement sets verified in a fresh throwaway venv — installs succeed
- [x] Docker digests taken directly from Scorecard's own remediation tips (not independently resolved) to guarantee an exact match
- [ ] CI (path-scoped build/lint) green on this PR
- [ ] Manual Scorecard re-run after merge to confirm alerts flip to `fixed` (Scorecard only scans on schedule/dispatch, not per-push)

Linked issues: N/A — direct alert remediation, no tracking issue opened for this tail sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)