### PR TITLE
feat(gitops): enable EKS node auto repair on the bootstrap node group

### DIFF
--- a/openbank-infra/aws/modules/eks/main.tf
+++ b/openbank-infra/aws/modules/eks/main.tf
@@ -181,6 +181,13 @@ resource "aws_eks_node_group" "bootstrap" {
     max_unavailable = 1
   }
 
+  # EKS Node Auto Repair: replaces nodes that boot but never join the cluster
+  # (or go NotReady) — the ASG's EC2 health check alone can't detect this class
+  # of guest-level hang (silent zombie instance, fully billed, never Ready).
+  node_repair_config {
+    enabled = true
+  }
+
   labels = {
     "openbank.io/pool" = "bootstrap"
   }


### PR DESCRIPTION
## Summary

Enables AWS EKS Node Auto Repair on the `bootstrap` managed node group so a
node that boots but never joins the cluster (or goes and stays `NotReady`)
is detected and replaced automatically, instead of sitting billed and idle
until someone notices.

## Type of change

- [x] feat (new functionality)

## Linked issues

Closes #216

## Changes

- Add `node_repair_config { enabled = true }` to `aws_eks_node_group.bootstrap`
  in `openbank-infra/aws/modules/eks/main.tf`.
- Only managed node group in the repo — Karpenter provisions all other
  capacity outside of `aws_eks_node_group`, so no other resource needs this.

## Verification

- `tofu validate` passes against the `sandbox-substrate` env with the AWS
  provider pinned in this repo (`~> 6.53`, resolved to `6.53.0`) — confirms
  the provider version supports `node_repair_config` (introduced upstream in
  `hashicorp/aws` v5.83.0).
- Ran a targeted `tofu plan` (`-target=module.eks.aws_eks_node_group.bootstrap`)
  against live remote state: the only change attributable to this diff is
  `+ node_repair_config { enabled = true }`, applied in-place with no
  replacement/destroy. (The targeted plan also surfaces pre-existing,
  unrelated drift in the same dependency graph — tag propagation and an addon
  version bump — that is not part of this change and is left for its own PR.)
- No local `apply` was run; this is left to the normal review + apply
  pipeline per this repo's GitOps process.

## Definition of Done

- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (N/A — no
      Kotlin/service code touched; this is Terraform/OpenTofu only.)
- [ ] Docs updated (README, ADR if architectural). — not architectural, no
      ADR needed; scoped to a single reliability-hardening config addition.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without
      justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — N/A
- [ ] PII path changed? — N/A
- [ ] Cardholder data path changed? — N/A

## Compliance impact

- [x] None