### PR TITLE
fix(ci): warm the Gradle wrapper before api-fuzz.yml's per-service loop

### DIFF
--- a/.github/workflows/api-fuzz.yml
+++ b/.github/workflows/api-fuzz.yml
@@ -67,6 +67,13 @@ jobs:
         with:
           cache-read-only: true
 
+      # A cold Gradle wrapper distribution download (services.gradle.org) can itself take
+      # 2-3 minutes on a cache miss — long enough to burn through the FIRST service's whole
+      # 90x2s readiness wait below before its JVM even starts, reporting a false "failed to
+      # boot". Pay that cost here, once, outside any per-service timing budget.
+      - name: Warm Gradle wrapper
+        run: ./gradlew --version
+
       - name: Install schemathesis
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
Follow-up to #233 (merged). After the 3 boot fixes there, a manual `workflow_dispatch` re-run confirmed all 5 services boot and fuzz cleanly — **except `openbank-dispute-service` (first in the `$SERVICES` loop), which reported "failed to boot" twice in a row.**

Its boot log showed nothing but:
```
Fetching distribution.
Downloading https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
```
The per-service readiness wait (90 x 2s = 180s) was entirely consumed by a **cold Gradle wrapper distribution download**, before `quarkusDev`'s JVM ever started — not an application bug. Reproduced locally against an empty `GRADLE_USER_HOME`: the cold download+unpack alone took **341 seconds**, nearly double the 180s budget any one service gets.

`setup-gradle` runs with `cache-read-only: true` in this workflow, so it never populates its own cache — whichever service happens to run first pays this tax whenever no other job has recently warmed the shared cache.

## Fix
Added a one-time `./gradlew --version` step right after `setup-gradle`, before the per-service loop starts, so the download (if needed) happens outside any individual service's readiness budget instead of silently eating it and producing a false "failed to boot".

## Test plan
- [x] Reproduced the failure twice via `workflow_dispatch` on the source branch of #233 (runs [28707401403](https://github.com/JiRaska/open-bank-oss/actions/runs/28707401403), [28707657553](https://github.com/JiRaska/open-bank-oss/actions/runs/28707657553)) — both times only `openbank-dispute-service` (first in the loop) failed this exact way while the other 4 services booted and fuzzed cleanly
- [x] Reproduced the cold-download timing locally (341s against an empty `GRADLE_USER_HOME`)
- [ ] Manual `workflow_dispatch` of `api-fuzz.yml` on this branch to confirm the fleet is fully green with the warm-up step in place

Linked issues: N/A — CI reliability gap found while verifying #233, no tracked issue existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)