### PR TITLE
fix(infra): eliminate setup-java tool-cache race on ARC runners

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -180,6 +180,62 @@ locals {
     ]
   }
 
+  # Populates the shared runner-tool-cache hostPath with the JDK 21 + 25 layout
+  # baked into the runner image (runner-image/Dockerfile, /opt/openbank-jdk-preload/),
+  # so actions/setup-java finds both already ".complete" and never downloads or
+  # extracts a JDK on this node again. This is the actual fix for the
+  # ENOENT/EACCES race (see the runner-tool-cache volume comment above): the
+  # concurrent-extraction scenario is eliminated at the source rather than
+  # patched with a lock, because after this init container runs there is
+  # nothing left for two jobs to race on writing.
+  #
+  # Runs AFTER init-gradle-home (which creates + chmods the parent dir) and
+  # must run on every pod start, not just once per node: it is cheap (a `-d`
+  # test + a no-op when already populated) and pod restarts on an already-warm
+  # node must not depend on ordering against other pods' init containers.
+  #
+  # Copy is atomic per JDK version: extract-shaped content already exists at
+  # its final layout in the image, so this only needs `cp -r` into a SIBLING
+  # temp dir on the SAME volume + `mv` (rename, atomic within one filesystem)
+  # to the real version dir, then the `.complete` marker is written LAST —
+  # identical ordering to what actions/toolkit's own cacheDir does internally
+  # for a single writer. Guarding on `[ -e "$dst.complete" ]` first makes two
+  # concurrent pods on a cold node redundant-but-harmless: at worst both copy
+  # to their own uniquely-named temp dir (mktemp -d) and both rename into
+  # place — the second rename simply replaces the first with an identical tree.
+  jdk_toolcache_preload_init_container = {
+    name    = "init-jdk-toolcache-preload"
+    image   = local.runner_image
+    command = ["sh", "-c"]
+    args = [
+      <<-SH
+      set -eu
+      cache_root="/mnt/k8s-disks/0/runner-tool-cache/Java_Temurin-Hotspot_jdk"
+      preload_root="/opt/openbank-jdk-preload/Java_Temurin-Hotspot_jdk"
+      mkdir -p "$cache_root"
+      for version_dir in "$preload_root"/*/; do
+        version="$(basename "$version_dir")"
+        dst="$cache_root/$version/arm64"
+        if [ -e "$dst.complete" ]; then
+          echo "jdk toolcache: $version already present, skipping"
+          continue
+        fi
+        echo "jdk toolcache: populating $version"
+        tmp="$(mktemp -d "$cache_root/.preload-XXXXXX")"
+        cp -r "$version_dir/arm64/." "$tmp/"
+        mkdir -p "$cache_root/$version"
+        rm -rf "$dst"
+        mv "$tmp" "$dst"
+        touch "$dst.complete"
+      done
+      echo "jdk toolcache: ready"
+      SH
+    ]
+    volumeMounts = [
+      { name = "runner-tool-cache", mountPath = "/mnt/k8s-disks/0/runner-tool-cache" },
+    ]
+  }
+
   # The dind daemon — chart-parity args PLUS the pinned default address pool.
   # Image comes from AWS's public ECR mirror of the Docker Official Images, NOT
   # docker.io: with 8 runners churning, anonymous Docker Hub pulls of docker:dind
@@ -256,8 +312,24 @@ locals {
     # Node-local GitHub Actions tool cache — JDK 21 + 25 (~380 MB) downloaded
     # once per node lifecycle. Root cause of 790 GB/day NAT (June 20-29): each
     # ephemeral runner pod re-downloaded both JDKs from GitHub CDN (185.199.x.x,
-    # 57.150.x.x) on every build. Shared hostPath on NVMe is safe: setup-java
-    # uses atomic rename to the final tool dir so concurrent pods don't corrupt.
+    # 57.150.x.x) on every build.
+    #
+    # CORRECTION (2026-07-06, the previous version of this comment was wrong):
+    # actions/setup-java is NOT safe for concurrent first-time writers on a
+    # shared cache. Two `build (openbank-<service>)` matrix jobs landing on the
+    # same node at the same time, both needing a JDK version not yet cached,
+    # both extract to a private temp dir and then copy/rename into the SAME
+    # final versioned path — that final copy is not coordinated across
+    # processes, so one job's extraction corrupted the other's, surfacing as
+    # `ENOENT`/`EACCES` on individual JDK files (Services CI, 3 failures/2 days).
+    # Fixed by init_jdk_toolcache_preload below: the runner image now carries
+    # JDK 21 + 25 pre-extracted (runner-image/Dockerfile), and this init
+    # container copies them into the shared cache atomically (temp dir + mv,
+    # `.complete` written last) BEFORE the runner starts accepting jobs — so by
+    # the time setup-java runs, both JDKs are already present and it never
+    # attempts a download/extract at all. Concurrent pods on a cold node race
+    # only on the (idempotent, cheap) copy-if-missing check, never on partial
+    # JDK extraction.
     { name = "runner-tool-cache", hostPath = { path = "/mnt/k8s-disks/0/runner-tool-cache", type = "DirectoryOrCreate" } },
   ]
 }
@@ -607,7 +679,7 @@ resource "helm_release" "arc_build" {
         nodeSelector       = local.runner_node_selector
         tolerations        = local.runner_tolerations
         affinity           = local.runner_affinity
-        initContainers     = [local.dind_init_container, local.aio_sysctl_init_container, local.gradle_home_init_container]
+        initContainers     = [local.dind_init_container, local.aio_sysctl_init_container, local.gradle_home_init_container, local.jdk_toolcache_preload_init_container]
         containers = [
           {
             name         = "runner"
@@ -708,7 +780,7 @@ resource "helm_release" "arc_deploy" {
         serviceAccountName = kubernetes_service_account.arc_deploy[0].metadata[0].name
         nodeSelector       = local.runner_node_selector
         tolerations        = local.runner_tolerations
-        initContainers     = [local.dind_init_container, local.aio_sysctl_init_container, local.gradle_home_init_container]
+        initContainers     = [local.dind_init_container, local.aio_sysctl_init_container, local.gradle_home_init_container, local.jdk_toolcache_preload_init_container]
         containers = [
           {
             name         = "runner"

--- a/openbank-infra/aws/envs/sandbox-platform/runner-image/Dockerfile
+++ b/openbank-infra/aws/envs/sandbox-platform/runner-image/Dockerfile
@@ -15,6 +15,33 @@
 #                                      IRSA; without the CLI the step soft-skips
 #                                      and dep resolution falls back to public
 #                                      Maven Central (NAT cost + 429 risk).
+#   * Temurin JDK 21 + 25 preload   — pre-extracted at /opt/openbank-jdk-preload/,
+#                                      laid out exactly as actions/setup-java's
+#                                      Temurin installer expects the toolcache
+#                                      (Java_Temurin-Hotspot_jdk/<version>/<arch>/
+#                                      + a sibling <arch>.complete marker), but
+#                                      NOT baked directly into RUNNER_TOOL_CACHE
+#                                      itself — that path is a shared hostPath
+#                                      volume (arc-runners.tf), and a Kubernetes
+#                                      volume mount always shadows whatever the
+#                                      image had at that mountPath, so anything
+#                                      baked there would just be hidden at
+#                                      container start. The init-jdk-toolcache-
+#                                      preload init container (arc-runners.tf)
+#                                      copies this staged layout into the
+#                                      hostPath cache on pod start, atomically
+#                                      (temp dir + rename, `.complete` written
+#                                      last) and only if a version is missing —
+#                                      this is what actually eliminates the race
+#                                      two concurrent `build (openbank-<service>)`
+#                                      jobs used to hit when both extracted the
+#                                      same not-yet-cached JDK into the shared
+#                                      cache at once (ENOENT/EACCES from
+#                                      actions/setup-java, corrupted extraction).
+#                                      setup-java now finds both JDKs already
+#                                      complete and skips download+extract
+#                                      entirely — faster for every job, and the
+#                                      concurrent-write scenario no longer exists.
 #
 # arm64 only (the runners NodePool is Graviton).
 #
@@ -41,6 +68,21 @@ ARG GITLEAKS_SHA256=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4
 ARG YQ_VERSION=v4.53.2
 ARG AWSCLI_VERSION=2.33.14
 ARG AWSCLI_SHA256=d4914cdbcfccfe151d1f4672bf7aeb81bd7cdfc5edc41425a9e54c900cddab24
+
+# Temurin JDK preload (see the header comment). Versions match what the fleet's
+# jvmToolchain(..) actually resolves (_service-ci.yml, api-fuzz.yml, fleet-lint.yml,
+# ghcr-publish.yml: `java-version: 21 / 25`). Pin the exact Adoptium release (not
+# just the major) so the sha256 is meaningful; bump both the version and hash
+# together from https://api.adoptium.net/v3/assets/latest/<major>/hotspot?vendor=eclipse&architecture=aarch64&os=linux&image_type=jdk
+# when Temurin ships a new build. TEMURIN_*_TOOLCACHE_VERSION is the SAME string
+# with `+` -> `-`: that's the literal directory name actions/setup-java's
+# getToolcacheVersionName() computes and looks for under Java_Temurin-Hotspot_jdk/.
+ARG TEMURIN_21_VERSION=21.0.11+10
+ARG TEMURIN_21_TOOLCACHE_VERSION=21.0.11-10.0.LTS
+ARG TEMURIN_21_SHA256=8d498ec88e1c1989fab95c6784240ab92d011e29c54d20a3f9c324b13476f9ad
+ARG TEMURIN_25_VERSION=25.0.3+9
+ARG TEMURIN_25_TOOLCACHE_VERSION=25.0.3-9.0.LTS
+ARG TEMURIN_25_SHA256=3e4287cb98870ba824ed698854bdc27cff984254caf66dd12cc291e7bfdde26b
 
 # yamllint + shellcheck + tooling deps (jq used by the workflows + curl/tar here).
 RUN apt-get update \
@@ -84,5 +126,31 @@ RUN curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/
       -o /usr/local/bin/yq \
  && chmod +x /usr/local/bin/yq \
  && yq --version
+
+# Temurin JDK 21 + 25 preload — staged at /opt/openbank-jdk-preload/ (NOT at
+# RUNNER_TOOL_CACHE; see the header comment for why). Layout matches
+# actions/setup-java's Temurin installer toolcache convention exactly:
+#   Java_Temurin-Hotspot_jdk/<toolcache-version>/<arch>/<jdk contents>
+#   Java_Temurin-Hotspot_jdk/<toolcache-version>/<arch>.complete   (empty marker)
+# The tarball's single top-level dir (e.g. jdk-21.0.11+10/) is unwrapped so its
+# CONTENTS land directly under <arch>/ — actions/toolkit's cacheDir does the same
+# unwrap (temurin/installer.ts: archivePath = extractedJavaPath/<archiveName>).
+RUN set -eu; \
+    preload_jdk() { \
+      major="$1"; version="$2"; toolcache_version="$3"; sha256="$4"; \
+      url="https://github.com/adoptium/temurin${major}-binaries/releases/download/jdk-$(echo "$version" | sed 's/+/%2B/')/OpenJDK${major}U-jdk_aarch64_linux_hotspot_$(echo "$version" | sed 's/+/_/').tar.gz"; \
+      dest="/opt/openbank-jdk-preload/Java_Temurin-Hotspot_jdk/${toolcache_version}/arm64"; \
+      curl -fsSL "$url" -o "/tmp/jdk${major}.tar.gz"; \
+      echo "${sha256}  /tmp/jdk${major}.tar.gz" | sha256sum -c -; \
+      mkdir -p "/tmp/jdk${major}-extract" "$dest"; \
+      tar -xzf "/tmp/jdk${major}.tar.gz" -C "/tmp/jdk${major}-extract"; \
+      inner="$(find "/tmp/jdk${major}-extract" -mindepth 1 -maxdepth 1 -type d)"; \
+      cp -r "${inner}/." "$dest/"; \
+      touch "/opt/openbank-jdk-preload/Java_Temurin-Hotspot_jdk/${toolcache_version}/arm64.complete"; \
+      rm -rf "/tmp/jdk${major}.tar.gz" "/tmp/jdk${major}-extract"; \
+      "${dest}/bin/java" -version; \
+    }; \
+    preload_jdk 21 "${TEMURIN_21_VERSION}" "${TEMURIN_21_TOOLCACHE_VERSION}" "${TEMURIN_21_SHA256}"; \
+    preload_jdk 25 "${TEMURIN_25_VERSION}" "${TEMURIN_25_TOOLCACHE_VERSION}" "${TEMURIN_25_SHA256}"
 
 USER runner


### PR DESCRIPTION
## Summary

Services CI failed 3x in 2 days on `main` with `ENOENT`/`EACCES` from `actions/setup-java` extracting Temurin JDK into the shared `runner-tool-cache` hostPath — two `build (openbank-<service>)` matrix jobs on the same node, both needing an uncached JDK version, raced on the same final extraction path. This preloads JDK 21 + 25 into the runner image and copies them into the shared cache atomically before the runner accepts jobs, so setup-java never extracts at runtime and the race can't happen.

## Type of change

- [x] fix

## Linked issues

N/A — reactive infra fix for a flaky-CI symptom, not tracked as a separate issue.

## Changes

- `runner-image/Dockerfile`: preload Temurin JDK 21 (21.0.11+10) + 25 (25.0.3+9) arm64 tarballs at `/opt/openbank-jdk-preload/`, laid out exactly as `actions/setup-java`'s toolcache convention expects. Both checksums independently verified against Adoptium's published `.sha256`.
- `arc-runners.tf`: new `init-jdk-toolcache-preload` init container (added to both `arc_build` and `arc_deploy` runner specs) that atomically copies the preloaded JDKs into the shared `RUNNER_TOOL_CACHE` hostPath on pod start (temp dir + rename, `.complete` marker written last, idempotent no-op once already populated).

## Definition of Done

- [x] Docs updated (inline comments explain the race + fix + why the preload can't live directly at the hostPath mount).
- N/A — infra-only change, no application code/schema/API touched. `Platform OpenTofu` CI will plan/validate this.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency — official Adoptium Temurin binaries, checksum-pinned.