### PR TITLE
fix: three api-fuzz.yml boot failures (dispute, party, consent)

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -55,10 +55,11 @@ class ConsentResource(
     @Operation(summary = "Create a new consent (PENDING_SCA); idempotent via tppTransactionId / X-Request-ID")
     @POST
     suspend fun create(
-        request: CreateConsentRequest,
+        request: CreateConsentRequest?,
         @HeaderParam("X-Request-ID") xRequestId: String?,
         @Context uriInfo: UriInfo,
     ): Response {
+        requireNotNull(request) { "request body is required" }
         val idempotencyKey = request.tppTransactionId?.takeIf { it.isNotBlank() }
             ?: xRequestId?.takeIf { it.isNotBlank() }
 
@@ -124,8 +125,9 @@ class ConsentResource(
     suspend fun revoke(
         @PathParam("id") id: UUID,
         @QueryParam("partyId") partyId: UUID,
-        request: RevokeConsentRequest,
+        request: RevokeConsentRequest?,
     ): ConsentResponse {
+        requireNotNull(request) { "request body is required" }
         val consent = revokeConsent.revokeConsent(RevokeConsentCommand(id, partyId, request.reason))
         return ConsentResponse.from(consent)
     }
@@ -145,7 +147,8 @@ class ConsentResource(
     @Operation(summary = "Validate whether a consent covers the requested scope and account (resource servers)")
     @POST
     @Path("/{id}/validate")
-    suspend fun validate(@PathParam("id") id: UUID, request: ValidateConsentRequest): ConsentValidationResponse {
+    suspend fun validate(@PathParam("id") id: UUID, request: ValidateConsentRequest?): ConsentValidationResponse {
+        requireNotNull(request) { "request body is required" }
         val result = validateConsent.validateConsent(
             ValidateConsentCommand(id, request.granteeId, request.requiredScope, request.accountIban),
         )

--- a/openbank-consent-service/src/main/resources/application.yaml
+++ b/openbank-consent-service/src/main/resources/application.yaml
@@ -36,18 +36,14 @@ quarkus:
     password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
     reactive:
       url: vertx-reactive:postgresql://localhost:5432/openbank_consents
+    jdbc:
+      url: jdbc:postgresql://localhost:5432/openbank_consents
 
   flyway:
     migrate-at-start: true
     connect-retries: 10
     connect-retries-interval: 2S
     locations: db/migration
-    datasource:
-      db-kind: postgresql
-      username: openbank
-      password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
-      jdbc:
-        url: jdbc:postgresql://localhost:5432/openbank_consents
 
   hibernate-orm:
     database:

--- a/openbank-dispute-service/src/main/resources/application.yaml
+++ b/openbank-dispute-service/src/main/resources/application.yaml
@@ -109,12 +109,6 @@ mp:
         ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
         ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
     outgoing:
-      dispute-events-out:
-        connector: smallrye-kafka
-        client.id: dispute-service-${quarkus.uuid}
-        topic: openbank.disputes.dispute.event
-        value.serializer: org.apache.kafka.common.serialization.StringSerializer
-        key.serializer: org.apache.kafka.common.serialization.StringSerializer
       dispute-outbox-out:
         connector: smallrye-kafka
         client.id: dispute-outbox-service-${quarkus.uuid}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -46,6 +46,7 @@ import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import io.quarkus.security.identity.SecurityIdentity
+import jakarta.enterprise.inject.Instance
 import org.eclipse.microprofile.jwt.JsonWebToken
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
@@ -64,8 +65,17 @@ class PartyResource {
 
     @Inject lateinit var flags: FeatureClient
 
-    @Inject @io.quarkus.arc.Unremovable
-    lateinit var jwt: JsonWebToken
+    // Instance<> rather than a hard @Inject: quarkus-oidc is the only producer of JsonWebToken in
+    // this service, and %dev/%test disable OIDC (no Keycloak available there) — a direct @Inject
+    // fails CDI validation at boot with no bean satisfying the type. Resolving lazily degrades to
+    // an anonymous caller (no subject/claims) when OIDC is off, which the @RolesAllowed/@Authenticated
+    // checks already turn into a 401/403 before any of these accessors run in a real unauthenticated
+    // request.
+    @Inject
+    lateinit var jwtInstance: Instance<JsonWebToken>
+
+    private val jwt: JsonWebToken?
+        get() = if (jwtInstance.isResolvable) jwtInstance.get() else null
 
     @Inject lateinit var auditPublisher: AuditEventPublisher
 
@@ -187,7 +197,7 @@ class PartyResource {
     suspend fun exportPartyGdpr(@PathParam("id") id: UUID): Response {
         val isAdmin = securityIdentity.hasRole("ROLE_ADMIN")
         val isDpo = securityIdentity.hasRole("ROLE_DPO")
-        val isSelf = jwt.subject != null && jwt.subject == partyUseCase.getPartyKeycloakSub(id)
+        val isSelf = jwt?.subject != null && jwt?.subject == partyUseCase.getPartyKeycloakSub(id)
         if (!isAdmin && !isDpo && !isSelf) return Response.status(Response.Status.FORBIDDEN).build()
         val export = partyUseCase.exportPartyData(id)
         // ADR-0118 / ADR-0086: a subject-access read exposes the full PII set — audit the
@@ -205,7 +215,7 @@ class PartyResource {
     private suspend fun auditGdpr(operation: String, partyId: UUID, gdprArticle: String) {
         auditPublisher.publish(
             AuditEvent(
-                actorId = jwt.subject ?: jwt.name ?: "unknown",
+                actorId = jwt?.subject ?: jwt?.name ?: "unknown",
                 actorType = "HUMAN",
                 operation = operation,
                 resourceType = "party",
@@ -223,7 +233,7 @@ class PartyResource {
     @Authenticated
     @Operation(summary = "Get my party (mobile: returns party for the calling Keycloak sub)")
     suspend fun getMyParty(): Response {
-        val sub = jwt.subject ?: return Response.status(401).build()
+        val sub = jwt?.subject ?: return Response.status(401).build()
         val party = partyUseCase.getMyParty(sub)
             ?: return Response.status(404).entity(mapOf("code" to "NOT_REGISTERED")).build()
         return Response.ok(party.toResponse()).build()
@@ -234,8 +244,8 @@ class PartyResource {
     @Authenticated
     @Operation(summary = "Self-register as a new party (mobile onboarding). Idempotent by Keycloak sub.")
     suspend fun selfRegister(req: SelfRegisterRequest): Response {
-        val sub = jwt.subject ?: return Response.status(401).build()
-        val emailVerified = jwt.getClaim<Boolean>("email_verified") ?: false
+        val sub = jwt?.subject ?: return Response.status(401).build()
+        val emailVerified = jwt?.getClaim<Boolean>("email_verified") ?: false
         if (!emailVerified) {
             return Response.status(403)
                 .entity(mapOf("code" to "EMAIL_NOT_VERIFIED", "message" to "Verify your email before registering"))
@@ -247,7 +257,7 @@ class PartyResource {
                 emailVerified = emailVerified,
                 partyType = PartyType.valueOf(req.partyType),
                 legalName = req.legalName,
-                email = jwt.getClaim("email") ?: req.email,
+                email = jwt?.getClaim("email") ?: req.email,
                 phone = req.phone,
                 dateOfBirth = req.dateOfBirth,
                 nationality = req.nationality,
@@ -267,7 +277,7 @@ class PartyResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Operation(summary = "Upload KYC document image (mobile). Stores binary content server-side.")
     suspend fun uploadDocument(@PathParam("id") id: UUID, @MultipartForm form: DocumentUploadForm): Response {
-        val sub = jwt.subject ?: return Response.status(401).build()
+        val sub = jwt?.subject ?: return Response.status(401).build()
         // Verify caller owns this party
         val party = partyUseCase.getMyParty(sub)
         if (party == null || party.id != id) return Response.status(403).build()

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -186,6 +186,8 @@ paths:
       tags: [Parties]
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/partyId'
       requestBody:
         content:
           multipart/form-data:

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
@@ -18,6 +18,7 @@ import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.microprofile.jwt.JsonWebToken
@@ -41,6 +42,10 @@ class PartyResourceAuditTest {
             coEvery { it.publish(capture(events)) } returns Unit
         }
         val token = mockk<JsonWebToken>().also { every { it.subject } returns actorSub }
+        val tokenInstance = mockk<Instance<JsonWebToken>>().also {
+            every { it.isResolvable } returns true
+            every { it.get() } returns token
+        }
         val identity = mockk<io.quarkus.security.identity.SecurityIdentity>().also {
             every { it.hasRole("ROLE_ADMIN") } returns true
             every { it.hasRole("ROLE_DPO") } returns false
@@ -48,7 +53,7 @@ class PartyResourceAuditTest {
         return PartyResource().apply {
             partyUseCase = mockk(relaxed = true)
             flags = mockk(relaxed = true)
-            jwt = token
+            jwtInstance = tokenInstance
             securityIdentity = identity
             auditPublisher = publisher
         }


### PR DESCRIPTION
## Summary
Fixes the 3 non-schemathesis-CLI boot failures reported by the weekly `api-fuzz.yml` run (https://github.com/JiRaska/open-bank-oss/actions/runs/28682265216, job "Fuzz services"), pre-existing and independent of the schemathesis 3.x→4.x CLI migration in #231 — **plus two additional bugs that this DAST job could only reach for the first time once those boot fixes landed** (confirmed via a manual `workflow_dispatch` re-run, see below).

Each fix was reproduced locally against a throwaway postgres (`quarkusDev`) and confirmed both locally and in a real CI run.

### Boot failures
- **dispute-service**: `dispute-events-out` was a dead Kafka outgoing channel in `application.yaml` — no code (`@Channel`/`@Outgoing`) ever published to it, and no other service consumes its topic. SmallRye Reactive Messaging's dev-mode connector interceptor fails validating this unclaimed channel, aborting startup; the `IllegalStateException: Result is already complete` reported in CI is a secondary artifact of the pool tearing down mid-failure, not the root cause. Removed the dead channel config.
- **party-service**: `PartyResource` hard-`@Inject`s `JsonWebToken`, but `quarkus-oidc` is the only producer of that bean and both `%dev`/`%test` disable OIDC (no Keycloak available). CDI build-time validation then has no bean to satisfy the injection point, failing the whole deployment before any request is served. Switched to a lazily-resolved `Instance<JsonWebToken>` — every call site already treats a missing subject as unauthenticated, so this now degrades to the same 401/403 the `@RolesAllowed`/`@Authenticated` checks already produce for anonymous callers, instead of the service never starting.
- **consent-service**: the default datasource's `jdbc.url` was nested under `quarkus.flyway.datasource` instead of `quarkus.datasource` — not a real config path, so `quarkus.datasource.jdbc.url` was never set. Quarkus deactivates the datasource bean whenever its URL is unset, Hibernate ORM's bootstrap fails, and dev mode loops stop/restart-on-failure indefinitely — the HTTP port never opens, matching the reported ~3 minute readiness timeout. Moved `jdbc.url` back under the top-level `datasource:` block, matching every sibling service.

### Newly-exposed bugs (found by the first-ever successful fuzz pass on party/consent)
- **consent-service**: `create`, `revoke`, and `validate` deserialize the JAX-RS body into a non-nullable Kotlin parameter, but a missing/empty body reaches the handler as an actual `null` (RESTEasy Reactive doesn't trigger Kotlin's own null-check here), so the first field access NPEs and the generic exception mapper turns it into a bare 500. None of these three endpoints carry `@RolesAllowed`/`@Authenticated` like every other write endpoint in the fleet, so unauthenticated fuzz input reaches the handler directly. Made the three parameters nullable with an explicit `requireNotNull(request) { ... }` guard, which the existing `IllegalArgumentExceptionMapper` turns into a clean 400.
- **party-service**: `POST /api/v1/parties/{id}/documents/upload` was the only `{id}`-scoped operation in `openapi.yaml` missing the `id` path parameter declaration (every sibling operation references the shared `partyId` parameter), so schemathesis reported a schema error instead of testing it. The route already reads `@PathParam("id")` — this only corrects the spec to match existing behavior.

No `openapi.yaml` API-contract changes beyond the party-service parameter fix (a spec correction, not a behavior change). Per this repo's release-please automation, `version.txt` is bumped by the automated Release PR after merge, not by this PR.

## Test plan
- [x] `openbank-dispute-service:quarkusDev` against a throwaway postgres: crashed on every attempt before the fix, boots cleanly (~30s) and stays up after
- [x] `openbank-party-service:quarkusDev` against a throwaway postgres: `UnsatisfiedResolutionException` before the fix, boots in ~30s after; unauthenticated requests return 403 (not 500)
- [x] `openbank-consent-service:quarkusDev` against a throwaway postgres: never became ready before the fix, boots in ~15-30s after
- [x] Local `schemathesis` run against running `party-service`: schema error gone, 13/13 operations pass
- [x] Local `schemathesis` run against running `consent-service`: 3 server errors → 0, 8/8 operations pass
- [x] `:openbank-party-service:ktlintCheck`, `:openbank-dispute-service:ktlintCheck`, `:openbank-consent-service:ktlintCheck`, `detekt` all pass
- [x] Manual `workflow_dispatch` of `api-fuzz.yml` against this branch (run https://github.com/JiRaska/open-bank-oss/actions/runs/28695255599): confirmed all 3 boot fixes work in real CI — all 5 services now boot and reach the fuzzing stage (previously 3 never did); surfaced the two bugs above, now fixed in this PR
- [ ] Re-run `workflow_dispatch` of `api-fuzz.yml` on the latest commit to confirm the full 5-service fleet is fully green

Linked issues: N/A — pre-existing CI-only boot/API defects found and fixed directly from investigating a failed scheduled run, no tracked issue existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)