### PR TITLE
chore(gitops): auto-deploy services @ 7513884dbc4aaf5e1a9a3bda37518724029cbd1d

### DIFF
--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -45,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ledger-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-02c6f66d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-7513884d
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 7513884dbc4aaf5e1a9a3bda37518724029cbd1d.

**Changed services:** ["openbank-ledger-service"]

Each image tag was updated to `sandbox-7513884dbc4aaf5e1a9a3bda37518724029cbd1d` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.