### PR TITLE
ci(auto-deploy): stop full 37-service rebuild on openbank-libs docs-only changes

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -27,10 +27,16 @@ on:
     branches: [main]
     paths:
       - "openbank-*/src/main/**"
-      - "openbank-libs/**"
-      # Governance catalogs are data for CI checks + admin-ui, not a compile
-      # input — an ADR/control edit must not trigger a 33-image fleet rebuild.
-      - "!openbank-libs/governance/**"
+      # openbank-libs/src/main no longer holds compiled code (ADR-0122 moved it to
+      # openbank-libs-domain / openbank-libs-runtime, both already covered by the
+      # openbank-*/src/main/** glob above) — only its build file and Gradle wrapper
+      # still affect the build. A bare "openbank-libs/**" glob also matches
+      # openbank-libs/docs/** and openbank-libs/governance/**, neither a compile
+      # input, so it silently triggered a 37-service rebuild on docs-only changes.
+      - "openbank-libs/build.gradle.kts"
+      - "openbank-libs/gradle/**"
+      - "openbank-libs-domain/build.gradle.kts"
+      - "openbank-libs-runtime/build.gradle.kts"
       - "build-logic/**"
   # Manual re-trigger: rebuild + push + gitops-PR on demand. Useful to recover
   # after a failed auto-deploy run left the gitops image tags stale, without
@@ -119,7 +125,10 @@ jobs:
           # (same footgun documented in services-ci.yml).
           CODE_FILES="$(grep -vE '^openbank-libs/governance/' <<< "$CHANGED_FILES" || true)"
           SHARED_CHANGED=0
-          grep -qE '^(openbank-libs|build-logic|gradle/|settings\.gradle\.kts|openbank-libs/gradle/)' <<< "$CODE_FILES" && SHARED_CHANGED=1 || true
+          # Precise per-module match (src/main + build file), not a bare "openbank-libs"
+          # prefix — that also matched openbank-libs/docs/** (non-compiled) and silently
+          # triggered a 37-service rebuild on doc-only changes (issue #375).
+          grep -qE '^(openbank-libs/(src/main|build\.gradle\.kts|gradle/)|openbank-libs-domain/(src/main|build\.gradle\.kts)|openbank-libs-runtime/(src/main|build\.gradle\.kts)|build-logic|gradle/|settings\.gradle\.kts)' <<< "$CODE_FILES" && SHARED_CHANGED=1 || true
 
           if [ "$SHARED_CHANGED" = "1" ]; then
             echo "Shared dependency changed → rebuilding all services."


### PR DESCRIPTION
## Summary

Merging PR #361 (pure `openbank-libs/docs/06-compliance.*.md` doc fixes, zero code) triggered `auto-deploy.yml`, which logged `Shared dependency changed → rebuilding all services.` and kicked off a build+push for **all 37 deployable services** for a documentation-only change.

Root cause: the push trigger and the internal `SHARED_CHANGED` regex both matched on the bare prefix `openbank-libs`/`openbank-libs/**`, excluding only `governance/**`. `openbank-libs/src/main/kotlin/...` no longer exists (moved to `openbank-libs-domain`/`openbank-libs-runtime` by ADR-0122) — `openbank-libs/src/` today holds only 3 resource files, so everything else under `openbank-libs/` (`docs/`, lint baselines) still matched the glob despite not being a compile input. Same root-cause class as the `.gitleaks.toml` stale-path incident (#341).

## Type of change
- [x] fix (bug fix)
- [x] ci

## Linked issues
Closes #375

## Changes
- `on.push.paths`: replace the broad `openbank-libs/**` (+ governance exclusion) with precise positive matches on `build.gradle.kts` and the Gradle wrapper dir, for all three post-split modules. Their `src/main/**` is already covered by the existing generic `openbank-*/src/main/**` pattern.
- Internal `SHARED_CHANGED` regex: same precision fix.

## Definition of Done
- [x] `actionlint` clean (one pre-existing, unrelated warning about a self-hosted runner label actionlint doesn't recognize — present on `main` before this change too).
- [x] Verified locally: differential test against realistic paths — old regex false-matches `openbank-libs/docs/*.md`; new regex correctly excludes docs/governance/lint-baseline while still matching every legitimate shared-rebuild trigger (both split modules' `src/main`/build files, `build-logic`, `settings.gradle.kts`, an individual service's own `src/main`).
- N/A for the rest — CI-only change, no service code touched.

## Security checklist
- [x] No secrets. Narrows what triggers a fleet rebuild; does not change what triggers a legitimate one.

## Compliance impact
None — pure CI efficiency fix; no change to what gets reviewed, tested, or deployed for real code changes.