### PR TITLE
fix(product-catalog): close two GraalVM native gotchas; measure ADR-0083 T1 promotion gate

### DIFF
--- a/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
+++ b/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
@@ -34,6 +34,47 @@ Author(s): Jiri Raska
 > GraalVM native before, so this may be a fleet-wide libs gap, not a product-catalog-only
 > one. **This blocks Enabler 1 from being considered done** — tracked as the first item
 > in #253 alongside the sandbox measurement, ahead of any deploy attempt.
+>
+> **Update (2026-07-06) — Enabler 1 bugs fixed; promotion gate still NOT met, for a
+> different reason than expected.** Root-caused and fixed both native-only defects (JVM
+> was unaffected by either — full detail in #253):
+> 1. `PostgresProductRepository.coAwait()` bridged Mutiny `Uni` → Kotlin coroutine via
+>    `subscribeAsCompletionStage().await()`, dropping the Vert.x duplicated context
+>    RESTEasy Reactive needs to write the response — a hand-rolled bridge; every other
+>    service in the fleet already uses the standard `mutiny-kotlin` `awaitSuspending()`
+>    for this. Switched to match the fleet.
+> 2. `Product` (JSONB-backed, deserialized via plain `ObjectMapper.readValue`, not a
+>    direct JAX-RS body) was never registered for reflection, so Jackson's Kotlin
+>    data-class Creator lookup failed under native with `InvalidDefinitionException`.
+>    Added `@RegisterForReflection`.
+>
+> With both fixed, `/api/v1/products` returns 200 with real data and `/q/health/ready`
+> on the management port returns `UP` with live DB connectivity — **the native image
+> itself now works correctly.** Deployed it to an isolated scratch namespace in the
+> sandbox cluster (own throwaway Postgres, no Ingress/HTTPScaledObject, zero blast
+> radius) and measured 5 scale-0→1 cycles: **3.5 s, 4.8 s, 8.8 s, 5.2 s, 7.5 s** (mixed
+> methodology — Pod-`Ready` time and Service-reachable time; both landed in the same
+> multi-second range). This is **7-25× the ADR's ~300-500 ms p95 target**, and the gap
+> is NOT the application — process start alone is ~0.2-0.3 s, confirmed repeatedly.
+> **The gap is Kubernetes Pod-lifecycle overhead**: scheduling, image pull when a node
+> hasn't cached the image (~3 s observed), and the kubelet's readiness-probe polling
+> interval — none of which a fast-starting binary can shortcut. The scratch test used a
+> *more aggressive* probe (`periodSeconds: 1`) than product-catalog's real gitops
+> manifest (`periodSeconds: 10`, plus a `startupProbe` with `initialDelaySeconds: 5`) —
+> so production would measure slower, not faster, than these numbers.
+>
+> **This means the ADR's promotion gate as written may be unmeasurable-as-stated for a
+> Pod-scale-from-zero mechanism, regardless of image type.** The KEDA HTTP add-on
+> interceptor hides this latency from the caller (parks the request, no 5xx — by
+> design, per the risk table above), but the ADR's own §"Promotion gate" asks to
+> "promote only if native cold start (0 → first-byte) ≤ ~300-500 ms p95," and that
+> number was scoped to *process* start, not *Kubernetes Pod* start. `rules.yaml`'s
+> `openbank-product-catalog` entry stays unclassified (not T1) — the SLO, as measured
+> end-to-end, is not met. Whether to (a) redefine the promotion gate around what's
+> actually controllable (process start) and treat multi-second interceptor latency as
+> an accepted trade-off, or (b) treat this as evidence T1 isn't viable for this service
+> without further platform work (node-level image pre-pulling, a faster probe) is a
+> product decision, not something this correction resolves — recorded in #253.
 
 > **Renumbered 0059 → 0083 (2026-06-11).** This ADR was originally filed as ADR-0059, a
 > number it accidentally shared with the (more widely referenced) outbound-oversight-webhooks

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -645,10 +645,16 @@ finops_tiers:
     # openbank-product-catalog was WRONGLY declared T1 here (#2800), citing a
     # non-existent issue (#2083), while only Enabler 2 (HTTPScaledObject) existed —
     # no commit ever added a native build (Enabler 1), so the claimed "native
-    # cold-start SLO gate passed in sandbox" never happened. Corrected 2026-07-05:
-    # reverted to unclassified until the ADR-0083 promotion gate is actually measured
-    # in-cluster and passes — tracked in #253. Do not re-declare T1 from this comment
-    # alone; only from a real measurement.
+    # cold-start SLO gate passed in sandbox" never happened. Corrected 2026-07-05.
+    # Update 2026-07-06: Enabler 1 (native build) is now real and its two native-only
+    # bugs are fixed (bad Mutiny/coroutine bridge, missing @RegisterForReflection —
+    # verified working end-to-end in a scratch namespace, #253) — but the ADR-0083
+    # promotion gate (native cold start ≤ ~300-500ms p95) was MEASURED and FAILS:
+    # 5 scale-0->1 cycles landed at 3.5-8.8s, dominated by Kubernetes Pod scheduling /
+    # image-pull / readiness-probe overhead, not the ~200ms application start. Stays
+    # unclassified — do not re-declare T1 until #253's product decision (redefine the
+    # gate around process start, or treat T1 as not viable here without platform work)
+    # is resolved.
 
   # Keep-honest classifier: reads measured signals (HTTP rate/idle ratio, Kafka lag +
   # active fraction, CPU/replica utilisation), emits a recommended tier + realised

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt
@@ -61,14 +61,10 @@ data class Fee(
     val frequency: String,
     val description: String? = null,
     val waivable: Boolean = false,
-    val waiveCondition: String? = null
+    val waiveCondition: String? = null,
 )
 
-data class InterestTier(
-    val fromAmount: Double,
-    val toAmount: Double?,
-    val rateAnnual: Double
-)
+data class InterestTier(val fromAmount: Double, val toAmount: Double?, val rateAnnual: Double)
 
 data class CardConfig(
     val enabled: Boolean = false,
@@ -81,7 +77,7 @@ data class CardConfig(
     val eligibilityMinAge: Int? = null,
     val eligibilitySegments: List<EligibilitySegment> = listOf(EligibilitySegment.ALL),
     val monthlyFeePerCard: Double = 0.0,
-    val cardCurrency: String? = null
+    val cardCurrency: String? = null,
 )
 
 data class MultiCurrencyConfig(
@@ -91,7 +87,7 @@ data class MultiCurrencyConfig(
     val fxMarginPct: Double = 1.5,
     val fxMarginBuyPct: Double? = null,
     val fxMarginSellPct: Double? = null,
-    val crossCurrencyTransferAllowed: Boolean = true
+    val crossCurrencyTransferAllowed: Boolean = true,
 )
 
 data class OverdraftConfig(
@@ -101,7 +97,7 @@ data class OverdraftConfig(
     val gracePeriodDays: Int = 0,
     val unarrangedDailyFee: Double? = null,
     val unarrangedRateAnnual: Double? = null,
-    val autoApprovalEnabled: Boolean = false
+    val autoApprovalEnabled: Boolean = false,
 )
 
 data class TermDepositConfig(
@@ -112,7 +108,7 @@ data class TermDepositConfig(
     val payoutFrequency: InterestPayoutFrequency = InterestPayoutFrequency.AT_MATURITY,
     val autoRenewEnabled: Boolean = true,
     val earlyWithdrawalPenaltyPct: Double = 50.0,
-    val earlyWithdrawalNoticeDays: Int = 0
+    val earlyWithdrawalNoticeDays: Int = 0,
 )
 
 data class SavingsConfig(
@@ -121,7 +117,7 @@ data class SavingsConfig(
     val freeWithdrawalsPerMonth: Int = 0,
     val excessWithdrawalFee: Double = 0.0,
     val bonusRateCondition: String? = null,
-    val bonusRateAnnual: Double? = null
+    val bonusRateAnnual: Double? = null,
 )
 
 data class TermsAndConditions(
@@ -131,7 +127,7 @@ data class TermsAndConditions(
     val effectiveFrom: LocalDate,
     val effectiveTo: LocalDate? = null,
     val language: String = "cs",
-    val summary: String? = null
+    val summary: String? = null,
 )
 
 data class ProductVersion(
@@ -140,7 +136,7 @@ data class ProductVersion(
     val validTo: LocalDate? = null,
     val isPublic: Boolean = true,
     val changeNote: String? = null,
-    val createdAt: Instant = Instant.EPOCH
+    val createdAt: Instant = Instant.EPOCH,
 )
 
 @RegisterForReflection
@@ -172,5 +168,5 @@ data class Product(
     val tags: List<String> = emptyList(),
     val eligibilitySegments: List<EligibilitySegment> = listOf(EligibilitySegment.ALL),
     val createdAt: Instant = Instant.EPOCH,
-    val updatedAt: Instant = Instant.EPOCH
+    val updatedAt: Instant = Instant.EPOCH,
 )

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt
@@ -4,9 +4,44 @@
 
 package com.openbank.productcatalog.domain
 
+import io.quarkus.runtime.annotations.RegisterForReflection
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
+
+/**
+ * [Product] round-trips through the JSONB `doc` column via plain
+ * `ObjectMapper.readValue(doc, Product::class.java)` (PostgresProductRepository), not as a direct
+ * JAX-RS request/response body — so Quarkus's automatic REST-endpoint-based reflection registration
+ * never sees it as reachable for DESERIALIZATION. Under GraalVM native this fails at request time with
+ * `InvalidDefinitionException: ... no delegate- or property-based Creator ... this appears to be a
+ * native image, in which case you may need to configure reflection` (verified locally, ADR-0083 T1
+ * pilot). `@RegisterForReflection` on every type in the graph Jackson needs a Kotlin-data-class
+ * Creator for fixes it; JVM mode never needed this because Jackson can always fall back to runtime
+ * reflection there.
+ */
+@RegisterForReflection(
+    targets = [
+        Fee::class,
+        InterestTier::class,
+        CardConfig::class,
+        MultiCurrencyConfig::class,
+        OverdraftConfig::class,
+        TermDepositConfig::class,
+        SavingsConfig::class,
+        TermsAndConditions::class,
+        ProductVersion::class,
+        ProductStatus::class,
+        ProductType::class,
+        CardNetwork::class,
+        CardTier::class,
+        InterestPayoutFrequency::class,
+        WithdrawalNotice::class,
+        OverdraftType::class,
+        EligibilitySegment::class,
+    ],
+)
+class ProductReflectionRegistration
 
 enum class ProductStatus { ACTIVE, INACTIVE, DRAFT, DEPRECATED, ARCHIVED }
 enum class ProductType { SAVINGS, CURRENT, LOAN, MORTGAGE, CREDIT_CARD, TERM_DEPOSIT, OVERDRAFT, INVESTMENT }
@@ -108,6 +143,7 @@ data class ProductVersion(
     val createdAt: Instant = Instant.EPOCH
 )
 
+@RegisterForReflection
 data class Product(
     val id: String = UUID.randomUUID().toString(),
     val code: String,

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/PostgresProductRepository.kt
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.productcatalog.application.port.out.ProductRepository
 import com.openbank.productcatalog.domain.Product
 import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
-import kotlinx.coroutines.future.await
 import org.hibernate.reactive.mutiny.Mutiny
 import java.util.UUID
 
@@ -28,24 +28,24 @@ class PostgresProductRepository(
 
     override suspend fun findAll(): List<Product> = sf.withSession { s ->
         s.createQuery("FROM ProductEntity ORDER BY code", ProductEntity::class.java).resultList
-    }.map { rows -> rows.map { it.toDomain() } }.coAwait()
+    }.map { rows -> rows.map { it.toDomain() } }.awaitSuspending()
 
     override suspend fun findById(id: UUID): Product? =
         sf.withSession { s -> s.find(ProductEntity::class.java, id) }
             .map { it?.toDomain() }
-            .coAwait()
+            .awaitSuspending()
 
     override suspend fun findByCode(code: String): Product? = sf.withSession { s ->
         s.createQuery(
             "FROM ProductEntity WHERE code = :c OR legacyCode = :c",
             ProductEntity::class.java,
         ).setParameter("c", code).resultList
-    }.map { rows -> rows.firstOrNull()?.toDomain() }.coAwait()
+    }.map { rows -> rows.firstOrNull()?.toDomain() }.awaitSuspending()
 
     override suspend fun save(product: Product, legacyCode: String?): Product =
         sf.withTransaction { s -> s.persist(newEntity(product, legacyCode)) }
             .replaceWith(product)
-            .coAwait()
+            .awaitSuspending()
 
     override suspend fun update(product: Product): Product = sf.withTransaction { s ->
         s.find(ProductEntity::class.java, UUID.fromString(product.id)).flatMap { existing ->
@@ -56,11 +56,11 @@ class PostgresProductRepository(
                 s.persist(newEntity(product, null)).replaceWith(product)
             }
         }
-    }.coAwait()
+    }.awaitSuspending()
 
     override suspend fun count(): Long =
         sf.withSession { s -> s.createQuery("SELECT COUNT(p) FROM ProductEntity p", Long::class.javaObjectType).singleResult }
-            .coAwait()
+            .awaitSuspending()
 
     private fun newEntity(p: Product, legacyCode: String?): ProductEntity =
         ProductEntity().apply {
@@ -78,7 +78,4 @@ class PostgresProductRepository(
     }
 
     private fun ProductEntity.toDomain(): Product = mapper.readValue(doc, Product::class.java)
-
-    /** Bridge a Mutiny [Uni] to a coroutine without pulling in mutiny-kotlin. */
-    private suspend fun <T> Uni<T>.coAwait(): T = subscribeAsCompletionStage().await()
 }


### PR DESCRIPTION
## Summary

Follow-up to #258, which added `openbank-product-catalog/Dockerfile.native` but found
(and left open) that every HTTP request 500'd once the native image was running.

- **Root-caused and fixed both native-only bugs** (verified: JVM mode was unaffected by
  either):
  1. `PostgresProductRepository.coAwait()` hand-rolled a Mutiny `Uni` → Kotlin coroutine
     bridge via `subscribeAsCompletionStage().await()`, dropping the Vert.x duplicated
     context RESTEasy Reactive needs to write the response. Every other service in the
     fleet already uses the standard `mutiny-kotlin` `awaitSuspending()` for this
     (transitively available here too) — switched to match.
  2. `Product` round-trips through the JSONB `doc` column via plain
     `ObjectMapper.readValue`, so Quarkus's automatic REST-endpoint reflection
     registration never saw it as reachable for deserialization. Native failed with
     `InvalidDefinitionException`. Added `@RegisterForReflection`.
- **Verified locally end-to-end**: `/api/v1/products` → 200 with real data;
  `/q/health/ready` on the management port → `UP` with live DB connectivity. The native
  image works correctly.
- **Deployed to an isolated scratch namespace** in the sandbox cluster (own throwaway
  Postgres, no Ingress/HTTPScaledObject, zero blast radius, cosign-signed to satisfy
  the enforced Kyverno image-verify policy) and **measured the ADR-0083 promotion
  gate**: 5 scale-0→1 cycles landed at 3.5-8.8s — 7-25× the ADR's ~300-500ms p95
  target. Application process start was consistently ~0.2-0.3s (confirming the ADR's
  native-image premise); the gap is Kubernetes Pod-lifecycle overhead (scheduling,
  image pull, kubelet readiness-probe interval), not the image itself.
- **`rules.yaml` stays unclassified** (not T1) — the SLO as literally written isn't met,
  and no image type can shortcut Pod-lifecycle overhead. Updated ADR-0083's correction
  note and the `rules.yaml` comment with the measured numbers. Whether to redefine the
  promotion gate around process start or treat T1 as not viable here without further
  platform work (node-level image pre-pulling, a faster probe) is a product decision,
  not resolved by this PR — recorded in #253 for whoever picks it up next, ahead of
  #230 (fleet sweep) treating this pilot as its worked example.

## Test plan

- [x] Local compile (`./gradlew :openbank-product-catalog:compileKotlin`, JDK 25)
- [x] Local native build (`docker build -f openbank-product-catalog/Dockerfile.native .`)
- [x] Local smoke test against a throwaway Postgres: `/api/v1/products` → 200 with data,
      `/q/health/ready` (management port 8085) → `UP` with live DB check
- [x] Deployed to sandbox cluster scratch namespace, cosign-signed image, Pod
      `Ready=True`, verified via readiness probe + direct HTTP request
- [x] Measured 5 scale-0→1 cold-start cycles (3.5s, 4.8s, 8.8s, 5.2s, 7.5s)
- [x] Scratch namespace deleted after measurement (zero residue in the cluster)
- [x] `bash .github/scripts/check-adr-status.sh` — OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('openbank-libs/governance/rules.yaml'))"` — parses

Linked issues: Refs #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)