### PR TITLE
docs(libs): fix ADR-0122 stale-path references found in a repo-wide audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,9 @@ repo is the single source of truth.
 
 - Rules (authoritative): `openbank-libs/governance/rules.yaml`
 - Architecture decisions: `docs/adr/` (start at 0001; governance is 0029/0030)
-- Shared runtime plumbing: `openbank-libs/src/main/kotlin/com/openbank/libs/`
-  (`web/ServiceInfoResource`, security, audit, outbox, idempotency)
+- Shared runtime plumbing (ADR-0122 domain/runtime split): pure domain logic —
+  security, audit envelope, outbox ports, idempotency store — lives in
+  `openbank-libs-domain/src/main/kotlin/com/openbank/libs/`; framework-touching
+  code — `web/ServiceInfoResource`, audit publisher, outbox dispatchers,
+  idempotency impl — lives in `openbank-libs-runtime/src/main/kotlin/com/openbank/libs/`.
 - Per-service specifics: that service's own `CLAUDE.md`.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,6 +49,8 @@
 # --- Platform / infra ---
 /openbank-infra/                        @JiRaska
 /openbank-libs/                         @JiRaska
+/openbank-libs-domain/                  @JiRaska
+/openbank-libs-runtime/                 @JiRaska
 
 # --- CI / security tooling ---
 /.github/                               @JiRaska

--- a/openbank-libs/docs/06-compliance.cs.md
+++ b/openbank-libs/docs/06-compliance.cs.md
@@ -90,9 +90,9 @@ Audit 2026-05-28 hodnotí compliance posture takto:
 Když auditor zeptá *"jak víš, že každá služba maskuje email stejně?"* odpověď je:
 
 1. Otevři [`02-architecture.md § 5. PiiMasking`](./02-architecture.md)
-2. Klikni odkaz na zdrojový kód `openbank-libs/src/main/kotlin/com/openbank/libs/security/PiiMasking.kt`
+2. Klikni odkaz na zdrojový kód `openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/PiiMasking.kt`
 3. Reviewuj 1 soubor, 80 řádků
-4. Ověř testy `openbank-libs/src/test/kotlin/com/openbank/libs/security/PiiMaskTest.kt` (15 cases)
+4. Ověř testy `openbank-libs-domain/src/test/kotlin/com/openbank/libs/security/PiiMaskTest.kt` (15 cases)
 5. Ověř že každá z 27 služeb importuje `com.openbank.libs.security.PiiMask` (grep)
 
 Bez libs by stejná otázka znamenala review 27 různých implementací s rizikem, že 3 z nich PII rotin maskují špatně.

--- a/openbank-libs/docs/06-compliance.en.md
+++ b/openbank-libs/docs/06-compliance.en.md
@@ -90,9 +90,9 @@ The 2026-05-28 audit rates the compliance posture as follows:
 When the auditor asks *"how do you know every service masks email the same way?"* the answer is:
 
 1. Open [`02-architecture.md § 5. PiiMasking`](./02-architecture.md)
-2. Click the link to the source `openbank-libs/src/main/kotlin/com/openbank/libs/security/PiiMasking.kt`
+2. Click the link to the source `openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/PiiMasking.kt`
 3. Review 1 file, 80 lines
-4. Verify tests `openbank-libs/src/test/kotlin/com/openbank/libs/security/PiiMaskTest.kt` (15 cases)
+4. Verify tests `openbank-libs-domain/src/test/kotlin/com/openbank/libs/security/PiiMaskTest.kt` (15 cases)
 5. Verify each of the 27 services imports `com.openbank.libs.security.PiiMask` (grep)
 
 Without libs, the same question would mean reviewing 27 different implementations with the risk that 3 of them mask PII incorrectly.

--- a/openbank-libs/docs/06-compliance.md
+++ b/openbank-libs/docs/06-compliance.md
@@ -90,9 +90,9 @@ Audit 2026-05-28 hodnotí compliance posture takto:
 Když auditor zeptá *"jak víš, že každá služba maskuje email stejně?"* odpověď je:
 
 1. Otevři [`02-architecture.md § 5. PiiMasking`](./02-architecture.md)
-2. Klikni odkaz na zdrojový kód `openbank-libs/src/main/kotlin/com/openbank/libs/security/PiiMasking.kt`
+2. Klikni odkaz na zdrojový kód `openbank-libs-domain/src/main/kotlin/com/openbank/libs/security/PiiMasking.kt`
 3. Reviewuj 1 soubor, 80 řádků
-4. Ověř testy `openbank-libs/src/test/kotlin/com/openbank/libs/security/PiiMaskTest.kt` (15 cases)
+4. Ověř testy `openbank-libs-domain/src/test/kotlin/com/openbank/libs/security/PiiMaskTest.kt` (15 cases)
 5. Ověř že každá z 27 služeb importuje `com.openbank.libs.security.PiiMask` (grep)
 
 Bez libs by stejná otázka znamenala review 27 různých implementací s rizikem, že 3 z nich PII rotin maskují špatně.


### PR DESCRIPTION
## Summary

Following up on the `.gitleaks.toml` stale-path fix (issue #341 / PR #342), audited the repo for other references to the pre-split `openbank-libs/src/main/kotlin/...` path left over from the ADR-0122 domain/runtime split.

## Type of change
- [x] docs

## Linked issues
Closes #360

## Changes
- **`CLAUDE.md`**: corrected the "Where things are" pointer for shared runtime plumbing to name both post-split modules and which pieces live where (verified against the actual current tree).
- **`openbank-libs/docs/06-compliance.{md,en.md,cs.md}`**: the GDPR/PCI auditor walkthrough pointed at `PiiMasking.kt`/`PiiMaskTest.kt` under the old path — both moved to `openbank-libs-domain/`. Fixed in all three locale variants.
- **`CODEOWNERS`**: added explicit entries for `/openbank-libs-domain/` and `/openbank-libs-runtime/` (siblings of `/openbank-libs/`, not subdirectories, so the old rule never matched them). Not an active gap today (the top wildcard `* @JiRaska` already covers everything under one owner) — a future-proofing correction for when area-scoped maintainers are added, per the file's own stated intent.

**Deliberately not touched:** three ADRs (0047, 0055, 0116) reference the old path in historical prose — per this repo's convention (Delivery-note addenda, not rewrites), left as-is.

## Definition of Done
- [x] Verified every replacement path exists on disk (`find` against the actual tree) before editing.
- [x] Re-ran the original stale-path grep after fixing — only the 3 intentionally-untouched ADRs remain.
- N/A for the rest — doc/config-only change, no `src/main/**` touched.

## Security checklist
- [x] No secrets. CODEOWNERS change only adds coverage, never removes it.

## Compliance impact
Positive — the auditor-facing compliance walkthrough (`06-compliance.md`) now points at a file that actually exists.