### PR TITLE
test(contracts): activate balance-ledger Pact provider verification via git-pact

### DIFF
--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/LedgerTrialBalancePactConsumerTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/contract/LedgerTrialBalancePactConsumerTest.kt
@@ -20,7 +20,15 @@ import org.junit.jupiter.api.extension.ExtendWith
 /**
  * Consumer-driven contract for the ledger trial-balance endpoint called by the ADR-0039 Phase A
  * reconciliation. The generated pact file is committed to `pacts/` (git-pact pattern, ADR-0063)
- * and replayed by [LedgerPactProviderVerificationTest] in openbank-ledger-service.
+ * and replayed by `LedgerPactProviderVerificationTest` (`@PactFolder("../pacts")`) in
+ * openbank-ledger-service — that test always runs, no Pact Broker involved.
+ *
+ * IMPORTANT — regenerate on change: if this test's `@Pact` methods change (new interaction,
+ * different matcher, renamed field), re-run this test (`./gradlew :openbank-balance-service:test
+ * --tests "*LedgerTrialBalancePactConsumerTest*"`) and commit the updated
+ * `pacts/openbank-balance-service-openbank-ledger-service.json` in the same PR. There is no CI
+ * drift check yet (planned for ADR-0063 Phase 2) — an un-regenerated pact file silently verifies
+ * the OLD contract on the provider side.
  *
  * Uses Pact DSL — not the actual MicroProfile REST Client — so the test has zero Quarkus
  * boot overhead and runs in < 100 ms. What is verified: the shape and types the client DTO

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactProviderVerificationTest.kt
@@ -10,26 +10,33 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
-import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 
 /**
- * Provider-side Pact verification for contracts published by consumers (ADR-0063 → ADR-0092).
- * Fetches the consumer pacts from the Pact Broker (`@PactBroker`, configured via the
- * `pactbroker.*` system properties CI passes with `-D`) and replays each interaction against
- * the running Quarkus test instance to prove the ledger service fulfils the consumer contracts;
- * the verification result is published back to the broker so `can-i-deploy` can gate on it.
+ * Provider-side Pact verification for contracts published by consumers (ADR-0063: Phase 1
+ * pilot, `balance-service` → `ledger-service`).
  *
- * Gated on `pactbroker.url`: with no broker configured (local `./gradlew build`) the class is
- * skipped and the committed `pacts/` (git-pact) remains the offline fallback until retirement.
- * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a transient broker outage a skip, not a failure.
+ * Reads the consumer pact from the git-pact folder (`@PactFolder`, resolved relative to this
+ * module's working directory at `../pacts` = the monorepo-root `pacts/` dir) and replays each
+ * interaction against the running Quarkus test instance to prove the ledger service fulfils the
+ * consumer contract. This always runs — no broker, no gate, no CI secret required (ADR-0063
+ * chose git-pact over a Pact Broker for exactly this reason: zero new infra dependency).
+ *
+ * IMPORTANT: if `LedgerTrialBalancePactConsumerTest` (openbank-balance-service) changes the
+ * contract, regenerate the pact JSON (`./gradlew :openbank-balance-service:test --tests
+ * "*LedgerTrialBalancePactConsumerTest*"`) and commit the updated `pacts/openbank-balance-service-
+ * openbank-ledger-service.json` in the same PR, or this test will fail against a stale contract.
+ *
+ * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact file a skip, not a
+ * failure — relevant if the folder is ever emptied ahead of a broker migration (see ADR-0063
+ * "Migration to a broker is the natural follow-up").
  *
  * Authentication: [TestSecurity] cannot annotate @TestTemplate; instead a request filter is
  * configured below so Pact injects the service role on every replayed request. This matches the
@@ -39,9 +46,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 @QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
 @TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
 @Provider("openbank-ledger-service")
-@PactBroker
+@PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
-@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class LedgerPactProviderVerificationTest {
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")


### PR DESCRIPTION
## Summary

- The `LedgerPactProviderVerificationTest` (ledger-service) was silently dead code since ADR-0063 Phase 1: gated on `@EnabledIfSystemProperty(named = "pactbroker.url", ...)` with no Pact Broker ever deployed (Option A of #36 was never taken, and CI's `_service-ci.yml` never sets a non-empty `pactbroker.url`) — so the test skipped in every local run and in CI.
- Switches to Option B (git-pact, per issue #36 and matching ADR-0063's own delivery note, which already claims this is "shipped"): `@PactFolder("../pacts")` reading the already-committed `pacts/openbank-balance-service-openbank-ledger-service.json`, gate removed, test now always runs.
- Documents the "regenerate pact on consumer contract change" convention as a doc comment on the consumer test (no CI drift check yet — that's ADR-0063 Phase 2).

## Type of change

- [x] test (tests only)
- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Closes #36

## Changes

- `openbank-ledger-service/.../contract/LedgerPactProviderVerificationTest.kt`: `@PactBroker` → `@PactFolder("../pacts")`, drop `@EnabledIfSystemProperty`, updated docstring to reflect ADR-0063 git-pact (no broker).
- `openbank-balance-service/.../contract/LedgerTrialBalancePactConsumerTest.kt`: doc comment documenting the regenerate-and-recommit-on-change convention.
- No production code touched. No new pact JSON needed — regenerated the consumer pact locally and confirmed it is byte-identical to the already-committed `pacts/openbank-balance-service-openbank-ledger-service.json`.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — N/A, test-only change.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved) — N/A.
- [x] Contract tests updated (if public API changed) — this PR *activates* the existing contract test; no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — ran `ktlintCheck`/`detekt` for both modules touched; clean. Full `build` not re-run (no production code changed; ran the targeted test tasks directly, see verification below).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed) — N/A.
- [ ] Flyway migration added + rollback note (if DB changed) — N/A.
- [ ] Avro schema versioned backward-compatibly (if event changed) — N/A.
- [x] Docs updated (README, ADR if architectural) — regenerate-on-change convention documented inline; ADR-0063 already describes this as the intended Phase 1 design, no ADR edit needed.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency — `@PactFolder` ships in the same `au.com.dius.pact:provider` artifact already used for `@PactBroker`.
- [ ] Auth / crypto / payment code changed? — N/A, test-only.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (test-only change, no runtime artifact behavior change).
- Rollback plan: revert the commit; the provider test returns to its previous (skipped) state.
- Data migration reversible: N/A.

## Reviewer notes

**Money-path flag:** both `openbank-ledger-service` and `openbank-balance-service` are in `rules.yaml: money_path_services`, so this nominally needs 2 approvals + a threat model per the repo's money-path rule. However, this PR touches **only test code** (activates a previously dead/skipped provider verification test) — no production code, no API, no DB, no runtime behavior change. Flagging for visibility; recommend the 2-approval requirement is still honored per policy even though risk is low.

**Verification performed (see PR description, not just claimed):**
1. Regenerated the consumer pact: `./gradlew :openbank-balance-service:test --tests "*LedgerTrialBalancePactConsumerTest*"` → BUILD SUCCESSFUL; diffed the regenerated JSON against the already-committed `pacts/openbank-balance-service-openbank-ledger-service.json` — byte-identical, no drift.
2. Ran the provider test after the `@PactFolder` switch: `./gradlew :openbank-ledger-service:test --tests "*LedgerPactProviderVerificationTest*"` → BUILD SUCCESSFUL, JUnit XML shows **3 tests, 0 failures, 0 errors**: both balance→ledger trial-balance interactions plus the existing transaction→ledger journal-posting pact (also in the shared `pacts/` folder, picked up automatically — expected with folder-based loading, unaffected by this change).
3. `ktlintCheck` + `detekt` for both `openbank-ledger-service` and `openbank-balance-service` — BUILD SUCCESSFUL, no new violations.

**Path note:** the issue text suggested `openbank-balance-service/pacts/` as the commit location, but the repo's actual, already-established convention (per `ADR-0063`, `.gitignore` notwithstanding — see below — and 4 pre-existing pact files) is a single top-level `pacts/<consumer>-<provider>.json` directory at the monorepo root, wired via the `pact.rootDir` system property in both services' `build.gradle.kts`. I followed the existing convention rather than the issue's suggested path.

**Pre-existing inconsistency spotted (not fixed here, out of scope):** `.gitignore` still has a `pacts/` entry with a comment claiming these files are "published to the Pact Broker by CI, not committed" — but 4 pact JSON files (including this one) are already force-tracked in git, and ADR-0063 explicitly mandates committing them (git-pact). The `.gitignore` rule is stale relative to actual practice and ADR-0063's decision. Worth a small follow-up cleanup PR to remove the stale `pacts/` gitignore entry/comment, but left untouched here to keep this PR focused on the issue's scope.