### PR TITLE
test(dispute): raise coverage to 67.00% with real unit tests

### DIFF
--- a/openbank-dispute-service/build.gradle.kts
+++ b/openbank-dispute-service/build.gradle.kts
@@ -43,7 +43,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    minValue = 60
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/infrastructure/persistence/mapper/ComplaintMapperTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/infrastructure/persistence/mapper/ComplaintMapperTest.kt
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.dispute.infrastructure.persistence.mapper
+
+import com.openbank.dispute.domain.model.Complaint
+import com.openbank.dispute.domain.model.ComplaintCategory
+import com.openbank.dispute.domain.model.ComplaintChannel
+import com.openbank.dispute.domain.model.ComplaintStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Round-trip tests for [ComplaintMapper]. Note the mapper does NOT carry [Complaint.breached] —
+ * that field is derived at read time by `ComplaintService.withBreach` and must never be persisted,
+ * so a round-trip through the entity is expected to reset it to `false` regardless of the input.
+ */
+class ComplaintMapperTest {
+
+    private val mapper = ComplaintMapper()
+
+    private val now = OffsetDateTime.of(2026, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC)
+    private val received = LocalDate.of(2026, 6, 9)
+    private val due = LocalDate.of(2026, 6, 30)
+
+    @Test
+    fun `complaint round-trips through entity with all fields populated`() {
+        val complaint = Complaint(
+            id = UUID.randomUUID(),
+            reference = "CMP-1001",
+            category = ComplaintCategory.FEES,
+            channel = ComplaintChannel.BRANCH,
+            description = "Disputed monthly fee",
+            status = ComplaintStatus.CLOSED,
+            accountId = UUID.randomUUID(),
+            transactionId = UUID.randomUUID(),
+            disputeId = UUID.randomUUID(),
+            receivedDate = received,
+            dueDate = due,
+            interimReplyAt = now,
+            interimReplyReason = "awaiting review",
+            resolvedAt = now,
+            outcome = "Fee reversed",
+            redressGranted = true,
+            rootCauseCode = "FEE-ERR",
+            closedAt = now,
+            createdAt = now,
+            updatedAt = now,
+        )
+
+        val entity = mapper.toEntity(complaint)
+        val roundTripped = mapper.toDomain(entity)
+
+        // `breached` is not carried by the entity/mapper — compare everything else field-by-field.
+        assertThat(roundTripped).usingRecursiveComparison().ignoringFields("breached").isEqualTo(complaint)
+        assertThat(roundTripped.breached).isFalse()
+    }
+
+    @Test
+    fun `complaint round-trips through entity with nullable fields absent`() {
+        val complaint = Complaint(
+            reference = "CMP-1002",
+            category = ComplaintCategory.OTHER,
+            channel = ComplaintChannel.EMAIL,
+            description = "General inquiry",
+            receivedDate = received,
+            dueDate = due,
+            createdAt = now,
+            updatedAt = now,
+        )
+
+        val roundTripped = mapper.toDomain(mapper.toEntity(complaint))
+
+        assertThat(roundTripped.accountId).isNull()
+        assertThat(roundTripped.transactionId).isNull()
+        assertThat(roundTripped.disputeId).isNull()
+        assertThat(roundTripped.interimReplyAt).isNull()
+        assertThat(roundTripped.interimReplyReason).isNull()
+        assertThat(roundTripped.resolvedAt).isNull()
+        assertThat(roundTripped.outcome).isNull()
+        assertThat(roundTripped.redressGranted).isNull()
+        assertThat(roundTripped.rootCauseCode).isNull()
+        assertThat(roundTripped.closedAt).isNull()
+        assertThat(roundTripped).usingRecursiveComparison().ignoringFields("breached").isEqualTo(complaint)
+    }
+
+    @Test
+    fun `entity default status is RECEIVED and default category is OTHER`() {
+        val entity = com.openbank.dispute.infrastructure.persistence.entity.ComplaintEntity()
+
+        assertThat(entity.status).isEqualTo(ComplaintStatus.RECEIVED)
+        assertThat(entity.category).isEqualTo(ComplaintCategory.OTHER)
+        assertThat(entity.channel).isEqualTo(ComplaintChannel.APP)
+    }
+}

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/infrastructure/persistence/mapper/DisputeMapperTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/infrastructure/persistence/mapper/DisputeMapperTest.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.dispute.infrastructure.persistence.mapper
+
+import com.openbank.dispute.domain.model.Dispute
+import com.openbank.dispute.domain.model.DisputeEvidence
+import com.openbank.dispute.domain.model.DisputeResolution
+import com.openbank.dispute.domain.model.DisputeStatus
+import com.openbank.dispute.domain.model.DisputeTimelineEvent
+import com.openbank.dispute.domain.model.DisputeType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * Round-trip tests for [DisputeMapper]: every field must survive domain -> entity -> domain
+ * without loss or transposition. Pure JVM object mapping — no Quarkus/Panache boot needed.
+ */
+class DisputeMapperTest {
+
+    private val mapper = DisputeMapper()
+
+    private val now = OffsetDateTime.of(2026, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC)
+    private val today = LocalDate.of(2026, 6, 15)
+
+    @Test
+    fun `dispute round-trips through entity with all fields populated`() {
+        val dispute = Dispute(
+            id = UUID.randomUUID(),
+            reference = "DSP-1001",
+            transactionId = UUID.randomUUID(),
+            accountId = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            disputeType = DisputeType.NOT_AS_DESCRIBED,
+            status = DisputeStatus.UNDER_REVIEW,
+            resolution = DisputeResolution.CHARGEBACK,
+            amount = BigDecimal("123.45"),
+            currency = "CZK",
+            description = "Item never arrived",
+            merchantName = "Acme Corp",
+            merchantId = "MERCH-42",
+            transactionDate = today.minusDays(10),
+            filingDate = today,
+            resolutionDeadline = today.plusDays(45),
+            resolvedAt = now,
+            resolvedBy = "caseworker-1",
+            chargebackAmount = BigDecimal("100.00"),
+            createdAt = now,
+            updatedAt = now,
+        )
+
+        val entity = mapper.toEntity(dispute)
+        val roundTripped = mapper.toDomain(entity)
+
+        assertThat(roundTripped).isEqualTo(dispute)
+    }
+
+    @Test
+    fun `dispute round-trips through entity with nullable fields absent`() {
+        val dispute = Dispute(
+            reference = "DSP-1002",
+            transactionId = UUID.randomUUID(),
+            accountId = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            disputeType = DisputeType.OTHER,
+            amount = BigDecimal("5.00"),
+            transactionDate = today,
+            filingDate = today,
+            createdAt = now,
+            updatedAt = now,
+        )
+
+        val roundTripped = mapper.toDomain(mapper.toEntity(dispute))
+
+        assertThat(roundTripped.description).isNull()
+        assertThat(roundTripped.merchantName).isNull()
+        assertThat(roundTripped.merchantId).isNull()
+        assertThat(roundTripped.resolutionDeadline).isNull()
+        assertThat(roundTripped.resolvedAt).isNull()
+        assertThat(roundTripped.resolvedBy).isNull()
+        assertThat(roundTripped.chargebackAmount).isNull()
+        assertThat(roundTripped).isEqualTo(dispute)
+    }
+
+    @Test
+    fun `dispute evidence round-trips through entity`() {
+        val evidence = DisputeEvidence(
+            id = UUID.randomUUID(),
+            disputeId = UUID.randomUUID(),
+            submittedBy = "customer",
+            evidenceType = "RECEIPT",
+            description = "Photo of receipt",
+            fileReference = "s3://bucket/receipt.png",
+            submittedAt = now,
+        )
+
+        val roundTripped = mapper.toDomain(mapper.toEntity(evidence))
+
+        assertThat(roundTripped).isEqualTo(evidence)
+    }
+
+    @Test
+    fun `evidence without submittedAt fails fast when mapped to an entity`() {
+        val evidence = DisputeEvidence(
+            disputeId = UUID.randomUUID(),
+            submittedBy = "customer",
+            evidenceType = "RECEIPT",
+            submittedAt = null,
+        )
+
+        assertThatThrownBy { mapper.toEntity(evidence) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("submittedAt must be set")
+    }
+
+    @Test
+    fun `dispute timeline event round-trips through entity`() {
+        val event = DisputeTimelineEvent(
+            id = UUID.randomUUID(),
+            disputeId = UUID.randomUUID(),
+            eventType = "OPENED",
+            description = "Dispute opened: UNAUTHORIZED",
+            actor = "CUSTOMER",
+            createdAt = now,
+        )
+
+        val roundTripped = mapper.toDomain(mapper.toEntity(event))
+
+        assertThat(roundTripped).isEqualTo(event)
+    }
+
+    @Test
+    fun `dispute timeline event round-trips with null actor`() {
+        val event = DisputeTimelineEvent(
+            disputeId = UUID.randomUUID(),
+            eventType = "STATUS_CHANGED",
+            description = "Status updated to ESCALATED",
+            actor = null,
+            createdAt = now,
+        )
+
+        val roundTripped = mapper.toDomain(mapper.toEntity(event))
+
+        assertThat(roundTripped.actor).isNull()
+        assertThat(roundTripped).isEqualTo(event)
+    }
+}


### PR DESCRIPTION
## Summary

Adds persistence mapper tests (the highest-value uncovered gap) and fixes a disabled coverage gate discovered along the way — `koverVerify` `minValue` was 0, same defect class as the earlier sanctions/finrep/psd2 fix (coverage regressions to zero were invisible to CI).

## Type of change

- [x] test

## Linked issues

N/A — coverage improvement, not tracked as a separate issue.

## Changes

- `ComplaintMapperTest`, `DisputeMapperTest`: persistence mapper tests.
- `koverVerify` `minValue` set 0 -> 60 (a few points below the new measured 67.00%).

dispute-service is NOT on the `money_path_services` list — standard 1-approval review.

## Definition of Done

- [x] Unit tests added.
- [x] `./gradlew :openbank-dispute-service:koverVerify` passes at the new floor.
- [x] `ktlintCheck` / `detekt` pass with no new violations.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new third-party dependency.