### PR TITLE
fix: set real koverVerify floors for sanctions/finrep/psd2-service

### DIFF
--- a/openbank-finrep-service/build.gradle.kts
+++ b/openbank-finrep-service/build.gradle.kts
@@ -39,7 +39,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    minValue = 55
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-psd2-service/build.gradle.kts
+++ b/openbank-psd2-service/build.gradle.kts
@@ -58,7 +58,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    minValue = 28
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-sanctions-service/build.gradle.kts
+++ b/openbank-sanctions-service/build.gradle.kts
@@ -43,7 +43,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    minValue = 15
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }


### PR DESCRIPTION
## Summary

Three services (`sanctions-service`, `finrep-service`, `psd2-service`) had `koverVerify` `minValue = 0`, meaning their coverage could silently regress to zero with no CI failure. This sets each floor to a real value just below currently measured coverage, so future regressions become visible. Raising the bar further is left to future PRs (coverage is ratchet-only, never lowered).

## Type of change

- [x] fix

## Linked issues

N/A — reactive coverage-gate fix, not tracked as a separate issue.

## Changes

- `sanctions-service`: measured LINE coverage 18.36% (130/708) → floor set to 15.
- `finrep-service`: measured LINE coverage 57.58% (38/66) → floor set to 55.
- `psd2-service`: measured LINE coverage 30.14% (308/1022) → floor set to 28.

None of these three services are on the `money_path_services` list (`openbank-libs/governance/rules.yaml`), so standard 1-approval review applies — no threat model required.

## Definition of Done

- [x] `./gradlew :<service>:koverVerify` passes locally at the new floor for all three services (verified against a real Docker-backed test run, not skipped).
- N/A for the rest — build-config-only change, no application code/schema/API touched.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency.