### PR TITLE
ci(ci): move CI to free GitHub-hosted runners, hosted-first FinOps order

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -35,7 +35,16 @@ permissions:
 jobs:
   build:
     name: ${{ inputs.service }}
-    runs-on: openbank-build
+    # Split lane (FinOps, public repo): PR and nightly/scheduled builds run on free
+    # unlimited GitHub-hosted runners (4 vCPU/16 GB on public repos) — same
+    # no-broker/no-ECR environment a fork PR already gets. ONLY the main-PUSH build
+    # stays on the self-hosted pool (ARC scale-to-zero): the Pact broker has no
+    # public ingress (ADR-0056) and provider verification results MUST be published
+    # from the main-push build or can-i-deploy blocks the auto-deploy of that SHA.
+    # KEEP THIS EXPRESSION IN LOCKSTEP with the PACT_BROKER_URL env below — a hosted
+    # runner with a set (unreachable) broker URL fails the provider tests instead
+    # of skipping them.
+    runs-on: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'openbank-build' || 'ubuntu-latest' }}
     timeout-minutes: 45
     env:
       # Pact Broker (ADR-0092). The broker has no public ingress (ADR-0056); the
@@ -46,7 +55,11 @@ jobs:
       # cluster DNS). When PACT_BROKER_URL is unset (var not configured) the build
       # passes empty -D and the @PactBroker provider tests are @EnabledIfSystemProperty
       # -skipped, and the publish step no-ops — so this is inert until the var lands.
-      PACT_BROKER_URL: ${{ vars.PACT_BROKER_URL }}
+      # Blanked on the hosted lanes (a GitHub-hosted runner can't reach the
+      # cluster-DNS broker; a set-but-unreachable URL would fail the provider tests
+      # instead of skipping them). Main-push behaviour is unchanged: verify + publish.
+      # KEEP IN LOCKSTEP with the runs-on expression above.
+      PACT_BROKER_URL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.PACT_BROKER_URL || '' }}
       PACT_BROKER_USERNAME: ${{ vars.PACT_BROKER_USERNAME }}
       PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
       # Testcontainers pulls postgres:16.3-alpine and redpandadata/redpanda through
@@ -342,7 +355,13 @@ jobs:
           # exhausting the shared storage quota during full-fleet rebuilds
           # ("Failed to CreateArtifact: Artifact storage quota has been hit"), which failed
           # otherwise-green service builds.
-          cache-disabled: true
+          #
+          # The NAT-cost analysis above applies to SELF-HOSTED runners in the VPC.
+          # On GitHub-hosted runners (the PR lane) the Actions cache is
+          # network-internal and free, and there is no in-cluster remote build
+          # cache to fall back on — so the cache is enabled there and disabled
+          # on the self-hosted main lane.
+          cache-disabled: ${{ runner.environment == 'self-hosted' }}
 
       # No --no-daemon (ADR-0043): on a persistent runner the Gradle daemon is kept
       # warm and reused across jobs, so the JVM + 30-module configuration is not paid
@@ -373,13 +392,29 @@ jobs:
             -Dpact.provider.branch="${BRANCH}" \
             -Dpact.provider.tag="${BRANCH}"
 
+      # Coverage upload (Codecov is free for public repos; tokenless via the OIDC
+      # id-token this job already has). Advisory only — never gates the build.
+      # koverVerify stays the enforcement mechanism (ratchet-only, rules.yaml).
+      - name: Generate Kover XML report
+        continue-on-error: true
+        run: ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain
+
+      - name: Upload coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ${{ inputs.service }}/build/reports/kover/report.xml
+          flags: ${{ inputs.service }}
+          use_oidc: true
+          fail_ci_if_error: false
+
       # Publish this service's CONSUMER pacts to the broker (ADR-0092). The consumer
       # tests regenerate pacts/<consumer>-<provider>.json (pact.rootDir → repo /pacts);
       # publish only the files where THIS service is the consumer, keyed by git SHA +
       # branch via the /contracts/publish API. curl (not the pact-cli docker image):
       # the runner pod resolves the broker's cluster DNS, a dind container would not.
       - name: Publish consumer pacts to broker
-        if: ${{ vars.PACT_BROKER_URL != '' }}
+        if: ${{ env.PACT_BROKER_URL != '' }}
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -71,7 +71,9 @@ jobs:
     # The GitOps commit message always starts with "chore(admin-ui): deploy" and it
     # touches cluster-topology.json / infra-lifecycle.json which match the path filter.
     if: "!startsWith(github.event.head_commit.message, 'chore(admin-ui): deploy')"
-    runs-on: openbank-build
+    # Native arm64 GitHub-hosted runner (free on public repos): the admin-ui image
+    # is linux/arm64. ECR push + cosign use the same GitHub-OIDC role as before.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -45,7 +45,7 @@ concurrency:
 jobs:
   fuzz:
     name: schemathesis
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 45
     env:
       GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -58,7 +58,7 @@ jobs:
   # ── 1. Detect which service modules actually changed ─────────────────────────
   changes:
     name: Detect changed services
-    runs-on: openbank-build
+    runs-on: ubuntu-latest  # pure git; hosted-first (public repo, free)
     permissions:
       contents: write
       pull-requests: write
@@ -157,7 +157,13 @@ jobs:
     name: Build + push
     needs: changes
     if: needs.changes.outputs.any == 'true'
-    runs-on: openbank-build
+    # Native arm64 GitHub-hosted runner (free on public repos) — the runtime images
+    # are linux/arm64, so buildx builds natively with no QEMU. ECR push + KMS cosign
+    # authenticate via the same GitHub-OIDC role as before (it trusts repo:*, not a
+    # runner identity). The in-cluster Gradle remote cache / Reposilite mirror are
+    # simply absent here (their probes fall through to Maven Central — free egress
+    # on hosted runners, unlike the NAT-metered VPC).
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
       pull-requests: write
@@ -501,6 +507,9 @@ jobs:
     name: can-i-deploy
     needs: [changes, build-push]
     if: needs.changes.outputs.any == 'true'
+    # Stays on the self-hosted pool: the Pact Broker has no public ingress
+    # (ADR-0056) and is only resolvable over cluster DNS. ARC scale-to-zero
+    # serves this label at ~$0 idle.
     runs-on: openbank-build
     permissions:
       contents: write
@@ -600,7 +609,7 @@ jobs:
     name: Gitops PR
     needs: [changes, build-push, can-i-deploy]
     if: needs.changes.outputs.any == 'true'
-    runs-on: openbank-build
+    runs-on: ubuntu-latest  # manifest rewrite + PR only; hosted-first (public repo, free)
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/backfill-release-evidence.yml
+++ b/.github/workflows/backfill-release-evidence.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   backfill:
     name: Backfill ${{ inputs.tag }}
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     permissions:
       contents: write   # upload release assets
       id-token: write   # OIDC → assume the build-runner role for KMS cosign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   # ---------------------------------------------------------------------------
   changes-ui:
     name: Detect UI changes
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       changed: ${{ steps.check.outputs.changed }}
@@ -55,7 +55,7 @@ jobs:
     name: Admin UI build
     needs: changes-ui
     if: needs.changes-ui.outputs.changed == 'true'
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     defaults:
       run:
@@ -159,7 +159,7 @@ jobs:
     name: Admin UI
     needs: [changes-ui, ui-build]
     if: always()
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Check build result
@@ -175,15 +175,21 @@ jobs:
   # ---------------------------------------------------------------------------
   validate:
     name: Validate manifests
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # yamllint/shellcheck run as the host binaries (brew) rather than Docker
-      # container actions — container actions don't execute on the macOS pool
-      # member, so a direct CLI invocation keeps this job OS-portable across the
-      # mixed [self-hosted, openbank-sandbox] pool (ADR-0040).
+      # yamllint/shellcheck run as direct CLI invocations rather than Docker
+      # container actions (ADR-0040). shellcheck is pre-installed on the hosted
+      # ubuntu image; yamllint is not.
+      - name: Install lint tools
+        run: |
+          command -v yamllint >/dev/null 2>&1 || {
+            sudo apt-get update -q
+            sudo apt-get install -y -q yamllint
+          }
+
       - name: yamllint
         run: |
           # Lint the infra/CI manifests this job is named for. Quarkus service
@@ -465,7 +471,7 @@ jobs:
   app-status:
     name: Customer-app dossier
     if: github.event_name == 'pull_request'
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
@@ -574,7 +580,7 @@ jobs:
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request' && github.event.repository.private == false
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/finops-lifecycle.yml
+++ b/.github/workflows/finops-lifecycle.yml
@@ -23,7 +23,7 @@ jobs:
   gate:
     name: Version lifecycle gate
     if: github.event_name == 'pull_request'
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -37,7 +37,7 @@ jobs:
   audit:
     name: Weekly lifecycle audit
     if: github.event_name != 'pull_request'
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/fleet-lint.yml
+++ b/.github/workflows/fleet-lint.yml
@@ -60,7 +60,7 @@ concurrency:
 jobs:
   fleet-lint:
     name: fleet lint + compile
-    runs-on: openbank-build
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/platform-tofu.yml
+++ b/.github/workflows/platform-tofu.yml
@@ -52,7 +52,7 @@ jobs:
   plan:
     name: tofu plan (preview)
     if: github.event_name != 'workflow_dispatch'
-    runs-on: openbank-batch # non-blocking, credential-free pool (ADR-0053)
+    runs-on: ubuntu-latest # hosted-first (public repo, free); OIDC plan role unchanged (ADR-0060)
     timeout-minutes: 20
     env:
       TF_VAR_governance_gh_pat: ${{ secrets.GOVERNANCE_GH_PAT }}
@@ -126,7 +126,7 @@ jobs:
   infracost:
     name: infracost cost delta
     if: github.event_name == 'pull_request'
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 10
     continue-on-error: true   # non-blocking until INFRACOST_API_KEY is set
     steps:
@@ -170,7 +170,7 @@ jobs:
   apply:
     name: tofu apply (manual dispatch)
     if: github.event_name == 'workflow_dispatch'
-    runs-on: openbank-deploy # credentialed lane (ADR-0053)
+    runs-on: ubuntu-latest # hosted-first; security boundary is the OIDC job_workflow_ref pin + manual dispatch (ADR-0060), not the runner
     timeout-minutes: 30
     # Audit trail + future reviewer gate (issue #282). The openbank-ci-tofu-apply
     # trust policy now accepts the environment-form OIDC sub

--- a/.github/workflows/public-readiness.yml
+++ b/.github/workflows/public-readiness.yml
@@ -35,8 +35,8 @@ concurrency:
 jobs:
   audit:
     name: Public-readiness audit
-    # openbank-build = Hetzner + Mac Mini pool (always-online, zero AWS cost).
-    runs-on: openbank-build
+    # Public repo ⇒ GitHub-hosted runners are free and unlimited (FinOps: hosted-first).
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -46,6 +46,19 @@ jobs:
           # On PRs we SKIP_GITLEAKS (secret-scan.yml already gates gitleaks per-PR),
           # so a shallow checkout there is fine and faster.
           fetch-depth: ${{ github.event_name == 'pull_request' && 1 || 0 }}
+
+      # The full-history gitleaks leg (scheduled/manual runs) needs the binary,
+      # which hosted runners don't pre-install.
+      - name: Install gitleaks
+        if: github.event_name != 'pull_request'
+        env:
+          GITLEAKS_VERSION: "8.21.2"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
 
       - name: Run public-readiness audit
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   release-please:
     name: Release Please
-    runs-on: [self-hosted, openbank-sandbox]
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     permissions:
       contents: write
       pull-requests: write
@@ -109,7 +109,7 @@ jobs:
     name: Release evidence (SBOM + SLSA + VEX bundle)
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 30
     continue-on-error: true
     permissions:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,11 +17,9 @@ concurrency:
 jobs:
   gitleaks:
     name: Gitleaks
-    # openbank-build pool covers Hetzner + Mac Mini (always online). The original
-    # openbank-batch ARC runners (dedicated isolated VPC) are currently offline;
-    # migrated to openbank-build so scans are not blocked while ARC is down.
-    # The egress control is now provided at the VPC / SG level for Hetzner nodes.
-    runs-on: openbank-build
+    # Public repo ⇒ GitHub-hosted runners are free and unlimited; no reason to
+    # spend self-hosted capacity on a credential-free scan (FinOps: hosted-first).
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -29,12 +27,21 @@ jobs:
         with:
           fetch-depth: 0  # full history for scan
 
-      # gitleaks runs as the host binary (brew / package) rather than the
-      # gitleaks-action: the action downloads its binary to a fixed $TMPDIR path
-      # and breaks on a reused self-hosted runner ("gitleaks.tmp already exists"),
-      # and its SARIF upload assumes a hosted-runner HOME layout. A direct CLI
-      # invocation is OS-portable across the mixed pool and has no such state
-      # (ADR-0040). exit-code 1 on a leak gates the job.
+      # gitleaks runs as a directly-invoked CLI rather than the gitleaks-action:
+      # the action's SARIF upload and $TMPDIR handling have bitten us before
+      # (ADR-0040), and a pinned binary download keeps the invocation identical
+      # to what contributors run locally. exit-code 1 on a leak gates the job.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: "8.21.2"
+        run: |
+          set -euo pipefail
+          curl -fsSL -o /tmp/gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
       #
       # Scope the history scan to the commits the event actually introduces
       # (gitleaks passes --log-opts straight to `git log`). With fetch-depth:0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -142,7 +142,7 @@ jobs:
   # ---------------------------------------------------------------------------
   trivy:
     name: Trivy
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     permissions:
       contents: read
       security-events: write # upload-sarif
@@ -150,7 +150,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Trivy runs as the host binary (brew) rather than the Docker container
+      # Hosted runners don't pre-install trivy; the pinned setup action fetches it.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+
+      # Trivy runs as the host binary rather than the Docker container
       # action — container actions don't execute on the macOS pool member, so a
       # direct CLI invocation keeps this OS-portable across the mixed
       # [self-hosted, openbank-sandbox] pool (ADR-0040).
@@ -232,8 +236,8 @@ jobs:
   # This complements (does not replace) the repo-wide job above.
   sbom-per-service:
     name: SBOM (per service)
-    runs-on: openbank-batch
-    timeout-minutes: 30
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
+    timeout-minutes: 45  # cold Maven-Central resolution on a hosted runner (no in-cluster mirror)
     # Builds the full runtime classpath of all modules — far too heavy to run on
     # every PR or on dependency-neutral commits (e.g. gitops auto-deploy). Runs on
     # schedule/manual and on main pushes only when dependencies changed (detect-deps).

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   changes:
     name: Detect changed services
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       services: ${{ steps.detect.outputs.services }}
@@ -197,7 +197,7 @@ jobs:
     name: all-green
     needs: [changes, build]
     if: always()
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Verify no service failed
@@ -214,7 +214,7 @@ jobs:
     name: nightly fleet-health alert
     needs: [changes, build]
     if: always() && github.event_name == 'schedule' && (needs.build.result == 'failure' || needs.changes.result == 'failure')
-    runs-on: openbank-build
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/verify-release-evidence.yml
+++ b/.github/workflows/verify-release-evidence.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   verify:
     name: Verify ${{ inputs.tag }}
-    runs-on: openbank-batch
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -427,25 +427,31 @@ ci_runners:
   model: ephemeral-scale-to-zero        # ADR-0053; per-job ARC pods, NOT persistent
   platform: arc-on-eks                  # actions-runner-controller; Karpenter spot nodes
   scale_to_zero: true                   # minRunners=0 idle; spend -> $0 when no CI
-  # FinOps dispatch order — AGENTS MUST ENFORCE THIS, never bypass:
-  #   1. Hetzner (x86, CPX42) + Mac mini (arm64) = primary; zero AWS cost; always-on
-  #   2. ARC on EKS Spot = overflow only; scales to zero when idle
-  # Consequence: if a build FAILS on Hetzner/Mac due to an arch/platform issue, fix the
-  # root cause (e.g. Dockerfile --platform=$BUILDPLATFORM on build-only stages so x86
-  # runners can build arm64 images without QEMU). NEVER "fix" it by removing Hetzner/Mac
-  # from the runner label pool — that silently routes work to expensive ARC.
-  # Removing openbank-build from a Hetzner runner to avoid a crash is a FinOps violation.
-  static_hosts:
+  # FinOps dispatch order — AGENTS MUST ENFORCE THIS, never bypass.
+  # REVISED when the repo went PUBLIC: GitHub-hosted standard runners became free
+  # and unlimited (ubuntu-latest = 4 vCPU/16 GB; ubuntu-24.04-arm = native arm64),
+  # which inverts the old Hetzner-first order:
+  #   1. GitHub-hosted (ubuntu-latest / ubuntu-24.04-arm) = primary for every job
+  #      that does NOT need the cluster network — $0, no idle cost, no NAT exposure.
+  #   2. ARC on EKS Spot (scale-to-zero) = ONLY for jobs that genuinely need
+  #      VPC/cluster-DNS reachability (Pact broker can-i-deploy, main-lane service
+  #      builds that verify+publish pacts, runner-image build) — idle cost $0.
+  #   3. Static hosts (Hetzner/Mac) = being decommissioned; do NOT add new jobs to
+  #      openbank-build/openbank-batch labels unless the job needs the cluster network.
+  # Consequence: if a build fails on a hosted runner due to an arch issue, fix the
+  # root cause (native ubuntu-24.04-arm runner or --platform=$BUILDPLATFORM on
+  # build-only stages) — never route it back to a paid pool as a workaround.
+  static_hosts:                          # DECOMMISSIONING (public-repo FinOps shift, issue #196)
     hetzner:
-      type: cpx42                        # x86_64, 8 vCPU, 16 GB; pending migration to CAX31 ARM (~40% saving)
+      type: cpx42                        # x86_64, 8 vCPU, 16 GB; retire after hosted-runner burn-in
       labels: [openbank-build, openbank-batch, openbank-sandbox, hetzner]
       count: 2
-      role: primary_build_and_batch      # first pick for ALL jobs; never remove from pool to work around a build failure
+      role: legacy_cluster_lane_backup   # serves remaining cluster-network jobs until retired; ARC covers the label after that
     mac_mini:
       arch: arm64
       labels: [openbank-build, openbank-sandbox]
       count: 1
-      role: primary_build_arm64          # native arm64 fallback; offline = ARC takes over
+      role: legacy_arm64_backup          # native arm64 now served free by ubuntu-24.04-arm; retire from pool
   spot:
     provider: karpenter                 # diversified Graviton spot, price-capacity-optimized
     interruption: karpenter-managed     # no persistent spot request; node replaced on reclaim


### PR DESCRIPTION
## Summary

The repo is public ⇒ GitHub-hosted standard runners are **free and unlimited** (`ubuntu-latest` = 4 vCPU/16 GB on public repos, plus native **`ubuntu-24.04-arm`**). This inverts the Hetzner-first FinOps order: every job that doesn't need the cluster network moves to hosted runners; only cluster-network jobs stay on the self-hosted labels (served by ARC scale-to-zero at ~$0 idle). Outcome: the Hetzner boxes and the Mac mini can be retired from the pool, and ARC bursts shrink to a handful of main-lane jobs.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #196

## Changes

**Moved to `ubuntu-latest`** (with tool-install steps where the hosted image lacks a binary):
- `ci.yml` — all 6 jobs (validate gets an apt `yamllint` install; Playwright deps now install cleanly with hosted sudo)
- `services-ci.yml` — changes / all-green / nightly-alert helper jobs
- `secret-scan.yml` (pinned gitleaks 8.21.2 install), `public-readiness.yml` (gitleaks only on scheduled runs)
- `security.yml` — trivy (pinned `aquasecurity/setup-trivy`) + sbom-per-service (timeout 30→45 for cold Maven resolution)
- `dependency-review.yml`, `finops-lifecycle.yml` (Prometheus leg already soft-fails), `verify-release-evidence.yml`
- `fleet-lint.yml`, `api-fuzz.yml`, `release-please.yml` (both jobs), `backfill-release-evidence.yml`
- `platform-tofu.yml` — plan **and** apply: ADR-0060's security boundary is the OIDC `job_workflow_ref` pin + manual dispatch, not the runner identity (both roles already trust any job in this repo)
- `auto-deploy.yml` — changes + gitops-pr

**Moved to `ubuntu-24.04-arm`** (native arm64, free): `auto-deploy.yml` build-push, `admin-ui-deploy.yml` build-push. ECR push + KMS cosign keep the same GitHub-OIDC role (`openbank-arc-build-runner` trusts `repo:JiRaska/open-bank-oss:*`).

**Split lane in `_service-ci.yml`** (the one non-mechanical change): PR + nightly builds → `ubuntu-latest` with the Gradle Actions cache enabled (network-internal + free on hosted; the NAT analysis that disabled it applies only to the VPC); **main-push builds stay on `openbank-build`** because the Pact broker has no public ingress (ADR-0056) and can-i-deploy needs the provider verification results published from that exact SHA. `PACT_BROKER_URL` is blanked on hosted lanes (kept in lockstep with `runs-on`) so provider tests skip instead of failing — the same environment a fork PR already gets.

**Stays self-hosted** (cluster network genuinely required): `auto-deploy.yml` can-i-deploy (Pact broker cluster DNS), `runner-image.yml` (ambient IRSA), `runner-smoke.yml` / `runner-tune-hetzner.yml` (fleet-internal).

**Bonus in the same `_service-ci.yml` diff** (avoids a conflicting follow-up PR): Codecov coverage upload of the per-service Kover XML (tokenless OIDC, free for public repos, `continue-on-error` — advisory only; koverVerify remains the enforcement). Feeds the codecov badge added in #197.

**`rules.yaml: ci_runners`** — dispatch order rewritten to hosted-first; `static_hosts` marked decommissioning.

## Definition of Done

- [x] Docs updated (rules.yaml is the authoritative rule change).
- All workflows YAML-parse; the PR's own CI run exercises the PR-lane jobs live (validate, secret-scan, dependency-review, finops gate, per-service builds on hosted runners).
- N/A — no service code touched.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency, OR: dependency review attached — two new pinned actions: `aquasecurity/setup-trivy` (v0.3.1, SHA-pinned) and `codecov/codecov-action` (v7.0.0, SHA-pinned).

## Compliance impact

- [x] None (CI infrastructure; the supply-chain controls — cosign, SBOM, provenance — are unchanged, only the runner substrate moves)

## Rollout / Rollback

- Deployment strategy: merge and observe; PR-lane behaviour is proven by this PR's own checks. Post-merge lanes to watch: first main push (auto-deploy build on `ubuntu-24.04-arm` + can-i-deploy on ARC), next release cut (evidence job on hosted).
- Rollback plan: revert the commit — labels return to the self-hosted pools, which remain registered until the burn-in ends.
- Data migration reversible: N/A

## Reviewer notes

- **Docker Hub pulls on hosted PR lane**: the ECR pre-warm is self-hosted-gated, so Testcontainers pulls ~4 images anonymously per job. Each hosted runner VM has its own IP, so the anonymous rate limit is per-job — with 4-5 images this fits. If flakes appear, add a `docker/login-action` with a free Docker Hub token.
- **ECR egress**: main-lane image builds now pull base layers from ECR over the internet ($0.09/GB) instead of in-VPC — a few $/month at current merge volume, versus the Hetzner boxes it retires.
- **Decommissioning** (after burn-in): remove Hetzner/Mac from the runner pool, cancel the CPX42s. ARC stays as the scale-to-zero cluster-network lane. Tracked in #196.