### PR TITLE
chore(gitops): auto-deploy services @ d627e0a0d9c7514f65b53f8d253c2ae5394e5386

### DIFF
--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: audit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-audit-service:sandbox-06d5f932
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-audit-service:sandbox-d627e0a0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: party-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-571cbd2e
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-d627e0a0
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit d627e0a0d9c7514f65b53f8d253c2ae5394e5386.

**Changed services:** ["openbank-party-service","openbank-audit-service"]

Each image tag was updated to `sandbox-d627e0a0d9c7514f65b53f8d253c2ae5394e5386` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.