### PR TITLE
test(settlement): raise real test coverage from 31.66% to 85.49%

### DIFF
--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -53,7 +53,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 18
+                    // Ratchet: measured 85.49% line coverage after adding workflow-saga,
+                    // outbound-adapter and repository tests (was 31.66%, floor was a stale 18).
+                    minValue = 80
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.usecase
+
+import com.openbank.settlement.application.port.out.CreditPort
+import com.openbank.settlement.application.port.out.DebitPort
+import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.infrastructure.temporal.TemporalConfig
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.temporal.client.WorkflowClient
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Coverage for [SettlementService.settle]: the legacy-path claim race and the not-found guard.
+ * The Temporal-enabled dispatch path is covered separately in SettlementServiceTemporalSettleTest
+ * (driven against a real in-memory TestWorkflowEnvironment rather than mocking Temporal's static
+ * [WorkflowClient.start] entry point). SettlementServiceOriginateTest covers originate() with
+ * Temporal disabled.
+ */
+class SettlementServiceSettleTest {
+
+    private val repo: SettlementRepository = mockk(relaxed = true)
+    private val debitPort: DebitPort = mockk(relaxed = true)
+    private val creditPort: CreditPort = mockk(relaxed = true)
+    private val ledgerPort: LedgerPort = mockk(relaxed = true)
+    private val temporalConfig: TemporalConfig = mockk(relaxed = true)
+
+    private fun pendingSettlement(id: UUID = UUID.randomUUID()) = Settlement(
+        id = id,
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("10.00"),
+        currency = "CZK",
+        status = SettlementStatus.PENDING,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `settle throws when the settlement does not exist`() {
+        val workflowClient: WorkflowClient = mockk(relaxed = true)
+        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val id = UUID.randomUUID()
+        coEvery { repo.findById(id) } returns null
+
+        assertThatThrownBy { runBlocking { service.settle(id) } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining(id.toString())
+    }
+
+    @Test
+    fun `settle runs the legacy saga and reaches BOOKED when Temporal is disabled`() {
+        val workflowClient: WorkflowClient = mockk(relaxed = true)
+        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val settlement = pendingSettlement()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        every { temporalConfig.enabled() } returns false
+        coEvery { repo.claimForProcessing(settlement.id) } returns true
+        coEvery { repo.updateStatus(settlement.id, any()) } returns settlement
+
+        val result = runBlocking { service.settle(settlement.id) }
+
+        assertThat(result).isEqualTo(SettlementStatus.BOOKED)
+        coVerify { debitPort.debit(settlement.id) }
+        coVerify { creditPort.credit(settlement.id) }
+        coVerify { ledgerPort.book(settlement.id) }
+    }
+
+    @Test
+    fun `settle loses the legacy claim race and returns the current status without re-processing`() {
+        val workflowClient: WorkflowClient = mockk(relaxed = true)
+        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val settlement = pendingSettlement().copy(status = SettlementStatus.DEBITED)
+        coEvery { repo.findById(settlement.id) } returnsMany listOf(
+            settlement.copy(status = SettlementStatus.PENDING),
+            settlement,
+        )
+        every { temporalConfig.enabled() } returns false
+        coEvery { repo.claimForProcessing(settlement.id) } returns false
+
+        val result = runBlocking { service.settle(settlement.id) }
+
+        assertThat(result).isEqualTo(SettlementStatus.DEBITED)
+        coVerify(exactly = 0) { debitPort.debit(any()) }
+    }
+
+    @Test
+    fun `settle rejects when the legacy saga throws mid-flight`() {
+        val workflowClient: WorkflowClient = mockk(relaxed = true)
+        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val settlement = pendingSettlement()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        every { temporalConfig.enabled() } returns false
+        coEvery { repo.claimForProcessing(settlement.id) } returns true
+        coEvery { debitPort.debit(settlement.id) } throws RuntimeException("balance-service down")
+        coEvery { repo.updateStatus(settlement.id, SettlementStatus.REJECTED) } returns settlement
+
+        val result = runBlocking { service.settle(settlement.id) }
+
+        assertThat(result).isEqualTo(SettlementStatus.REJECTED)
+        coVerify { repo.updateStatus(settlement.id, SettlementStatus.REJECTED) }
+        coVerify(exactly = 0) { creditPort.credit(any()) }
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.usecase
+
+import com.openbank.settlement.application.port.out.CreditPort
+import com.openbank.settlement.application.port.out.DebitPort
+import com.openbank.settlement.application.port.out.LedgerPort
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.application.workflow.SettlementActivities
+import com.openbank.settlement.application.workflow.SettlementWorkflowImpl
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.infrastructure.temporal.TemporalConfig
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.temporal.testing.TestWorkflowEnvironment
+import io.temporal.worker.Worker
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Coverage for [SettlementService.settle]'s Temporal-enabled dispatch, including the idempotent
+ * double-start no-op (WorkflowExecutionAlreadyStarted), driven against a real in-memory
+ * [TestWorkflowEnvironment] rather than mocking Temporal's static `WorkflowClient.start` entry
+ * point. SettlementServiceSettleTest covers the legacy (Temporal-disabled) path.
+ */
+class SettlementServiceTemporalSettleTest {
+
+    private val repo: SettlementRepository = mockk(relaxed = true)
+    private val debitPort: DebitPort = mockk(relaxed = true)
+    private val creditPort: CreditPort = mockk(relaxed = true)
+    private val ledgerPort: LedgerPort = mockk(relaxed = true)
+    private val temporalConfig: TemporalConfig = mockk(relaxed = true)
+
+    private lateinit var env: TestWorkflowEnvironment
+    private lateinit var worker: Worker
+    private lateinit var service: SettlementService
+
+    private companion object {
+        const val TASK_QUEUE = "openbank-settlement"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        env = TestWorkflowEnvironment.newInstance()
+        worker = env.newWorker(TASK_QUEUE)
+        worker.registerWorkflowImplementationTypes(SettlementWorkflowImpl::class.java)
+        worker.registerActivitiesImplementations(RelaxedActivities())
+        env.start()
+        every { temporalConfig.enabled() } returns true
+        every { temporalConfig.taskQueue() } returns TASK_QUEUE
+        service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, env.workflowClient)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        env.close()
+    }
+
+    private fun pendingSettlement(id: UUID = UUID.randomUUID()) = Settlement(
+        id = id,
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("10.00"),
+        currency = "CZK",
+        status = SettlementStatus.PENDING,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `settle starts the Temporal workflow and returns the pre-dispatch status`() {
+        val settlement = pendingSettlement()
+        coEvery { repo.findById(settlement.id) } returns settlement
+
+        val result = runBlocking { service.settle(settlement.id) }
+
+        // settle() returns the status read BEFORE workflow dispatch; the workflow itself
+        // reaches BOOKED asynchronously (verified separately by SettlementWorkflowImplTest).
+        assertThat(result).isEqualTo(SettlementStatus.PENDING)
+    }
+
+    @Test
+    fun `settle is idempotent when the workflow-id is already running`() {
+        val settlement = pendingSettlement()
+        coEvery { repo.findById(settlement.id) } returns settlement
+
+        // First call starts "settlement-$id"; the second call for the SAME id must not throw
+        // even though the workflow id is already in use (WorkflowExecutionAlreadyStarted is
+        // caught and swallowed as an idempotent no-op).
+        runBlocking { service.settle(settlement.id) }
+        val second = runBlocking { service.settle(settlement.id) }
+
+        assertThat(second).isEqualTo(SettlementStatus.PENDING)
+    }
+
+    /** Activities stub that never throws — this test suite only exercises SettlementService dispatch. */
+    private class RelaxedActivities : SettlementActivities {
+        override fun debitPayer(settlementId: UUID) = Unit
+        override fun creditPayee(settlementId: UUID) = Unit
+        override fun bookToLedger(settlementId: UUID) = Unit
+        override fun reverseDebit(settlementId: UUID) = Unit
+        override fun reverseCredit(settlementId: UUID) = Unit
+        override fun reverseBookToLedger(settlementId: UUID) = Unit
+        override fun rejectSettlement(settlementId: UUID) = Unit
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.application.workflow
+
+import com.openbank.settlement.domain.model.SettlementStatus
+import io.temporal.client.WorkflowOptions
+import io.temporal.failure.ApplicationFailure
+import io.temporal.testing.TestWorkflowEnvironment
+import io.temporal.worker.Worker
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Coverage for the Temporal settlement saga (ADR-0101 P3): debitPayer -> creditPayee ->
+ * bookToLedger, with reverse-order compensation when any activity fails. Runs the real
+ * [SettlementWorkflowImpl] against Temporal's in-memory [TestWorkflowEnvironment] with a
+ * recording [SettlementActivities] stub, mirroring PaymentWorkflowImplTest (transaction-service)
+ * and SepaPaymentWorkflowImplTest (sepa-payment).
+ */
+class SettlementWorkflowImplTest {
+
+    private lateinit var env: TestWorkflowEnvironment
+    private lateinit var worker: Worker
+
+    private companion object {
+        const val TASK_QUEUE = "test-settlement"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        env = TestWorkflowEnvironment.newInstance()
+        worker = env.newWorker(TASK_QUEUE)
+        worker.registerWorkflowImplementationTypes(SettlementWorkflowImpl::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        env.close()
+    }
+
+    private fun newWorkflow(): SettlementWorkflow = env.workflowClient.newWorkflowStub(
+        SettlementWorkflow::class.java,
+        WorkflowOptions.newBuilder()
+            .setTaskQueue(TASK_QUEUE)
+            .setWorkflowId("settlement-${UUID.randomUUID()}")
+            .build(),
+    )
+
+    @Test
+    fun `happy path debits, credits and books without any compensation`() {
+        val calls = RecordingActivities()
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result).isEqualTo(SettlementStatus.BOOKED)
+        assertThat(calls.debitPayer.get()).isEqualTo(1)
+        assertThat(calls.creditPayee.get()).isEqualTo(1)
+        assertThat(calls.bookToLedger.get()).isEqualTo(1)
+        assertThat(calls.reverseDebit.get()).isZero()
+        assertThat(calls.reverseCredit.get()).isZero()
+        assertThat(calls.reverseBookToLedger.get()).isZero()
+        assertThat(calls.rejectSettlement.get()).isZero()
+    }
+
+    @Test
+    fun `bookToLedger failure reverses credit and debit, in that order, then rejects`() {
+        val calls = RecordingActivities(failBookToLedger = true)
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result).isEqualTo(SettlementStatus.REJECTED)
+        // Debit and credit both ran before the ledger booking failed.
+        assertThat(calls.debitPayer.get()).isEqualTo(1)
+        assertThat(calls.creditPayee.get()).isEqualTo(1)
+        // Both prior steps get compensated (most-recent-first), booking itself is not reversed.
+        assertThat(calls.reverseCredit.get()).isEqualTo(1)
+        assertThat(calls.reverseDebit.get()).isEqualTo(1)
+        assertThat(calls.reverseBookToLedger.get()).isZero()
+        assertThat(calls.rejectSettlement.get()).isEqualTo(1)
+        assertThat(calls.order).containsExactly("debitPayer", "creditPayee", "bookToLedger", "reverseCredit", "reverseDebit")
+    }
+
+    @Test
+    fun `creditPayee failure reverses only the debit then rejects`() {
+        val calls = RecordingActivities(failCreditPayee = true)
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result).isEqualTo(SettlementStatus.REJECTED)
+        assertThat(calls.debitPayer.get()).isEqualTo(1)
+        assertThat(calls.creditPayee.get()).isEqualTo(1)
+        assertThat(calls.reverseDebit.get()).isEqualTo(1)
+        assertThat(calls.reverseCredit.get()).isZero()
+        assertThat(calls.bookToLedger.get()).isZero()
+        assertThat(calls.rejectSettlement.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `debitPayer failure compensates nothing and rejects directly`() {
+        val calls = RecordingActivities(failDebitPayer = true)
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        assertThat(result).isEqualTo(SettlementStatus.REJECTED)
+        assertThat(calls.debitPayer.get()).isEqualTo(1)
+        assertThat(calls.creditPayee.get()).isZero()
+        assertThat(calls.reverseDebit.get()).isZero()
+        assertThat(calls.reverseCredit.get()).isZero()
+        assertThat(calls.reverseBookToLedger.get()).isZero()
+        assertThat(calls.rejectSettlement.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `a compensation activity that itself fails does not stop the remaining compensations`() {
+        val calls = RecordingActivities(failBookToLedger = true, failReverseCredit = true)
+        worker.registerActivitiesImplementations(calls)
+        env.start()
+
+        val result = newWorkflow().settle(UUID.randomUUID())
+
+        // reverseCredit throws, but the workflow still runs reverseDebit and rejects.
+        assertThat(result).isEqualTo(SettlementStatus.REJECTED)
+        assertThat(calls.reverseCredit.get()).isEqualTo(1)
+        assertThat(calls.reverseDebit.get()).isEqualTo(1)
+        assertThat(calls.rejectSettlement.get()).isEqualTo(1)
+    }
+
+    /** In-process activities stub that records call order/counts and can fail selected steps. */
+    private class RecordingActivities(
+        private val failDebitPayer: Boolean = false,
+        private val failCreditPayee: Boolean = false,
+        private val failBookToLedger: Boolean = false,
+        private val failReverseCredit: Boolean = false,
+    ) : SettlementActivities {
+        val debitPayer = AtomicInteger(0)
+        val creditPayee = AtomicInteger(0)
+        val bookToLedger = AtomicInteger(0)
+        val reverseDebit = AtomicInteger(0)
+        val reverseCredit = AtomicInteger(0)
+        val reverseBookToLedger = AtomicInteger(0)
+        val rejectSettlement = AtomicInteger(0)
+        val order = mutableListOf<String>()
+
+        override fun debitPayer(settlementId: UUID) {
+            order += "debitPayer"
+            debitPayer.incrementAndGet()
+            if (failDebitPayer) throw ApplicationFailure.newNonRetryableFailure("balance down", "BalanceError")
+        }
+
+        override fun creditPayee(settlementId: UUID) {
+            order += "creditPayee"
+            creditPayee.incrementAndGet()
+            if (failCreditPayee) throw ApplicationFailure.newNonRetryableFailure("balance down", "BalanceError")
+        }
+
+        override fun bookToLedger(settlementId: UUID) {
+            order += "bookToLedger"
+            bookToLedger.incrementAndGet()
+            if (failBookToLedger) throw ApplicationFailure.newNonRetryableFailure("ledger down", "LedgerError")
+        }
+
+        override fun reverseDebit(settlementId: UUID) {
+            order += "reverseDebit"
+            reverseDebit.incrementAndGet()
+        }
+
+        override fun reverseCredit(settlementId: UUID) {
+            order += "reverseCredit"
+            reverseCredit.incrementAndGet()
+            if (failReverseCredit) throw ApplicationFailure.newNonRetryableFailure("balance down", "BalanceError")
+        }
+
+        override fun reverseBookToLedger(settlementId: UUID) {
+            order += "reverseBookToLedger"
+            reverseBookToLedger.incrementAndGet()
+        }
+
+        override fun rejectSettlement(settlementId: UUID) {
+            order += "rejectSettlement"
+            rejectSettlement.incrementAndGet()
+        }
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementWorkflowImplTest.kt
@@ -87,7 +87,14 @@ class SettlementWorkflowImplTest {
         assertThat(calls.reverseDebit.get()).isEqualTo(1)
         assertThat(calls.reverseBookToLedger.get()).isZero()
         assertThat(calls.rejectSettlement.get()).isEqualTo(1)
-        assertThat(calls.order).containsExactly("debitPayer", "creditPayee", "bookToLedger", "reverseCredit", "reverseDebit")
+        assertThat(calls.order).containsExactly(
+            "debitPayer",
+            "creditPayee",
+            "bookToLedger",
+            "reverseCredit",
+            "reverseDebit",
+            "rejectSettlement",
+        )
     }
 
     @Test

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceCreditAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceCreditAdapterTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.infrastructure.client.BalanceRestClient
+import com.openbank.settlement.infrastructure.client.BalanceResponse
+import com.openbank.settlement.infrastructure.client.MoneyMovementRequest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/** Unit coverage for the balance-api credit adapter, with a mocked REST client (Uni-wrapped). */
+class BalanceCreditAdapterTest {
+
+    private val settlement = Settlement(
+        id = UUID.randomUUID(),
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("42.00"),
+        currency = "EUR",
+        status = SettlementStatus.DEBITED,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `credit posts the payee credit with a settlement-scoped reference`(): Unit = runBlocking {
+        val balanceClient = mockk<BalanceRestClient>()
+        val repo = mockk<SettlementRepository>()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        val request = slot<MoneyMovementRequest>()
+        every { balanceClient.credit(settlement.payeeAccountId, capture(request)) } returns
+            Uni.createFrom().item(
+                BalanceResponse(settlement.payeeAccountId, "EUR", BigDecimal("42"), BigDecimal("42")),
+            )
+
+        BalanceCreditAdapter(balanceClient, repo).credit(settlement.id)
+
+        assertThat(request.captured.amount).isEqualByComparingTo("42.00")
+        assertThat(request.captured.currency).isEqualTo("EUR")
+        assertThat(request.captured.referenceId).isEqualTo("settlement-credit-${settlement.id}")
+        verify { balanceClient.credit(settlement.payeeAccountId, any()) }
+    }
+
+    @Test
+    fun `credit throws when the settlement is not found`(): Unit = runBlocking {
+        val balanceClient = mockk<BalanceRestClient>()
+        val repo = mockk<SettlementRepository>()
+        val missingId = UUID.randomUUID()
+        coEvery { repo.findById(missingId) } returns null
+
+        assertThatThrownBy {
+            runBlocking { BalanceCreditAdapter(balanceClient, repo).credit(missingId) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining(missingId.toString())
+    }
+
+    @Test
+    fun `credit propagates a failure from the balance client`(): Unit = runBlocking {
+        val balanceClient = mockk<BalanceRestClient>()
+        val repo = mockk<SettlementRepository>()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        every { balanceClient.credit(any(), any()) } returns
+            Uni.createFrom().failure(RuntimeException("balance-service down"))
+
+        assertThatThrownBy {
+            runBlocking { BalanceCreditAdapter(balanceClient, repo).credit(settlement.id) }
+        }.isInstanceOf(RuntimeException::class.java).hasMessageContaining("balance-service down")
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceCreditAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceCreditAdapterTest.kt
@@ -7,8 +7,8 @@ package com.openbank.settlement.infrastructure.adapter
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
-import com.openbank.settlement.infrastructure.client.BalanceRestClient
 import com.openbank.settlement.infrastructure.client.BalanceResponse
+import com.openbank.settlement.infrastructure.client.BalanceRestClient
 import com.openbank.settlement.infrastructure.client.MoneyMovementRequest
 import io.mockk.coEvery
 import io.mockk.every

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceDebitAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceDebitAdapterTest.kt
@@ -7,8 +7,8 @@ package com.openbank.settlement.infrastructure.adapter
 import com.openbank.settlement.application.port.out.SettlementRepository
 import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
-import com.openbank.settlement.infrastructure.client.BalanceRestClient
 import com.openbank.settlement.infrastructure.client.BalanceResponse
+import com.openbank.settlement.infrastructure.client.BalanceRestClient
 import com.openbank.settlement.infrastructure.client.MoneyMovementRequest
 import io.mockk.coEvery
 import io.mockk.every

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceDebitAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/BalanceDebitAdapterTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.infrastructure.client.BalanceRestClient
+import com.openbank.settlement.infrastructure.client.BalanceResponse
+import com.openbank.settlement.infrastructure.client.MoneyMovementRequest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/** Unit coverage for the balance-api debit adapter, with a mocked REST client (Uni-wrapped). */
+class BalanceDebitAdapterTest {
+
+    private val settlement = Settlement(
+        id = UUID.randomUUID(),
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("125.50"),
+        currency = "CZK",
+        status = SettlementStatus.PENDING,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `debit posts the payer debit with a settlement-scoped reference`(): Unit = runBlocking {
+        val balanceClient = mockk<BalanceRestClient>()
+        val repo = mockk<SettlementRepository>()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        val request = slot<MoneyMovementRequest>()
+        every { balanceClient.debit(settlement.payerAccountId, capture(request)) } returns
+            Uni.createFrom().item(
+                BalanceResponse(settlement.payerAccountId, "CZK", BigDecimal("100"), BigDecimal("100")),
+            )
+
+        BalanceDebitAdapter(balanceClient, repo).debit(settlement.id)
+
+        assertThat(request.captured.amount).isEqualByComparingTo("125.50")
+        assertThat(request.captured.currency).isEqualTo("CZK")
+        assertThat(request.captured.referenceId).isEqualTo("settlement-debit-${settlement.id}")
+        verify { balanceClient.debit(settlement.payerAccountId, any()) }
+    }
+
+    @Test
+    fun `debit throws when the settlement is not found`(): Unit = runBlocking {
+        val balanceClient = mockk<BalanceRestClient>()
+        val repo = mockk<SettlementRepository>()
+        val missingId = UUID.randomUUID()
+        coEvery { repo.findById(missingId) } returns null
+
+        assertThatThrownBy {
+            runBlocking { BalanceDebitAdapter(balanceClient, repo).debit(missingId) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining(missingId.toString())
+    }
+
+    @Test
+    fun `debit propagates a failure from the balance client`(): Unit = runBlocking {
+        val balanceClient = mockk<BalanceRestClient>()
+        val repo = mockk<SettlementRepository>()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        every { balanceClient.debit(any(), any()) } returns
+            Uni.createFrom().failure(RuntimeException("balance-service down"))
+
+        assertThatThrownBy {
+            runBlocking { BalanceDebitAdapter(balanceClient, repo).debit(settlement.id) }
+        }.isInstanceOf(RuntimeException::class.java).hasMessageContaining("balance-service down")
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapterTest.kt
@@ -98,7 +98,13 @@ class LedgerBookAdapterTest {
 
         assertThatThrownBy {
             runBlocking {
-                LedgerBookAdapter(ledgerClient, repo, glDebitAccountId, glCreditAccountId, fixedClock).book(settlement.id)
+                LedgerBookAdapter(
+                    ledgerClient,
+                    repo,
+                    glDebitAccountId,
+                    glCreditAccountId,
+                    fixedClock,
+                ).book(settlement.id)
             }
         }.isInstanceOf(RuntimeException::class.java).hasMessageContaining("ledger-service down")
     }

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapterTest.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.infrastructure.client.JournalResponse
+import com.openbank.settlement.infrastructure.client.LedgerRestClient
+import com.openbank.settlement.infrastructure.client.PostJournalRequest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/** Unit coverage for the ledger-api booking adapter, with a mocked REST client (Uni-wrapped). */
+class LedgerBookAdapterTest {
+
+    private val glDebitAccountId = UUID.randomUUID()
+    private val glCreditAccountId = UUID.randomUUID()
+    private val fixedClock = Clock.fixed(Instant.parse("2026-07-06T10:00:00Z"), ZoneOffset.UTC)
+
+    private val settlement = Settlement(
+        id = UUID.randomUUID(),
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("999.99"),
+        currency = "CZK",
+        status = SettlementStatus.CREDITED,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `book posts a balanced debit-credit journal dated from the injected clock`(): Unit = runBlocking {
+        val ledgerClient = mockk<LedgerRestClient>()
+        val repo = mockk<SettlementRepository>()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        val request = slot<PostJournalRequest>()
+        every { ledgerClient.postJournal(capture(request)) } returns
+            Uni.createFrom().item(JournalResponse(UUID.randomUUID(), settlement.id, "POSTED"))
+
+        LedgerBookAdapter(ledgerClient, repo, glDebitAccountId, glCreditAccountId, fixedClock).book(settlement.id)
+
+        assertThat(request.captured.idempotencyKey).isEqualTo("settlement-book-${settlement.id}")
+        assertThat(request.captured.transactionId).isEqualTo(settlement.id)
+        assertThat(request.captured.entryDate).isEqualTo("2026-07-06")
+        assertThat(request.captured.valueDate).isEqualTo("2026-07-06")
+        assertThat(request.captured.lines).hasSize(2)
+
+        val debitLine = request.captured.lines.single { it.side == "DEBIT" }
+        assertThat(debitLine.glAccountId).isEqualTo(glDebitAccountId)
+        assertThat(debitLine.subAccountId).isEqualTo(settlement.payerAccountId)
+        assertThat(debitLine.amount).isEqualByComparingTo("999.99")
+
+        val creditLine = request.captured.lines.single { it.side == "CREDIT" }
+        assertThat(creditLine.glAccountId).isEqualTo(glCreditAccountId)
+        assertThat(creditLine.subAccountId).isEqualTo(settlement.payeeAccountId)
+        assertThat(creditLine.amount).isEqualByComparingTo("999.99")
+
+        verify { ledgerClient.postJournal(any()) }
+    }
+
+    @Test
+    fun `book throws when the settlement is not found`(): Unit = runBlocking {
+        val ledgerClient = mockk<LedgerRestClient>()
+        val repo = mockk<SettlementRepository>()
+        val missingId = UUID.randomUUID()
+        coEvery { repo.findById(missingId) } returns null
+
+        assertThatThrownBy {
+            runBlocking {
+                LedgerBookAdapter(ledgerClient, repo, glDebitAccountId, glCreditAccountId, fixedClock).book(missingId)
+            }
+        }.isInstanceOf(IllegalArgumentException::class.java).hasMessageContaining(missingId.toString())
+    }
+
+    @Test
+    fun `book propagates a failure from the ledger client`(): Unit = runBlocking {
+        val ledgerClient = mockk<LedgerRestClient>()
+        val repo = mockk<SettlementRepository>()
+        coEvery { repo.findById(settlement.id) } returns settlement
+        every { ledgerClient.postJournal(any()) } returns
+            Uni.createFrom().failure(RuntimeException("ledger-service down"))
+
+        assertThatThrownBy {
+            runBlocking {
+                LedgerBookAdapter(ledgerClient, repo, glDebitAccountId, glCreditAccountId, fixedClock).book(settlement.id)
+            }
+        }.isInstanceOf(RuntimeException::class.java).hasMessageContaining("ledger-service down")
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/persistence/SettlementRepositoryImplIT.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/persistence/SettlementRepositoryImplIT.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.persistence
+
+import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.settlement.it.PostgresTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Real-Postgres coverage for [SettlementRepositoryImpl] (previously zero-covered): the Panache
+ * reactive create/findById/updateStatus round-trip, and the atomic PENDING -> DEBITED
+ * claimForProcessing compare-and-set that the legacy settle path relies on to prevent a
+ * concurrent double-debit. Reuses the same Testcontainers Postgres resource as
+ * SettlementBootSmokeIT (#578 pattern) — no downstream service is called.
+ *
+ * The repository's suspend functions open a reactive Panache session, which requires an ambient
+ * Vert.x context; a plain JUnit test thread has none (same root cause documented on
+ * SettlementActivitiesImpl.runOnVertxContext), so every call is bridged via
+ * VertxContextSupport.subscribeAndAwait, mirroring AmlOutboxDispatchIT (aml-service).
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class SettlementRepositoryImplIT {
+
+    @Inject
+    lateinit var repository: SettlementRepository
+
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    private fun newSettlement(status: SettlementStatus = SettlementStatus.PENDING) = Settlement(
+        id = UUID.randomUUID(),
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("321.45"),
+        currency = "CZK",
+        status = status,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
+
+    @Test
+    fun `create persists the settlement and findById reads it back`() {
+        val settlement = newSettlement()
+
+        val created = onVertxContext { repository.create(settlement) }
+        val found = onVertxContext { repository.findById(settlement.id) }
+
+        assertThat(created.id).isEqualTo(settlement.id)
+        assertThat(found).isNotNull
+        assertThat(found!!.payerAccountId).isEqualTo(settlement.payerAccountId)
+        assertThat(found.payeeAccountId).isEqualTo(settlement.payeeAccountId)
+        assertThat(found.amount).isEqualByComparingTo(settlement.amount)
+        assertThat(found.currency).isEqualTo("CZK")
+        assertThat(found.status).isEqualTo(SettlementStatus.PENDING)
+    }
+
+    @Test
+    fun `findById returns null for an unknown id`() {
+        assertThat(onVertxContext { repository.findById(UUID.randomUUID()) }).isNull()
+    }
+
+    @Test
+    fun `updateStatus transitions the row and is reflected on the next read`() {
+        val settlement = newSettlement()
+        onVertxContext { repository.create(settlement) }
+
+        val updated = onVertxContext { repository.updateStatus(settlement.id, SettlementStatus.BOOKED) }
+
+        assertThat(updated.status).isEqualTo(SettlementStatus.BOOKED)
+        assertThat(onVertxContext { repository.findById(settlement.id) }!!.status).isEqualTo(SettlementStatus.BOOKED)
+    }
+
+    @Test
+    fun `claimForProcessing atomically wins PENDING to DEBITED exactly once`() {
+        val settlement = newSettlement()
+        onVertxContext { repository.create(settlement) }
+
+        val firstClaim = onVertxContext { repository.claimForProcessing(settlement.id) }
+        val secondClaim = onVertxContext { repository.claimForProcessing(settlement.id) }
+
+        assertThat(firstClaim).isTrue()
+        assertThat(secondClaim).isFalse()
+        assertThat(onVertxContext { repository.findById(settlement.id) }!!.status).isEqualTo(SettlementStatus.DEBITED)
+    }
+
+    @Test
+    fun `claimForProcessing fails for a settlement that is not PENDING`() {
+        val settlement = newSettlement(status = SettlementStatus.BOOKED)
+        onVertxContext { repository.create(settlement) }
+
+        val claimed = onVertxContext { repository.claimForProcessing(settlement.id) }
+
+        assertThat(claimed).isFalse()
+        assertThat(onVertxContext { repository.findById(settlement.id) }!!.status).isEqualTo(SettlementStatus.BOOKED)
+    }
+}


### PR DESCRIPTION
## Summary

Raises real unit/integration test coverage for `openbank-settlement-service` from a measured
**31.66%** to **85.49%** line coverage (the previous `koverVerify` floor of 18 was stale — far
below actual coverage, not a meaningful gate). Targets the highest-value, previously
zero-covered classes: the Temporal settlement saga, the three outbound REST adapters, the
Panache reactive repository, and `SettlementService.settle()`'s legacy/Temporal dispatch paths.

## Type of change

- [x] test (coverage only, no behavior change)

## Linked issues

N/A — coverage improvement, not tied to a tracked issue.

## Changes

- `SettlementWorkflowImplTest`: exercises the Temporal saga (`debitPayer` → `creditPayee` →
  `bookToLedger`) and its reverse-order compensation on failure at each step, plus a
  compensation-activity-itself-fails case, via `TestWorkflowEnvironment` (was 0% covered).
- `BalanceDebitAdapterTest` / `BalanceCreditAdapterTest` / `LedgerBookAdapterTest`: mockk unit
  tests for the three outbound REST-client adapters (happy path, settlement-not-found,
  downstream-client failure propagation) — all were 0% covered.
- `SettlementServiceSettleTest` / `SettlementServiceTemporalSettleTest`: cover
  `SettlementService.settle()`'s not-found guard, the legacy claim-race loser path, the
  mid-flight-failure rejection, and the Temporal-enabled dispatch including the idempotent
  `WorkflowExecutionAlreadyStarted` no-op (the latter driven against a real in-memory
  `TestWorkflowEnvironment` rather than mocking Temporal's static `WorkflowClient.start`).
- `SettlementRepositoryImplIT`: Testcontainers-Postgres-backed IT for `SettlementRepositoryImpl`
  (was 0% covered) — create/findById/updateStatus round-trip and the atomic
  PENDING→DEBITED `claimForProcessing` compare-and-set that guards against a concurrent
  double-debit. Reuses the existing `PostgresTestResource`.
- `build.gradle.kts`: ratchet `koverVerify` line-coverage floor from the stale `18` to `80`
  (a few points below the measured 85.49%).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports; no domain/main code
      touched by this PR).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (repository IT against real Postgres via Testcontainers).
- [ ] Contract tests updated — N/A, no public API changed.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes for `:openbank-settlement-service`.
- [x] No new lint warnings (ktlintFormat applied to the new test files).
- [ ] OpenAPI spec regenerated — N/A, no REST API changed.
- [ ] Flyway migration — N/A, no schema changed.
- [ ] Avro schema — N/A, no event changed.
- [ ] Docs updated — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification — none added.
- [x] No new third-party dependency (only existing `temporal-testing`, `mockk`, `assertj`,
      `testcontainers` test deps already declared in this module's `build.gradle.kts`).
- [ ] Auth / crypto / payment code changed? — No production code changed, tests only.
- [ ] PII path changed? — No.
- [ ] Cardholder data path changed? — No.

## Compliance impact

- [x] None (test-only change).

## Money-path status (flagging per repo convention)

`openbank-settlement-service` clearly performs real money movement (debit → credit → ledger
booking, with compensation), but it is **not currently listed** in
`openbank-libs/governance/rules.yaml: money_path_services`. Per that list's current membership,
this PR does **not** require 2 approvals + a threat model. I have not added a threat model and
am not asserting money-path status myself — flagging this discrepancy for a maintainer to
triage separately (possible gap in the money-path list, out of scope for this coverage-only PR).

## Rollout / Rollback

- Deployment strategy: N/A (test-only change, no runtime behavior change).
- Rollback plan: revert the PR; the `koverVerify` floor change is the only non-test-code edit
  and reverting it just restores the stale `18` floor.
- Data migration reversible: N/A.

## Reviewer notes

- Baseline was measured via `koverXmlReport` before any changes: 120/379 lines covered (31.66%).
- Final measured coverage: 324/379 lines (85.49%). Remaining gaps are low-value CDI/plumbing
  classes (`TemporalClientProducer` — needs a real gRPC/Micrometer connection; `SettlementResource`
  DTOs and the REST endpoint itself — already exercised end-to-end by the existing
  `SettlementBootSmokeIT` but not asserted at unit level; `SettlementWorkerRegistrar` — needs a
  real `WorkerFactory`), judged not worth the added test complexity for the coverage gained.
- The `SettlementRepositoryImplIT` suspend calls needed to be bridged onto a Vert.x context via
  `VertxContextSupport.subscribeAndAwait` (a plain JUnit thread has no ambient Vert.x context) —
  mirrors the existing `AmlOutboxDispatchIT` (aml-service) and this service's own
  `SettlementActivitiesImpl.runOnVertxContext`.