### PR TITLE
test(party): switch dead pactbroker-gated provider test to git-pact

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
@@ -11,7 +11,7 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
-import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.party.domain.model.KycStatus
@@ -19,7 +19,6 @@ import com.openbank.party.domain.model.PartyStatus
 import com.openbank.party.domain.model.PartyType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.Instant
 import java.util.UUID
@@ -31,14 +30,24 @@ import java.util.UUID
  * [com.openbank.party.infrastructure.kafka.KafkaPartyEventPublisher] and is serialized with the
  * same Jackson modules so the contract is verified against the real envelope.
  *
- * Pacts are fetched from the Pact Broker (`@PactBroker`, configured via `pactbroker.*` system
- * properties from CI `-D`) and the result published back for `can-i-deploy`. Gated on
- * `pactbroker.url`: skipped locally, where committed `pacts/` (git-pact) stays the fallback.
+ * Reads the consumer pact from the git-pact folder (`@PactFolder`, resolved relative to this
+ * module's working directory at `../pacts` = the monorepo-root `pacts/` dir) and replays each
+ * interaction. This always runs — no broker, no gate, no CI secret required (ADR-0063 chose
+ * git-pact over a Pact Broker for exactly this reason: zero new infra dependency), matching the
+ * pattern already applied to `LedgerPactProviderVerificationTest` (openbank-ledger-service).
+ *
+ * IMPORTANT: if `PartyCreatedMessagePactConsumerTest` (openbank-account-service) changes the
+ * contract, regenerate the pact JSON (`./gradlew :openbank-account-service:test --tests
+ * "*PartyCreatedMessagePactConsumerTest*"`) and commit the updated `pacts/openbank-account-
+ * service-openbank-party-service.json` in the same PR, or this test will fail — or worse, pass
+ * against a stale contract that no longer matches what the consumer actually expects.
+ *
+ * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact file a skip, not a
+ * failure — relevant if the folder is ever emptied ahead of a broker migration.
  */
 @Provider("openbank-party-service")
-@PactBroker
+@PactFolder("../pacts")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
-@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class PartyEventPactProviderVerificationTest {
 
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())

--- a/pacts/openbank-account-service-openbank-party-service.json
+++ b/pacts/openbank-account-service-openbank-party-service.json
@@ -5,6 +5,50 @@
   "messages": [
     {
       "contents": {
+        "eventType": "KYC_STATUS_CHANGED",
+        "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "status": "ACTIVE"
+      },
+      "description": "a KYC_STATUS_CHANGED event",
+      "generators": {
+        "body": {
+          "$.partyId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.partyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.status": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "a party KYC status has changed"
+        }
+      ]
+    },
+    {
+      "contents": {
         "eventType": "PARTY_CREATED",
         "legalName": "Jane Smith",
         "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
@@ -53,6 +97,50 @@
       "providerStates": [
         {
           "name": "a party has been created"
+        }
+      ]
+    },
+    {
+      "contents": {
+        "eventType": "PARTY_UPDATED",
+        "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "status": "ACTIVE"
+      },
+      "description": "a PARTY_UPDATED event",
+      "generators": {
+        "body": {
+          "$.partyId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.partyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.status": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "a party has been updated"
         }
       ]
     }


### PR DESCRIPTION
## Summary

`PartyEventPactProviderVerificationTest` was gated on `@EnabledIfSystemProperty(named = "pactbroker.url", ...)` with no Pact Broker ever deployed, so it silently skipped in every local run **and in CI**. Same fleet-wide bug PR #348 fixed for `LedgerPactProviderVerificationTest` — this extends the fix (see audit in #370).

## Type of change
- [x] test (tests only)

## Linked issues
Refs #370

## Changes
- `PartyEventPactProviderVerificationTest.kt`: `@PactBroker` → `@PactFolder("../pacts")` (git-pact, ADR-0063), drop `@EnabledIfSystemProperty` gate. Always runs now, no broker needed.
- `pacts/openbank-account-service-openbank-party-service.json`: regenerated. **Bonus finding:** the committed file was itself stale — missing the `KYC_STATUS_CHANGED` interaction the consumer test already generates. The provider test would have silently verified an incomplete contract even after un-gating it.

## Definition of Done
- [x] `./gradlew :openbank-party-service:test --tests "*PartyEventPactProviderVerificationTest*"` — 3/3 pass (PARTY_CREATED, PARTY_UPDATED, KYC_STATUS_CHANGED), verified via JUnit XML (`tests="3" failures="0" errors="0"`), not just build-success.
- [x] `ktlintCheck` clean.
- [x] No production code touched, no `version.txt` bump (test-only, per repo convention).
- [x] Confirmed no file overlap with PR #348 (different provider test files entirely).

## Security checklist
- [x] No secrets. Test-only change.

## Compliance impact
None — party-service is not a money-path service.