### PR TITLE
fix(infra): restore Environment/Service tags + Config recording-mode budget guardrail

### DIFF
--- a/openbank-infra/aws/envs/sandbox-substrate/finops-budget.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/finops-budget.tf
@@ -158,3 +158,41 @@ resource "aws_budgets_budget" "nat_daily" {
     subscriber_email_addresses = [var.finops_alert_email]
   }
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AWS Config recording-mode drift guardrail (2026-07-06 incident)
+# ─────────────────────────────────────────────────────────────────────────────
+# Root cause: aws_config_configuration_recorder.recording_mode can drift to the
+# AWS default (CONTINUOUS) on the live resource without tofu apply ever failing
+# — it only surfaced via AWS Cost Anomaly Detection 1-2 days later
+# (EUN1-ConfigurationItemRecordedDaily, +$59/day, Karpenter's ~30min node churn
+# turned every node replace into a burst of recorded configuration items).
+# This budget catches the same signature same-day instead of via cost-anomaly
+# latency. Verify recording_mode directly after every audit-baseline apply:
+#   aws configservice describe-configuration-recorders (boto3 — an older AWS
+#   CLI can silently omit the recordingMode field from its output).
+resource "aws_budgets_budget" "config_recording_daily" {
+  name         = "openbank-config-recording-daily"
+  budget_type  = "COST"
+  limit_amount = "3"
+  limit_unit   = "USD"
+  time_unit    = "DAILY"
+
+  cost_filter {
+    name   = "Service"
+    values = ["AWS Config"]
+  }
+  cost_filter {
+    name   = "UsageType"
+    values = ["EUN1-ConfigurationItemRecordedDaily"]
+  }
+
+  # DAILY budgets only support ACTUAL notifications (see nat_daily above).
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 60 # $1.80/day actual — DAILY recording_mode is normally ~$0
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.finops_alert_email]
+  }
+}

--- a/openbank-infra/aws/envs/sandbox-substrate/main.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/main.tf
@@ -33,6 +33,13 @@ module "eks" {
   node_desired_size   = 2
   node_min_size       = 2
   node_max_size       = 4
+
+  tags = {
+    Project     = "openbank"
+    ManagedBy   = "opentofu"
+    Environment = "sandbox"
+    Service     = "openbank"
+  }
 }
 
 module "karpenter_iam" {
@@ -43,6 +50,13 @@ module "karpenter_iam" {
   # Must match the Karpenter Helm release in the platform root.
   controller_namespace       = "kube-system"
   controller_service_account = "karpenter"
+
+  tags = {
+    Project     = "openbank"
+    ManagedBy   = "opentofu"
+    Environment = "sandbox"
+    Service     = "karpenter"
+  }
 }
 
 # Public DNS (open-bank.tech) + zone-scoped Pod Identity IAM for external-dns


### PR DESCRIPTION
## Summary
- `module.eks` / `module.karpenter_iam` calls in `sandbox-substrate/main.tf` never passed a `tags` argument (the module's `var.tags` defaults to `{}`), silently dropping `Environment`/`Service` tags from every resource those modules manage. Restored to match the `network`/`audit-baseline` module calls.
- Added a `DAILY` `aws_budgets_budget` on `EUN1-ConfigurationItemRecordedDaily` (same pattern as the existing NAT-egress budget) so an `aws_config_configuration_recorder.recording_mode` drift to `CONTINUOUS` — AWS's silent default, doesn't fail `tofu apply` — is caught same-day instead of via Cost Anomaly Detection 1-2 days later.

## Context
2026-07-06 AWS Cost Anomaly Detection flagged +$59/day on `EUN1-ConfigurationItemRecordedDaily` (Karpenter's ~30min node churn turning every node replace into a burst of recorded configuration items once `recording_mode` drifted off `DAILY`). Root cause and immediate recorder fix already applied directly (`tofu apply`, verified `recordingMode.recordingFrequency = DAILY` via boto3 post-apply — an older AWS CLI silently omits that field from `describe-configuration-recorders` output). This PR is the remaining code-side guardrail + tag fix, applied and verified against the same `sandbox/substrate.tfstate` state.

## Test plan
- [x] `tofu plan` clean except the already-known, separately-tracked `fck-nat` AMI replace (blocked by an open EC2 vCPU quota increase, unrelated to this change)
- [x] `tofu apply` — tags + budget resource applied cleanly
- [x] Config recorder verified `DAILY` post-apply

Linked issues: N/A — incident remediation, no tracked issue opened yet