### PR TITLE
fix(libs-domain): carry interbank settlement date through to pacs.008 (IntrBkSttlmDt)

### DIFF
--- a/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/ClearingSimulatorApiIT.kt
+++ b/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/ClearingSimulatorApiIT.kt
@@ -31,6 +31,7 @@ class ClearingSimulatorApiIT {
         CreditTransferInstruction(
             messageId = "OB-MSG-0001",
             creationDateTime = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
+            interbankSettlementDate = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
             endToEndId = "E2E-0001",
             transactionId = "TX-0001",
             amount = BigDecimal(amount),

--- a/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/ClearingSimulatorServiceTest.kt
+++ b/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/ClearingSimulatorServiceTest.kt
@@ -28,6 +28,7 @@ class ClearingSimulatorServiceTest {
         CreditTransferInstruction(
             messageId = "OB-MSG-0001",
             creationDateTime = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
+            interbankSettlementDate = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
             endToEndId = "E2E-0001",
             transactionId = "TX-0001",
             amount = BigDecimal(amount),

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/SchemeGatewayAdapter.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/infrastructure/client/SchemeGatewayAdapter.kt
@@ -91,23 +91,29 @@ class SchemeGatewayAdapter(
         debtorIban: String,
         creditorIban: String,
         creditorAgentBic: String,
-    ) = CreditTransferInstruction(
-        messageId = "DOM-${payment.endToEndId}".take(MAX_35),
-        creationDateTime = OffsetDateTime.now(ZoneOffset.UTC),
-        endToEndId = payment.endToEndId,
-        transactionId = null,
-        amount = payment.amount,
-        currency = payment.currency,
-        chargeBearer = ChargeBearer.SLEV,
-        settlementMethod = SettlementMethod.CLRG,
-        debtorName = payment.debtorName,
-        debtorIban = debtorIban,
-        debtorAgentBic = "$ownBankBic",
-        creditorAgentBic = creditorAgentBic,
-        creditorName = payment.creditorName,
-        creditorIban = creditorIban,
-        remittanceInfo = buildRemittanceInfo(payment),
-    )
+    ): CreditTransferInstruction {
+        // Domestic transfers settle same-day via the clearing system (SttlmMtd CLRG) — there
+        // is no scheme-supplied value date to carry, unlike SWIFT MT103's field 32A.
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        return CreditTransferInstruction(
+            messageId = "DOM-${payment.endToEndId}".take(MAX_35),
+            creationDateTime = now,
+            interbankSettlementDate = now,
+            endToEndId = payment.endToEndId,
+            transactionId = null,
+            amount = payment.amount,
+            currency = payment.currency,
+            chargeBearer = ChargeBearer.SLEV,
+            settlementMethod = SettlementMethod.CLRG,
+            debtorName = payment.debtorName,
+            debtorIban = debtorIban,
+            debtorAgentBic = "$ownBankBic",
+            creditorAgentBic = creditorAgentBic,
+            creditorName = payment.creditorName,
+            creditorIban = creditorIban,
+            remittanceInfo = buildRemittanceInfo(payment),
+        )
+    }
 
     private fun buildRemittanceInfo(payment: DomesticPayment): String? {
         val parts = listOfNotNull(

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs008Builder.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/iso20022/Pacs008Builder.kt
@@ -12,13 +12,17 @@ import java.time.format.DateTimeFormatter
 /**
  * A single FI-to-FI customer credit transfer instruction, in scheme-neutral domain terms.
  *
- * This is the rail's input to [Pacs008Builder]; it carries exactly the fields the SEPA SCT
- * pilot populates (ADR-0104). Amount is a [BigDecimal] in major units (e.g. `12.34` EUR);
- * the builder renders it with the scheme's decimal rules. Agents are BICs; accounts are IBANs.
+ * This is the rail's input to [Pacs008Builder]. Amount is a [BigDecimal] in major units
+ * (e.g. `12.34` EUR); the builder renders it with the scheme's decimal rules. Agents are
+ * BICs; accounts are IBANs. [interbankSettlementDate] maps to `IntrBkSttlmDt`: same-day for
+ * clearing-settled rails (SEPA/domestic, which have no explicit value date of their own —
+ * pass `creationDateTime`'s date), or the scheme-supplied value date for rails that carry one
+ * (e.g. SWIFT MT103 field 32A).
  */
 data class CreditTransferInstruction(
     val messageId: String,
     val creationDateTime: OffsetDateTime,
+    val interbankSettlementDate: OffsetDateTime,
     val endToEndId: String,
     val transactionId: String?,
     val amount: BigDecimal,
@@ -79,6 +83,7 @@ class Pacs008Builder {
         i.transactionId?.let { doc.text(pmtId, "TxId", it) }
 
         doc.text(tx, "IntrBkSttlmAmt", i.amount.toPlainString()).setAttribute("Ccy", i.currency)
+        doc.text(tx, "IntrBkSttlmDt", i.interbankSettlementDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
         doc.text(tx, "ChrgBr", i.chargeBearer.name)
 
         doc.child(tx, "Dbtr").also { doc.text(it, "Nm", i.debtorName) }

--- a/openbank-libs-domain/src/main/resources/iso20022/schemas/pacs.008.001.08.xsd
+++ b/openbank-libs-domain/src/main/resources/iso20022/schemas/pacs.008.001.08.xsd
@@ -60,6 +60,7 @@
     <xs:sequence>
       <xs:element name="PmtId" type="PaymentIdentification7"/>
       <xs:element name="IntrBkSttlmAmt" type="ActiveCurrencyAndAmount"/>
+      <xs:element name="IntrBkSttlmDt" type="ISODate"/>
       <xs:element name="ChrgBr" type="ChargeBearerType1Code"/>
       <xs:element name="Dbtr" type="PartyIdentification135"/>
       <xs:element name="DbtrAcct" type="CashAccount38"/>
@@ -152,6 +153,10 @@
 
   <xs:simpleType name="ISODateTime">
     <xs:restriction base="xs:dateTime"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="ISODate">
+    <xs:restriction base="xs:date"/>
   </xs:simpleType>
 
   <xs:simpleType name="ActiveCurrencyCode">

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/iso20022/Pacs008BuilderTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/iso20022/Pacs008BuilderTest.kt
@@ -25,6 +25,7 @@ class Pacs008BuilderTest {
     ) = CreditTransferInstruction(
         messageId = "OB-MSG-0001",
         creationDateTime = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
+        interbankSettlementDate = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
         endToEndId = "E2E-0001",
         transactionId = "TX-0001",
         amount = amount,
@@ -49,6 +50,7 @@ class Pacs008BuilderTest {
         assertThat(xml).contains("<EndToEndId>E2E-0001</EndToEndId>")
         assertThat(xml).contains("Ccy=\"EUR\"")
         assertThat(xml).contains(">12.34<")
+        assertThat(xml).contains("<IntrBkSttlmDt>2026-06-22</IntrBkSttlmDt>")
         assertThat(xml).contains("<BICFI>COBADEFFXXX</BICFI>")
         assertThat(xml).contains("<IBAN>FR1420041010050500013M02606</IBAN>")
         assertThat(xml).contains("<Ustrd>Invoice 2026-0042</Ustrd>")

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/iso20022/Pacs008ReaderTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/iso20022/Pacs008ReaderTest.kt
@@ -18,6 +18,7 @@ class Pacs008ReaderTest {
     private val instruction = CreditTransferInstruction(
         messageId = "OB-MSG-0001",
         creationDateTime = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
+        interbankSettlementDate = OffsetDateTime.of(2026, 6, 22, 10, 15, 30, 0, ZoneOffset.UTC),
         endToEndId = "E2E-0001",
         transactionId = "TX-0001",
         amount = BigDecimal("12.34"),

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/application/usecase/ScaServiceTest.kt
@@ -89,7 +89,6 @@ class ScaServiceTest {
     @Test
     fun `initiate creates challenge with PUSH_NOTIFICATION as default method`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
-        val savedChallenge = challenge(partyId = partyId, method = ScaMethod.PUSH_NOTIFICATION)
 
         coEvery { idempotencyStore.get(any()) } returns null
         coEvery { repository.save(any()) } answers { firstArg() }

--- a/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/application/SecurityScannerService.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/application/SecurityScannerService.kt
@@ -59,14 +59,16 @@ class SecurityScannerService(private val clock: Clock) {
         val findings = mutableListOf<SecurityFinding>()
         val mgmt = mgmtUrl(url)
 
-        // 1. Reachability check — tries management port first, falls back to API port
-        val (reachable, responseHeaders) = try {
+        // 1. Reachability check — tries management port first, falls back to API port.
+        // (Security headers are checked separately in step 2, against the API port —
+        // this response's headers are not used.)
+        val reachable = try {
             val req = HttpRequest.newBuilder(URI.create("$mgmt/q/health"))
                 .GET().timeout(Duration.ofSeconds(5)).build()
             val resp = http.send(req, HttpResponse.BodyHandlers.ofString())
-            Pair(resp.statusCode() in 200..599, resp.headers().map())
+            resp.statusCode() in 200..599
         } catch (e: Exception) {
-            Pair(false, emptyMap<String, List<String>>())
+            false
         }
 
         if (!reachable) {

--- a/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/client/SchemeGatewayAdapter.kt
+++ b/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/client/SchemeGatewayAdapter.kt
@@ -67,23 +67,29 @@ class SchemeGatewayAdapter(
             .onFailure().transform { SchemeGatewayUnavailableException(it) }
     }
 
-    private fun instruction(payment: SctInstPayment, creditorAgentBic: String) = CreditTransferInstruction(
-        messageId = "MSG-${payment.endToEndId}".take(MAX_35),
-        creationDateTime = OffsetDateTime.now(ZoneOffset.UTC),
-        endToEndId = payment.endToEndId,
-        transactionId = null,
-        amount = payment.amount,
-        currency = payment.currency,
-        chargeBearer = ChargeBearer.SLEV,
-        settlementMethod = SettlementMethod.CLRG,
-        debtorName = payment.debtorName,
-        debtorIban = payment.debtorIban,
-        debtorAgentBic = ownBankBic,
-        creditorAgentBic = creditorAgentBic,
-        creditorName = payment.creditorName,
-        creditorIban = payment.creditorIban,
-        remittanceInfo = payment.remittanceInfo,
-    )
+    private fun instruction(payment: SctInstPayment, creditorAgentBic: String): CreditTransferInstruction {
+        // SEPA Instant settles same-day via the clearing system (SttlmMtd CLRG) — there is no
+        // scheme-supplied value date to carry, unlike SWIFT MT103's field 32A.
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        return CreditTransferInstruction(
+            messageId = "MSG-${payment.endToEndId}".take(MAX_35),
+            creationDateTime = now,
+            interbankSettlementDate = now,
+            endToEndId = payment.endToEndId,
+            transactionId = null,
+            amount = payment.amount,
+            currency = payment.currency,
+            chargeBearer = ChargeBearer.SLEV,
+            settlementMethod = SettlementMethod.CLRG,
+            debtorName = payment.debtorName,
+            debtorIban = payment.debtorIban,
+            debtorAgentBic = ownBankBic,
+            creditorAgentBic = creditorAgentBic,
+            creditorName = payment.creditorName,
+            creditorIban = payment.creditorIban,
+            remittanceInfo = payment.remittanceInfo,
+        )
+    }
 
     private companion object {
         const val MAX_35 = 35

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/SchemeGatewayAdapter.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/SchemeGatewayAdapter.kt
@@ -101,24 +101,30 @@ class SchemeGatewayAdapter(
         return client.submitCreditTransfer("Bearer $token", pacs008Xml).awaitSuspending()
     }
 
-    private fun instruction(payment: SepaPayment, creditorAgentBic: String) = CreditTransferInstruction(
-        messageId = "MSG-${payment.endToEndId}".take(MAX_35),
-        creationDateTime = OffsetDateTime.now(ZoneOffset.UTC),
-        endToEndId = payment.endToEndId,
-        transactionId = null,
-        amount = payment.amount,
-        currency = payment.currency,
-        // SEPA SCT rulebook: charges shared at service level, settled via the clearing system.
-        chargeBearer = ChargeBearer.SLEV,
-        settlementMethod = SettlementMethod.CLRG,
-        debtorName = payment.debtorName,
-        debtorIban = payment.debtorIban,
-        debtorAgentBic = ownBankBic,
-        creditorAgentBic = creditorAgentBic,
-        creditorName = payment.creditorName,
-        creditorIban = payment.creditorIban,
-        remittanceInfo = payment.remittanceInfo,
-    )
+    private fun instruction(payment: SepaPayment, creditorAgentBic: String): CreditTransferInstruction {
+        // SEPA Credit Transfer settles same-day via the clearing system (SttlmMtd CLRG) — there
+        // is no scheme-supplied value date to carry, unlike SWIFT MT103's field 32A.
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        return CreditTransferInstruction(
+            messageId = "MSG-${payment.endToEndId}".take(MAX_35),
+            creationDateTime = now,
+            interbankSettlementDate = now,
+            endToEndId = payment.endToEndId,
+            transactionId = null,
+            amount = payment.amount,
+            currency = payment.currency,
+            // SEPA SCT rulebook: charges shared at service level, settled via the clearing system.
+            chargeBearer = ChargeBearer.SLEV,
+            settlementMethod = SettlementMethod.CLRG,
+            debtorName = payment.debtorName,
+            debtorIban = payment.debtorIban,
+            debtorAgentBic = ownBankBic,
+            creditorAgentBic = creditorAgentBic,
+            creditorName = payment.creditorName,
+            creditorIban = payment.creditorIban,
+            remittanceInfo = payment.remittanceInfo,
+        )
+    }
 
     private companion object {
         const val MAX_35 = 35

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/client/SchemeGatewayAdapter.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/client/SchemeGatewayAdapter.kt
@@ -98,6 +98,7 @@ class SchemeGatewayAdapter(@RestClient private val client: ClearingSimulatorClie
         return CreditTransferInstruction(
             messageId = "SWIFT-${msg.transactionReference}".take(MAX_35),
             creationDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+            interbankSettlementDate = valueDate,
             endToEndId = msg.transactionReference.take(MAX_35),
             transactionId = null,
             amount = BigDecimal.valueOf(msg.amountMinorUnits).movePointLeft(2),


### PR DESCRIPTION
## Summary

**Root cause (CodeQL `java/local-variable-is-never-read`, note-severity triage):**
`openbank-swift-service`'s `SchemeGatewayAdapter` parses the MT103 value date (field 32A) into a local `valueDate`, but never passes it anywhere. `CreditTransferInstruction` (the shared domain model in `openbank-libs-domain`, used by every FI-to-FI rail) had no field for it at all, so `Pacs008Builder` never emitted `IntrBkSttlmDt` (Interbank Settlement Date) in any outbound pacs.008 message — SWIFT, SEPA Instant, SEPA Credit Transfer, or domestic.

**Fix:**
- `CreditTransferInstruction`: add `interbankSettlementDate: OffsetDateTime`.
- `Pacs008Builder`: emit `<IntrBkSttlmDt>` right after `<IntrBkSttlmAmt>` (matches the real pacs.008.001.08 element order).
- SWIFT `SchemeGatewayAdapter`: wire the already-parsed `valueDate` through — this is the actual bug fix.
- SEPA-instant / SEPA-payment / domestic-payment `SchemeGatewayAdapter`s: these rails settle same-day via clearing and have no scheme-supplied value date input, so they default `interbankSettlementDate` to `creationDateTime`'s date (same behavior as today, just now explicit in the message).
- Vendored `pacs.008.001.08.xsd` (ADR-0104 D1 — a deliberately reduced subset modeling only the fields the rail populates): added `IntrBkSttlmDt` to `CreditTransferTransaction39` + a new `ISODate` simpleType, since the rail's own pre-submission XSD validation would otherwise reject the field it now emits.
- Updated test fixtures for the new required field; added an XML-content assertion for `IntrBkSttlmDt` in `Pacs008BuilderTest`.

Bundled in the same triage pass (both `java/local-variable-is-never-read`, unrelated to the above, low-risk):
- `ScaServiceTest`: removed an unused `savedChallenge` local (test-only, dead since the mock stubs never referenced it).
- `SecurityScannerService`: removed a dead destructured `responseHeaders` from the reachability check — the actual OWASP security-headers check (step 2) already fetches its own headers from the API port independently.

Closes the 3 real (non-false-positive) `java/local-variable-is-never-read` code-scanning alerts (#84, #86, #87).

## Test plan
- [x] `compileKotlin`/`compileTestKotlin` green on all 9 touched modules (libs-domain, swift-service, sepa-instant, sepa-payment, domestic-payment, sca-service, security-scanner, clearing-simulator)
- [x] `Pacs008BuilderTest` (incl. XSD validation against the extended vendored schema) — green after extending the schema
- [x] `Pacs008ReaderTest`, `ClearingSimulatorServiceTest`, `ScaServiceTest` — green
- [x] `ktlintCheck` green on all touched modules
- [ ] CI

## ⚠️ Not merging — needs explicit approval
`openbank-swift-service`, `openbank-sepa-instant`, `openbank-sepa-payment`, and `openbank-domestic-payment` are all `money_path_services` (2 approvals required per `rules.yaml`). This PR is left open for review rather than admin-merged.

Linked issues: N/A — direct code-scanning alert remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)