### PR TITLE
fix(gitops): point VPA targetRef at Rollout for services migrated off Deployment

### DIFF
--- a/openbank-infra/gitops/components/vpa-objects/vpa-objects.yaml
+++ b/openbank-infra/gitops/components/vpa-objects/vpa-objects.yaml
@@ -20,8 +20,8 @@ metadata:
   namespace: accounts
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: account-service
   updatePolicy:
     updateMode: "Off"
@@ -42,8 +42,8 @@ metadata:
   namespace: balances
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: balance-service
   updatePolicy:
     updateMode: "Off"
@@ -64,8 +64,8 @@ metadata:
   namespace: ledger
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: ledger-service
   updatePolicy:
     updateMode: "Off"
@@ -87,8 +87,8 @@ metadata:
   namespace: payments
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: transaction-service
   updatePolicy:
     updateMode: "Off"
@@ -109,8 +109,8 @@ metadata:
   namespace: payments
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: sepa-payment
   updatePolicy:
     updateMode: "Off"
@@ -133,8 +133,8 @@ metadata:
   namespace: fx
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: fx-service
   updatePolicy:
     updateMode: "Off"
@@ -179,8 +179,8 @@ metadata:
   namespace: party
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: party-service
   updatePolicy:
     updateMode: "Off"
@@ -201,8 +201,8 @@ metadata:
   namespace: kyc
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: kyc-service
   updatePolicy:
     updateMode: "Off"
@@ -223,8 +223,8 @@ metadata:
   namespace: consent
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: consent-service
   updatePolicy:
     updateMode: "Off"
@@ -337,8 +337,8 @@ metadata:
   namespace: customer-edge
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: customer-edge
   updatePolicy:
     updateMode: "Off"
@@ -359,8 +359,8 @@ metadata:
   namespace: fraud
 spec:
   targetRef:
-    apiVersion: apps/v1
-    kind: Deployment
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
     name: fraud-service
   updatePolicy:
     updateMode: "Off"


### PR DESCRIPTION
## Summary

Found while investigating the FinOps right-sizing panel (admin-ui `/finops`): **11 of the 17 VerticalPodAutoscaler objects have been silently non-functional** since their service migrated to Argo Rollouts (~15 days ago). Their status shows `"Cannot read targetRef. Reason: Deployment <ns>/<svc> does not exist"` / `"No pods match this VPA object"` — `targetRef.kind` still says `Deployment`, but `kubectl get rollout -n <ns> <svc>` confirms the actual workload is an Argo Rollout.

Practical effect: for these 11 services, VPA has never observed real pods. The recommendations the admin-ui FinOps panel reads are stuck at `resourcePolicy.minAllowed` (the configured floor), not an actual usage-based recommendation — the panel's "not yet providing recommendations" caveat undersells it; for these 11 it will *never* provide one without this fix, no matter how long you wait.

## Type of change

- [x] fix

## Linked issues

N/A — found via the admin-ui FinOps panel + a live cluster audit, no tracked issue existed.

## Changes

`openbank-infra/gitops/components/vpa-objects/vpa-objects.yaml` — for the 11 affected VPAs, `targetRef.apiVersion: apps/v1` → `argoproj.io/v1alpha1` and `targetRef.kind: Deployment` → `Rollout`:

- account-service (accounts), balance-service (balances), ledger-service (ledger)
- transaction-service (payments), sepa-payment (payments)
- fx-service (fx), party-service (party), kyc-service (kyc), consent-service (consent)
- customer-edge (customer-edge), fraud-service (fraud)

Left untouched (no `ConfigUnsupported` condition — confirmed still plain Deployments via `kubectl`): aml, interest, dispute, psd2, audit, copilot.

VPA (`updateMode: Off`, recommendation-only — never mutates/evicts pods) natively supports `Rollout` as a scale-capable `targetRef`; no other spec changes needed.

## Definition of Done

- [x] Verified against the live cluster before writing anything: `kubectl get vpa -A -o json` to confirm exactly which 11 have the `ConfigUnsupported` condition, then `kubectl get rollout -n <ns> <name>` for all 11 to confirm the replacement target actually exists with the same name before touching the manifest.
- [x] `yaml.safe_load_all` passes clean; exact count check (11 `kind: Rollout`, 6 `kind: Deployment`) matches the audit.
- [ ] After merge + ArgoCD sync, re-check `kubectl get vpa -A` — all 17 should show no `ConfigUnsupported` condition, and recommendations should start reflecting real usage within Kubernetes' VPA observation window (not immediate — needs a data collection period).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None — this fixes a monitoring/recommendation tool, not the money-path services themselves (no resource requests/limits are changed by this PR, VPA is recommendation-only).

## Rollout / Rollback

- Deployment strategy: merge; the `vpa-objects` components directory syncs via ArgoCD `selfHeal` automatically, no manual `kubectl apply` needed.
- Rollback plan: revert this commit; ArgoCD syncs the revert automatically. VPA in `updateMode: Off` never touches running pods regardless, so there's no pod-level rollback needed either way.
- Data migration reversible: N/A

## Reviewer notes

This explains the dashboard's "VPA not yet providing recommendations (CRDs installed; allow ≥1h for initial data)" message being misleading for a large chunk of services — it reads as "just wait," but for these 11 it was structurally impossible regardless of wait time until this targetRef fix lands. Once merged, the *actual* per-namespace right-sizing conversation (several namespaces showing CPU efficiency in the low single digits against static requests, per the FinOps panel's "Right-sizing" table) becomes meaningful to have — recommend revisiting request/limit tuning only after this has had a real observation window, not off the current CPU%/Mem% snapshot alone.