### PR TITLE
fix(infra): use ACTUAL notification type for daily NAT budget

### DIFF
--- a/openbank-infra/aws/envs/sandbox-substrate/finops-budget.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/finops-budget.tf
@@ -152,9 +152,9 @@ resource "aws_budgets_budget" "nat_daily" {
   }
   notification {
     comparison_operator        = "GREATER_THAN"
-    threshold                  = 100 # $5/day forecast
+    threshold                  = 100 # $5/day actual (DAILY budgets only support ACTUAL, not FORECASTED)
     threshold_type             = "PERCENTAGE"
-    notification_type          = "FORECASTED"
+    notification_type          = "ACTUAL"
     subscriber_email_addresses = [var.finops_alert_email]
   }
 }


### PR DESCRIPTION
## Summary
- `aws_budgets_budget.nat_daily`'s second notification block used `notification_type = "FORECASTED"`, but AWS Budgets only allows `FORECASTED` on `MONTHLY`/`QUARTERLY`/`ANNUALLY` budgets — `DAILY` only supports `ACTUAL`. `tofu apply` rejected it with `InvalidParameterException`.
- Switches it to `ACTUAL` at the same 100% threshold, alongside the existing 60% `ACTUAL` alert.
- This surfaced during a manual reconciliation apply of `sandbox-substrate` (which has no CI plan/apply pipeline — see #225) — the block had been merged but never actually applied until now.

Linked issues: Refs #225

## Test plan
- [x] `AWS_PROFILE=openbank tofu plan` in `openbank-infra/aws/envs/sandbox-substrate` shows no diff for `aws_budgets_budget.nat_daily` after the fix
- [x] `tofu apply -target=aws_budgets_budget.nat_daily` applied cleanly against live AWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)