### PR TITLE
fix(security): pin openbank-security-scanner Dockerfile.prebuilt base image digest

### DIFF
--- a/openbank-security-scanner/Dockerfile.prebuilt
+++ b/openbank-security-scanner/Dockerfile.prebuilt
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
 WORKDIR /app
 RUN addgroup -S openbank && adduser -S openbank -G openbank
 USER openbank


### PR DESCRIPTION
## Summary
- Closes the last unfixed `PinnedDependenciesID` alert (#212): `openbank-security-scanner/Dockerfile.prebuilt` FROM eclipse-temurin:25-jre-alpine, missed in #190 because it's a distinct file from the already-pinned repo-root `Dockerfile.scanner`.

## Test plan
- [x] Digest matches the already-verified `eclipse-temurin:25-jre-alpine` pin used in 3 other files in #190
- [ ] CI green

Linked issues: N/A — direct alert remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)