### PR TITLE
fix(gitops): scope payments' IncludeMutationWebhook to the Rollout Services that need it

### DIFF
--- a/openbank-infra/gitops/apps/payments.yaml
+++ b/openbank-infra/gitops/apps/payments.yaml
@@ -3,10 +3,6 @@ kind: Application
 metadata:
   name: payments
   namespace: argocd
-  annotations:
-    # Server-Side Diff must run the Kyverno verify-images mutation in its dry-run, otherwise the
-    # digest-pinning annotation it injects reads as a permanent OutOfSync diff (issue #856).
-    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -24,25 +20,25 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      # RespectIgnoreDifferences: this app also carries compare-options:
-      # IncludeMutationWebhook=true (Kyverno digest-pin dry-run, #856) — with
-      # that comparison mode, the ignoreDifferences.jqPathExpressions entry
-      # below (card-issuance-service) suppresses the OutOfSync *status* but
-      # NOT what selfHeal actually pushes on a triggered sync; without this
-      # option selfHeal kept re-applying replicas:1 from git every reconcile,
-      # fighting KEDA's scale-to-zero forever (confirmed live in
-      # openbank-sandbox — repeated ScalingReplicaSet 0->1 events minutes
-      # apart). product-catalog and sdd don't need this because neither sets
-      # IncludeMutationWebhook.
-      - RespectIgnoreDifferences=true
   # Argo Rollouts (ADR-0098) sets spec.selector.rollouts-pod-template-hash on the
   # stable and canary Services at runtime; git holds only the base selector, so
   # without this every Rollout-backed Service reads as permanently OutOfSync.
   # Ignore exactly that one controller-managed selector key — git-owned selector
   # changes are still reconciled. NB: jqPathExpressions, NOT managedFieldsManagers:
-  # the latter is silently bypassed on apps with compare-options
+  # the latter is silently bypassed on resources with compare-options
   # IncludeMutationWebhook (Kyverno digest-pin, #856), which left 6 apps OutOfSync
   # (verified in-cluster). Rollback = delete this block.
+  #
+  # IncludeMutationWebhook itself moved from an app-wide annotation to a
+  # per-resource `argocd.argoproj.io/compare-options` annotation on just the 14
+  # Rollout-backed Service objects (stable+canary) that need it — see
+  # gitops/components/payments/payments-services.yaml. App-wide it silently
+  # defeated the ignoreDifferences.jqPathExpressions on card-issuance-service's
+  # replicas below, keeping the whole app permanently OutOfSync even with
+  # RespectIgnoreDifferences protecting the actual apply (#230 T1 follow-up).
+  # Scoping it per-resource fixes both problems at once; confirmed live in
+  # openbank-sandbox (all resources Synced, card-issuance-service replicas
+  # stayed at 0, no regression on the Rollout Service selector diff).
   ignoreDifferences:
     - group: ""
       kind: Service

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -215,6 +215,8 @@ kind: Service
 metadata:
   name: transaction-service
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: transaction-service
 spec:
@@ -231,6 +233,8 @@ kind: Service
 metadata:
   name: transaction-service-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: transaction-service
 spec:
@@ -476,6 +480,8 @@ kind: Service
 metadata:
   name: sepa-payment
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: sepa-payment
 spec:
@@ -491,6 +497,8 @@ kind: Service
 metadata:
   name: sepa-payment-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: sepa-payment
 spec:
@@ -705,6 +713,8 @@ kind: Service
 metadata:
   name: domestic-payment
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: domestic-payment
 spec:
@@ -720,6 +730,8 @@ kind: Service
 metadata:
   name: domestic-payment-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: domestic-payment
 spec:
@@ -926,6 +938,8 @@ kind: Service
 metadata:
   name: sepa-instant
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: sepa-instant
 spec:
@@ -941,6 +955,8 @@ kind: Service
 metadata:
   name: sepa-instant-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: sepa-instant
 spec:
@@ -1120,6 +1136,8 @@ kind: Service
 metadata:
   name: clearing-service
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: clearing-service
 spec:
@@ -1135,6 +1153,8 @@ kind: Service
 metadata:
   name: clearing-service-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: clearing-service
 spec:
@@ -1551,6 +1571,8 @@ kind: Service
 metadata:
   name: settlement-service
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: settlement-service
 spec:
@@ -1567,6 +1589,8 @@ kind: Service
 metadata:
   name: settlement-service-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: settlement-service
 spec:
@@ -1870,6 +1894,8 @@ kind: Service
 metadata:
   name: swift-service
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: swift-service
 spec:
@@ -1885,6 +1911,8 @@ kind: Service
 metadata:
   name: swift-service-canary
   namespace: payments
+  annotations:
+    argocd.argoproj.io/compare-options: IncludeMutationWebhook=true
   labels:
     app.kubernetes.io/name: swift-service
 spec:


### PR DESCRIPTION
## Summary

Follow-up to #273 and #279. That pair fixed `interest`'s cosmetic `OutOfSync` by removing an app-wide `compare-options: IncludeMutationWebhook=true` annotation that wasn't actually needed there. `payments` genuinely needs it (7 Rollout-backed Service pairs, #856), so it couldn't just be deleted — this PR **scopes it down to only the resources that need it**, fixing `card-issuance-service`'s cosmetic `OutOfSync` without reopening #856.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #230

## Root cause (recap from #273/#279)

`payments.yaml`'s app-wide `IncludeMutationWebhook=true` switches ArgoCD to server-side-diff for the *whole* Application. That's needed for 7 Rollout services (`clearing-service`, `domestic-payment`, `sepa-instant`, `sepa-payment`, `settlement-service`, `swift-service`, `transaction-service`) whose stable+canary Services get `spec.selector.rollouts-pod-template-hash` set by the Rollout controller at runtime. But applied app-wide, it also silently defeats `ignoreDifferences.jqPathExpressions` on `card-issuance-service`'s `.spec.replicas` (the KEDA T1 field), leaving the app permanently `OutOfSync` and re-triggering no-op syncs every ~5 minutes.

## Changes

- `gitops/apps/payments.yaml`: remove the app-level `compare-options: IncludeMutationWebhook=true` annotation and the now-unneeded `RespectIgnoreDifferences` syncOption (matches #279's cleanup of `interest.yaml` — once nothing at the app-level forces server-side-diff, `card-issuance-service` falls back to standard diffing where plain `ignoreDifferences` is sufficient, same as `product-catalog`/`sdd`).
- `gitops/components/payments/payments-services.yaml`: add `argocd.argoproj.io/compare-options: IncludeMutationWebhook=true` directly to each of the **14 Rollout-backed Service objects** (7 stable + 7 canary) — ArgoCD supports this same annotation at the resource level, not just the Application level. `card-issuance-service`, `standing-order-service`, `redis`, `clearing-simulator` (plain Deployments, no Rollout) get none.

## Verification (live, in openbank-sandbox)

- Tested the hypothesis on one pair first (`clearing-service`/`clearing-service-canary`) before rolling out to all 14 — confirmed both the Rollout-Service-selector suppression AND `card-issuance-service`'s replicas suppression worked simultaneously.
- Applied to all 14 Services, hard-refreshed: **`payments` Application `Synced` with zero exceptions across all ~90 resources.**
- `card-issuance-service` replicas stayed at 0 throughout, no new `ScalingReplicaSet` events (no regression on the T1 scale-to-zero fix from #273).
- Confirmed the Rollout Service selector diff (#856's original concern) stays suppressed — spot-checked `clearing-service`/`clearing-service-canary` explicitly.

## Definition of Done

- [x] No new lint warnings (yamllint clean on both changed files).
- [x] Docs — updated the inline comment in `payments.yaml` explaining the per-resource move and why.

## Security checklist

- [x] No secrets/PII, no new dependency. Pure ArgoCD comparison-mode config, no workload behavior change.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: GitOps (ArgoCD auto-sync on merge).
- Rollback: revert this commit; ArgoCD resyncs, `card-issuance-service`'s cosmetic `OutOfSync` returns (harmless, no functional regression — #273's `ignoreDifferences`/`RespectIgnoreDifferences` guard would need re-adding too since this PR removes it as no-longer-needed... actually a straight revert restores it exactly, since it's all in the same diff).