### PR TITLE
chore(gitops): auto-deploy services @ 7a2761c2dbd86bb49eaacc8f94a6f662d7c26cb9

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-8cbcd411
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-7a2761c2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 7a2761c2dbd86bb49eaacc8f94a6f662d7c26cb9.

**Changed services:** ["openbank-product-catalog"]

Each image tag was updated to `sandbox-7a2761c2dbd86bb49eaacc8f94a6f662d7c26cb9` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.