### PR TITLE
test(sanctions): raise coverage 18.36% -> 63.56% with real unit tests

### DIFF
--- a/openbank-sanctions-service/build.gradle.kts
+++ b/openbank-sanctions-service/build.gradle.kts
@@ -43,7 +43,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 15
+                    minValue = 60
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsImportServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsImportServiceTest.kt
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.application.usecase
+
+import com.openbank.sanctions.application.port.out.SanctionsEntryRepository
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.SanctionsEntry
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.sun.net.httpserver.HttpServer
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Covers the import pipeline: format dispatch (OFAC XML / OpenSanctions CSV / skipped formats),
+ * name normalization, CSV parsing edge cases, and the catch-all error path. Uses a real loopback
+ * [HttpServer] instead of mocking [java.net.http.HttpClient] directly — the service builds its own
+ * HttpClient internally, so the only seam available is the actual socket.
+ */
+class SanctionsImportServiceTest {
+
+    private val entryRepo = mockk<SanctionsEntryRepository>()
+    private val clock = Clock.fixed(Instant.parse("2024-01-15T12:00:00Z"), ZoneOffset.UTC)
+    private val service = SanctionsImportService(entryRepo, clock)
+
+    private var server: HttpServer? = null
+
+    @AfterEach
+    fun tearDown() {
+        server?.stop(0)
+    }
+
+    private fun serveOnce(body: String, contentType: String = "text/plain"): String {
+        val httpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        httpServer.createContext("/feed") { exchange ->
+            val bytes = body.toByteArray(Charsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", contentType)
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        httpServer.start()
+        server = httpServer
+        return "http://127.0.0.1:${httpServer.address.port}/feed"
+    }
+
+    // ──── normalizeForSearch ─────────────────────────────────────────────────
+
+    @Test
+    fun `normalizeForSearch strips diacritics, lowercases and trims`() {
+        assertThat(service.normalizeForSearch("  Andrej Babiš  ")).isEqualTo("andrej babis")
+        assertThat(service.normalizeForSearch("VLADIMIR PUTIN")).isEqualTo("vladimir putin")
+        assertThat(service.normalizeForSearch("Śrí Lãnká")).isEqualTo("sri lanka")
+    }
+
+    // ──── importList — format dispatch ───────────────────────────────────────
+
+    @Test
+    fun `importList skips FATF_HIGH_RISK as country-risk`(): Unit = runBlocking {
+        val count = service.importList(SanctionsListType.FATF_HIGH_RISK, "https://example.com/unused")
+
+        assertThat(count).isZero()
+    }
+
+    @Test
+    fun `importList skips CNB_DOMESTIC as seeded via migration`(): Unit = runBlocking {
+        val count = service.importList(SanctionsListType.CNB_DOMESTIC, "https://example.com/unused")
+
+        assertThat(count).isZero()
+    }
+
+    @Test
+    fun `importList returns zero and swallows exception when download fails`(): Unit = runBlocking {
+        val count = service.importList(SanctionsListType.OFAC_SDN, "http://127.0.0.1:1/does-not-exist")
+
+        assertThat(count).isZero()
+    }
+
+    @Test
+    fun `importList parses OFAC SDN XML and upserts entries`(): Unit = runBlocking {
+        val xml = """
+            <?xml version="1.0"?>
+            <sdnList>
+              <sdnEntry>
+                <uid>17766</uid>
+                <firstName>Vladimir</firstName>
+                <lastName>Putin</lastName>
+                <sdnType>Individual</sdnType>
+                <programList><program>RUSSIA-EO14024</program></programList>
+                <akaList>
+                  <aka>
+                    <firstName>Vova</firstName>
+                    <lastName>Putin</lastName>
+                  </aka>
+                </akaList>
+                <dateOfBirthList>
+                  <dateOfBirthItem><dateOfBirth>07 Oct 1952</dateOfBirth></dateOfBirthItem>
+                </dateOfBirthList>
+              </sdnEntry>
+              <sdnEntry>
+                <uid>99999</uid>
+                <firstName>Acme</firstName>
+                <lastName>Corp</lastName>
+                <sdnType>Entity</sdnType>
+              </sdnEntry>
+            </sdnList>
+        """.trimIndent()
+        val url = serveOnce(xml, "application/xml")
+
+        val entriesSlot = slot<List<SanctionsEntry>>()
+        coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 2
+
+        val count = service.importList(SanctionsListType.OFAC_SDN, url)
+
+        assertThat(count).isEqualTo(2)
+        val entries = entriesSlot.captured
+        assertThat(entries).hasSize(2)
+
+        val putin = entries.first { it.externalId == "ofac-17766" }
+        assertThat(putin.primaryName).isEqualTo("Vladimir Putin")
+        assertThat(putin.entityType).isEqualTo(EntityType.INDIVIDUAL)
+        assertThat(putin.aliases).containsExactly("Vova Putin")
+        assertThat(putin.dateOfBirth).isEqualTo("07 Oct 1952")
+        assertThat(putin.programs).containsExactly("RUSSIA-EO14024")
+        assertThat(putin.listType).isEqualTo(SanctionsListType.OFAC_SDN)
+
+        val acme = entries.first { it.externalId == "ofac-99999" }
+        assertThat(acme.entityType).isEqualTo(EntityType.ORGANIZATION)
+        assertThat(acme.primaryName).isEqualTo("Acme Corp")
+    }
+
+    @Test
+    fun `importList skips OFAC entries without uid or with blank name`(): Unit = runBlocking {
+        val xml = """
+            <sdnList>
+              <sdnEntry>
+                <firstName>NoUid</firstName>
+                <lastName>Person</lastName>
+              </sdnEntry>
+              <sdnEntry>
+                <uid>123</uid>
+                <firstName></firstName>
+                <lastName></lastName>
+              </sdnEntry>
+            </sdnList>
+        """.trimIndent()
+        val url = serveOnce(xml, "application/xml")
+
+        coEvery { entryRepo.upsertAll(any()) } returns 0
+
+        val count = service.importList(SanctionsListType.OFAC_SDN, url)
+
+        assertThat(count).isZero()
+    }
+
+    @Test
+    fun `importList parses OpenSanctions CSV and upserts entries with defaults`(): Unit = runBlocking {
+        val csv = "id,schema,name,aliases,birth_date,countries,addresses,identifiers,sanctions," +
+            "phones,emails,program_ids,dataset,first_seen,last_seen,last_change\n" +
+            "os-1,Person,Andrej Babis,\"Ondrej Babis;A. Babis\",1954-09-13,cz,,,,,,,,,,\n" +
+            "os-2,Organization,Acme Sanctioned Co,,,,,,,,,\"EU-SANCTIONS\",,,,\n"
+        val url = serveOnce(csv, "text/csv")
+
+        coEvery { entryRepo.deactivateByListType(SanctionsListType.PEP_GLOBAL) } returns 0
+        val entriesSlot = slot<List<SanctionsEntry>>()
+        coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 2
+
+        val count = service.importList(SanctionsListType.PEP_GLOBAL, url)
+
+        assertThat(count).isEqualTo(2)
+        val entries = entriesSlot.captured
+        val person = entries.first { it.externalId == "os-1" }
+        assertThat(person.primaryName).isEqualTo("Andrej Babis")
+        assertThat(person.aliases).containsExactlyInAnyOrder("Ondrej Babis", "A. Babis")
+        assertThat(person.nationalities).containsExactly("cz")
+        assertThat(person.dateOfBirth).isEqualTo("1954-09-13")
+        assertThat(person.entityType).isEqualTo(EntityType.INDIVIDUAL)
+        assertThat(person.programs).containsExactly("PEP") // default program applied, no program_ids
+
+        val org = entries.first { it.externalId == "os-2" }
+        assertThat(org.entityType).isEqualTo(EntityType.ORGANIZATION)
+        assertThat(org.programs).containsExactly("EU-SANCTIONS") // program_ids column wins
+    }
+
+    @Test
+    fun `importList returns zero when CSV header is missing required columns`(): Unit = runBlocking {
+        val csv = "foo,bar\nbaz,qux\n"
+        val url = serveOnce(csv, "text/csv")
+
+        val count = service.importList(SanctionsListType.EU_CONSOLIDATED, url)
+
+        assertThat(count).isZero()
+    }
+
+    @Test
+    fun `importList skips blank CSV rows and rows with blank name`(): Unit = runBlocking {
+        val csv = "id,schema,name,aliases,birth_date,countries,addresses,identifiers,sanctions," +
+            "phones,emails,program_ids,dataset,first_seen,last_seen,last_change\n" +
+            "\n" +
+            "os-3,Person,,,,,,,,,,,,,,\n"
+        val url = serveOnce(csv, "text/csv")
+
+        coEvery { entryRepo.deactivateByListType(SanctionsListType.UN_CONSOLIDATED) } returns 0
+
+        val count = service.importList(SanctionsListType.UN_CONSOLIDATED, url)
+
+        assertThat(count).isZero()
+    }
+
+    @Test
+    fun `importList handles vessel and aircraft schema types`(): Unit = runBlocking {
+        val csv = "id,schema,name,aliases,birth_date,countries,addresses,identifiers,sanctions," +
+            "phones,emails,program_ids,dataset,first_seen,last_seen,last_change\n" +
+            "os-4,Vessel,MV Example,,,,,,,,,,,,,\n" +
+            "os-5,Aircraft,N12345,,,,,,,,,,,,,\n"
+        val url = serveOnce(csv, "text/csv")
+
+        coEvery { entryRepo.deactivateByListType(SanctionsListType.HM_TREASURY) } returns 0
+        val entriesSlot = slot<List<SanctionsEntry>>()
+        coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 2
+
+        service.importList(SanctionsListType.HM_TREASURY, url)
+
+        val entries = entriesSlot.captured
+        assertThat(entries.first { it.externalId == "os-4" }.entityType).isEqualTo(EntityType.VESSEL)
+        assertThat(entries.first { it.externalId == "os-5" }.entityType).isEqualTo(EntityType.AIRCRAFT)
+    }
+
+    @Test
+    fun `importList handles quoted CSV fields with embedded commas and escaped quotes`(): Unit = runBlocking {
+        val csv = "id,schema,name,aliases,birth_date,countries,addresses,identifiers,sanctions," +
+            "phones,emails,program_ids,dataset,first_seen,last_seen,last_change\n" +
+            "os-6,Person,\"Doe, John \"\"The Rock\"\"\",,,,,,,,,,,,,\n"
+        val url = serveOnce(csv, "text/csv")
+
+        coEvery { entryRepo.deactivateByListType(SanctionsListType.PEP_GLOBAL) } returns 0
+        val entriesSlot = slot<List<SanctionsEntry>>()
+        coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 1
+
+        service.importList(SanctionsListType.PEP_GLOBAL, url)
+
+        assertThat(entriesSlot.captured.single().primaryName).isEqualTo("""Doe, John "The Rock"""")
+    }
+}

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsListServiceTest.kt
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.application.usecase
+
+import com.openbank.sanctions.domain.model.SanctionsList
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.openbank.sanctions.domain.model.UpdateSanctionsListRequest
+import com.openbank.sanctions.infrastructure.persistence.repository.SanctionsListRepositoryImpl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.NotFoundException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Covers cron validation branches, the refresh/refreshAll fan-out, and the scheduled-refresh
+ * due-check — all pure/mockable logic that does not require a real datasource.
+ */
+class SanctionsListServiceTest {
+
+    private val repo = mockk<SanctionsListRepositoryImpl>()
+    private val importer = mockk<SanctionsImportService>()
+    private val clock = Clock.fixed(Instant.parse("2024-01-15T12:00:00Z"), ZoneOffset.UTC)
+    private val service = SanctionsListService(repo, importer, clock)
+
+    // ──── listAll / getById ─────────────────────────────────────────────────
+
+    @Test
+    fun `listAll delegates to repo`(): Unit = runBlocking {
+        val expected = listOf(sampleList())
+        coEvery { repo.listSanctionsLists() } returns expected
+
+        assertThat(service.listAll()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getById delegates to repo`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        val expected = sampleList(id = id)
+        coEvery { repo.findSanctionsListById(id) } returns expected
+
+        assertThat(service.getById(id)).isEqualTo(expected)
+    }
+
+    // ──── update — cron validation ──────────────────────────────────────────
+
+    @Test
+    fun `update normalizes cronDays and trims sourceUrl`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        val expected = sampleList(id = id)
+        coEvery {
+            repo.updateSanctionsList(id, true, "https://example.com/feed", 6, 30, "MON,TUE")
+        } returns expected
+
+        val result = service.update(
+            id,
+            UpdateSanctionsListRequest(
+                enabled = true,
+                sourceUrl = "  https://example.com/feed  ",
+                cronHour = 6,
+                cronMinute = 30,
+                cronDays = " mon,, tue,mon ",
+            ),
+        )
+
+        assertThat(result).isEqualTo(expected)
+        coVerify { repo.updateSanctionsList(id, true, "https://example.com/feed", 6, 30, "MON,TUE") }
+    }
+
+    @Test
+    fun `update maps blank sourceUrl to null`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.updateSanctionsList(id, null, null, null, null, null) } returns sampleList(id = id)
+
+        service.update(id, UpdateSanctionsListRequest(null, "   ", null, null, null))
+
+        coVerify { repo.updateSanctionsList(id, null, null, null, null, null) }
+    }
+
+    @Test
+    fun `update returns null when repo finds nothing`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.updateSanctionsList(id, null, null, null, null, null) } returns null
+
+        assertThat(service.update(id, UpdateSanctionsListRequest(null, null, null, null, null))).isNull()
+    }
+
+    @Test
+    fun `update rejects cronHour out of range`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+
+        assertThatThrownBy {
+            runBlocking { service.update(id, UpdateSanctionsListRequest(null, null, 24, null, null)) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("cronHour must be between 0 and 23")
+    }
+
+    @Test
+    fun `update rejects cronMinute out of range`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+
+        assertThatThrownBy {
+            runBlocking { service.update(id, UpdateSanctionsListRequest(null, null, null, 60, null)) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("cronMinute must be between 0 and 59")
+    }
+
+    @Test
+    fun `update rejects unsupported cronDays token`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+
+        assertThatThrownBy {
+            runBlocking { service.update(id, UpdateSanctionsListRequest(null, null, null, null, "FUNDAY")) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("cronDays contains unsupported day value")
+    }
+
+    @Test
+    fun `update rejects cronDays that normalizes to empty`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+
+        assertThatThrownBy {
+            runBlocking { service.update(id, UpdateSanctionsListRequest(null, null, null, null, " , , ")) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("cronDays must contain at least one valid day")
+    }
+
+    @Test
+    fun `update allows null cronDays (no change)`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.updateSanctionsList(id, null, null, null, null, null) } returns sampleList(id = id)
+
+        service.update(id, UpdateSanctionsListRequest(null, null, null, null, null))
+
+        coVerify { repo.updateSanctionsList(id, null, null, null, null, null) }
+    }
+
+    // ──── refresh ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `refresh throws NotFoundException when list is unknown`(): Unit = runBlocking {
+        coEvery { repo.findByListType("OFAC_SDN") } returns null
+
+        assertThatThrownBy {
+            runBlocking { service.refresh("OFAC_SDN") }
+        }.isInstanceOf(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `refresh uses importer count when import succeeds`(): Unit = runBlocking {
+        val list = sampleList(listType = "OFAC_SDN", sourceUrl = "https://example.com/sdn.xml")
+        coEvery { repo.findByListType("OFAC_SDN") } returns list
+        coEvery { importer.importList(SanctionsListType.OFAC_SDN, "https://example.com/sdn.xml") } returns 42
+        coEvery { repo.markUpdated("OFAC_SDN", 42) } returns list.copy(lastEntryCount = 42)
+
+        val result = service.refresh("OFAC_SDN")
+
+        assertThat(result.lastEntryCount).isEqualTo(42)
+        coVerify { repo.markUpdated("OFAC_SDN", 42) }
+    }
+
+    @Test
+    fun `refresh falls back to stored count when importer returns zero`(): Unit = runBlocking {
+        val list = sampleList(listType = "FATF_HIGH_RISK", lastEntryCount = 7)
+        coEvery { repo.findByListType("FATF_HIGH_RISK") } returns list
+        coEvery { importer.importList(SanctionsListType.FATF_HIGH_RISK, any()) } returns 0
+        coEvery { repo.markUpdated("FATF_HIGH_RISK", 7) } returns list
+
+        service.refresh("FATF_HIGH_RISK")
+
+        coVerify { repo.markUpdated("FATF_HIGH_RISK", 7) }
+    }
+
+    @Test
+    fun `refresh falls back to zero when stored count is null and importer returns zero`(): Unit = runBlocking {
+        val list = sampleList(listType = "CNB_DOMESTIC", lastEntryCount = null)
+        coEvery { repo.findByListType("CNB_DOMESTIC") } returns list
+        coEvery { importer.importList(SanctionsListType.CNB_DOMESTIC, any()) } returns 0
+        coEvery { repo.markUpdated("CNB_DOMESTIC", 0) } returns list
+
+        service.refresh("CNB_DOMESTIC")
+
+        coVerify { repo.markUpdated("CNB_DOMESTIC", 0) }
+    }
+
+    @Test
+    fun `refresh uses stored count directly for an unrecognized listType enum`(): Unit = runBlocking {
+        val list = sampleList(listType = "NOT_A_REAL_TYPE", lastEntryCount = 3)
+        coEvery { repo.findByListType("NOT_A_REAL_TYPE") } returns list
+        coEvery { repo.markUpdated("NOT_A_REAL_TYPE", 3) } returns list
+
+        service.refresh("NOT_A_REAL_TYPE")
+
+        coVerify(exactly = 0) { importer.importList(any(), any()) }
+        coVerify { repo.markUpdated("NOT_A_REAL_TYPE", 3) }
+    }
+
+    @Test
+    fun `refresh throws IllegalStateException when markUpdated fails to persist`(): Unit = runBlocking {
+        val list = sampleList(listType = "OFAC_SDN")
+        coEvery { repo.findByListType("OFAC_SDN") } returns list
+        coEvery { importer.importList(SanctionsListType.OFAC_SDN, any()) } returns 5
+        coEvery { repo.markUpdated("OFAC_SDN", 5) } returns null
+
+        assertThatThrownBy {
+            runBlocking { service.refresh("OFAC_SDN") }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Failed to persist sanctions list refresh")
+    }
+
+    // ──── refreshAll ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `refreshAll only refreshes enabled lists`(): Unit = runBlocking {
+        val enabled = sampleList(listType = "OFAC_SDN", enabled = true)
+        val disabled = sampleList(listType = "FATF_HIGH_RISK", enabled = false)
+        coEvery { repo.listSanctionsLists() } returns listOf(enabled, disabled)
+        coEvery { repo.findByListType("OFAC_SDN") } returns enabled
+        coEvery { importer.importList(SanctionsListType.OFAC_SDN, any()) } returns 1
+        coEvery { repo.markUpdated("OFAC_SDN", 1) } returns enabled.copy(lastEntryCount = 1)
+
+        val result = service.refreshAll()
+
+        assertThat(result).hasSize(1)
+        coVerify(exactly = 0) { repo.findByListType("FATF_HIGH_RISK") }
+    }
+
+    @Test
+    fun `refreshAll returns empty list when nothing is enabled`(): Unit = runBlocking {
+        coEvery { repo.listSanctionsLists() } returns listOf(sampleList(enabled = false))
+
+        assertThat(service.refreshAll()).isEmpty()
+    }
+
+    // ──── scheduledRefresh — Uni pipeline ──────────────────────────────────
+
+    @Test
+    fun `scheduledRefresh skips lists whose cron schedule does not match now`(): Unit = runBlocking {
+        // clock fixed at 2024-01-15T12:00:00Z (a Monday, UTC); list scheduled for hour 6 never matches
+        val notDue = sampleList(
+            listType = "OFAC_SDN",
+            cronHour = 6,
+            cronMinute = 0,
+            cronDays = "MON,TUE,WED,THU,FRI",
+        )
+        every { repo.listSanctionsListsUni() } returns Uni.createFrom().item(listOf(notDue))
+
+        service.scheduledRefresh().await().indefinitely()
+
+        coVerify(exactly = 0) { repo.markUpdatedUni(any(), any(), any()) }
+    }
+
+    private fun sampleList(
+        id: UUID = UUID.randomUUID(),
+        listType: String = "OFAC_SDN",
+        enabled: Boolean = true,
+        sourceUrl: String = "https://example.com/feed",
+        lastEntryCount: Int? = null,
+        cronHour: Int = 6,
+        cronMinute: Int = 0,
+        cronDays: String = "MON,TUE,WED,THU,FRI",
+    ) = SanctionsList(
+        id = id,
+        listType = listType,
+        displayName = listType,
+        sourceUrl = sourceUrl,
+        enabled = enabled,
+        lastUpdatedAt = null,
+        lastEntryCount = lastEntryCount,
+        cronHour = cronHour,
+        cronMinute = cronMinute,
+        cronDays = cronDays,
+        createdAt = Instant.EPOCH,
+        updatedAt = Instant.EPOCH,
+    )
+}

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/domain/model/SanctionsCheckTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/domain/model/SanctionsCheckTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/** Plain domain test (ADR-0002: zero framework imports) for [SanctionsCheck.isHighRisk]. */
+class SanctionsCheckTest {
+
+    @Test
+    fun `isHighRisk is true for HIT regardless of score`() {
+        assertThat(sampleCheck(status = SanctionsCheckStatus.HIT, overallScore = 0.10).isHighRisk()).isTrue()
+    }
+
+    @Test
+    fun `isHighRisk is true for POTENTIAL_HIT above the 0-85 threshold`() {
+        assertThat(sampleCheck(status = SanctionsCheckStatus.POTENTIAL_HIT, overallScore = 0.90).isHighRisk()).isTrue()
+    }
+
+    @Test
+    fun `isHighRisk is false for POTENTIAL_HIT at or below the 0-85 threshold`() {
+        assertThat(sampleCheck(status = SanctionsCheckStatus.POTENTIAL_HIT, overallScore = 0.85).isHighRisk()).isFalse()
+        assertThat(sampleCheck(status = SanctionsCheckStatus.POTENTIAL_HIT, overallScore = 0.50).isHighRisk()).isFalse()
+    }
+
+    @Test
+    fun `isHighRisk is false for CLEAR, WHITELISTED and ESCALATED`() {
+        assertThat(sampleCheck(status = SanctionsCheckStatus.CLEAR, overallScore = 1.0).isHighRisk()).isFalse()
+        assertThat(sampleCheck(status = SanctionsCheckStatus.WHITELISTED, overallScore = 1.0).isHighRisk()).isFalse()
+        assertThat(sampleCheck(status = SanctionsCheckStatus.ESCALATED, overallScore = 1.0).isHighRisk()).isFalse()
+    }
+
+    private fun sampleCheck(status: SanctionsCheckStatus, overallScore: Double) = SanctionsCheck(
+        id = UUID.randomUUID(),
+        idempotencyKey = "idem-1",
+        entityType = EntityType.INDIVIDUAL,
+        name = "Test Entity",
+        aliases = emptyList(),
+        dateOfBirth = null,
+        nationality = null,
+        identifiers = emptyMap(),
+        status = status,
+        matches = emptyList(),
+        overallScore = overallScore,
+        checkedLists = SanctionsListType.entries,
+        reviewedBy = null,
+        reviewNote = null,
+        checkedAt = Instant.EPOCH,
+        reviewedAt = null,
+    )
+}

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/persistence/mapper/SanctionsMapperTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/persistence/mapper/SanctionsMapperTest.kt
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.infrastructure.persistence.mapper
+
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.MatchType
+import com.openbank.sanctions.domain.model.SanctionsCheck
+import com.openbank.sanctions.domain.model.SanctionsCheckStatus
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.openbank.sanctions.domain.model.SanctionsMatch
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/** Pure JSON round-trip mapping between the domain [SanctionsCheck] and its JPA entity. */
+class SanctionsMapperTest {
+
+    @Test
+    fun `toEntity followed by toDomain round-trips a check with matches and identifiers`() {
+        val check = SanctionsCheck(
+            id = UUID.randomUUID(),
+            idempotencyKey = "idem-42",
+            entityType = EntityType.INDIVIDUAL,
+            name = "Vladimir Putin",
+            aliases = listOf("Vova Putin", "V. Putin"),
+            dateOfBirth = "1952-10-07",
+            nationality = "RU",
+            identifiers = mapOf("passport" to "123456", "taxId" to "999-88"),
+            status = SanctionsCheckStatus.HIT,
+            matches = listOf(
+                SanctionsMatch(
+                    listType = SanctionsListType.OFAC_SDN,
+                    matchType = MatchType.EXACT,
+                    matchScore = 0.97,
+                    matchedName = "Vladimir Putin",
+                    matchedId = "ofac-17766",
+                    listEntryDate = null,
+                    programs = listOf("RUSSIA-EO14024"),
+                ),
+            ),
+            overallScore = 0.97,
+            checkedLists = listOf(SanctionsListType.OFAC_SDN, SanctionsListType.EU_CONSOLIDATED),
+            reviewedBy = "analyst-1",
+            reviewNote = "confirmed hit",
+            checkedAt = Instant.parse("2024-01-15T12:00:00Z"),
+            reviewedAt = Instant.parse("2024-01-16T09:30:00Z"),
+        )
+
+        val entity = check.toEntity()
+        assertThat(entity.id).isEqualTo(check.id)
+        assertThat(entity.idempotencyKey).isEqualTo("idem-42")
+        assertThat(entity.aliasesJson).contains("Vova Putin")
+        assertThat(entity.identifiersJson).contains("passport")
+        assertThat(entity.matchesJson).contains("ofac-17766")
+        assertThat(entity.checkedListsJson).contains("OFAC_SDN")
+
+        val roundTripped = entity.toDomain()
+        assertThat(roundTripped).isEqualTo(check)
+    }
+
+    @Test
+    fun `toEntity followed by toDomain round-trips a check with empty collections and nulls`() {
+        val check = SanctionsCheck(
+            id = UUID.randomUUID(),
+            idempotencyKey = "idem-clear",
+            entityType = EntityType.ORGANIZATION,
+            name = "Acme Corp",
+            aliases = emptyList(),
+            dateOfBirth = null,
+            nationality = null,
+            identifiers = emptyMap(),
+            status = SanctionsCheckStatus.CLEAR,
+            matches = emptyList(),
+            overallScore = 0.0,
+            checkedLists = SanctionsListType.entries,
+            reviewedBy = null,
+            reviewNote = null,
+            checkedAt = Instant.EPOCH,
+            reviewedAt = null,
+        )
+
+        val roundTripped = check.toEntity().toDomain()
+
+        assertThat(roundTripped).isEqualTo(check)
+        assertThat(roundTripped.aliases).isEmpty()
+        assertThat(roundTripped.reviewedBy).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the earlier koverVerify floor fix (minValue 0 -> 15). This raises actual measured coverage from 18.36% to 63.56% with real unit tests targeting the highest-value gaps found via `koverHtmlReport`.

## Type of change

- [x] test

## Linked issues

N/A — coverage improvement, not tracked as a separate issue.

## Changes

- `SanctionsImportServiceTest`: application use-case tests for the import flow.
- `SanctionsListServiceTest`: application use-case tests for list management.
- `SanctionsCheckTest`: domain test for `isHighRisk` threshold behavior (HIT/POTENTIAL_HIT/CLEAR/WHITELISTED/ESCALATED, score boundaries) — framework-import-free per ADR-0002.
- `SanctionsMapperTest`: persistence mapper round-trip test.
- `koverVerify` `minValue` bumped 15 -> 60 (a few points below the new measured 63.56%, ratchet-only).

sanctions-service is NOT on the `money_path_services` list — standard 1-approval review.

## Definition of Done

- [x] Unit tests added.
- [x] `./gradlew :openbank-sanctions-service:koverVerify` passes at the new floor.
- [x] `ktlintCheck` / `detekt` pass with no new violations.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency.