### PR TITLE
fix(ci): agent-review — same SIGPIPE anti-pattern in the JSON-extraction step

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -181,8 +181,15 @@ jobs:
           RESPONSE: ${{ steps.ghmodels.outputs.response }}
         run: |
           set -euo pipefail
-          # Extract the first {...} JSON object; tolerate stray prose.
-          JSON="$(printf '%s' "$RESPONSE" | grep -oE '\{.*\}' | head -1)"
+          # Extract the first {...} JSON object; tolerate stray prose. Same fix as the
+          # diff-truncation step (#359): write to a file first, THEN filter with
+          # head/grep -m1 — piping straight into a command that can stop reading early
+          # lets the writer get SIGPIPE (exit 141) under pipefail. max-tokens: 400 keeps
+          # $RESPONSE small enough that this hasn't been observed failing in practice,
+          # but the pattern is identical to the one that did fail on a real PR — fixed
+          # here too rather than leaving a second instance of the same footgun.
+          printf '%s' "$RESPONSE" > /tmp/response.txt
+          JSON="$(grep -oE '\{.*\}' -m1 /tmp/response.txt || true)"
           DECISION="$(printf '%s' "$JSON" | jq -r '.decision // "REQUEST_CHANGES"')"
           SUMMARY="$(printf '%s' "$JSON" | jq -r '.summary // "no summary"')"
           BODY="🤖 **Agent review (GitHub Models · gpt-4o)**


### PR DESCRIPTION
## Summary

#359 fixed a SIGPIPE bug in the diff-truncation step (`git diff | head -c 30000` dying under `pipefail` on a real PR, #356). The exact same anti-pattern survives one step later in `Submit review (GitHub Models)`: `grep -oE '\{.*\}' | head -1`. Reproduced it (460KB stress input → exit 141); not currently exploitable given `max-tokens: 400` on the model call, but it's the identical footgun in the same file — fixed for consistency and defense in depth, plus a bonus fix for a no-JSON-response crash.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #377

## Changes

- `.github/workflows/agent-review.yml` — `Submit review (GitHub Models)` step: write `$RESPONSE` to a file first (no live pipe to SIGPIPE), `grep -m1` (grep stops itself, no reliance on `head` cutting it off), `|| true` so a response with no `{...}` degrades gracefully to `REQUEST_CHANGES` instead of aborting the step under `set -e`.

Tested locally (isolated the exact shell logic, ran under `bash -euo pipefail`) against: single-line happy path, multi-line-with-prose, no-JSON-at-all, and a 460KB stress input — all exit 0 with the correct decision; the no-match case still safely falls through to `--request-changes` rather than silently approving or crashing.

## Definition of Done

- [x] `yamllint` passes; YAML re-parses.
- [x] Fix verified against 4 local test cases including a reproduction of the original failure mode.

## Security checklist

- [x] No secrets, tokens, or PII.
- [x] No new third-party dependency.
- [x] This touches the auto-approval mechanism itself — the safety property (never silently APPROVE on ambiguous/garbage model output) was explicitly tested and holds.

## Compliance impact

- [x] None (CI tooling hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)