### PR TITLE
ci(agent-review): close gitops/money-path directory-mismatch gap

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -93,6 +93,25 @@ jobs:
             [ -n "$sensitive" ] && break
           done <<< "$CHANGED"
 
+          # Money-path gitops deploy — content-based, not directory-name-based.
+          # openbank-infra/gitops/ does NOT mirror service names 1:1: several
+          # money-path services (transaction, sepa-payment, sepa-instant,
+          # domestic-payment, clearing, swift) are bundled into one shared
+          # component (components/payments/payments-services.yaml), so no
+          # per-service directory exists to pattern-match on (surfaced while
+          # reviewing PR #347, tracked as a gap in ADR-0154). Instead, scan the
+          # diff of any changed openbank-infra/gitops/** file for an `image:`
+          # line referencing a money-path service's ECR repo name.
+          if [ -z "$sensitive" ] && echo "$CHANGED" | grep -q '^openbank-infra/gitops/'; then
+            GITOPS_DIFF="$(git diff "origin/${BASE_REF}...HEAD" -- openbank-infra/gitops/)"
+            for svc in $MP; do
+              if echo "$GITOPS_DIFF" | grep -qE "image:.*${svc}:"; then
+                sensitive="money-path gitops deploy (image references ${svc})"
+                break
+              fi
+            done
+          fi
+
           if [ -n "$sensitive" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "reason=$sensitive" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

ADR-0154 flagged a known gap in the `agent-review` scope-gate: the money-path check matched source-tree paths only, not the parallel `openbank-infra/gitops/` tree, so a money-path service's gitops redeploy could bypass the directory-name heuristic entirely.

Confirmed the mismatch is structural: gitops directories are **not** 1:1 with money-path service names — `transaction`, `sepa-payment`, `sepa-instant`, `domestic-payment`, `clearing`, and `swift` are all deployed together via one shared `components/payments/payments-services.yaml`. No directory-name mapping could ever have covered all six.

## Type of change
- [x] CI / automation

## Linked issues
Closes #357

## Changes
- `.github/workflows/agent-review.yml`: add a **content-based** check — scan the diff of any changed `openbank-infra/gitops/**` file for an `image:` line referencing a money-path service's ECR repo name (sourced live from `rules.yaml`, same source as the existing directory check). Falls back to nothing changing for non-gitops or non-money-path PRs.

## Definition of Done
- [x] `actionlint` clean.
- [x] Verified against PR #347's actual merged diff (`git show bc19c15e -- openbank-infra/gitops/`) under `bash` (matches the GHA runner shell): correctly flags `money-path gitops deploy (image references openbank-ledger-service)`.
- [x] False-positive check: a synthetic diff referencing a non-money-path service (`openbank-notifications-service`) is correctly **not** flagged.
- [x] No `version.txt` bump — CI-only change.

## Security checklist
- [x] No secrets. Narrows what can be auto-approved (moves more cases into human-deferred), never widens.

## Compliance impact
None — closes a gap that could otherwise let a money-path gitops deploy bypass human review; does not touch ADR-0030's 2-approval/threat-model requirement.