### PR TITLE
fix(gitops): raise otel-collector's Tempo exporter timeout to stop dropped traces

### DIFF
--- a/openbank-infra/gitops/apps/otel-collector.yaml
+++ b/openbank-infra/gitops/apps/otel-collector.yaml
@@ -62,6 +62,14 @@ spec:
               endpoint: tempo.observability.svc:4317
               tls:
                 insecure: true
+              # Client-side call deadline for a single push. The exporter default
+              # (5s) was shorter than Tempo's own ingester needs to consume a batch
+              # under routine load, so nearly every push landed as "context
+              # canceled" server-side (tempo pusher log) — the collector gave up
+              # before Tempo finished, even though Tempo was healthy (low CPU/mem,
+              # no restarts). 15s gives real headroom while staying well inside the
+              # queue's ability to absorb the wait.
+              timeout: 15s
               # Absorb Tempo backpressure here so the receiver can ack the services
               # immediately instead of blocking past their 10s OTLP deadline. The
               # queue buffers spikes; retry rides out brief Tempo slowness.


### PR DESCRIPTION
## Summary

Found while auditing observability-namespace logs for errors: Tempo (`tempo-0`) was logging `"pusher failed to consume trace data" err="context canceled"` roughly every 10-30 seconds (138 hits in the last 6h of tail alone). Tempo itself was healthy the whole time — 9m CPU / 522Mi memory against a 500m/2Gi limit, zero restarts — so this wasn't Tempo struggling under load. It was the **client** (otel-collector's `otlp/tempo` exporter) giving up: the OTel Collector's gRPC exporter default call timeout is 5s, and that's shorter than Tempo sometimes needs to consume a batch, so the collector cancels the in-flight push before Tempo finishes.

## Type of change

- [x] fix

## Linked issues

N/A — found via a log audit, no tracked issue existed.

## Changes

- `openbank-infra/gitops/apps/otel-collector.yaml` — added explicit `timeout: 15s` to the `otlp/tempo` exporter. The existing `sending_queue`/`retry_on_failure` config already anticipated "brief Tempo slowness" (per its own comment) but never actually raised the per-call deadline causing it — this closes that gap.

## Definition of Done

- [x] `yaml.safe_load` passes clean.
- [ ] Confirm after ArgoCD auto-syncs (`syncPolicy.automated.selfHeal: true`, no manual apply needed) that Tempo's "context canceled" rate drops to ~0 going forward.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None — observability pipeline tuning, not a money-path service.

## Rollout / Rollback

- Deployment strategy: merge; ArgoCD self-heals the Application automatically, no manual kubectl apply needed.
- Rollback plan: revert this commit; ArgoCD syncs the revert automatically.
- Data migration reversible: N/A

## Reviewer notes

Other observability-namespace error-pattern hits found in the same audit were false positives (Postgres `error_severity` JSON field names in `glitchtip-pg`/`goalert-db`, an empty `ErrorCode:` field in a Grafana feature-flag log line) — not touched. One real but separately-scoped and low-severity finding not fixed here: a single Alloy DaemonSet replica (`alloy-jtxb2`, freshly restarted) was re-shipping stale log backlog that Loki correctly rejected as out-of-order — an inherent trade-off of Alloy's `loki.source.kubernetes` (API-based tailing, no persistent position file across pod restarts) rather than a config bug; self-limits once the backlog drains and doesn't warrant a live-infra change without further design discussion.