### PR TITLE
fix(gitops): stop ArgoCD selfHeal fighting KEDA scale-to-zero on T1 sweep services

### DIFF
--- a/openbank-infra/gitops/apps/interest.yaml
+++ b/openbank-infra/gitops/apps/interest.yaml
@@ -31,3 +31,25 @@ spec:
         maxDuration: 5m
     syncOptions:
       - ServerSideApply=true
+      # RespectIgnoreDifferences: this app also carries compare-options:
+      # IncludeMutationWebhook=true (Kyverno digest-pin dry-run, #856) — with
+      # that comparison mode, the ignoreDifferences.jqPathExpressions entry
+      # below suppresses the OutOfSync *status* but NOT what selfHeal actually
+      # pushes on a triggered sync; without this option selfHeal kept
+      # re-applying replicas:1 from git every reconcile, fighting KEDA's
+      # scale-to-zero forever (confirmed live in openbank-sandbox — repeated
+      # ScalingReplicaSet 0->1 events minutes apart). product-catalog and sdd
+      # don't need this because neither sets IncludeMutationWebhook.
+      - RespectIgnoreDifferences=true
+  # ADR-0057 T1 pilot (#248): the KEDA HTTP add-on owns replicas 0<->1 on
+  # interest-service, not ArgoCD. Without this, selfHeal fights KEDA every
+  # reconcile — forces replicas back to the git-declared 1, KEDA promptly
+  # scales it back to 0 on idle, permanent OutOfSync/flap loop (same pattern
+  # as product-catalog's ADR-0083 pilot, gitops/apps/product-catalog.yaml).
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      name: interest-service
+      namespace: interest
+      jqPathExpressions:
+        - .spec.replicas

--- a/openbank-infra/gitops/apps/payments.yaml
+++ b/openbank-infra/gitops/apps/payments.yaml
@@ -24,6 +24,17 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # RespectIgnoreDifferences: this app also carries compare-options:
+      # IncludeMutationWebhook=true (Kyverno digest-pin dry-run, #856) — with
+      # that comparison mode, the ignoreDifferences.jqPathExpressions entry
+      # below (card-issuance-service) suppresses the OutOfSync *status* but
+      # NOT what selfHeal actually pushes on a triggered sync; without this
+      # option selfHeal kept re-applying replicas:1 from git every reconcile,
+      # fighting KEDA's scale-to-zero forever (confirmed live in
+      # openbank-sandbox — repeated ScalingReplicaSet 0->1 events minutes
+      # apart). product-catalog and sdd don't need this because neither sets
+      # IncludeMutationWebhook.
+      - RespectIgnoreDifferences=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.
@@ -37,3 +48,15 @@ spec:
       kind: Service
       jqPathExpressions:
         - .spec.selector."rollouts-pod-template-hash"
+    # ADR-0057 T1 pilot (#249): the KEDA HTTP add-on owns replicas 0<->1 on
+    # card-issuance-service, not ArgoCD. Without this, selfHeal fights KEDA
+    # every reconcile — forces replicas back to the git-declared 1, KEDA
+    # promptly scales it back to 0 on idle, permanent OutOfSync/flap loop
+    # (same pattern as product-catalog's ADR-0083 pilot,
+    # gitops/apps/product-catalog.yaml).
+    - group: apps
+      kind: Deployment
+      name: card-issuance-service
+      namespace: payments
+      jqPathExpressions:
+        - .spec.replicas

--- a/openbank-infra/gitops/apps/sdd.yaml
+++ b/openbank-infra/gitops/apps/sdd.yaml
@@ -28,3 +28,15 @@ spec:
         maxDuration: 5m
     syncOptions:
       - CreateNamespace=false
+  # ADR-0057 T1 pilot (#251): the KEDA HTTP add-on owns replicas 0<->1 on
+  # sdd-service, not ArgoCD. Without this, selfHeal fights KEDA every
+  # reconcile — forces replicas back to the git-declared 1, KEDA promptly
+  # scales it back to 0 on idle, permanent OutOfSync/flap loop (same pattern
+  # as product-catalog's ADR-0083 pilot, gitops/apps/product-catalog.yaml).
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      name: sdd-service
+      namespace: sdd
+      jqPathExpressions:
+        - .spec.replicas


### PR DESCRIPTION
## Summary

Follow-up to #261. While verifying that fix live in `openbank-sandbox`, found that the #230 T1 sweep (`interest-service` #248, `card-issuance-service` #249, `sdd-service` #251) left ArgoCD's `selfHeal` actively fighting KEDA's scale-to-zero on all three services — none of them carry the `ignoreDifferences` guard on `.spec.replicas` that `product-catalog`'s ADR-0083 pilot already uses (`gitops/apps/product-catalog.yaml`).

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #230

## Changes

- `gitops/apps/interest.yaml`, `gitops/apps/payments.yaml`, `gitops/apps/sdd.yaml`: add `ignoreDifferences` for `.spec.replicas` on the respective T1 Deployment (`interest-service`, `card-issuance-service`, `sdd-service`), matching the proven `product-catalog` pattern.
- `interest.yaml` and `payments.yaml` also need `syncOptions: RespectIgnoreDifferences=true` — both carry `compare-options: IncludeMutationWebhook=true` (Kyverno digest-pin dry-run, #856), and under that comparison mode `ignoreDifferences.jqPathExpressions` alone suppresses the OutOfSync *status* but not what selfHeal actually applies on a triggered sync. `sdd.yaml` has no such annotation, so plain `ignoreDifferences` is sufficient there (same as `product-catalog`).

## Verification (live, in openbank-sandbox)

- Confirmed the bug: `interest-service` and `card-issuance-service` were both being forcibly scaled `0 -> 1` by ArgoCD repeatedly (`kubectl get events`), immediately followed by KEDA scaling back to 0 on idle — a permanent flap loop that defeats the T1 migration's entire purpose and needlessly restarts pods.
- Patched all three Applications directly in the cluster to match this PR's changes; confirmed replicas settled at 0 and stopped flapping.
- **Caught a second-order issue mid-verification**: the `root` app-of-apps (which owns these Application manifests itself) selfHealed my live-only patch away from `payments` within minutes, since git didn't have the change yet — card-issuance-service got scaled up again as a result. Re-applied the live patch immediately as a stopgap and confirmed it holds; this PR is what makes the fix durable once merged (root will then sync the real desired state instead of reverting it).
- After merge, ArgoCD will resync `interest`, `payments`, `sdd` to this state and the manual live patch becomes redundant/superseded.

## Definition of Done

- [ ] Hexagonal layering / unit tests / etc. — N/A, pure GitOps Application config, no service code touched.
- [x] No new lint warnings (validated the 3 YAML files parse cleanly).
- [x] Docs updated — inline comments in each Application manifest explain the KEDA/ArgoCD interaction and why `RespectIgnoreDifferences` is needed for two of the three but not the third.

## Security checklist

- [x] No secrets/tokens/PII.
- [x] No new dependency.
- N/A auth/crypto/PII/cardholder paths — this only changes ArgoCD diff/sync behavior for non-money-path T1 services.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: GitOps (ArgoCD auto-sync on merge to `main`).
- Rollback plan: revert this commit; ArgoCD resyncs and removes the `ignoreDifferences`/`RespectIgnoreDifferences` entries (selfHeal-vs-KEDA flapping would resume, but no worse than the pre-existing state).
- Data migration reversible: N/A.

## Reviewer notes

This is a second, independent gap in the same #230 T1 sweep as #261 (that one was a NetworkPolicy ingress gap; this one is an ArgoCD reconciliation gap). Both stem from the sweep PRs not replicating every piece of `product-catalog`'s original ADR-0083 pilot recipe. Worth checking future T1 onboarding PRs for both.