### PR TITLE
fix(customer-edge): mark validatedUri() inline to fix recurring CodeQL SSRF false positive

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -86,8 +86,14 @@ class UpstreamClient {
      * validation has already passed. A leading "." in an entry (e.g. ".svc") matches any host
      * ending in that domain suffix; anything else (e.g. "127.0.0.1", "localhost") must match the
      * whole host exactly.
+     *
+     * `inline`: every caller (get/patch/put/delete/post) invokes this as a separate function,
+     * and CodeQL's SSRF barrier recognition does not follow the sanitizer across that call
+     * boundary — it re-flags a fresh alert at each new caller (#239-241, #288, #289). Inlining
+     * puts the regex check in the same function body as the URI.create() sink at every call
+     * site, which is what the barrier recognition needs to see.
      */
-    private fun validatedUri(url: String): URI {
+    private inline fun validatedUri(url: String): URI {
         val entries = allowedHostSuffixes.split(",").map { it.trim() }.filter { it.isNotEmpty() }
         val alternatives = entries.joinToString("|") { entry ->
             if (entry.startsWith(".")) {


### PR DESCRIPTION
## Summary
`UpstreamClient.validatedUri()` regex-validates the host before `URI.create()` — CodeQL's `java/ssrf` query is documented to recognize regex checks as a sanitizing barrier. But every caller (`get`/`patch`/`put`/`delete`/`post`) calls it as a *separate function*, and CodeQL's barrier recognition doesn't appear to follow the sanitizer across that call boundary: it has now flagged a fresh alert on 3 separate occasions as new callers were added (#239-241 dismissed earlier, then #288 and #289 from two newly merged features).

This PR marks `validatedUri()` `inline`, so the regex check and the `URI.create()` sink end up in the same compiled function body at every call site — the shape CodeQL's barrier recognition is documented to expect. This is an attempt at an actual fix rather than another dismissal.

## Test plan
- [x] `compileKotlin` + `ktlintCheck` + `detekt` all green
- [ ] Fresh CodeQL scan confirms alert #289 (and the underlying pattern) is recognized as sanitized — **not yet verified**, recommend running a full Security scan against this branch/after merge before treating this as proven

## Not verified yet
This is a real hypothesis (informed by the existing code comment from an earlier investigation this session), not a confirmed fix. If a fresh CodeQL scan still flags it after this merges, the fallback is the same documented dismissal pattern already used for #239-241/#288/#289.

Linked issues: N/A — direct alert remediation attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)