### PR TITLE
chore(repo): add devcontainer, CITATION.cff, SUPPORT.md, live README badges

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "OpenBank",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "25",
+      "jdkDistro": "tem"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
+  "postCreateCommand": "./gradlew --version",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "fwcd.kotlin",
+        "vscjava.vscode-gradle",
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "TESTCONTAINERS_RYUK_DISABLED": "false"
+  }
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: "If you use this software or reference its architecture, please cite it as below."
+title: "OpenBank — open-source retail banking platform reference implementation"
+type: software
+authors:
+  - family-names: "Raška"
+    given-names: "Jiří"
+repository-code: "https://github.com/JiRaska/open-bank-oss"
+url: "https://open-bank.tech/"
+license: Apache-2.0
+keywords:
+  - banking
+  - fintech
+  - open-banking
+  - psd2
+  - kotlin
+  - quarkus
+  - microservices
+  - hexagonal-architecture
+  - event-driven
+abstract: >-
+  Cloud-native, open-source retail banking platform reference implementation:
+  Kotlin/Quarkus event-driven microservices with a double-entry ledger,
+  ISO 20022 payment rails, machine-enforced governance, supply-chain
+  security, and AI-agent operations baked in as code.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 > Cloud-native, open-source retail banking platform built on Kotlin + Quarkus, Next.js, and event-driven microservices — with governance, supply-chain security, and AI-agent operations baked in as code.
 
+[![Services CI](https://github.com/JiRaska/open-bank-oss/actions/workflows/services-ci.yml/badge.svg)](https://github.com/JiRaska/open-bank-oss/actions/workflows/services-ci.yml)
+[![CI](https://github.com/JiRaska/open-bank-oss/actions/workflows/ci.yml/badge.svg)](https://github.com/JiRaska/open-bank-oss/actions/workflows/ci.yml)
+[![Security scan](https://github.com/JiRaska/open-bank-oss/actions/workflows/security.yml/badge.svg)](https://github.com/JiRaska/open-bank-oss/actions/workflows/security.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/JiRaska/open-bank-oss/badge)](https://scorecard.dev/viewer/?uri=github.com/JiRaska/open-bank-oss)
+[![codecov](https://codecov.io/gh/JiRaska/open-bank-oss/graph/badge.svg)](https://codecov.io/gh/JiRaska/open-bank-oss)
+[![Open in GitHub Codespaces](https://img.shields.io/badge/Codespaces-Open-181717?logo=github)](https://codespaces.new/JiRaska/open-bank-oss)
 [![Platform: Apache 2.0](https://img.shields.io/badge/Platform-Apache_2.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![AI agents: AGPL-3.0 + commercial](https://img.shields.io/badge/AI_agents-AGPL--3.0--only_%2B_commercial-blue.svg)](docs/adr/0136-agent-services-agpl-in-repo-open-core.md)
 [![Status: Beta](https://img.shields.io/badge/Status-Beta-blue.svg)](#project-status)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,32 @@
+# Getting support
+
+OpenBank is a community-driven open-source project. Here is where to go depending on
+what you need — picking the right channel gets you an answer fastest.
+
+## Questions & discussion
+
+- **[GitHub Discussions](https://github.com/JiRaska/open-bank-oss/discussions)** — the place
+  for "how do I…", architecture questions, feedback, and show-and-tell. Search first; many
+  topics already have answers.
+- **[Project site](https://open-bank.tech/)** — docs, live sandbox, and the operator
+  back-office demo.
+
+## Bugs & feature requests
+
+- **[GitHub Issues](https://github.com/JiRaska/open-bank-oss/issues)** — bug reports and
+  enhancement proposals, using the issue templates. Please include reproduction steps and
+  the affected service (`openbank-<service>`).
+- Architectural decisions are made through ADRs in [`docs/adr/`](docs/adr/), not issues —
+  see [GOVERNANCE.md](GOVERNANCE.md).
+
+## Security vulnerabilities
+
+**Do not open a public issue.** Report privately via
+[GitHub Security Advisories](https://github.com/JiRaska/open-bank-oss/security/advisories/new) —
+see [SECURITY.md](SECURITY.md) for scope and response expectations.
+
+## Contributing
+
+Want to fix it yourself? Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[`good first issue`](https://github.com/JiRaska/open-bank-oss/contribute) list. A ready-to-code
+environment is one click away with GitHub Codespaces (see the badge in the README).


### PR DESCRIPTION
## Summary

Public-repo community polish: one-click contributor onboarding via Codespaces (`.devcontainer`), citation metadata, a SUPPORT.md routing guide, and live README badges (Services CI, CI, Security scan, OpenSSF Scorecard, Codecov placeholder, Codespaces).

## Type of change

- [x] chore (build / tooling)
- [x] docs

## Linked issues

Refs #196

## Changes

- `.devcontainer/devcontainer.json` — Temurin JDK 25 + Node 20 + docker-in-docker (Testcontainers); 4-core/16 GB host requirements matching the Gradle build profile
- `CITATION.cff` — GitHub renders a "Cite this repository" button
- `SUPPORT.md` — routes questions → Discussions, bugs → Issues, vulns → private Security Advisories
- `README.md` — live badges: Services CI, CI, Security scan, OpenSSF Scorecard (results already published by scorecard.yml), Codecov (goes live with the coverage-upload PR), Open-in-Codespaces

## Definition of Done

- [x] Docs updated (README, ADR if architectural).
- N/A — no service code touched; remaining checklist items don't apply (docs/tooling-only change).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (repo metadata only)
- Rollback plan: revert commit
- Data migration reversible: N/A

## Reviewer notes

Codecov badge will show "unknown" until the coverage-upload PR (follow-up to #196) lands — intentional, keeps all README badge edits in one diff.