### PR TITLE
fix(gitops): add missing PodDisruptionBudgets for observability stateful pods

### DIFF
--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -27,6 +27,14 @@ spec:
         # block referencing a Vault-sourced webhook secret).
         alertmanager:
           enabled: true
+          # Single replica -> minAvailable:1 blocks ANY voluntary eviction (Karpenter
+          # consolidation respects PDBs). Closes the same gap prometheus/loki/tempo
+          # had: the observability NodePool's consolidationPolicy is only safe to
+          # tighten from WhenEmpty because this now exists (see
+          # nodepool-observability.yaml).
+          podDisruptionBudget:
+            enabled: true
+            minAvailable: 1
           alertmanagerSpec:
             replicas: 1
             # Mount the GoAlert integration URL (with its token) from a Secret so the
@@ -110,6 +118,11 @@ spec:
                       {{ .Annotations.description }}
                       {{ end }}
         prometheus:
+          # Single replica -> minAvailable:1 blocks ANY voluntary eviction. Same
+          # rationale as alertmanager above.
+          podDisruptionBudget:
+            enabled: true
+            minAvailable: 1
           prometheusSpec:
             replicas: 1
             # 12h retention (FinOps per ADR-0027; the 5Gi PVC below is sized for it).

--- a/openbank-infra/gitops/components/observability/pdb-loki.yaml
+++ b/openbank-infra/gitops/components/observability/pdb-loki.yaml
@@ -1,0 +1,20 @@
+# Loki's chart (singleBinary deployment mode, loki.yaml) has no native
+# podDisruptionBudget toggle for this mode (checked: `helm show values
+# grafana/loki --version 6.55.0` — the read/write/backend/ingester/distributor
+# components each expose one, singleBinary does not). Hand-authored to close
+# the same gap alertmanager/prometheus had: single replica -> minAvailable:1
+# blocks ANY voluntary eviction, which is what makes it safe to tighten the
+# observability NodePool's consolidationPolicy from WhenEmpty (see
+# nodepool-observability.yaml).
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: loki
+  namespace: observability
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: loki
+      app.kubernetes.io/component: single-binary

--- a/openbank-infra/gitops/components/observability/pdb-tempo.yaml
+++ b/openbank-infra/gitops/components/observability/pdb-tempo.yaml
@@ -1,0 +1,20 @@
+# Tempo's chart has no native podDisruptionBudget toggle (checked: `helm show
+# values grafana/tempo --version 1.24.4` — no disruption/unavailable keys at
+# all). Hand-authored to close the same gap alertmanager/prometheus/loki had:
+# single replica -> minAvailable:1 blocks ANY voluntary eviction, which is
+# what makes it safe to tighten the observability NodePool's
+# consolidationPolicy from WhenEmpty (see nodepool-observability.yaml). Tempo
+# was one of the two services (with Prometheus) explicitly named in that
+# file's incident history (spot reclamation mid-WAL-replay), so it's the
+# highest-priority gap to close here.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: tempo
+  namespace: observability
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: tempo
+      app.kubernetes.io/name: tempo


### PR DESCRIPTION
## Summary

**Step 1 of 2** toward safely tightening the observability NodePool's consolidation policy (see follow-up). Found while investigating why 7 on-demand `observability`-nodepool nodes sit at only 6-37% resource-request utilization: `consolidationPolicy: WhenEmpty` (never bin-packs busy nodes) was deliberately chosen after spot reclamation + consolidation killed Prometheus/Tempo (WAL corruption, stuck EBS Multi-Attach — see `nodepool-observability.yaml`'s own comment). That protection was necessary because **Prometheus, Alertmanager, Loki, and Tempo had no PodDisruptionBudget** — unlike `pyroscope`/`glitchtip-pg`/`goalert-db`, which already have one (`kubectl get pdb -n observability` showed only those 3).

This PR closes that gap. It changes nothing about current scheduling/eviction on its own — it only adds protection. The consolidation policy itself stays untouched until this is confirmed live.

## Type of change

- [x] fix

## Linked issues

N/A — found via a cost/utilization audit, no tracked issue existed.

## Changes

- `openbank-infra/gitops/apps/kube-prometheus-stack.yaml` — `alertmanager.podDisruptionBudget.enabled: true` + `prometheus.podDisruptionBudget.enabled: true` (both `minAvailable: 1`). Chart-native; verified the exact key path and default (`false`) against `helm show values prometheus-community/kube-prometheus-stack --version 87.0.0` rather than assume it.
- `openbank-infra/gitops/components/observability/pdb-loki.yaml` (new) — hand-authored PDB. Loki's chart in `singleBinary` deployment mode (the mode this repo uses) has no native PDB toggle — verified via `helm show values grafana/loki --version 6.55.0`; only the distributed-mode components (read/write/backend/ingester/distributor) expose one.
- `openbank-infra/gitops/components/observability/pdb-tempo.yaml` (new) — hand-authored PDB. Tempo's chart has no disruption-budget key at all (verified the same way, `helm show values grafana/tempo --version 1.24.4`). Tempo was one of the two services explicitly named in the original incident, so closing this one matters most.

Both new manifests are picked up automatically by the `observability-components` Application (`directory: recurse: true`, no Kustomization resource list needed — confirmed by reading that Application's spec).

## Definition of Done

- [x] `yaml.safe_load_all` passes clean on all 3 changed/new files.
- [x] Verified exact Helm values schema for all 4 components before writing anything, rather than guessing a plausible-looking key that Helm would silently ignore if wrong.
- [ ] After merge, confirm `kubectl get pdb -n observability` shows all 4 new/updated PDBs live with `ALLOWED DISRUPTIONS: 0` before the follow-up PR touches `consolidationPolicy`.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None — observability reliability/FinOps prep, not a money-path service.

## Rollout / Rollback

- Deployment strategy: merge; ArgoCD self-heals automatically (`syncPolicy.automated.selfHeal: true` on both the `kube-prometheus-stack` and `observability-components` Applications), no manual `kubectl apply` needed.
- Rollback plan: revert this commit; ArgoCD syncs the revert automatically. Removing a PDB has zero effect on already-running pods.
- Data migration reversible: N/A

## Reviewer notes

This is intentionally the **safe, inert half** of a two-part change — protection lands and gets verified live first. The actual consolidation-policy relaxation (the part that changes cluster behavior and could theoretically reintroduce risk if these PDBs weren't actually working) is a separate follow-up PR, opened only after this one is confirmed merged and the PDBs are visibly enforcing `ALLOWED DISRUPTIONS: 0`.