### PR TITLE
test(finrep): raise coverage 57.58% -> 78.79% with real unit tests

### DIFF
--- a/openbank-finrep-service/build.gradle.kts
+++ b/openbank-finrep-service/build.gradle.kts
@@ -39,7 +39,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 55
+                    minValue = 75
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/application/usecase/FinrepServiceTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.application.usecase
+
+import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.application.port.out.LedgerPort
+import com.openbank.finrep.application.port.out.TrialBalanceLineDto
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class FinrepServiceTest {
+
+    private val ledgerPort: LedgerPort = mockk()
+
+    @Test
+    fun `getTemplate dispatches F01_01 to the balance sheet mapper`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        val lines = listOf(
+            TrialBalanceLineDto(code = "1000", accountType = "ASSET", net = BigDecimal("500000")),
+            TrialBalanceLineDto(code = "2000", accountType = "LIABILITY", net = BigDecimal("300000")),
+        )
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
+        val service = FinrepService(ledgerPort)
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F01.01", asOf = asOf))
+
+        assertThat(template.templateId).isEqualTo("F01.01")
+        assertThat(template.period).isEqualTo(asOf)
+        assertThat(template.cells).anyMatch { it.rowRef == "r490" && it.value == BigDecimal("200000") }
+        coVerify(exactly = 1) { ledgerPort.getTrialBalance(asOf) }
+    }
+
+    @Test
+    fun `getTemplate dispatches F02_00 to the P&L mapper`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        val lines = listOf(
+            TrialBalanceLineDto(code = "4000", accountType = "INCOME", net = BigDecimal("120000")),
+            TrialBalanceLineDto(code = "5000", accountType = "EXPENSE", net = BigDecimal("80000")),
+        )
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns lines
+        val service = FinrepService(ledgerPort)
+
+        val template = service.getTemplate(GetFinrepTemplateQuery(templateId = "F02.00", asOf = asOf))
+
+        assertThat(template.templateId).isEqualTo("F02.00")
+        assertThat(template.cells).anyMatch { it.rowRef == "r450" && it.value == BigDecimal("40000") }
+    }
+
+    @Test
+    fun `getTemplate throws for an unknown template id`(): Unit = runBlocking {
+        val asOf = LocalDate.of(2026, 6, 30)
+        coEvery { ledgerPort.getTrialBalance(asOf) } returns emptyList()
+        val service = FinrepService(ledgerPort)
+
+        assertThatThrownBy {
+            runBlocking { service.getTemplate(GetFinrepTemplateQuery(templateId = "F99.99", asOf = asOf)) }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("F99.99")
+    }
+}

--- a/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
+++ b/openbank-finrep-service/src/test/kotlin/com/openbank/finrep/infrastructure/rest/FinrepResourceTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.finrep.infrastructure.rest
+
+import com.openbank.finrep.application.port.inbound.FinrepUseCase
+import com.openbank.finrep.application.port.inbound.GetFinrepTemplateQuery
+import com.openbank.finrep.domain.model.FinrepCell
+import com.openbank.finrep.domain.model.FinrepTemplate
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class FinrepResourceTest {
+
+    private lateinit var finrepUseCase: FinrepUseCase
+    private lateinit var fixedClock: Clock
+    private lateinit var resource: FinrepResource
+
+    private val fixedInstant: Instant = Instant.parse("2026-06-30T10:00:00Z")
+
+    @BeforeEach
+    fun setUp() {
+        finrepUseCase = mockk()
+        fixedClock = Clock.fixed(fixedInstant, ZoneOffset.UTC)
+        resource = FinrepResource(finrepUseCase, fixedClock)
+    }
+
+    @Test
+    fun `getTemplate defaults asOf to the injected clock's date when blank`(): Unit = runBlocking {
+        val expected = FinrepTemplate(
+            templateId = "F01.01",
+            period = LocalDate.now(fixedClock),
+            cells = listOf(FinrepCell(rowRef = "r010", colRef = "c010", value = BigDecimal.ZERO)),
+        )
+        val captured = slot<GetFinrepTemplateQuery>()
+        coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected
+
+        val resp: Response = resource.getTemplate(templateId = "F01.01", asOf = "")
+
+        assertThat(resp.status).isEqualTo(200)
+        assertThat(resp.entity).isEqualTo(expected)
+        assertThat(captured.captured.asOf).isEqualTo(LocalDate.now(fixedClock))
+        assertThat(captured.captured.templateId).isEqualTo("F01.01")
+    }
+
+    @Test
+    fun `getTemplate parses an explicit asOf query param`(): Unit = runBlocking {
+        val explicitDate = LocalDate.of(2025, 12, 31)
+        val expected = FinrepTemplate(
+            templateId = "F02.00",
+            period = explicitDate,
+            cells = emptyList(),
+        )
+        val captured = slot<GetFinrepTemplateQuery>()
+        coEvery { finrepUseCase.getTemplate(capture(captured)) } returns expected
+
+        val resp: Response = resource.getTemplate(templateId = "F02.00", asOf = "2025-12-31")
+
+        assertThat(resp.status).isEqualTo(200)
+        assertThat(resp.entity).isEqualTo(expected)
+        assertThat(captured.captured.asOf).isEqualTo(explicitDate)
+        coVerify(exactly = 1) { finrepUseCase.getTemplate(any()) }
+    }
+}


### PR DESCRIPTION
## Summary

Raises measured coverage from 57.58% to 78.79% with real unit tests, following this small mapper-heavy service's existing test conventions.

## Type of change

- [x] test

## Linked issues

N/A — coverage improvement, not tracked as a separate issue.

## Changes

- `FinrepServiceTest`: application use-case tests.
- `FinrepResourceTest`: REST resource tests.
- `koverVerify` `minValue` bumped 55 -> 75 (a few points below the new measured 78.79%, ratchet-only).

finrep-service is NOT on the `money_path_services` list — standard 1-approval review.

## Definition of Done

- [x] Unit tests added.
- [x] `./gradlew :openbank-finrep-service:koverVerify` passes at the new floor.
- [x] `ktlintCheck` / `detekt` pass with no new violations.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency.