### PR TITLE
fix(ci): bump pinned trivy version (v0.63.0 release no longer exists)

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -389,7 +389,7 @@ jobs:
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
         with:
-          version: v0.63.0
+          version: v0.72.0
 
       - name: Prune Docker build cache before scan
         run: |


### PR DESCRIPTION
## Summary
- Follow-up to #224. That PR fixed the wrong hypothesis: I assumed the failure was the GitHub API's anonymous rate limit, and switched to the authenticated `aquasecurity/setup-trivy` action — but the job still failed identically.
- Root cause is actually simpler: the hard-pinned `v0.63.0` trivy release no longer exists (`gh api repos/aquasecurity/trivy/releases/tags/v0.63.0` → 404; the releases list jumps from `v0.26.0` straight to `v0.69.2`). `setup-trivy`'s own install step runs the exact same upstream `contrib/install.sh`, which fails right after "found version" for the same reason the original raw curl did — there's just no asset to download for that tag anymore.
- Fix: bump the pin to `v0.72.0`, the latest currently-published release (verified live via the GitHub releases API). The trivy CLI flags used later in the job (`--scanners`, `--severity`, `--ignore-unfixed`, `--format cyclonedx`) are stable across this range, so no other change needed.

## Test plan
- [x] Confirmed `v0.63.0` 404s and `v0.72.0` is a real, current release via `gh api repos/aquasecurity/trivy/releases`
- [x] YAML validated
- [ ] CI green on this PR
- [ ] Re-dispatch `Auto deploy` after merge and confirm `Install Trivy` + the image scan gate both pass

Linked issues: N/A — CI infra fix, continuation of #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)