### PR TITLE
chore(infra): codify orphan openbank-sandbox-daily budget in Terraform

### DIFF
--- a/openbank-infra/aws/envs/sandbox-substrate/finops-budget.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/finops-budget.tf
@@ -70,6 +70,34 @@ output "finops_budget_name" {
   value       = aws_budgets_budget.monthly_cost.name
 }
 
+# Faster-feedback daily companion to monthly_cost above (created 2026-06-13,
+# manually — codified here via `tofu import` so it stops being a silent
+# unmanaged resource). $50/day is a tighter early-warning than waiting for the
+# monthly ceiling's 50/80/100% thresholds to trip; actual spend has regularly
+# exceeded it since creation (real-money account, no more Activate credits).
+resource "aws_budgets_budget" "daily_cost" {
+  name         = "openbank-sandbox-daily"
+  budget_type  = "COST"
+  limit_amount = "50"
+  limit_unit   = "USD"
+  time_unit    = "DAILY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.finops_alert_email]
+  }
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.finops_alert_email]
+  }
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # NAT egress early-warning — CloudWatch alarm + daily NAT budget
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- While investigating today's FinOps picture, found `openbank-sandbox-daily` — a $50/day, account-wide `aws_budgets_budget` with ACTUAL notifications at 80%/100% — existing live in AWS since 2026-06-13 but **not defined anywhere in Terraform**. It was never in state, never showed up in any plan, and was one `tofu destroy`/account-rebuild away from silently disappearing.
- Imports it as `aws_budgets_budget.daily_cost`, matching its live config exactly (same limit, same thresholds, same subscriber). No behavior change — this alert has already been in `ALARM` state (daily spend has been running $54–$116/day against the $50 limit for at least two weeks), so it's presumably already emailing `finops_alert_email`; this PR just stops it from being silent drift.

Linked issues: N/A — housekeeping discovered during unrelated sandbox-substrate drift reconciliation, not tied to a tracked issue.

## Test plan
- [x] `tofu import aws_budgets_budget.daily_cost 265175468565:openbank-sandbox-daily` succeeded
- [x] `AWS_PROFILE=openbank tofu plan` shows only a `tags_all` diff (default_tags reconciliation) after import, no resource replacement
- [x] Applied the `tags_all` diff against live AWS; budget name/limit/thresholds/subscriber unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)