### PR TITLE
ci(services-ci): fix stale nightly comment + raise max-parallel to 4

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -178,9 +178,13 @@ jobs:
       # Set 4 for PR/push: safe for both runner pools; the TC pre-warm step already
       # serialises the registry-cache cold-start window, so the NAT benefit is preserved.
       # Raise back to 8 once runner-tune-hetzner runs and persists aio-max-nr=1048576.
-      # Set 2 for nightly schedule: keeps the full-fleet build within Hetzner+Mac mini
-      # capacity (3 always-on self-hosted runners) so the nightly cron never spills onto
-      # ARC spot nodes. FinOps rule: ARC is overflow-only, not a guaranteed daily cost.
+      # Set 2 for nightly schedule: not a self-hosted-capacity constraint anymore. Since
+      # #198 the schedule/nightly matrix runs on ubuntu-latest (hosted, unlimited on this
+      # public repo) — same pool as PR/push — and Hetzner was deleted entirely in #208, so
+      # the old "stay within Hetzner+Mac mini capacity" rationale no longer applies. Kept
+      # at 2 (instead of matching PR/push's 4) because nightly is the full-fleet run (every
+      # ~30 services, not just the touched few); left conservative pending a deliberate
+      # look at whether it's safe to raise now that runner capacity isn't the limiter.
       max-parallel: ${{ github.event_name == 'schedule' && 2 || 4 }}
       matrix:
         service: ${{ fromJSON(needs.changes.outputs.services) }}

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -178,14 +178,15 @@ jobs:
       # Set 4 for PR/push: safe for both runner pools; the TC pre-warm step already
       # serialises the registry-cache cold-start window, so the NAT benefit is preserved.
       # Raise back to 8 once runner-tune-hetzner runs and persists aio-max-nr=1048576.
-      # Set 2 for nightly schedule: not a self-hosted-capacity constraint anymore. Since
-      # #198 the schedule/nightly matrix runs on ubuntu-latest (hosted, unlimited on this
-      # public repo) — same pool as PR/push — and Hetzner was deleted entirely in #208, so
-      # the old "stay within Hetzner+Mac mini capacity" rationale no longer applies. Kept
-      # at 2 (instead of matching PR/push's 4) because nightly is the full-fleet run (every
-      # ~30 services, not just the touched few); left conservative pending a deliberate
-      # look at whether it's safe to raise now that runner capacity isn't the limiter.
-      max-parallel: ${{ github.event_name == 'schedule' && 2 || 4 }}
+      # Nightly schedule now matches PR/push at 4 (was capped at 2). The old cap was a
+      # self-hosted-capacity guard (Hetzner+Mac mini) that no longer applies: since #198
+      # the schedule/nightly matrix runs on ubuntu-latest (hosted, free & unlimited on this
+      # public repo) — same pool and same proven-safe concurrency as PR/push — and Hetzner
+      # was deleted entirely in #208. Not raised past 4: the GitHub account is on the Free
+      # plan, capped at 20 concurrent hosted-runner jobs account-wide (shared with other
+      # repos/workflows), and nightly's matrix is ~30 services, so 4 keeps healthy headroom
+      # under that ceiling instead of racing other concurrent CI for the same slots.
+      max-parallel: 4
       matrix:
         service: ${{ fromJSON(needs.changes.outputs.services) }}
     uses: ./.github/workflows/_service-ci.yml


### PR DESCRIPTION
## Summary

The comment justifying `max-parallel` for the nightly-schedule matrix in `.github/workflows/services-ci.yml` cited Hetzner+Mac mini self-hosted runner capacity — stale on two counts: Hetzner was deleted entirely in #208, and since #198 the schedule/nightly matrix runs on `ubuntu-latest` (hosted), not the self-hosted pool at all. Fixed the comment, and since nightly never touches the paid ARC pool either way, raised `max-parallel` for schedule from 2 to 4 to match PR/push's already-proven-safe concurrency on the same hosted pool — zero incremental cost, faster nightly full-fleet build.

## Type of change

- [ ] feat (new functionality)
- [x] fix (bug fix / stale-config correction)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — drive-by comment-accuracy + config fix found during unrelated review, no tracked issue.

## Changes

- Rewrote the "Set 2 for nightly schedule" comment to state the actual current reason instead of the outdated self-hosted-capacity rationale.
- Raised nightly's `max-parallel` from 2 to 4 (now the same constant as PR/push — the ternary collapses since both branches were 4). Nightly always runs on `ubuntu-latest`, so this has no AWS/ARC cost impact; kept at 4 rather than higher because the GitHub account is on the Free plan (20 concurrent hosted-runner jobs, account-wide).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — N/A, workflow-only change
- [ ] Unit tests added/updated. — N/A, CI config change, verified via first scheduled/manual run
- [ ] Integration tests added/updated (if service boundary involved). — N/A
- [ ] Contract tests updated (if public API changed). — N/A
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no service code touched
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural). — comment is the doc here

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification (state it in this PR).
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`. — N/A
- [ ] PII path changed? → tag `gdpr-review-required`. — N/A
- [ ] Cardholder data path changed? → tag `pci-review-required`. — N/A

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: takes effect on the next scheduled (03:00 UTC) or manual (`workflow_dispatch`) nightly run.
- Rollback plan: revert this PR (or manually restore `max-parallel: 2` for schedule) if the nightly full-fleet build shows new flakiness at 4-wide concurrency.
- Data migration reversible: N/A

## Reviewer notes

Watch the next nightly (or trigger a manual `workflow_dispatch` run) to confirm 4-wide concurrency on `ubuntu-latest` doesn't reintroduce any of the resource contention the original cap was trying to avoid (that contention was specific to shared self-hosted hosts, which nightly no longer uses — but worth eyeballing once). Did not touch the aio-max-nr/PR-push rationale a few lines above; that's a separate, still-self-hosted-relevant path.