### PR TITLE
feat(gitops): relax observability NodePool consolidation now that PDBs protect it

### DIFF
--- a/openbank-infra/gitops/components/observability/nodepool-observability.yaml
+++ b/openbank-infra/gitops/components/observability/nodepool-observability.yaml
@@ -2,8 +2,19 @@
 # The `default` pool allows spot, and spot reclamation was killing Prometheus/Tempo
 # every ~15-30 min (node dies mid-WAL-replay → stuck EBS volume → Multi-Attach). A
 # bank's monitoring plane must not ride spot. On-demand + a taint so ONLY tolerating
-# observability stateful pods land here; consolidation is conservative (WhenEmpty)
-# so a busy Prometheus node is never disrupted for bin-packing.
+# observability stateful pods land here.
+#
+# consolidationPolicy relaxed WhenEmpty -> WhenEmptyOrUnderutilized (FinOps):
+# WhenEmpty was the right call back when Prometheus/Tempo/Loki/Alertmanager had
+# NO PodDisruptionBudget — Karpenter's voluntary consolidation-driven eviction
+# could hit the exact same failure mode as spot reclaim (a stateful pod evicted
+# mid-WAL-replay). All 4 now have a PDB (minAvailable:1 -> 0 allowed disruptions,
+# same mechanism pyroscope/glitchtip-pg/goalert-db already relied on — see the
+# observability-components PDB manifests), confirmed live via `kubectl get pdb
+# -n observability` before this change. Karpenter's disruption controller
+# respects PDBs before evicting, so consolidation can now safely bin-pack idle
+# capacity without risking the original incident. Fleet was sitting at 7
+# on-demand nodes @ 6-37% resource-request utilization before this change.
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
@@ -48,5 +59,5 @@ spec:
   limits:
     cpu: "16"
   disruption:
-    consolidationPolicy: WhenEmpty
+    consolidationPolicy: WhenEmptyOrUnderutilized
     consolidateAfter: 1h


### PR DESCRIPTION
## Summary

**Step 2 of 2** (after #241, merged). Relaxes the observability NodePool's `consolidationPolicy` from `WhenEmpty` to `WhenEmptyOrUnderutilized`, now that all 4 previously-unprotected stateful services (Prometheus, Alertmanager, Loki, Tempo) have a live PodDisruptionBudget.

**Why this is safe now:** `WhenEmpty` existed because Karpenter's own voluntary consolidation-driven eviction could hit the exact same failure mode as the original incident (spot reclamation killing Prometheus/Tempo mid-WAL-replay → stuck EBS Multi-Attach) — just via a different trigger. With `minAvailable:1` PDBs in place (0 allowed disruptions on a single-replica pod), Karpenter's disruption controller will refuse to evict these pods for bin-packing purposes, same protection `pyroscope`/`glitchtip-pg`/`goalert-db` already had.

**Verified before opening this PR**: `kubectl get pdb -n observability` shows all 4 live with `ALLOWED DISRUPTIONS: 0`:
```
kube-prometheus-stack-alertmanager   1   N/A   0   9m25s
kube-prometheus-stack-prometheus     1   N/A   0   9m25s
loki                                 1   N/A   0   10m
tempo                                1   N/A   0   10m
```

## Type of change

- [x] feat (new functionality) — changes cluster scheduling/disruption behavior

## Linked issues

N/A — found via a cost/utilization audit, no tracked issue existed. Refs the same investigation as #241.

## Changes

- `openbank-infra/gitops/components/observability/nodepool-observability.yaml` — `consolidationPolicy: WhenEmpty` → `WhenEmptyOrUnderutilized`. `consolidateAfter: 1h` unchanged (still the minimum idle/underutilized duration before Karpenter considers a node).

## Definition of Done

- [x] Prerequisite (PDBs) merged and confirmed live before this PR was opened — not just assumed.
- [x] `yaml.safe_load` passes clean.
- [ ] After merge + ArgoCD sync, watch `kubectl get nodes -l karpenter.sh/nodepool=observability` over the following hours — expect node count to drop from 7 toward 2-3 as Karpenter bin-packs the ~6.6GB total requested memory currently spread thin. Also worth spot-checking Prometheus/Tempo/Loki/Alertmanager pod health across any resulting node transition (should be a clean, graceful reschedule given the PDB + graceful termination on-demand, not an abrupt kill).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency.

## Compliance impact

- [x] None — observability infra, not a money-path service.

## Rollout / Rollback

- Deployment strategy: merge; ArgoCD self-heals the `observability-components` Application automatically.
- Rollback plan: revert this commit (back to `WhenEmpty`) if consolidation ever causes an unexpected disruption; ArgoCD syncs the revert automatically. The PDBs from #241 stay in place regardless (they're a separate, independently-valuable safety net).
- Data migration reversible: N/A

## Reviewer notes

This is a genuine behavior change to a stateful, incident-sensitive part of the cluster — recommend watching the node count and pod health for the first consolidation cycle or two before considering this fully proven, even though the PDB protection should make it safe by construction.