### PR TITLE
test(pid): raise unit test coverage for openbank-pid-service

### DIFF
--- a/openbank-pid-service/build.gradle.kts
+++ b/openbank-pid-service/build.gradle.kts
@@ -57,7 +57,10 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet-only floor (ADR-0029 rule #5): measured line coverage is ~57.6% as of
+                    // this change (up from 0/unset); set a few points below so routine variance
+                    // doesn't trip CI, but the floor never goes back down.
+                    minValue = 55
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/application/usecase/VerificationCaseServiceTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/application/usecase/VerificationCaseServiceTest.kt
@@ -6,12 +6,14 @@ package com.openbank.pid.application.usecase
 
 import com.openbank.pid.application.port.`in`.DecideCaseCommand
 import com.openbank.pid.application.port.`in`.OpenCaseCommand
+import com.openbank.pid.application.port.`in`.ReopenCaseCommand
 import com.openbank.pid.application.port.out.PartyEventPublisher
 import com.openbank.pid.application.port.out.VerificationCaseRepository
 import com.openbank.pid.domain.event.VerificationCaseDecidedEvent
 import com.openbank.pid.domain.event.VerificationCaseOpenedEvent
 import com.openbank.pid.domain.model.ApplicantSnapshot
 import com.openbank.pid.domain.model.CaseVerdict
+import com.openbank.pid.domain.model.IllegalCaseTransition
 import com.openbank.pid.domain.model.VerificationCase
 import com.openbank.pid.domain.model.VerificationCaseStatus
 import com.openbank.pid.domain.model.VerificationTrigger
@@ -21,6 +23,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
@@ -121,5 +124,72 @@ class VerificationCaseServiceTest {
         coVerify(exactly = 1) { events.publish(capture(decidedSlot)) }
         assertThat(decidedSlot.captured.firstApprover).isEqualTo("alice")
         assertThat(decidedSlot.captured.secondApprover).isEqualTo("bob")
+    }
+
+    @Test
+    fun `decide throws VerificationCaseNotFoundException for an unknown case`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.findById(id) } returns null
+
+        assertThatThrownBy {
+            runBlocking { svc.decide(DecideCaseCommand(id, "alice", CaseVerdict.DISTINCT_NEW, null, null)) }
+        }.isInstanceOf(VerificationCaseNotFoundException::class.java)
+    }
+
+    @Test
+    fun `decide on an already-DECIDED case throws IllegalCaseTransition`(): Unit = runBlocking {
+        val decided = storedCase(VerificationCaseStatus.DECIDED)
+        coEvery { repo.findById(decided.id) } returns decided
+
+        assertThatThrownBy {
+            runBlocking { svc.decide(DecideCaseCommand(decided.id, "alice", CaseVerdict.DISTINCT_NEW, null, null)) }
+        }.isInstanceOf(IllegalCaseTransition::class.java)
+        coVerify(exactly = 0) { repo.update(any()) }
+    }
+
+    @Test
+    fun `reopen resets an AWAITING case back to OPEN`(): Unit = runBlocking {
+        val awaiting = storedCase(VerificationCaseStatus.AWAITING_SECOND_APPROVAL).copy(
+            firstApprover = "alice",
+            firstVerdict = CaseVerdict.DISTINCT_NEW,
+        )
+        coEvery { repo.findById(awaiting.id) } returns awaiting
+        coEvery { repo.update(any()) } answers { firstArg() }
+
+        val result = svc.reopen(ReopenCaseCommand(awaiting.id, "supervisor"))
+
+        assertThat(result.status).isEqualTo(VerificationCaseStatus.OPEN)
+        assertThat(result.firstApprover).isNull()
+        coVerify(exactly = 1) { repo.update(any()) }
+    }
+
+    @Test
+    fun `reopen throws VerificationCaseNotFoundException for an unknown case`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.findById(id) } returns null
+
+        assertThatThrownBy {
+            runBlocking { svc.reopen(ReopenCaseCommand(id, "supervisor")) }
+        }.isInstanceOf(VerificationCaseNotFoundException::class.java)
+    }
+
+    @Test
+    fun `listActive delegates to the repository with OPEN and AWAITING_SECOND_APPROVAL statuses`(): Unit =
+        runBlocking {
+            val expected = listOf(storedCase(VerificationCaseStatus.OPEN))
+            val activeStatuses = listOf(VerificationCaseStatus.OPEN, VerificationCaseStatus.AWAITING_SECOND_APPROVAL)
+            coEvery { repo.listByStatuses(activeStatuses) } returns expected
+
+            val result = svc.listActive()
+
+            assertThat(result).isEqualTo(expected)
+        }
+
+    @Test
+    fun `get delegates to the repository by id`(): Unit = runBlocking {
+        val case = storedCase(VerificationCaseStatus.OPEN)
+        coEvery { repo.findById(case.id) } returns case
+
+        assertThat(svc.get(case.id)).isEqualTo(case)
     }
 }

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/application/usecase/VerificationCaseServiceTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/application/usecase/VerificationCaseServiceTest.kt
@@ -174,16 +174,15 @@ class VerificationCaseServiceTest {
     }
 
     @Test
-    fun `listActive delegates to the repository with OPEN and AWAITING_SECOND_APPROVAL statuses`(): Unit =
-        runBlocking {
-            val expected = listOf(storedCase(VerificationCaseStatus.OPEN))
-            val activeStatuses = listOf(VerificationCaseStatus.OPEN, VerificationCaseStatus.AWAITING_SECOND_APPROVAL)
-            coEvery { repo.listByStatuses(activeStatuses) } returns expected
+    fun `listActive delegates to the repository with OPEN and AWAITING_SECOND_APPROVAL statuses`(): Unit = runBlocking {
+        val expected = listOf(storedCase(VerificationCaseStatus.OPEN))
+        val activeStatuses = listOf(VerificationCaseStatus.OPEN, VerificationCaseStatus.AWAITING_SECOND_APPROVAL)
+        coEvery { repo.listByStatuses(activeStatuses) } returns expected
 
-            val result = svc.listActive()
+        val result = svc.listActive()
 
-            assertThat(result).isEqualTo(expected)
-        }
+        assertThat(result).isEqualTo(expected)
+    }
 
     @Test
     fun `get delegates to the repository by id`(): Unit = runBlocking {

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/domain/model/PartyTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/domain/model/PartyTest.kt
@@ -18,19 +18,17 @@ class PartyTest {
 
     private val now: OffsetDateTime = OffsetDateTime.parse("2025-01-01T00:00:00Z")
 
-    private fun relationship(
-        role: PartyRole,
-        status: RelationshipStatus = RelationshipStatus.ACTIVE,
-    ) = PartyRelationship(
-        id = UUID.randomUUID(),
-        partyId = UUID.randomUUID(),
-        role = role,
-        status = status,
-        onboardedAt = now,
-        onboardingChannel = OnboardingChannel.API,
-        terminatedAt = null,
-        terminationReason = null,
-    )
+    private fun relationship(role: PartyRole, status: RelationshipStatus = RelationshipStatus.ACTIVE) =
+        PartyRelationship(
+            id = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            role = role,
+            status = status,
+            onboardedAt = now,
+            onboardingChannel = OnboardingChannel.API,
+            terminatedAt = null,
+            terminationReason = null,
+        )
 
     private fun party(
         relationships: List<PartyRelationship> = emptyList(),

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/domain/model/PartyTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/domain/model/PartyTest.kt
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.pid.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Unit tests for the [Party] aggregate's small role/relationship/external-id helpers.
+ * Pure domain — no framework boot.
+ */
+class PartyTest {
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2025-01-01T00:00:00Z")
+
+    private fun relationship(
+        role: PartyRole,
+        status: RelationshipStatus = RelationshipStatus.ACTIVE,
+    ) = PartyRelationship(
+        id = UUID.randomUUID(),
+        partyId = UUID.randomUUID(),
+        role = role,
+        status = status,
+        onboardedAt = now,
+        onboardingChannel = OnboardingChannel.API,
+        terminatedAt = null,
+        terminationReason = null,
+    )
+
+    private fun party(
+        relationships: List<PartyRelationship> = emptyList(),
+        externalIds: List<ExternalId> = emptyList(),
+    ) = Party(
+        id = UUID.randomUUID(),
+        partyType = PartyType.NATURAL_PERSON,
+        status = PartyStatus.ACTIVE,
+        externalIds = externalIds,
+        coreAttributes = CoreAttributes(
+            givenName = "Jan",
+            familyName = "Novak",
+            birthdate = LocalDate.of(1990, 1, 1),
+            birthNumberEncrypted = null,
+            gender = null,
+            birthplace = null,
+            nationalities = listOf("CZ"),
+            idDocuments = emptyList(),
+            verificationSource = VerificationSource.BANKID,
+            verifiedAt = now,
+        ),
+        addressAttributes = null,
+        contactAttributes = ContactAttributes(null, null, null, null),
+        kycAttributes = KycAttributes(KycLevel.BASIC, null, null, AmlRiskScore.LOW, false, false, null, null),
+        relationships = relationships,
+        caseLifecycle = null,
+        createdAt = now,
+        updatedAt = now,
+        version = 0,
+    )
+
+    @Test
+    fun `hasRole is true only for an ACTIVE relationship with that role`() {
+        val p = party(relationships = listOf(relationship(PartyRole.CUSTOMER)))
+        assertThat(p.hasRole(PartyRole.CUSTOMER)).isTrue()
+        assertThat(p.hasRole(PartyRole.EMPLOYEE)).isFalse()
+    }
+
+    @Test
+    fun `hasRole is false when the matching relationship is TERMINATED`() {
+        val p = party(
+            relationships = listOf(relationship(PartyRole.CUSTOMER, status = RelationshipStatus.TERMINATED)),
+        )
+        assertThat(p.hasRole(PartyRole.CUSTOMER)).isFalse()
+    }
+
+    @Test
+    fun `isCustomer and isEmployee reflect active relationships`() {
+        val customer = party(relationships = listOf(relationship(PartyRole.CUSTOMER)))
+        assertThat(customer.isCustomer()).isTrue()
+        assertThat(customer.isEmployee()).isFalse()
+
+        val employee = party(relationships = listOf(relationship(PartyRole.EMPLOYEE)))
+        assertThat(employee.isCustomer()).isFalse()
+        assertThat(employee.isEmployee()).isTrue()
+    }
+
+    @Test
+    fun `activeRelationships filters out non-ACTIVE entries`() {
+        val active = relationship(PartyRole.CUSTOMER, status = RelationshipStatus.ACTIVE)
+        val terminated = relationship(PartyRole.EMPLOYEE, status = RelationshipStatus.TERMINATED)
+        val suspended = relationship(PartyRole.AGENT, status = RelationshipStatus.SUSPENDED)
+        val p = party(relationships = listOf(active, terminated, suspended))
+
+        assertThat(p.activeRelationships()).containsExactly(active)
+    }
+
+    @Test
+    fun `activeRelationships is empty when there are no relationships`() {
+        assertThat(party().activeRelationships()).isEmpty()
+    }
+
+    @Test
+    fun `externalId returns the value for a matching type`() {
+        val p = party(externalIds = listOf(ExternalId(ExternalIdType.BANKID_SUB, "sub-1")))
+        assertThat(p.externalId(ExternalIdType.BANKID_SUB)).isEqualTo("sub-1")
+    }
+
+    @Test
+    fun `externalId returns null when the type is not present`() {
+        val p = party(externalIds = listOf(ExternalId(ExternalIdType.BANKID_SUB, "sub-1")))
+        assertThat(p.externalId(ExternalIdType.ROB_AIFO)).isNull()
+    }
+
+    @Test
+    fun `externalId returns the first matching entry when duplicates exist`() {
+        val p = party(
+            externalIds = listOf(
+                ExternalId(ExternalIdType.KEYCLOAK_ID, "first"),
+                ExternalId(ExternalIdType.KEYCLOAK_ID, "second"),
+            ),
+        )
+        assertThat(p.externalId(ExternalIdType.KEYCLOAK_ID)).isEqualTo("first")
+    }
+}

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/domain/model/VerificationCaseTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/domain/model/VerificationCaseTest.kt
@@ -115,4 +115,47 @@ class VerificationCaseTest {
             .isInstanceOf(IllegalCaseTransition::class.java)
             .hasMessageContaining("no first proposal")
     }
+
+    @Test
+    fun `a second approver proposing a different link target is rejected as disagreement`() {
+        val otherCandidate = UUID.randomUUID()
+        val awaiting = VerificationCase.open(
+            id = UUID.randomUUID(),
+            dedupKey = "RN:abc123",
+            trigger = VerificationTrigger.RN_COLLISION,
+            applicant = ApplicantSnapshot("Jan", "Novak", LocalDate.of(1976, 5, 6), null, listOf("CZ")),
+            blindIndex = "abc123",
+            candidatePartyIds = listOf(candidate, otherCandidate),
+            now = now,
+        ).proposeFirst("alice", CaseVerdict.LINK_TO_EXISTING, candidate, null, now)
+
+        assertThatThrownBy { awaiting.confirmSecond("bob", CaseVerdict.LINK_TO_EXISTING, otherCandidate, now) }
+            .isInstanceOf(IllegalCaseTransition::class.java)
+            .hasMessageContaining("disagrees")
+    }
+
+    @Test
+    fun `linkPartyId is rejected on a non-LINK_TO_EXISTING verdict`() {
+        assertThatThrownBy { openCase().proposeFirst("alice", CaseVerdict.DISTINCT_NEW, candidate, null, now) }
+            .isInstanceOf(IllegalCaseTransition::class.java)
+            .hasMessageContaining("only valid with verdict LINK_TO_EXISTING")
+    }
+
+    @Test
+    fun `reopen requires an AWAITING_SECOND_APPROVAL case — cannot reopen a fresh OPEN case`() {
+        assertThatThrownBy { openCase().reopen(now) }
+            .isInstanceOf(IllegalCaseTransition::class.java)
+            .hasMessageContaining("only an AWAITING case can be reopened")
+    }
+
+    @Test
+    fun `reopen requires an AWAITING_SECOND_APPROVAL case — cannot reopen a DECIDED case`() {
+        val decided = openCase()
+            .proposeFirst("alice", CaseVerdict.DISTINCT_NEW, null, null, now)
+            .confirmSecond("bob", CaseVerdict.DISTINCT_NEW, null, now)
+
+        assertThatThrownBy { decided.reopen(now) }
+            .isInstanceOf(IllegalCaseTransition::class.java)
+            .hasMessageContaining("only an AWAITING case can be reopened")
+    }
 }

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/openid4vci/StatusListServiceTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/openid4vci/StatusListServiceTest.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.pid.infrastructure.openid4vci
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.jose4j.jwk.EcJwkGenerator
+import org.jose4j.jwk.JsonWebKey
+import org.jose4j.jws.JsonWebSignature
+import org.jose4j.keys.EllipticCurves
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Optional
+
+/**
+ * Unit tests for [StatusListService] itself (ADR-0094 Token Status List), independent of the
+ * [CredentialIssuerService] round-trip test — the allocate/revoke delegation to the store, the
+ * fail-closed [StatusListService.enabled] flag, and the published URI/metadata shape.
+ */
+class StatusListServiceTest {
+
+    private val mapper = ObjectMapper()
+    private val issuerId = "https://test-pid-issuer.openbank.local"
+    private val testClock: Clock = Clock.fixed(Instant.parse("2024-01-15T12:00:00Z"), ZoneOffset.UTC)
+    private val issuerKeyPair = EcJwkGenerator.generateJwk(EllipticCurves.P256).also { it.keyId = "issuer-1" }
+
+    private fun eudiKey(withKey: Boolean = true) = EudiIssuerKey(
+        signingKeyJwk = if (withKey) {
+            Optional.of(issuerKeyPair.toJson(JsonWebKey.OutputControlLevel.INCLUDE_PRIVATE))
+        } else {
+            Optional.empty()
+        },
+        issuerId = issuerId,
+    )
+
+    private fun service(
+        withKey: Boolean = true,
+        listId: String = "1",
+        ttlSeconds: Long = 3600,
+    ) = StatusListService(eudiKey(withKey), mapper, InMemoryStatusListStore(), listId, ttlSeconds, testClock)
+
+    @Test
+    fun `enabled mirrors whether an issuer signing key is configured`() {
+        assertThat(service(withKey = true).enabled).isTrue()
+        assertThat(service(withKey = false).enabled).isFalse()
+    }
+
+    @Test
+    fun `statusListUri embeds the issuer id and list id`() {
+        val svc = service(listId = "42")
+        assertThat(svc.statusListUri).isEqualTo("$issuerId/api/v1/parties/eudi/status-lists/42")
+        assertThat(svc.id).isEqualTo("42")
+    }
+
+    @Test
+    fun `cacheTtlSeconds mirrors the configured ttl`() {
+        assertThat(service(ttlSeconds = 900).cacheTtlSeconds).isEqualTo(900L)
+    }
+
+    @Test
+    fun `allocate delegates to the store and returns increasing indices`(): Unit = runBlocking {
+        val svc = service()
+        assertThat(svc.allocate()).isZero()
+        assertThat(svc.allocate()).isEqualTo(1L)
+    }
+
+    @Test
+    fun `revoke and isRevoked round-trip through the store`(): Unit = runBlocking {
+        val svc = service()
+        val idx = svc.allocate()
+        assertThat(svc.isRevoked(idx)).isFalse()
+        assertThat(svc.revoke(idx)).isTrue()
+        assertThat(svc.isRevoked(idx)).isTrue()
+    }
+
+    @Test
+    fun `revoke of a never-allocated index fails`(): Unit = runBlocking {
+        assertThat(service().revoke(999L)).isFalse()
+    }
+
+    @Test
+    fun `CredentialStatusPort isRevoked only resolves for OUR statusListUri`(): Unit = runBlocking {
+        val svc = service()
+        val idx = svc.allocate()
+        svc.revoke(idx)
+
+        assertThat(svc.isRevoked(svc.statusListUri, idx)).isTrue()
+        assertThat(svc.isRevoked("https://someone-else.example/status/1", idx)).isFalse()
+    }
+
+    @Test
+    fun `statusListToken is a JWS signed by the issuer key with typ statuslist+jwt`(): Unit = runBlocking {
+        val svc = service()
+        val token = svc.statusListToken()
+
+        val header = mapper.readTree(
+            String(
+                org.jose4j.base64url.Base64Url.decode(token.split(".")[0]),
+                Charsets.UTF_8,
+            ),
+        )
+        assertThat(header["typ"].asText()).isEqualTo("statuslist+jwt")
+
+        val jws = JsonWebSignature().apply {
+            compactSerialization = token
+            key = issuerKeyPair.publicKey
+        }
+        assertThat(jws.verifySignature()).isTrue()
+    }
+
+    @Test
+    fun `statusListToken carries iat and exp derived from the clock and ttl`(): Unit = runBlocking {
+        val svc = service(ttlSeconds = 120)
+        val token = svc.statusListToken()
+        val payload = mapper.readTree(
+            String(org.jose4j.base64url.Base64Url.decode(token.split(".")[1]), Charsets.UTF_8),
+        )
+        val expectedIat = testClock.instant().epochSecond
+        assertThat(payload["iat"].asLong()).isEqualTo(expectedIat)
+        assertThat(payload["exp"].asLong()).isEqualTo(expectedIat + 120)
+        assertThat(payload["ttl"].asLong()).isEqualTo(120L)
+        assertThat(payload["sub"].asText()).isEqualTo(svc.statusListUri)
+    }
+}

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/openid4vci/StatusListServiceTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/openid4vci/StatusListServiceTest.kt
@@ -38,11 +38,8 @@ class StatusListServiceTest {
         issuerId = issuerId,
     )
 
-    private fun service(
-        withKey: Boolean = true,
-        listId: String = "1",
-        ttlSeconds: Long = 3600,
-    ) = StatusListService(eudiKey(withKey), mapper, InMemoryStatusListStore(), listId, ttlSeconds, testClock)
+    private fun service(withKey: Boolean = true, listId: String = "1", ttlSeconds: Long = 3600) =
+        StatusListService(eudiKey(withKey), mapper, InMemoryStatusListStore(), listId, ttlSeconds, testClock)
 
     @Test
     fun `enabled mirrors whether an issuer signing key is configured`() {

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/openid4vci/StatusListStoreTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/openid4vci/StatusListStoreTest.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.pid.infrastructure.openid4vci
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [InMemoryStatusListStore] (ADR-0094 Token Status List) — allocation is a
+ * monotonic counter, revocation only sticks for an index that was actually allocated, and
+ * [InMemoryStatusListStore.revokedIndices] reports exactly the revoked set in ascending order.
+ */
+class StatusListStoreTest {
+
+    private val store = InMemoryStatusListStore()
+
+    @Test
+    fun `allocate returns a strictly increasing sequence starting at zero`(): Unit = runBlocking {
+        assertThat(store.allocate()).isZero()
+        assertThat(store.allocate()).isEqualTo(1L)
+        assertThat(store.allocate()).isEqualTo(2L)
+    }
+
+    @Test
+    fun `revoke succeeds for an allocated index and isRevoked reflects it`(): Unit = runBlocking {
+        val idx = store.allocate()
+        assertThat(store.isRevoked(idx)).isFalse()
+
+        assertThat(store.revoke(idx)).isTrue()
+
+        assertThat(store.isRevoked(idx)).isTrue()
+    }
+
+    @Test
+    fun `revoke is idempotent — revoking twice still reports revoked`(): Unit = runBlocking {
+        val idx = store.allocate()
+        assertThat(store.revoke(idx)).isTrue()
+        assertThat(store.revoke(idx)).isTrue()
+        assertThat(store.isRevoked(idx)).isTrue()
+    }
+
+    @Test
+    fun `revoke fails for an index that was never allocated`(): Unit = runBlocking {
+        assertThat(store.revoke(42L)).isFalse()
+        assertThat(store.isRevoked(42L)).isFalse()
+    }
+
+    @Test
+    fun `isRevoked is false for an allocated but never-revoked index`(): Unit = runBlocking {
+        val idx = store.allocate()
+        assertThat(store.isRevoked(idx)).isFalse()
+    }
+
+    @Test
+    fun `revokedIndices reports exactly the revoked set in ascending order`(): Unit = runBlocking {
+        repeat(5) { store.allocate() } // indices 0..4
+        store.revoke(3L)
+        store.revoke(1L)
+
+        assertThat(store.revokedIndices()).containsExactly(1L, 3L)
+    }
+
+    @Test
+    fun `revokedIndices is empty when nothing has been revoked`(): Unit = runBlocking {
+        repeat(3) { store.allocate() }
+        assertThat(store.revokedIndices()).isEmpty()
+    }
+}

--- a/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/rest/ExceptionMappersTest.kt
+++ b/openbank-pid-service/src/test/kotlin/com/openbank/pid/infrastructure/rest/ExceptionMappersTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.pid.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import com.openbank.pid.application.port.out.PidVerificationException
+import com.openbank.pid.application.usecase.InvalidPartyCaseTransitionException
+import com.openbank.pid.application.usecase.PartyAlreadyExistsException
+import com.openbank.pid.application.usecase.PartyNotFoundException
+import com.openbank.pid.application.usecase.RelationshipAlreadyExistsException
+import com.openbank.pid.application.usecase.VerificationCaseNotFoundException
+import com.openbank.pid.domain.model.IllegalCaseTransition
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Every JAX-RS [jakarta.ws.rs.ext.ExceptionMapper] maps its domain exception to the correct HTTP
+ * status and echoes the exception message into the [ApiError] body. Pure mapping logic — no
+ * Quarkus boot required.
+ */
+class ExceptionMappersTest {
+
+    @Test
+    fun `PartyNotFoundException maps to 404 with the exception message`() {
+        val response = PartyNotFoundMapper().toResponse(PartyNotFoundException("party missing"))
+        assertThat(response.status).isEqualTo(404)
+        assertThat((response.entity as ApiError).message).isEqualTo("party missing")
+    }
+
+    @Test
+    fun `PartyAlreadyExistsException maps to 409`() {
+        val response = PartyAlreadyExistsMapper().toResponse(PartyAlreadyExistsException("dup party"))
+        assertThat(response.status).isEqualTo(409)
+        assertThat((response.entity as ApiError).message).isEqualTo("dup party")
+    }
+
+    @Test
+    fun `RelationshipAlreadyExistsException maps to 409`() {
+        val response = RelationshipAlreadyExistsMapper().toResponse(
+            RelationshipAlreadyExistsException("dup relationship"),
+        )
+        assertThat(response.status).isEqualTo(409)
+        assertThat((response.entity as ApiError).message).isEqualTo("dup relationship")
+    }
+
+    @Test
+    fun `InvalidPartyCaseTransitionException maps to 400`() {
+        val response = InvalidPartyCaseTransitionMapper().toResponse(
+            InvalidPartyCaseTransitionException("bad transition"),
+        )
+        assertThat(response.status).isEqualTo(400)
+        assertThat((response.entity as ApiError).message).isEqualTo("bad transition")
+    }
+
+    @Test
+    fun `VerificationCaseNotFoundException maps to 404`() {
+        val response = VerificationCaseNotFoundMapper().toResponse(
+            VerificationCaseNotFoundException("case missing"),
+        )
+        assertThat(response.status).isEqualTo(Response.Status.NOT_FOUND.statusCode)
+        assertThat((response.entity as ApiError).message).isEqualTo("case missing")
+    }
+
+    @Test
+    fun `IllegalCaseTransition maps to 409 CONFLICT`() {
+        val response = IllegalCaseTransitionMapper().toResponse(IllegalCaseTransition("illegal"))
+        assertThat(response.status).isEqualTo(Response.Status.CONFLICT.statusCode)
+        assertThat((response.entity as ApiError).message).isEqualTo("illegal")
+    }
+
+    @Test
+    fun `PidVerificationException maps to 422 UNPROCESSABLE_ENTITY`() {
+        val response = PidVerificationExceptionMapper().toResponse(PidVerificationException("bad presentation"))
+        assertThat(response.status).isEqualTo(422)
+        assertThat((response.entity as ApiError).message).isEqualTo("bad presentation")
+    }
+}


### PR DESCRIPTION
## Summary

Raises real unit test coverage for `openbank-pid-service` (largest main-file-count
service in the fleet relative to test coverage). Adds tests for previously-uncovered
domain helpers, use-case edge cases, and the Token Status List store/service, then
ratchets the `koverVerify` floor to match.

## Type of change

- [x] test (coverage only — no production behavior change)

## Linked issues

N/A

## Changes

- `PartyTest.kt` (new): `Party` domain helpers — `hasRole`, `isCustomer`/`isEmployee`,
  `activeRelationships`, `externalId` — had zero direct coverage.
- `VerificationCaseTest.kt`: added the `confirmSecond` link-target-disagreement branch
  and the `reopen`-from-illegal-state branches (OPEN, DECIDED) to the state-machine tests.
- `VerificationCaseServiceTest.kt`: added `decide()`/`reopen()` not-found and
  already-DECIDED paths, plus `listActive`/`get` delegation — previously untested.
- `StatusListStoreTest.kt` (new): `InMemoryStatusListStore` (ADR-0094 Token Status List)
  had no dedicated test, only exercised transitively via `CredentialIssuerServiceTest`.
- `StatusListServiceTest.kt` (new): direct coverage of `StatusListService` — allocate/
  revoke delegation, the fail-closed `enabled` flag, and the signed status-list token
  shape (typ, iat/exp/ttl, sub).
- `ExceptionMappersTest.kt` (new): the seven JAX-RS `ExceptionMapper`s had zero tests
  despite being pure HTTP-status mapping logic.
- `build.gradle.kts`: `koverVerify` `minValue` raised from `0` (unset) to `55` —
  measured line coverage went from 56.38% (origin/main baseline) to 57.65% on this
  branch; the floor is set a few points below per the ratchet-only rule (ADR-0029 #5).

All new tests are pure unit tests (mockk + assertj, JUnit5), no framework/Quarkus boot,
consistent with this module's existing conventions. Domain-layer tests remain
framework-import-free (ADR-0002).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved) — N/A, no service
      boundary changed.
- [ ] Contract tests updated (if public API changed) — N/A, no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes (ran targeted
      `:openbank-pid-service:ktlintCheck :openbank-pid-service:detekt
      :openbank-pid-service:koverVerify`, all green).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — N/A, no REST API changed.
- [ ] Flyway migration — N/A, no DB change.
- [ ] Avro schema — N/A, no event change.
- [ ] Docs updated — N/A, no architectural change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — No (tests only; touches crypto/status-list
      *test* coverage, not the implementation).
- [ ] PII path changed? — No.
- [ ] Cardholder data path changed? — No.

## Compliance impact

- [x] None (test-only change).

## Rollout / Rollback

- Deployment strategy: N/A (test-only; no runtime behavior change).
- Rollback plan: revert the PR.
- Data migration reversible: N/A.

## Reviewer notes

- `openbank-pid-service` is **not** in `rules.yaml: money_path_services` (confirmed by
  reading `openbank-libs/governance/rules.yaml` on this branch) — so the 2-approval +
  threat-model requirement does not apply here. Flagging explicitly per instructions
  since it's an eIDAS/identity-verification service and easy to assume otherwise.
- Baseline vs. after coverage was measured via a throwaway `git worktree` pointed at
  `origin/main` with the same isolated `GRADLE_USER_HOME`, to get a true apples-to-apples
  before/after (56.38% → 57.65%, +1.27pp, both out of 3292 measurable lines).