### PR TITLE
feat(gitops): CI plan/apply pipeline for sandbox-substrate (ADR-0060 follow-up)

### DIFF
--- a/.github/workflows/substrate-tofu.yml
+++ b/.github/workflows/substrate-tofu.yml
@@ -1,0 +1,255 @@
+# Substrate OpenTofu (ADR-0060 follow-up, issue #225). Mirrors
+# platform-tofu.yml so envs/sandbox-substrate (EKS cluster, VPC/network, DNS,
+# audit baseline, FinOps budget) gets the same CI-driven `tofu plan`/
+# `tofu apply` pipeline instead of an unpredictable laptop `tofu apply`. That
+# gap already caused real drift: an unapplied security-hardening flag, EKS
+# add-ons sitting versions behind, and an inert budget-notification config bug
+# that nothing ever ran `plan` against (issue #225).
+#
+# A SEPARATE workflow file (not a matrix extension of platform-tofu.yml):
+#   - the OIDC trust design pins the admin apply role to the EXACT workflow
+#     file via job_workflow_ref, so plan/apply for this root need their own
+#     workflow file the same way they need their own IAM roles (see
+#     ci-tofu-apply.tf in this directory) — a matrix job sharing one workflow
+#     file would let one `job_workflow_ref` cover both roots, which is exactly
+#     the widened-trust outcome issue #225 says not to do.
+#   - keeps the already-working platform-tofu.yml completely untouched.
+#
+#   pull_request / push -> `plan` job: read-only `tofu plan` to the job summary
+#       (PLAN role, batch lane). On a PR this is the pre-merge preview.
+#   workflow_dispatch   -> `apply` job: manual "Run workflow" on main (deploy
+#       lane, admin APPLY role). It re-plans with `-out=tfplan` and applies THAT
+#       file in the same job, so the executed change is exactly the freshly
+#       computed plan against current (locked) state; a stale plan is rejected.
+#
+# Why manual dispatch, not auto-on-merge: same as platform-tofu.yml — a
+# reviewer-gated GitHub Environment is the stronger design, but environment
+# protection rules need GitHub Pro/Team on a private repo (Free returns 422 —
+# ADR-0060). So the gate is: a human dispatches the apply (write access
+# required) after reading the PR's plan preview, and the admin APPLY role's
+# trust is pinned to THIS workflow file on main (job_workflow_ref) so nothing
+# else can assume it. Upgrade to an Environment gate if the plan allows.
+#
+# Auth is GitHub OIDC -> IAM (no static AWS keys). Roles + trust live in
+# envs/sandbox-substrate/ci-tofu-apply.tf (dedicated roles, NOT the platform
+# root's openbank-ci-tofu-{plan,apply} — see that file's header for why).
+# State is S3 with use_lockfile=true.
+name: Substrate OpenTofu
+
+on:
+  pull_request:
+    paths:
+      - "openbank-infra/aws/envs/sandbox-substrate/**"
+      - "openbank-infra/aws/modules/**"
+      - ".github/workflows/substrate-tofu.yml"
+  push:
+    branches: [main]
+    paths:
+      - "openbank-infra/aws/envs/sandbox-substrate/**"
+      - "openbank-infra/aws/modules/**"
+      - ".github/workflows/substrate-tofu.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write   # infracost PR comment
+
+concurrency:
+  group: substrate-tofu-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: eu-north-1
+  TOFU_VERSION: "1.12.1"
+  ENV_DIR: openbank-infra/aws/envs/sandbox-substrate
+  PLAN_ROLE: arn:aws:iam::265175468565:role/openbank-ci-tofu-plan-substrate
+  APPLY_ROLE: arn:aws:iam::265175468565:role/openbank-ci-tofu-apply-substrate
+
+jobs:
+  plan:
+    name: tofu plan (preview)
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest # hosted-first (public repo, free); OIDC plan role unchanged (ADR-0060)
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Configure AWS credentials (OIDC, read-only plan role)
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ env.PLAN_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # The custom ARC runner image ships docker/jq/yq/trivy but NOT the AWS CLI.
+      # Install v2 without root/unzip (python3 is present via the image's yamllint).
+      # Durable follow-up: bake awscli into the runner image (runner-image/Dockerfile).
+      - name: Ensure AWS CLI
+        run: |
+          if command -v aws >/dev/null; then aws --version; exit 0; fi
+          # Arch-aware: the openbank-batch pool mixes ARC Graviton (aarch64) and Hetzner
+          # (x86_64) hosts, so a hardcoded aarch64 bundle gives "Exec format error" (exit
+          # 126) when the job lands on an x86_64 host. Map uname -m to the AWS CLI suffix.
+          case "$(uname -m)" in
+            aarch64 | arm64) aws_arch=aarch64 ;;
+            x86_64 | amd64) aws_arch=x86_64 ;;
+            *) aws_arch=aarch64 ;;
+          esac
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip" -o /tmp/awscliv2.zip
+          python3 -m zipfile -e /tmp/awscliv2.zip /tmp/
+          # python zipfile extraction drops ALL execute bits; restore them (lowercase
+          # x, unconditional). Run the self-contained v2 bundle in place from dist/
+          # (no installer needed) and put it on PATH for the tofu steps.
+          chmod -R +x /tmp/aws/dist
+          echo "/tmp/aws/dist" >> "$GITHUB_PATH"
+          /tmp/aws/dist/aws --version
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+          tofu_wrapper: false
+
+      - name: tofu init
+        working-directory: ${{ env.ENV_DIR }}
+        run: tofu init -input=false
+
+      - name: tofu plan (read-only, no lock)
+        working-directory: ${{ env.ENV_DIR }}
+        run: |
+          set -o pipefail
+          tofu plan -input=false -lock=false -no-color -detailed-exitcode \
+            2>&1 | tee /tmp/plan.txt && code=0 || code=$?
+          {
+            echo "### \`tofu plan\` — ${ENV_DIR}"
+            if [ "$code" = "2" ]; then echo "_Changes pending._";
+            elif [ "$code" = "0" ]; then echo "_No changes._";
+            else echo "_Plan errored (exit $code)._"; fi
+            echo '```'
+            tail -c 60000 /tmp/plan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          [ "$code" = "1" ] && exit 1 || exit 0
+
+  # ── Infracost cost delta ───────────────────────────────────────────────────
+  # Posts a PR comment with the AWS cost delta introduced by this change.
+  # Runs without AWS credentials — Infracost parses HCL and fetches pricing
+  # from its own cloud API (free tier). INFRACOST_API_KEY must be set as a
+  # GitHub Actions secret (Settings → Secrets → Actions). Without the key the
+  # job soft-fails (continue-on-error) and blocks nothing.
+  infracost:
+    name: infracost cost delta
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
+    timeout-minutes: 10
+    continue-on-error: true   # non-blocking until INFRACOST_API_KEY is set
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Checkout base branch (for baseline)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: infracost-base
+
+      - name: Setup Infracost
+        uses: infracost/actions/setup@fb736a8f219195d6efdca58682069b16fe1bc280 # v4.2.0
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+
+      - name: Generate baseline cost estimate
+        run: |
+          infracost breakdown \
+            --path infracost-base/${{ env.ENV_DIR }} \
+            --format json \
+            --out-file /tmp/infracost-base.json
+
+      - name: Generate cost delta
+        run: |
+          infracost diff \
+            --path ${{ env.ENV_DIR }} \
+            --format json \
+            --compare-to /tmp/infracost-base.json \
+            --out-file /tmp/infracost-diff.json
+
+      - name: Post PR comment
+        run: |
+          infracost comment github \
+            --path /tmp/infracost-diff.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --github-token "${{ github.token }}" \
+            --pull-request "${{ github.event.pull_request.number }}" \
+            --behavior update
+
+  apply:
+    name: tofu apply (manual dispatch)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest # hosted-first; security boundary is the OIDC job_workflow_ref pin + manual dispatch (ADR-0060), not the runner
+    timeout-minutes: 30
+    # Audit trail + future reviewer gate, same pattern as platform-apply
+    # (issue #282). The openbank-ci-tofu-apply-substrate trust policy accepts
+    # the environment-form OIDC sub
+    # ("repo:OWNER/REPO:environment:substrate-apply") alongside the ref form,
+    # so declaring this environment doesn't break AssumeRole. Security
+    # boundary remains the job_workflow_ref pin + manual dispatch on main.
+    environment: substrate-apply
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Configure AWS credentials (OIDC, admin apply role)
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ env.APPLY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # The custom ARC runner image ships docker/jq/yq/trivy but NOT the AWS CLI.
+      # Install v2 without root/unzip (python3 is present via the image's yamllint).
+      # Durable follow-up: bake awscli into the runner image (runner-image/Dockerfile).
+      - name: Ensure AWS CLI
+        run: |
+          if command -v aws >/dev/null; then aws --version; exit 0; fi
+          # Arch-aware: the openbank-batch pool mixes ARC Graviton (aarch64) and Hetzner
+          # (x86_64) hosts, so a hardcoded aarch64 bundle gives "Exec format error" (exit
+          # 126) when the job lands on an x86_64 host. Map uname -m to the AWS CLI suffix.
+          case "$(uname -m)" in
+            aarch64 | arm64) aws_arch=aarch64 ;;
+            x86_64 | amd64) aws_arch=x86_64 ;;
+            *) aws_arch=aarch64 ;;
+          esac
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip" -o /tmp/awscliv2.zip
+          python3 -m zipfile -e /tmp/awscliv2.zip /tmp/
+          # python zipfile extraction drops ALL execute bits; restore them (lowercase
+          # x, unconditional). Run the self-contained v2 bundle in place from dist/
+          # (no installer needed) and put it on PATH for the tofu steps.
+          chmod -R +x /tmp/aws/dist
+          echo "/tmp/aws/dist" >> "$GITHUB_PATH"
+          /tmp/aws/dist/aws --version
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2.0.2
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+          tofu_wrapper: false
+
+      - name: tofu init
+        working-directory: ${{ env.ENV_DIR }}
+        run: tofu init -input=false
+
+      # Re-plan to a file and apply THAT file in the same job: the executed change
+      # is exactly this plan, computed against current locked state. If state moved
+      # since planning, `tofu apply tfplan` rejects it as stale (no wrong apply).
+      - name: tofu plan -out
+        working-directory: ${{ env.ENV_DIR }}
+        run: |
+          set -o pipefail
+          tofu plan -input=false -lock-timeout=300s -no-color -out=tfplan 2>&1 | tee /tmp/apply-plan.txt
+          {
+            echo "### \`tofu apply\` plan — ${ENV_DIR}"
+            echo '```'
+            tail -c 60000 /tmp/apply-plan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: tofu apply (saved plan)
+        working-directory: ${{ env.ENV_DIR }}
+        run: tofu apply -input=false -no-color -lock-timeout=300s tfplan

--- a/openbank-infra/aws/envs/sandbox-substrate/ci-tofu-apply.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/ci-tofu-apply.tf
@@ -1,0 +1,182 @@
+# ===========================================================================
+# CI-applies-substrate-tofu (ADR-0060 follow-up, issue #225). Mirrors
+# envs/sandbox-platform/ci-tofu-apply.tf so envs/sandbox-substrate (the EKS
+# cluster, VPC/network, DNS, audit baseline, FinOps budget) gets the same
+# CI-driven `tofu plan`/`tofu apply` pipeline instead of an unpredictable
+# laptop `tofu apply`. That gap already caused real drift: an unapplied
+# security-hardening flag, EKS add-ons behind, and an inert budget-notification
+# config bug that nothing ever ran `plan` against (issue #225).
+#
+# Deliberately a SEPARATE pair of roles from openbank-ci-tofu-{plan,apply} in
+# envs/sandbox-platform/ci-tofu-apply.tf — the issue is explicit that the
+# existing platform apply role's trust is pinned to the exact
+# `platform-tofu.yml` workflow ref and must not simply be widened to cover a
+# second, less-reviewed root. Same two-role design, same OIDC provider
+# (imported by ARN, not re-declared — one GitHub OIDC provider per account),
+# pinned to `.github/workflows/substrate-tofu.yml` instead.
+#
+# Trust model (identical shape to the platform pair):
+#   * Two roles. A read-only PLAN role assumable from any ref/PR of this repo
+#     (the pull_request/push plan preview); an admin APPLY role whose trust is
+#     pinned to the EXACT workflow file on main via the `job_workflow_ref`
+#     claim — only `.github/workflows/substrate-tofu.yml@refs/heads/main` can
+#     assume it.
+#   * The apply job is `workflow_dispatch` only (a human presses "Run
+#     workflow"), so apply never runs unattended on a push.
+#   * No static AWS keys in GitHub. Both roles are assumed via the same GitHub
+#     OIDC provider already created for the platform pair.
+#
+# Permission scoping: substrate provisions VPC/networking (modules/network),
+# EKS + node groups + cluster KMS/OIDC (modules/eks), Karpenter controller IAM
+# + SQS interruption queue (modules/karpenter-iam), Route53 zone + DNSSEC KMS
+# key + external-dns/cert-manager Pod Identity roles (modules/dns), the
+# CloudTrail/Config/S3-Object-Lock audit trail (modules/audit-baseline), and
+# AWS Budgets/Cost-Anomaly-Detection/SNS (finops-budget.tf) — i.e. it creates
+# and manages IAM roles/policies itself (Karpenter controller role, DNS Pod
+# Identity roles, audit-baseline roles) alongside EC2/VPC, EKS, KMS, Route53,
+# S3, CloudTrail, Config, SNS, Budgets, and Cost Explorer anomaly detection.
+# That is the same breadth of foundational, IAM-creating infrastructure as
+# sandbox-platform (which also creates IAM for Karpenter/ECR/helm releases),
+# so the same reasoning applies: AdministratorAccess, because a trimmed policy
+# would silently break applies the moment a new resource type is introduced
+# (exactly the failure mode this issue is fixing — nothing ran `plan` against
+# a merged change for months). The security boundary is the OIDC
+# job_workflow_ref pin + manual dispatch, not a trimmed permission list — this
+# mirrors, not exceeds, the platform apply role's permission set.
+#
+# Unlike the platform apply role, this one does NOT need an EKS access entry:
+# sandbox-substrate has no `kubernetes`/`helm` provider (versions.tf declares
+# only `aws` + `tls`) — the k8s/helm providers that need cluster RBAC live in
+# the platform root, not here.
+#
+# Bootstrap (one-time, out of band — see ADR-0060): applied manually the first
+# time (the apply role can't apply itself before it exists); thereafter CI
+# maintains it.
+# ===========================================================================
+
+locals {
+  # Same repo as the platform pair (single source: JiRaska/open-bank-oss).
+  ci_substrate_github_repo = "JiRaska/open-bank-oss"
+  ci_substrate_oidc_host   = "token.actions.githubusercontent.com"
+  # The exact workflow file (on main) allowed to assume the admin apply role.
+  ci_substrate_apply_workflow_ref = "JiRaska/open-bank-oss/.github/workflows/substrate-tofu.yml@refs/heads/main"
+}
+
+# Reuse the GitHub Actions OIDC provider already created by the platform root
+# (one provider per AWS account/URL — a second `aws_iam_openid_connect_provider`
+# for the same URL would collide). Imported by ARN via a data source so this
+# root has no resource-level dependency on envs/sandbox-platform's state.
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://${local.ci_substrate_oidc_host}"
+}
+
+# ---------------------------------------------------------------------------
+# PLAN role — read-only, assumable from ANY ref/PR of this repo (the plan
+# preview). ReadOnlyAccess; plan runs with -lock=false so it never writes
+# state or the lock.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "ci_tofu_plan_substrate_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.ci_substrate_oidc_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "${local.ci_substrate_oidc_host}:sub"
+      # Any branch/tag push and any PR of this repo (read-only role).
+      values = [
+        "repo:${local.ci_substrate_github_repo}:ref:refs/*",
+        "repo:${local.ci_substrate_github_repo}:pull_request",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_tofu_plan_substrate" {
+  name                 = "openbank-ci-tofu-plan-substrate"
+  assume_role_policy   = data.aws_iam_policy_document.ci_tofu_plan_substrate_assume.json
+  max_session_duration = 3600
+  tags                 = { Project = "openbank", ManagedBy = "opentofu", Adr = "0060" }
+}
+
+resource "aws_iam_role_policy_attachment" "ci_tofu_plan_substrate_readonly" {
+  role       = aws_iam_role.ci_tofu_plan_substrate.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# ---------------------------------------------------------------------------
+# APPLY role — AdministratorAccess, assumable ONLY by the substrate-tofu
+# workflow file on main (job_workflow_ref pin). See the file header for why
+# this mirrors (not exceeds) the platform apply role's permission set.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "ci_tofu_apply_substrate_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.ci_substrate_oidc_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    # Primary gate: pin to main of this repo. `sub` is always present in the
+    # OIDC token for all runner types (GitHub-hosted and ARC self-hosted).
+    # Two legitimate sub forms for the apply, both accepted (StringEquals on a
+    # list is an OR):
+    #   - no environment  -> sub = "repo:OWNER/REPO:ref:refs/heads/main"
+    #   - environment gate -> sub = "repo:OWNER/REPO:environment:substrate-apply"
+    # GitHub rewrites the sub to the environment form whenever the job
+    # declares `environment:` (same audit-trail pattern as platform's
+    # `platform-apply`, issue #282). Accepting both lets the apply job opt
+    # into the environment without breaking AssumeRole, while the
+    # job_workflow_ref pin below remains the actual security boundary.
+    condition {
+      test     = "StringEquals"
+      variable = "${local.ci_substrate_oidc_host}:sub"
+      values = [
+        "repo:${local.ci_substrate_github_repo}:ref:refs/heads/main",
+        "repo:${local.ci_substrate_github_repo}:environment:substrate-apply",
+      ]
+    }
+    # Belt-and-suspenders: further restrict to the exact workflow file when
+    # the job_workflow_ref claim is present. ARC self-hosted runners omit this
+    # claim on older runner versions, so we use StringEqualsIfExists (absent =
+    # skip check).
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "${local.ci_substrate_oidc_host}:job_workflow_ref"
+      values   = [local.ci_substrate_apply_workflow_ref]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_tofu_apply_substrate" {
+  name                 = "openbank-ci-tofu-apply-substrate"
+  assume_role_policy   = data.aws_iam_policy_document.ci_tofu_apply_substrate_assume.json
+  max_session_duration = 3600
+  tags                 = { Project = "openbank", ManagedBy = "opentofu", Adr = "0060" }
+}
+
+resource "aws_iam_role_policy_attachment" "ci_tofu_apply_substrate_admin" {
+  role       = aws_iam_role.ci_tofu_apply_substrate.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+output "ci_tofu_plan_substrate_role_arn" {
+  description = "Role the substrate-tofu PR plan job assumes (read-only)."
+  value       = aws_iam_role.ci_tofu_plan_substrate.arn
+}
+
+output "ci_tofu_apply_substrate_role_arn" {
+  description = "Role the substrate-tofu apply job assumes (workflow-ref-pinned, manual dispatch)."
+  value       = aws_iam_role.ci_tofu_apply_substrate.arn
+}


### PR DESCRIPTION
## Summary

- ADR-0060 gave `envs/sandbox-platform` a CI-driven `tofu plan`/`tofu apply` pipeline (`platform-tofu.yml`) so merged infra changes no longer depend on a laptop apply. `envs/sandbox-substrate` (EKS cluster, VPC/network, DNS, audit baseline, FinOps budget) never got the same treatment — this already caused real drift (an unapplied security-hardening flag, EKS add-ons behind, an inert budget-notification config bug).
- Adds `.github/workflows/substrate-tofu.yml`, a **separate** workflow file mirroring `platform-tofu.yml`'s structure exactly: `plan` job on every PR/push touching `openbank-infra/aws/envs/sandbox-substrate/**` (posts to job summary), manual `workflow_dispatch`-only `apply` job on `main`. No auto-apply on merge.
- Adds `openbank-infra/aws/envs/sandbox-substrate/ci-tofu-apply.tf`: dedicated `openbank-ci-tofu-plan-substrate` (read-only, `ReadOnlyAccess`) and `openbank-ci-tofu-apply-substrate` (`AdministratorAccess`) IAM roles, reusing the existing GitHub OIDC provider. The apply role's trust is pinned via `job_workflow_ref` to `.github/workflows/substrate-tofu.yml@refs/heads/main` only — it does **not** widen the existing `openbank-ci-tofu-apply` role's trust, per the issue's explicit instruction.

### Why a separate workflow file, not a matrix
The platform apply role's security boundary is a `job_workflow_ref` pin to one exact workflow file. A matrix job inside `platform-tofu.yml` would mean either widening that pin to cover a second root (exactly what issue #225 says not to do) or adding awkward per-matrix-leg role selection inside an already-working, security-sensitive file. A second file keeps `platform-tofu.yml` completely untouched and gives substrate its own pin, mirroring the pattern issue #225 asks for.

### IAM permission scoping — reasoning
`sandbox-substrate` provisions VPC/networking, EKS + node groups + cluster KMS/OIDC, Karpenter controller IAM + SQS interruption queue, Route53 zone + DNSSEC KMS key + Pod Identity IAM roles for external-dns/cert-manager, the CloudTrail/Config/S3-Object-Lock audit trail, and AWS Budgets/Cost Anomaly Detection/SNS — i.e. it creates and manages IAM itself across a broad set of foundational AWS services. This is the same class of breadth as `sandbox-platform` (which also provisions IAM for Karpenter/ECR/helm releases) and uses `AdministratorAccess` for the same stated reason: a trimmed policy would silently break applies the moment a new resource type is introduced — exactly the failure mode this issue is fixing (nothing ran `plan` for months). So the new apply role mirrors (does not exceed) the platform apply role's permission set; the security boundary is the OIDC `job_workflow_ref` pin + manual `workflow_dispatch`, not a trimmed IAM policy.

One difference from platform: this role does **not** get an EKS access entry. `sandbox-substrate`'s `versions.tf` declares only the `aws` and `tls` providers (no `kubernetes`/`helm`), so there's no in-cluster resource for this root's provider config to need RBAC for.

## Not run
**No live `tofu plan`/`tofu apply` was executed against `sandbox-substrate` as part of this PR** — this change only authors the CI pipeline. Locally verified: `tofu fmt -check` (clean) and `tofu validate` (succeeds, one pre-existing unrelated deprecation warning in `modules/audit-baseline/main.tf` not touched by this PR) against the new `.tf` file plus the existing directory. The YAML was validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

**The first real CI `plan` run against `sandbox-substrate` on this PR is the actual verification of this pipeline** — please review its job summary output once CI runs. Please also review the new IAM role's scoping carefully: `openbank-ci-tofu-apply-substrate` is a new credential with real `AdministratorAccess`-equivalent apply permissions against the live EKS cluster/VPC/DNS root, gated only by the OIDC trust conditions in `ci-tofu-apply.tf`.

## Test plan
- [ ] CI `plan` job runs on this PR and posts a plan (or "no changes") to the job summary for `sandbox-substrate`
- [ ] Confirm no diff to `sandbox-platform` or `platform-tofu.yml` (untouched by this PR)
- [ ] After merge: manually dispatch `Substrate OpenTofu` → `apply` once and confirm plan/apply completes and the AssumeRole trust (`job_workflow_ref` pin) behaves as expected
- [ ] Review whether the drift called out in #225 (security hardening flag, EKS add-on versions, budget-notification config bug) shows up in the first real plan diff

Closes #225