### PR TITLE
fix(product-catalog,governance): correct false ADR-0083 T1 native claim; add real native build

### DIFF
--- a/.github/workflows/product-catalog-native-build.yml
+++ b/.github/workflows/product-catalog-native-build.yml
@@ -1,0 +1,82 @@
+# Native (Mandrel/GraalVM) build + cold-start smoke test for product-catalog.
+#
+# ADR-0083 Enabler 1 / risk analysis: native build cost (RAM-hungry, ~3-5 min) must NOT
+# sit on the JVM PR gate. This workflow is therefore deliberately NOT triggered on
+# `pull_request` and must never be added to branch-protection required status checks —
+# it is a diagnostic/measurement lane, run on demand or after a merge that touches the
+# native Dockerfile, not a merge gate.
+#
+# What this validates: that Dockerfile.native actually compiles to a native executable
+# and that the resulting container serves traffic — i.e. Enabler 1 from ADR-0083. It
+# does NOT validate the ADR-0083 promotion gate (measured p95 cold-start under the real
+# KEDA HTTP add-on in the sandbox cluster) — that requires deploying to the cluster,
+# which is out of scope for a GitHub Actions job with no cluster network access
+# (rules.yaml: ci_runners — this lane needs no cluster network, so it runs GitHub-hosted).
+# Promoting `openbank-product-catalog` to T1 in rules.yaml:finops_tiers.declared still
+# requires that separate, cluster-side measurement (see ADR-0083 "Pilot plan" step 5).
+#
+# EXPECTED RED as of 2026-07-05 (see ADR-0083 correction note + issue #253): the native
+# image currently 500s on every request once running, a suspected openbank-libs
+# native-compatibility gap. That is exactly the failure this smoke test exists to catch
+# — a red run here means "do not promote," which is correct; it is non-blocking so it
+# does not stop unrelated JVM PRs from merging while this is investigated.
+name: Product Catalog Native Build (T1 enabler smoke test)
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - "openbank-product-catalog/**"
+      - ".github/workflows/product-catalog-native-build.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: product-catalog-native-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-build-smoke-test:
+    name: Build native image + smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build native image (Mandrel container build)
+        run: |
+          docker build \
+            -f openbank-product-catalog/Dockerfile.native \
+            -t product-catalog:native-ci \
+            .
+
+      - name: Cold-start smoke test
+        run: |
+          set -euo pipefail
+          START=$(date +%s%N)
+          CID=$(docker run -d -p 8104:8104 product-catalog:native-ci)
+          READY=0
+          for _ in $(seq 1 60); do
+            if curl -sf http://localhost:8104/q/health/ready >/dev/null 2>&1; then
+              READY=1
+              break
+            fi
+            sleep 0.5
+          done
+          END=$(date +%s%N)
+          docker logs "$CID" || true
+          docker stop "$CID" >/dev/null || true
+
+          if [ "$READY" -ne 1 ]; then
+            echo "::error::native image never reported ready within the smoke-test budget"
+            exit 1
+          fi
+
+          ELAPSED_MS=$(( (END - START) / 1000000 ))
+          echo "Cold start (container start -> /q/health/ready): ${ELAPSED_MS} ms"
+          echo "NOTE: this measures container-runtime start on a GitHub-hosted runner, not"
+          echo "the ADR-0083 promotion-gate metric (p95 cold start behind the KEDA HTTP"
+          echo "add-on interceptor in the sandbox cluster). Treat this as a build-health"
+          echo "signal only; the real promotion measurement happens in-cluster."

--- a/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
+++ b/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
@@ -2,8 +2,38 @@
 
 Date: 2026-06-02
 Status: Accepted
-Delivery-Status: Shipped
+Delivery-Status: Partial
 Author(s): Jiri Raska
+
+> **Correction (2026-07-05).** A prior edit (#2800, 2026-06-30) marked this ADR
+> `Delivery-Status: Shipped` and declared `openbank-product-catalog: T1` in
+> `rules.yaml` on the strength of Enabler 2 alone (the `HTTPScaledObject` + KEDA HTTP
+> add-on) while citing a non-existent issue (`#2083`) for Enabler 1 (the native image).
+> **No commit in this repo's history ever added a native build for `product-catalog`**
+> — `git log --all -- openbank-product-catalog/Dockerfile` shows only JVM fast-jar
+> changes (base-image digest pins). The service is still deployed as a JVM image
+> today (see `openbank-infra/gitops/components/accounts/product-catalog.yaml`), which
+> means the live `HTTPScaledObject` (`minReplicas: 0`) is currently scaling a ~1-2 s
+> JVM cold start, not the ~tens-of-ms native cold start this ADR's promotion gate
+> requires — the SLO was never actually measured, let alone passed. `Dockerfile.native`
+> (this PR) closes Enabler 1 in code; the §"Promotion gate" measurement below is still
+> open, and `rules.yaml:finops_tiers.declared` has been reverted to leave
+> `product-catalog` unclassified until it is. Remaining sandbox deploy + measurement
+> tracked in #253 — re-declare T1 only from that, not from this correction.
+>
+> **Local verification of `Dockerfile.native` (2026-07-05) found exactly the "native
+> build gotcha" this ADR's own risk table warns about**, and it is NOT yet resolved:
+> the image compiles and cold-starts fast (~200-330 ms, confirming the ADR's cold-start
+> premise), but **every HTTP request — including `/q/health/live` and `/` — currently
+> returns 500** once running (JVM behavior is unaffected; this is native-only). Root
+> cause not yet isolated: `openbank-libs-runtime`'s JAX-RS filters
+> (`ApiVersionResponseFilter`, `CorrelationIdFilter`, `RateLimitFilter`) look reflection-free
+> on inspection, and no exception stack trace surfaces in the JSON console logger even at
+> DEBUG (`quarkus.log.console.json` is build-time-fixed for native, so it can't be flipped
+> at runtime to get one). No commit in this repo has ever exercised `openbank-libs` under
+> GraalVM native before, so this may be a fleet-wide libs gap, not a product-catalog-only
+> one. **This blocks Enabler 1 from being considered done** — tracked as the first item
+> in #253 alongside the sandbox measurement, ahead of any deploy attempt.
 
 > **Renumbered 0059 → 0083 (2026-06-11).** This ADR was originally filed as ADR-0059, a
 > number it accidentally shared with the (more widely referenced) outbound-oversight-webhooks
@@ -47,8 +77,14 @@ read/HTTP fleet; failure = revert to `min>0` with no harm.
 
 KEDA is deployed cluster-wide (ADR-0041 P1 confirmed).
 KEDA HTTP add-on is installed (tofu/sandbox-platform, HA interceptor 2 replicas).
-`HTTPScaledObject` for `product-catalog` is live (minReplicas: 0) and the tier is declared
-T1 in `rules.yaml: finops_tiers.declared` — pilot complete.
+`HTTPScaledObject` for `product-catalog` is live (minReplicas: 0) — Enabler 2 is done.
+Enabler 1 (native image) now has a build (`openbank-product-catalog/Dockerfile.native`
++ `.github/workflows/product-catalog-native-build.yml`, a non-blocking smoke-test lane),
+but it has not been deployed to the sandbox or measured against the promotion gate below
+— **the tier is NOT yet declared T1 in `rules.yaml`.** Until the measured cold-start SLO
+passes in-cluster, the live `HTTPScaledObject` is scaling a JVM image from zero, which
+does not meet this ADR's cold-start assumption; treat `minReplicas: 0` as running ahead
+of its own prerequisite, not as a completed pilot.
 
 ### Enabler 1 — native image build
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,7 +91,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0080](0080-pentest-remediation-p0-p2.md) | Pentest remediation (admin.open-bank.tech) — P0/P1/P2 | Accepted | Partial | — |
 | [0081](0081-cluster-segmentation-and-container-hardening-baseline.md) | Cluster segmentation & container hardening baseline | Accepted | Shipped | — |
 | [0082](0082-ci-runner-governance.md) | CI runner governance — trust-tiered persistent pools, no human in the merge path | Superseded by ADR-0053 | N/A | — |
-| [0083](0083-t1-http-scale-to-zero-native-pilot.md) | T1 (HTTP → 0): native-image + KEDA HTTP add-on pilot on product-catalog | Accepted | Shipped | — |
+| [0083](0083-t1-http-scale-to-zero-native-pilot.md) | T1 (HTTP → 0): native-image + KEDA HTTP add-on pilot on product-catalog | Accepted | Partial | — |
 | [0084](0084-fraud-detection-bounded-context.md) | Fraud detection bounded context — real-time transaction risk scoring | Accepted | Shipped | — |
 | [0085](0085-complaints-handling.md) | Complaints handling — regulatory complaints as a first-class process | Accepted | Partial | — |
 | [0086](0086-customer-payment-non-repudiation-and-audit-chain.md) | Customer payment non-repudiation — SCA settlement gate, identity threading, audit chain | Accepted | Shipped | — |

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -642,7 +642,13 @@ finops_tiers:
   # t0_baseline and need no explicit entry.
   declared:
     openbank-notification-service: T2     # proven pilot, live in sandbox (ADR-0057 best-first target, #228)
-    openbank-product-catalog: T1          # ADR-0083 pilot: HTTPScaledObject minReplicas:0 live; native cold-start SLO gate passed in sandbox (#2083)
+    # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
+    # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
+    # no commit ever added a native build (Enabler 1), so the claimed "native
+    # cold-start SLO gate passed in sandbox" never happened. Corrected 2026-07-05:
+    # reverted to unclassified until the ADR-0083 promotion gate is actually measured
+    # in-cluster and passes — tracked in #253. Do not re-declare T1 from this comment
+    # alone; only from a real measurement.
 
   # Keep-honest classifier: reads measured signals (HTTP rate/idle ratio, Kafka lag +
   # active fraction, CPU/replica utilisation), emits a recommended tier + realised

--- a/openbank-product-catalog/Dockerfile.native
+++ b/openbank-product-catalog/Dockerfile.native
@@ -1,0 +1,57 @@
+# Native (Mandrel/GraalVM) build variant for product-catalog — ADR-0083 Enabler 1.
+#
+# This is a SEPARATE file from the default Dockerfile (plain JVM fast-jar), which stays
+# the image every other pipeline (build-push-service.sh, services-ci.yml, auto-deploy)
+# builds by default. This file is built ONLY by the dedicated, non-blocking native CI
+# lane (.github/workflows/product-catalog-native-build.yml) — ADR-0083's own risk
+# analysis calls for a separate lane precisely so a slow/RAM-hungry native compile never
+# gates the JVM PR gate.
+#
+# KNOWN ISSUE (see ADR-0083 correction note + issue #253): the compiled native binary
+# starts fast (~200-330ms, verified locally) but currently 500s on EVERY request,
+# including /q/health/live — this is unresolved and likely an openbank-libs
+# native-compatibility gap (no service has run under GraalVM native before), not
+# something specific to this file. Do not treat a passing build of this Dockerfile as
+# proof the image is servable — the CI smoke-test lane below is expected to catch this.
+#
+# Unlike ADR-0083's literal `-Dquarkus.native.container-build=true` recipe (which has
+# quarkus-maven/gradle itself invoke Docker to spin up a Mandrel container — meant for a
+# host/CI runner that owns the Docker socket), this Dockerfile's build STAGE *is* the
+# Mandrel builder image: native-image is already on its PATH, so no nested
+# Docker-in-Docker is needed inside a `docker build`. Functionally equivalent output;
+# simpler to reason about inside a multi-stage build.
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-25@sha256:4dda6a3d677b57614849557d0d18aac7326c4f30175142b0f1bb91bdcfc5c29a AS build
+WORKDIR /build
+
+# Same full-repo-root context rationale as the JVM Dockerfile: settings.gradle.kts
+# unconditionally includes all 30+ modules with an explicit projectDir each.
+COPY . /build
+
+ENV GRADLE_OPTS="-Xmx2g -Xms256m -XX:MaxMetaspaceSize=512m"
+USER root
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-product-catalog:quarkusBuild \
+      -Dquarkus.package.type=native \
+      -Dquarkus.native.enabled=true \
+      -Dorg.gradle.java.installations.auto-detect=false \
+      --no-daemon \
+      --console=plain
+
+# Runtime base MUST match the builder's glibc generation. quay.io/quarkus/quarkus-micro-image:2.0
+# is RHEL8-based (glibc 2.28) while the jdk-25 Mandrel builder is RHEL9-based (glibc 2.34) —
+# tried micro-image:2.0 first and the binary failed at container startup with
+# "/lib64/libc.so.6: version `GLIBC_2.34' not found" (verified locally). ubi9/ubi-minimal
+# matches the builder's RHEL9 base; it is the "ubi-minimal" alternative ADR-0083 names
+# alongside quarkus-micro-image, so this stays within the ADR's own recipe.
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8@sha256:463cae32c6f6f5594b11a5c22de275016bd8545ce58a6373388e8b24f13fc15c
+WORKDIR /work
+
+RUN chown 1001 /work \
+    && chmod "g+rwX" /work \
+    && chown 1001:root /work
+COPY --from=build --chown=1001:root /build/openbank-product-catalog/build/*-runner /work/application
+
+EXPOSE 8104
+USER 1001
+
+ENTRYPOINT ["/work/application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
## Summary

- ADR-0083 and `rules.yaml` claimed `openbank-product-catalog` was T1 (native-image +
  KEDA HTTP add-on) "Shipped"/"pilot complete", citing a non-existent issue (`#2083`).
  `git log --all -- openbank-product-catalog/Dockerfile` proves this repo never had a
  native build for this service — the claim was false, not a migration artifact (the
  false declaration itself was committed here on 2026-06-30, #2800, four days after
  this repo's history starts).
- Corrects the record: ADR-0083 `Delivery-Status` reverted `Shipped` → `Partial` with a
  dated correction note; `rules.yaml`'s `openbank-product-catalog: T1` declaration
  reverted to unclassified; `docs/adr/README.md` regenerated.
- Adds the actually-missing native build: `openbank-product-catalog/Dockerfile.native`
  (Mandrel `jdk-25` builder → `ubi9-minimal` runtime, digest-pinned) and a non-blocking
  CI smoke-test lane, per ADR-0083's own Enabler-1 recipe.
- **Verified locally**: the native image compiles (`BUILD SUCCESSFUL in 32m 2s`) and
  cold-starts in ~200-330ms — confirms the ADR's core premise. Also found and fixed a
  real runtime-base/glibc mismatch (`quarkus-micro-image:2.0` is RHEL8, the Mandrel
  builder is RHEL9). **Found but did NOT fix** a second, harder issue: every HTTP
  request 500s once the native image is running — likely a fleet-wide `openbank-libs`
  native-compatibility gap (no service here has ever run under GraalVM native).
  Documented in the ADR correction note, the Dockerfile, the CI lane, and tracked in
  #253 so #230 isn't worked assuming Enabler 1 is a simple lift.

## Test plan

- [x] `bash .github/scripts/check-adr-status.sh` — OK
- [x] `bash docs/adr/gen-index.sh` regenerated and committed
- [x] `python3 -c "import yaml; yaml.safe_load(open('openbank-libs/governance/rules.yaml'))"` — parses
- [x] Local `docker build -f openbank-product-catalog/Dockerfile.native .` — succeeds
- [x] Local smoke test against a throwaway Postgres — native image starts in <350ms
      (confirms cold-start premise), but currently 500s all requests (tracked in #253,
      not fixed in this PR — root-causing an `openbank-libs` native gap is a separate,
      larger piece of work)
- [ ] Sandbox deploy + measured cold-start SLO (ADR-0083 promotion gate) — out of scope
      for this PR, tracked in #253

Linked issues: Refs #230, Refs #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)