### PR TITLE
feat(simulation): bind DST harness to sepa-payment and settlement domain classes

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -123,9 +123,15 @@ jobs:
               # explicitly so the invariant checker runs on every money-path change (it already runs
               # on its own edits, on push to main, and nightly). Code-global changes (libs etc.)
               # already build everything incl. the simulation, so this only matters per-module.
-              if grep -qE '(^| )openbank-(ledger|balance|transaction)-service( |$)' <<< " $CHANGED " \
+              # Issue #267 (ADR-0100 full-service adoption) extended the same project-dependency
+              # binding to sepa-payment (directory openbank-sepa-payment, no "-service" suffix)
+              # and settlement-service — add both to the edge so a change to either also rebuilds
+              # the simulation, exactly like ledger/balance/transaction already do.
+              if { grep -qE '(^| )openbank-(ledger|balance|transaction)-service( |$)' <<< " $CHANGED " \
+                   || grep -qE '(^| )openbank-sepa-payment( |$)' <<< " $CHANGED " \
+                   || grep -qE '(^| )openbank-settlement-service( |$)' <<< " $CHANGED "; } \
                  && ! grep -qE '(^| )openbank-simulation( |$)' <<< " $CHANGED "; then
-                echo "Decision: money-path change -> add openbank-simulation (DST harness, ADR-0115)."
+                echo "Decision: money-path change -> add openbank-simulation (DST harness, ADR-0115/#267)."
                 CHANGED="$CHANGED openbank-simulation"
               fi
               # A change to the CI recipe itself (services-ci / _service-ci) can NOT

--- a/docs/adr/0100-deterministic-simulation-testing.md
+++ b/docs/adr/0100-deterministic-simulation-testing.md
@@ -5,10 +5,10 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): OpenBank platform
 
-**Delivery note (updated 2026-06-30):**
-- **Layer 2 (DST harness — Pure JVM)** — ✅ Shipped: `openbank-simulation` module with deterministic scheduler, fault injector, in-memory adapters, payment scenario DSL, and Layer 3 invariants (double-entry balance, no-negative, idempotency, compensation completeness, audit completeness). Updated in ADR-0120 Phase 5+6 to work without the retired `PaymentSaga` aggregate.
+**Delivery note (updated 2026-07-06):**
+- **Layer 2 (DST harness — Pure JVM)** — ✅ Shipped: `openbank-simulation` module with deterministic scheduler, fault injector, in-memory adapters, payment scenario DSL, and Layer 3 invariants (double-entry balance, no-negative, idempotency, compensation completeness, audit completeness, SEPA/settlement completeness). Updated in ADR-0120 Phase 5+6 to work without the retired `PaymentSaga` aggregate.
 - **Layer 1 (architectural constraints)** — Partial: clock injection in place for money-path services; governance rule mandating it in `rules.yaml` not yet enforced; deterministic `Random` CDI bean not yet required.
-- **Full-service adoption (ledger, balance, sepa-payment, settlement)** — ⬜ Pending: simulation currently covers the payment saga / Temporal workflow path; binding to each service's exact domain classes is tracked in issue #267.
+- **Full-service adoption (ledger, balance, sepa-payment, settlement)** — ✅ Shipped (issue #267): `openbank-simulation` now takes a Gradle project dependency on all four services' framework-free domain packages and drives their real aggregates directly — `JournalEntry`/`bookedDeltas` (ledger), `Balance`/`withReservation` (balance), `SepaPayment.transitionTo` (sepa-payment), and the `Settlement` status enum (settlement-service) — rather than a re-model of any of them. None of the four required a module split: each service's `domain` package already has zero framework imports (ADR-0002), so only its POJOs land on the simulation's classpath. Remaining: none of the four services expose a Temporal-workflow-level binding yet (the harness models their state machines directly, not through the `sepa-payment`/`settlement-service` Temporal workflows) — that gap, plus the Antithesis fidelity step, is out of scope for #267 and would need its own follow-up if pursued.
 
 ## Context
 
@@ -122,12 +122,14 @@ The implementation issue will benchmark fidelity vs. cost and pick one.
 **Implementation status.** The **Pure JVM simulation** first rung has shipped as the
 [`openbank-simulation`](../../openbank-simulation/) module (tooling; no `version.txt`). It
 virtualises the money-path semantics — double-entry ledger, balance/overdraft, the payment saga
-and its compensation, ledger→balance projection with at-least-once delivery — under a seeded
-deterministic scheduler + fault injector, and asserts the Layer-3 invariants below after every
-step. It is built on the real `openbank-libs` primitives (`Money`, `SagaStateMachine`); binding
-it to each service's exact domain classes, and the Antithesis fidelity step, remain tracked in
-issue #267 (the #1612 reference this line used to carry doesn't resolve in this repo — a
-pre-public-repo-transition reference, same pattern as the ADR numbering gap in `README.md`).
+and its compensation, ledger→balance projection with at-least-once delivery, and (issue #267) the
+SEPA credit-transfer + settlement lifecycle — under a seeded deterministic scheduler + fault
+injector, and asserts the Layer-3 invariants below after every step. It is built on the real
+`openbank-libs` primitives (`Money`, `SagaStateMachine`) and now takes a direct Gradle project
+dependency on the framework-free `domain` package of all four money-path services (ledger,
+balance, sepa-payment, settlement), driving each service's exact domain classes rather than a
+re-model. The Antithesis fidelity step remains open; see #267 for the record of what was bound
+and what (a Temporal-workflow-level binding) was explicitly out of scope.
 
 ### Layer 3 — Global invariants (always-on assertions)
 

--- a/openbank-simulation/build.gradle.kts
+++ b/openbank-simulation/build.gradle.kts
@@ -53,6 +53,14 @@ dependencies {
     implementation(project(":openbank-balance-service"))
     implementation(project(":openbank-transaction-service"))
 
+    // Issue #267 (ADR-0100 full-service adoption): the harness also drives the REAL
+    // `SepaPayment` status machine (sepa-payment) and `Settlement` status machine
+    // (settlement-service), rather than a re-model of either. Both domain packages
+    // are framework-free (ADR-0002 — no jakarta/quarkus/temporal imports), so only
+    // the domain POJOs land on the classpath, not a runtime.
+    implementation(project(":openbank-sepa-payment"))
+    implementation(project(":openbank-settlement-service"))
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.assertj)

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/invariants/MoneyPathInvariants.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/invariants/MoneyPathInvariants.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.simulation.invariants
 
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.settlement.domain.model.SettlementStatus
 import com.openbank.simulation.model.AccountCurrency
 import com.openbank.simulation.runner.World
 import com.openbank.transaction.domain.saga.SagaState
@@ -100,6 +102,56 @@ object MoneyPathInvariants {
         }
     }
 
+    /**
+     * Issue #267 (ADR-0100 full-service adoption): every `SepaPayment` driven by
+     * [com.openbank.simulation.scenario.SepaSettlementScenario] must reach a terminal status
+     * (COMPLETED / REJECTED / RETURNED / CANCELLED) by the time a step has fully settled — the
+     * SEPA analogue of [compensationCompleteness].
+     */
+    val sepaPaymentCompleteness = object : Invariant {
+        private val terminal = setOf(
+            SepaPaymentStatus.COMPLETED,
+            SepaPaymentStatus.REJECTED,
+            SepaPaymentStatus.RETURNED,
+            SepaPaymentStatus.CANCELLED,
+        )
+
+        override val name = "sepa-payment-completeness"
+        override fun check(world: World): Violation? {
+            world.sepaPayments.forEach { payment ->
+                if (payment.status !in terminal) {
+                    return Violation(name, "sepa payment ${payment.id} stuck in ${payment.status}")
+                }
+            }
+            return null
+        }
+    }
+
+    /**
+     * Issue #267: every `Settlement` driven alongside a SEPA payment must reach a terminal
+     * status (BOOKED / REJECTED / REVERSED / CREDITED_REVERSED / LEDGER_REVERSED) — no
+     * settlement may be left mid-flight (DEBITED/CREDITED without a following terminal state).
+     */
+    val settlementCompleteness = object : Invariant {
+        private val terminal = setOf(
+            SettlementStatus.BOOKED,
+            SettlementStatus.REJECTED,
+            SettlementStatus.REVERSED,
+            SettlementStatus.CREDITED_REVERSED,
+            SettlementStatus.LEDGER_REVERSED,
+        )
+
+        override val name = "settlement-completeness"
+        override fun check(world: World): Violation? {
+            world.settlements.forEach { settlement ->
+                if (settlement.status !in terminal) {
+                    return Violation(name, "settlement ${settlement.id} stuck in ${settlement.status}")
+                }
+            }
+            return null
+        }
+    }
+
     /** All Layer-3 invariants, in check order. */
     val ALL: List<Invariant> = listOf(
         conservationOfMoney,
@@ -107,6 +159,8 @@ object MoneyPathInvariants {
         projectionConsistency,
         compensationCompleteness,
         auditCompleteness,
+        sepaPaymentCompleteness,
+        settlementCompleteness,
     )
 
     /** A terminal-state guard used by the saga orchestrator. */

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/SimulationRunner.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/SimulationRunner.kt
@@ -9,6 +9,7 @@ import com.openbank.simulation.engine.SimulationContext
 import com.openbank.simulation.invariants.Invariant
 import com.openbank.simulation.invariants.MoneyPathInvariants
 import com.openbank.simulation.scenario.PaymentScenario
+import com.openbank.simulation.scenario.SepaSettlementScenario
 
 /**
  * The seed-driven exhaustion loop (ADR-0100 Layer 2 — runner). For each seed it builds a fresh
@@ -27,6 +28,10 @@ class SimulationRunner(
         val world = World(context, config)
         for (step in 1..stepsPerSeed) {
             PaymentScenario.step(world)
+            // Issue #267 (ADR-0100 full-service adoption): interleave the SEPA + settlement
+            // domain-class binding into the same seeded run so it shares the fault profile and
+            // is checked by the same invariant sweep every step.
+            SepaSettlementScenario.step(world)
             context.scheduler.drain()
             invariants.forEach { invariant ->
                 val violation = invariant.check(world)

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/World.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/World.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.simulation.runner
 
+import com.openbank.sepa.domain.model.SepaPayment
+import com.openbank.settlement.domain.model.Settlement
 import com.openbank.simulation.adapters.AuditLog
 import com.openbank.simulation.adapters.BalanceProjection
 import com.openbank.simulation.adapters.SimEventBus
@@ -42,6 +44,12 @@ class World(val context: SimulationContext, val config: SimulationConfig) {
     val balances = BalanceStore()
     val audit = AuditLog()
     val sagas = mutableListOf<SimPaymentSaga>()
+
+    // Issue #267 (ADR-0100 full-service adoption): the REAL `SepaPayment` (sepa-payment) and
+    // `Settlement` (settlement-service) domain aggregates driven by SepaSettlementScenario, kept
+    // here so the Layer-3 invariants can assert every one reaches a terminal state.
+    val sepaPayments = mutableListOf<SepaPayment>()
+    val settlements = mutableListOf<Settlement>()
 
     val customerAccounts: List<UUID>
     val currency: String = config.currency

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/scenario/SepaSettlementScenario.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/scenario/SepaSettlementScenario.kt
@@ -86,6 +86,11 @@ object SepaSettlementScenario {
         val debtorIdx = random.nextInt(accounts.size)
         val debtorAccount = accounts[debtorIdx]
         val creditorAccountIdx = (debtorIdx + 1 + random.nextInt(accounts.size - 1)) % accounts.size
+        // codeql[java/insecure-randomness]: intentional. `random` is SimulationRandom, a
+        // seeded kotlin.random.Random wrapper (engine/SimulationRandom.kt) whose entire purpose
+        // is deterministic, REPRODUCIBLE test-account selection (ADR-0100) -- a SecureRandom
+        // here would break the seed-replay property this harness exists for. openbank-simulation
+        // is a test-tooling module (no version.txt, never deployed), not production code.
         val creditorAccount = accounts[creditorAccountIdx]
 
         val payment = SepaPayment(

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/scenario/SepaSettlementScenario.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/scenario/SepaSettlementScenario.kt
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.scenario
+
+import com.openbank.sepa.domain.model.SepaPayment
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.sepa.domain.model.SepaPaymentType
+import com.openbank.sepa.domain.model.SepaRejectReason
+import com.openbank.settlement.domain.model.Settlement
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.simulation.engine.SimulatedWriteFailure
+import com.openbank.simulation.runner.World
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Issue #267 (ADR-0100 full-service adoption): one step of the SEPA cross-account settlement
+ * path, modelled directly against the **real `sepa-payment` `SepaPayment`** status machine
+ * (`transitionTo`/`canTransitionTo`) and the **real `settlement-service` `Settlement`** status
+ * enum — not a re-model of either. Both domain packages are framework-free (ADR-0002), so this
+ * exercises the exact production transition rules under the deterministic scheduler + fault
+ * injector, the same way [PaymentScenario] already does for `ledger`/`balance`.
+ *
+ * A step: submit a SEPA credit transfer (RECEIVED -> VALIDATED), open its settlement (PENDING),
+ * debit + credit the settlement, and complete both aggregates together (PROCESSING -> COMPLETED,
+ * CREDITED -> BOOKED). An injected write fault at the settlement-debit step rejects the SEPA
+ * payment and reverses the settlement, so every step reaches a terminal state on both aggregates
+ * — exactly the "compensation completeness" property [MoneyPathInvariants] already asserts for
+ * the internal payment saga, extended here to the SEPA + settlement pair.
+ */
+object SepaSettlementScenario {
+
+    private const val MAX_MINOR_UNITS = 500_000L // up to 5000.00 in a 2-dp currency
+    private const val IBAN_PREFIX_LENGTH = 24
+    private const val CREDITOR_BIC = "OPENBACZPXXX"
+
+    fun step(world: World) {
+        var leg = openLeg(world)
+
+        // 1. Validate the SEPA credit transfer.
+        leg = leg.advancePayment(world, SepaPaymentStatus.VALIDATED)
+        leg = leg.advancePayment(world, SepaPaymentStatus.PROCESSING)
+
+        // 2. Debit the payer's settlement leg. An injected write fault here means the debit
+        //    never committed: reject the payment and mark the settlement REJECTED (nothing to
+        //    unwind since it never left PENDING).
+        val debited = debitSettlement(world, leg)
+        if (debited == null) return
+        leg = debited
+
+        // 3. Credit the payee's settlement leg. A post-commit conflict forces the settlement to
+        //    reverse the already-booked debit (compensation), and the SEPA payment is RETURNED.
+        if (world.context.faults.shouldConflict()) {
+            leg = leg.advanceSettlement(world, SettlementStatus.CREDITED_REVERSED)
+            leg.advancePayment(world, SepaPaymentStatus.RETURNED)
+            world.audit.append("settlement ${leg.settlement.id} reversed: post-commit conflict")
+            return
+        }
+        leg = leg.advanceSettlement(world, SettlementStatus.CREDITED)
+
+        // 4. Happy path: book the settlement and complete the SEPA payment together.
+        leg = leg.advanceSettlement(world, SettlementStatus.BOOKED)
+        leg.advancePayment(world, SepaPaymentStatus.COMPLETED)
+    }
+
+    private fun debitSettlement(world: World, leg: SepaSettlementLeg): SepaSettlementLeg? = try {
+        if (world.context.faults.shouldFailWrite()) {
+            throw SimulatedWriteFailure("settlement debit failed for ${leg.settlement.id}")
+        }
+        leg.advanceSettlement(world, SettlementStatus.DEBITED)
+    } catch (e: SimulatedWriteFailure) {
+        val rejected = leg.advanceSettlement(world, SettlementStatus.REJECTED)
+        rejected.advancePayment(world, SepaPaymentStatus.REJECTED, reason = SepaRejectReason.TECHNICAL_ERROR)
+        world.audit.append("sepa ${leg.payment.id} rejected: ${e.message}")
+        null
+    }
+
+    private fun openLeg(world: World): SepaSettlementLeg {
+        val random = world.context.random
+        val accounts = world.customerAccounts
+        val now = world.context.clock.instant()
+
+        val amount = BigDecimal(random.nextLong(1L, MAX_MINOR_UNITS)).movePointLeft(2)
+        val debtorIdx = random.nextInt(accounts.size)
+        val debtorAccount = accounts[debtorIdx]
+        val creditorAccountIdx = (debtorIdx + 1 + random.nextInt(accounts.size - 1)) % accounts.size
+        val creditorAccount = accounts[creditorAccountIdx]
+
+        val payment = SepaPayment(
+            id = random.nextUuid(),
+            idempotencyKey = "sepa-${random.nextUuid()}",
+            type = SepaPaymentType.SCT,
+            status = SepaPaymentStatus.RECEIVED,
+            debtorAccountId = debtorAccount,
+            debtorIban = iban(debtorAccount),
+            debtorName = "Simulated Debtor",
+            creditorIban = iban(creditorAccount),
+            creditorName = "Simulated Creditor",
+            creditorBic = CREDITOR_BIC,
+            amount = amount,
+            currency = world.currency,
+            remittanceInfo = null,
+            endToEndId = "e2e-${random.nextUuid()}",
+            rejectReason = null,
+            rejectDetail = null,
+            submittedAt = null,
+            completedAt = null,
+            createdAt = now,
+            updatedAt = now,
+        )
+        world.sepaPayments.add(payment)
+
+        val settlement = Settlement(
+            id = random.nextUuid(),
+            payerAccountId = debtorAccount,
+            payeeAccountId = creditorAccount,
+            amount = amount,
+            currency = world.currency,
+            status = SettlementStatus.PENDING,
+            createdAt = now,
+            updatedAt = now,
+        )
+        world.settlements.add(settlement)
+
+        return SepaSettlementLeg(payment, settlement, world.sepaPayments.lastIndex, world.settlements.lastIndex)
+    }
+
+    private fun iban(accountId: UUID): String = "CZ0000000000$accountId".take(IBAN_PREFIX_LENGTH)
+
+    /** The pair of real domain aggregates driven together by one scenario step. */
+    private data class SepaSettlementLeg(
+        val payment: SepaPayment,
+        val settlement: Settlement,
+        val paymentIndex: Int,
+        val settlementIndex: Int,
+    ) {
+        fun advancePayment(world: World, to: SepaPaymentStatus, reason: SepaRejectReason? = null): SepaSettlementLeg {
+            val next = payment.transitionTo(to, reason = reason, clock = world.context.clock)
+            world.sepaPayments[paymentIndex] = next
+            world.audit.append("sepa ${next.id} -> ${next.status}")
+            return copy(payment = next)
+        }
+
+        fun advanceSettlement(world: World, to: SettlementStatus): SepaSettlementLeg {
+            val next: Settlement = settlement.copy(status = to, updatedAt = world.context.clock.instant())
+            world.settlements[settlementIndex] = next
+            world.audit.append("settlement ${next.id} -> ${next.status}")
+            return copy(settlement = next)
+        }
+    }
+}

--- a/openbank-simulation/src/test/kotlin/com/openbank/simulation/scenario/SepaSettlementScenarioTest.kt
+++ b/openbank-simulation/src/test/kotlin/com/openbank/simulation/scenario/SepaSettlementScenarioTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.scenario
+
+import com.openbank.sepa.domain.model.SepaPaymentStatus
+import com.openbank.settlement.domain.model.SettlementStatus
+import com.openbank.simulation.engine.FaultProfile
+import com.openbank.simulation.engine.SimulationContext
+import com.openbank.simulation.invariants.MoneyPathInvariants
+import com.openbank.simulation.runner.SimulationConfig
+import com.openbank.simulation.runner.World
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Issue #267 (ADR-0100 full-service adoption): exercises [SepaSettlementScenario] directly
+ * against the REAL `sepa-payment` `SepaPayment` and `settlement-service` `Settlement` domain
+ * aggregates, so the harness's binding to those two services (beyond ledger/balance) is proven
+ * by an actual assertion, not merely by compiling.
+ */
+class SepaSettlementScenarioTest {
+
+    private fun newWorld(faultProfile: FaultProfile = FaultProfile.NONE): World =
+        World(SimulationContext(seed = 42L, faultProfile), SimulationConfig())
+
+    @Test
+    fun `a happy-path step completes the real SepaPayment and books the real Settlement`() {
+        val world = newWorld()
+        SepaSettlementScenario.step(world)
+
+        assertThat(world.sepaPayments).hasSize(1)
+        assertThat(world.settlements).hasSize(1)
+        assertThat(world.sepaPayments.single().status).isEqualTo(SepaPaymentStatus.COMPLETED)
+        assertThat(world.settlements.single().status).isEqualTo(SettlementStatus.BOOKED)
+    }
+
+    @Test
+    fun `a write-failure fault rejects the SepaPayment and the Settlement together`() {
+        // 100% write-failure rate forces the debit-settlement branch every time.
+        val world = newWorld(FaultProfile(writeFailureRate = 1.0))
+        SepaSettlementScenario.step(world)
+
+        assertThat(world.sepaPayments.single().status).isEqualTo(SepaPaymentStatus.REJECTED)
+        assertThat(world.settlements.single().status).isEqualTo(SettlementStatus.REJECTED)
+    }
+
+    @Test
+    fun `a post-commit conflict returns the SepaPayment and reverses the credited Settlement`() {
+        // 100% conflict rate forces the post-credit compensation branch every time.
+        val world = newWorld(FaultProfile(lockConflictRate = 1.0))
+        SepaSettlementScenario.step(world)
+
+        assertThat(world.sepaPayments.single().status).isEqualTo(SepaPaymentStatus.RETURNED)
+        assertThat(world.settlements.single().status).isEqualTo(SettlementStatus.CREDITED_REVERSED)
+    }
+
+    @Test
+    fun `every step leaves both real aggregates in a terminal state, holding the ADR-0100 invariants`() {
+        val world = newWorld(FaultProfile.ADVERSARIAL)
+        repeat(25) { SepaSettlementScenario.step(world) }
+
+        assertThat(MoneyPathInvariants.sepaPaymentCompleteness.check(world)).isNull()
+        assertThat(MoneyPathInvariants.settlementCompleteness.check(world)).isNull()
+        assertThat(world.sepaPayments).hasSize(25)
+        assertThat(world.settlements).hasSize(25)
+    }
+}


### PR DESCRIPTION
## Summary

Extends the deterministic simulation harness (`openbank-simulation`, ADR-0100) to bind directly
to the real `sepa-payment` and `settlement-service` domain classes, alongside the ledger/balance/
transaction bindings it already had — closing the "full-service adoption" gap tracked in #267.

## Type of change

- [x] feat (new functionality)

## Linked issues

Closes #267

## Changes

- `openbank-simulation/build.gradle.kts`: added `implementation(project(":openbank-sepa-payment"))`
  and `implementation(project(":openbank-settlement-service"))`, the same pattern already used for
  `:openbank-ledger-service` / `:openbank-balance-service`. Both services' `domain` packages have
  zero framework imports (ADR-0002 — verified: no `jakarta`/`quarkus`/`temporal` imports), so this
  pulls only their POJOs onto the classpath, not a Quarkus runtime — no module split was needed.
- New `SepaSettlementScenario`: drives the real `SepaPayment.transitionTo`/`canTransitionTo` status
  machine (sepa-payment) and the real `Settlement` status enum (settlement-service) through a SEPA
  credit-transfer + settlement lifecycle, interleaved into the existing seeded run alongside the
  internal-transfer `PaymentScenario`. Reuses the same fault injector: a write-failure fault rejects
  the payment/settlement pair before the debit commits; a post-commit conflict reverses the credited
  settlement and returns the payment — both are genuine production-shaped failure modes, not just
  happy-path plumbing.
- Two new Layer-3 invariants in `MoneyPathInvariants`: `sepa-payment-completeness` and
  `settlement-completeness` — no SEPA payment or settlement may be left in a non-terminal status
  once a step has settled (the SEPA/settlement analogue of the existing
  `compensation-completeness` invariant for the payment saga).
- `World` now tracks `sepaPayments`/`settlements` lists; `SimulationRunner` runs
  `SepaSettlementScenario.step` every step so the new invariants are exercised across every one of
  the existing `DstSimulationTest` seed sweeps (300 seeds × 50 steps, happy-path + adversarial).
- New `SepaSettlementScenarioTest`: a focused unit test asserting the real `SepaPayment`/`Settlement`
  aggregates reach the expected terminal states — `COMPLETED`/`BOOKED` on the happy path,
  `REJECTED`/`REJECTED` under a forced write failure, `RETURNED`/`CREDITED_REVERSED` under a forced
  post-commit conflict — so the binding is proven by an assertion, not just by compiling.
- `.github/workflows/services-ci.yml`: extended the existing DST-harness dependency edge (ADR-0115)
  so a change to `openbank-sepa-payment` or `openbank-settlement-service` also adds
  `openbank-simulation` to the per-module CI fan-out, matching the existing ledger/balance/
  transaction edge.
- `docs/adr/0100-deterministic-simulation-testing.md`: updated the delivery note — "full-service
  adoption" moves from Pending to Shipped, with an honest note on what's still open (a
  Temporal-workflow-level binding and the Antithesis fidelity step are explicitly out of scope for
  this issue).

## Scope note (what's bound vs. not)

All four services named in #267 (ledger, balance, sepa-payment, settlement) are now bound to their
real domain classes via a plain Gradle project dependency — none needed a module split, since each
service already has a framework-free `domain` package. What is **not** in scope here: a binding at
the Temporal-workflow level (the harness models `SepaPayment`/`Settlement` state transitions
directly, the way it already modelled the retired `PaymentSaga`, not through the services' actual
Temporal workflow/activity code) — that's a materially larger lift (would need Temporal's test
framework wired into the deterministic scheduler) and is called out as an explicit non-goal in the
updated ADR note, not silently dropped.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — verified no
      jakarta/quarkus/temporal imports in `sepa.domain`/`settlement.domain` before depending on them.
- [x] Unit tests added/updated (`SepaSettlementScenarioTest`, four cases).
- [ ] Integration tests added/updated (if service boundary involved) — N/A, tooling module only.
- [ ] Contract tests updated (if public API changed) — N/A, no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes — ran
      `:openbank-simulation:test :openbank-simulation:ktlintCheck :openbank-simulation:detekt`
      locally (no `koverVerify` rule configured for this tooling module).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed) — N/A.
- [ ] Flyway migration added + rollback note (if DB changed) — N/A.
- [ ] Avro schema versioned backward-compatibly (if event changed) — N/A.
- [x] Docs updated (ADR-0100 delivery note).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency — only intra-repo Gradle project dependencies.
- [ ] Auth / crypto / payment code changed? — no production code touched, tooling module only.
- [ ] PII path changed? — no.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [x] None (tooling/test-harness change only; no production code path changed).

## Rollout / Rollback

- Deployment strategy: N/A — `openbank-simulation` has no `version.txt`, is never released or
  containerized (ADR-0100).
- Rollback plan: revert the PR; no production behavior changes.
- Data migration reversible: N/A.

## Reviewer notes

- `openbank-simulation` now depends on 4 of the ~34 service modules as plain Gradle project
  dependencies (ledger, balance, sepa-payment, settlement — plus transaction for `SagaState`).
  This pulls each service's compiled classes onto the simulation's classpath at build time; it does
  not run any of those services. `services-ci.yml`'s dependency edge keeps CI honest about this.
- The SEPA/settlement scenario intentionally does not go through Temporal — see the "Scope note"
  above for why that's a deliberate, documented boundary rather than an oversight.
