### PR TITLE
feat(gitops): cut product-catalog over to the ADR-0083 native image

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -6,6 +6,18 @@
 # automatically.
 # Quarkus management endpoints (health, metrics) bind to a separate port (8085).
 # QUARKUS_MANAGEMENT_HOST=0.0.0.0 is required so kubelet probes can reach them.
+#
+# ADR-0083 T1 native cutover (2026-07-06, #253). This Deployment now runs the
+# Mandrel/GraalVM native image (openbank-product-catalog/Dockerfile.native), not the
+# JVM fast-jar image every other service in the fleet still uses — the first native
+# cutover in the repo. startupProbe/readinessProbe are tuned to match (initialDelaySeconds:
+# 0, periodSeconds: 1 — a ~0.2-0.3s native process doesn't need the ~5s of JVM-scoped
+# headroom the previous probe carried). Do NOT copy this probe config onto a JVM-image
+# service without re-adding that headroom. The existing `product-catalog-http-scaledobject.yaml`
+# HTTPScaledObject (minReplicas: 0) was already live against the old JVM image; this
+# cutover is what actually makes its cold-start assumption true. Burn-in window before
+# declaring `openbank-product-catalog: T1` in `rules.yaml:finops_tiers.declared` per the
+# ADR's own Pilot plan step 5 — do not declare T1 from this manifest alone.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -42,7 +54,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-7a2761c2
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:native-a2e14752
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -69,15 +81,15 @@ spec:
             httpGet:
               path: /q/health/ready
               port: management
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            failureThreshold: 30
+            initialDelaySeconds: 0
+            periodSeconds: 1
+            failureThreshold: 10
           readinessProbe:
             httpGet:
               path: /q/health/ready
               port: management
-            periodSeconds: 10
-            failureThreshold: 3
+            periodSeconds: 1
+            failureThreshold: 10
           livenessProbe:
             httpGet:
               path: /q/health/live


### PR DESCRIPTION
## Summary

First native-image cutover in the fleet — the payoff of #275/#280 (native bugs fixed,
promotion gate measured and redefined).

- Switches `product-catalog`'s Deployment from the JVM fast-jar image
  (`sandbox-7a2761c2`) to the Mandrel/GraalVM native image, re-tagged
  `native-a2e14752` from the exact digest verified end-to-end in a scratch namespace
  (#275/#253): `/api/v1/products` → 200 with real data, `/q/health/ready` → `UP` with
  live DB connectivity. Cosign-signed (satisfies the enforced
  `verify-openbank-image-signatures` Kyverno policy).
- Retunes `startupProbe`/`readinessProbe` from JVM-scoped headroom
  (`initialDelaySeconds: 5, periodSeconds: 5/10`) to native-appropriate values
  (`initialDelaySeconds: 0, periodSeconds: 1, failureThreshold: 10`) — measured ~28%
  faster scale-from-zero in the scratch pilot (#280).
- The `HTTPScaledObject` (`minReplicas: 0`) was already live against the *old JVM*
  image — this PR is what actually makes its native cold-start assumption true.
- **Does NOT declare `openbank-product-catalog: T1`** in `rules.yaml` — that's gated
  on a burn-in window against this cutover per ADR-0083's own Pilot plan (step 5),
  tracked in #253, not implied by merging this PR.

## Risk / rollback

- `product-catalog` is **non-money-path** (not in `rules.yaml: money_path_services`).
- Rollback is a one-line revert of the image tag back to `sandbox-7a2761c2` (still in
  ECR) if anything looks wrong post-deploy — no data-layer change, no schema change.
- Resource requests/limits are unchanged (left conservative on purpose, not tuned down
  for native's lower footprint, to minimize the number of variables changing at once).

## Test plan

- [x] `kubectl apply --dry-run=client` against the real cluster API — both resources
      validate
- [x] Re-verified the exact re-tagged image (`native-a2e14752`) locally against a
      throwaway Postgres after re-tagging (digest changed on re-tag due to manifest
      formatting, so didn't trust the carried-over signature — re-signed and
      re-verified the new tag from scratch): `/api/v1/products` 200, `/q/health/ready`
      (management port) 200
- [ ] Post-merge: watch ArgoCD sync + Pod health in `accounts` namespace, confirm
      `Ready` and serving via the `product-catalog` Service before considering this
      cutover successful (not something a dry-run can prove)

Linked issues: Refs #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)