### PR TITLE
ci(runner-image): sign + attest the ci-runner image SBOM (ADR-0030 D4 step 4)

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -65,6 +65,7 @@ jobs:
           # Digest comes straight from the buildx push metadata — no aws CLI /
           # ECR describe round-trip (jq is baked into the runner image).
           DIGEST="$(jq -r '."containerimage.digest"' /tmp/buildx-meta.json)"
+          echo "IMAGE_DIGEST_REF=${IMAGE}@${DIGEST}" >> "$GITHUB_ENV"
           {
             echo "## Runner image pushed"
             echo ""
@@ -72,3 +73,36 @@ jobs:
             echo ""
             echo "Pin this digest in \`local.runner_image\` (arc-runners.tf) and \`tofu apply\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Supply-chain provenance for the runner image itself (ADR-0030 D4 step 4, issue #310).
+      # The kyverno attestation policy (verify-openbank-image-sbom-attestation, Audit) matches
+      # openbank-* — the ci-runner image was the last fleet image with neither a signature nor
+      # a CycloneDX SBOM attestation, so the Audit PolicyReport could never reach 0 fail and the
+      # Enforce graduation stayed blocked. Same KMS key + trivy pattern as auto-deploy.yml.
+      # Non-fatal (continue-on-error): a cosign/trivy hiccup must never block a runner rebuild;
+      # the PolicyReport surfaces a missed attestation on the next audit pass anyway.
+      - name: Sign + attest runner image SBOM (cosign + KMS)
+        timeout-minutes: 15
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          COSIGN_KEY="awskms:///alias/openbank-cosign-signing"
+          COSIGN_VERSION="v2.4.3"
+          arch="$(uname -m)"; case "$arch" in aarch64) arch=arm64 ;; x86_64) arch=amd64 ;; esac
+          bin="$(command -v cosign || true)"
+          if ! { [ -n "$bin" ] && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; }; then
+            bin="${RUNNER_TEMP}/cosign2"
+            curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${arch}"
+            chmod +x "$bin"
+          fi
+          echo "==> cosign sign ${IMAGE_DIGEST_REF}"
+          COSIGN_YES=true "$bin" sign --key "$COSIGN_KEY" "$IMAGE_DIGEST_REF" \
+            || echo "::warning::cosign sign failed"
+          sbom="${RUNNER_TEMP}/ci-runner.cdx.json"
+          if trivy image --format cyclonedx --output "$sbom" "$IMAGE_DIGEST_REF" 2>/dev/null; then
+            echo "==> cosign attest (cyclonedx) ${IMAGE_DIGEST_REF}"
+            COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type cyclonedx --predicate "$sbom" "$IMAGE_DIGEST_REF" \
+              || echo "::warning::cosign attest failed"
+          else
+            echo "::warning::trivy image SBOM generation failed — attestation skipped"
+          fi

--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -597,6 +597,17 @@ resource "aws_iam_role_policy" "arc_deploy_ecr" {
   policy = data.aws_iam_policy_document.arc_deploy_ecr.json
 }
 
+# The openbank-deploy runner also rebuilds AND signs/attests the ci-runner image
+# itself (runner-image.yml, ADR-0030 D4 step 4 / issue #310) — it needs the same
+# cosign KMS grant as the build runner (reuses arc_build_cosign's policy document,
+# scoped to the single signing key).
+resource "aws_iam_role_policy" "arc_deploy_cosign" {
+  count  = var.arc_runner_enabled ? 1 : 0
+  name   = "cosign-kms-sign"
+  role   = aws_iam_role.arc_deploy[0].id
+  policy = data.aws_iam_policy_document.arc_build_cosign.json
+}
+
 # ---------------------------------------------------------------------------
 # Runner namespace + the deploy pod ServiceAccount (IRSA-annotated).
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The SBOM-attestation Audit policy (#311) reports exactly **6 failing pods**: 5× `openbank-ci-runner` (arc-runners) + 1× stale copilot image. The runner image ships with no signature/attestation, so the Audit report can never reach 0 fail and the Enforce graduation stays blocked. This PR closes the runner-image gap; the copilot pod was already redeployed via `auto-deploy.yml` dispatch (fresh attested image).

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #310

## Changes

- **`runner-image.yml`**: after buildx push — `cosign sign` + trivy CycloneDX SBOM + `cosign attest` against the pushed digest. Exact `auto-deploy.yml` pattern (same KMS alias, cosign v2.4.3 pin, `continue-on-error` so a provenance hiccup never blocks a runner rebuild).
- **`arc-runners.tf`**: `cosign-kms-sign` role policy for the `openbank-deploy` runner role (runner-image.yml runs there via ambient IRSA; only the build runner had the grant). Reuses the existing `arc_build_cosign` policy document — scoped to the single signing key.

## Rollout sequence (after merge)

1. `platform-tofu` applies the IAM grant
2. `gh workflow run runner-image.yml` → attested digest pushed
3. ARC runner pods roll to the new digest → `kubectl get polr -A` = 0 fail for the attestation policy
4. Enforce flip after the clean observation window (**not** this PR — provenance.enforce_criteria #4)

## Definition of Done

- [x] `tofu fmt -check` clean; workflow YAML parses (actionlint: only the pre-existing self-hosted label warning)
- [x] No service code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)