### PR TITLE
chore(security): fix stale gitleaks allowlist path for PiiMasking after ADR-0122 split

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -101,12 +101,15 @@ paths = [
   # AWS/GCP/key detectors, iban/pan/rod-cislo) still scans them for real secrets.
   '''(^|/)openbank-infra/docker-compose\.yml$''',
   # PiiMasking holds card-/birth-number REGEXES by design (it masks them), so the
-  # pan-card-number and rod-cislo rules match its own pattern literals.
-  '''(^|/)openbank-libs/src/main/kotlin/com/openbank/libs/security/PiiMasking\.kt$''',
+  # pan-card-number and rod-cislo rules match its own pattern literals. Anchored on
+  # the package path (not the module dir) so it survives module moves — the file
+  # relocated openbank-libs → openbank-libs-domain in the ADR-0122 domain/runtime split.
+  '''(^|/)com/openbank/libs/security/PiiMasking\.kt$''',
   # CzechAccountNumber implements the ČNB mod-11 BBAN check; its doc/test literals
   # (e.g. the comment "rejects 0000000000") are example digit strings that match
   # the rod-cislo numeric heuristic — account-number validation logic, not a secret.
-  '''(^|/)openbank-libs/src/main/kotlin/com/openbank/libs/domain/account/CzechAccountNumber\.kt$''',
+  # Package-path anchored for the same ADR-0122 relocation reason as PiiMasking above.
+  '''(^|/)com/openbank/libs/domain/account/CzechAccountNumber\.kt$''',
   # GitOps manifests carry numeric infra config (Kafka retention.ms, JDBC ports)
   # that trips the numeric rod-cislo / generic-api-key heuristics. Real secrets
   # are delivered via Vault/SealedSecrets, never inlined in these manifests.


### PR DESCRIPTION
## Summary

The `.gitleaks.toml` allowlist anchored `PiiMasking.kt` (and its neighbour `CzechAccountNumber.kt`) by the **pre-split** `openbank-libs/` module path. The ADR-0122 domain/runtime split relocated both to `openbank-libs-domain/`, so the globs no longer match. Both files carry PII-shaped literals **by design** — `PiiMasking.kt` holds the card-/birth-number regexes it masks with, `CzechAccountNumber.kt` has ČNB mod-11 example digits — so with the allowlist broken they now trip the `pan-card-number` and `rod-cislo` custom rules.

Latent today because path-scoped gitleaks only scans the commit range; the next PR touching either file would fail the secret-scan gate on a false positive.

## Type of change
- [x] Chore / tooling (no runtime code change)

## Linked issues
Closes #341

## Changes
- Re-anchor both allowlist globs on the **package path** (`(^|/)com/openbank/libs/…`) instead of the module directory, so they survive this and future module moves.
- Update the surrounding comments to note the ADR-0122 relocation.

## Definition of Done
- [x] Verified locally: `gitleaks detect --source . --config .gitleaks.toml --no-git` → **no leaks found**.
- [x] Differential check: scanning `PiiMasking.kt` with the stale path trips **2 findings**; with the fix it is **clean**.
- [x] No `version.txt` bump — root tooling config, no change under any `<service>/src/main/**`.

## Security checklist
- [x] No secret added or removed — this only corrects which paths are allowlisted from the PII heuristics. `openbank-dev-creds` and all default detectors still scan these files for real secrets.

## Compliance impact
None — restores the intended allowlist behaviour for two files whose PII-shaped literals are validation/masking logic, not secrets.