### PR TITLE
ci(governance): diff-aware threat-model gate for money-path trust-boundary changes (ADR-0030 D2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,22 @@ jobs:
       - name: threat-model coverage (ADR-0030 D2)
         run: python3 openbank-infra/scripts/check-threat-models.py
 
+      # ADR-0030 D2, diff-aware half (issue #265): when a PR moves a money-path
+      # service's TRUST BOUNDARIES — inbound REST surface, a new outbound
+      # HTTP/gRPC edge, authn/listener/transport keys in application.yaml, or
+      # its NetworkPolicy / Deployment/Rollout in gitops — the same diff must
+      # update docs/threat-models/<service>.md. ADVISORY until rules.yaml
+      # trust_boundary_diff_change flips to enforced (target 2026-09-15,
+      # ADR-0144) — findings are ::warning annotations; add --enforce to flip.
+      # PR-only: the gate diffs 3-dot against the PR base.
+      - name: "threat-model updated on trust-boundary change (ADR-0030 D2, advisory)"
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --depth=1 origin "${PR_BASE_SHA}" 2>/dev/null || true
+          python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_BASE_SHA}"
+
       # CLAUDE.md rule 3 / ADR-0029: a module is a released component iff it has
       # a version.txt, and must be registered in release-please-config.json AND
       # .release-please-manifest.json. stdlib-only gate; catches a new service

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "1d244119447cffc2"
+    openbank.tech/policy-checksum: "57cbfd22fb44016a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -993,6 +993,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1d244119447cffc2"
+        openbank.tech/policy-checksum: "57cbfd22fb44016a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "2602d9cef2f2d216"
+    openbank.tech/policy-checksum: "39ec68c2b0b33019"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1037,6 +1037,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2602d9cef2f2d216"
+        openbank.tech/policy-checksum: "39ec68c2b0b33019"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "91a7f1b9ce710824"
+    openbank.tech/policy-checksum: "9a15658f773bd1e2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -942,6 +942,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "91a7f1b9ce710824"
+        openbank.tech/policy-checksum: "9a15658f773bd1e2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "25c2f55561e417e3"
+    openbank.tech/policy-checksum: "a1b0e9bd79a588a5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -960,6 +960,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "25c2f55561e417e3"
+        openbank.tech/policy-checksum: "a1b0e9bd79a588a5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "91314d525fb75006"
+    openbank.tech/policy-checksum: "c007641bb2c3979f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1025,6 +1025,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "91314d525fb75006"
+        openbank.tech/policy-checksum: "c007641bb2c3979f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
+    openbank.tech/policy-checksum: "6910d0b913040b70"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -590,6 +590,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
+        openbank.tech/policy-checksum: "6910d0b913040b70"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "7a715a6a6bf2b480"
+    openbank.tech/policy-checksum: "04a341fa902af71a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -953,6 +953,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7a715a6a6bf2b480"
+        openbank.tech/policy-checksum: "04a341fa902af71a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "713d6f0fb119e372"
+    openbank.tech/policy-checksum: "cbea8fe008052429"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -990,6 +990,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "713d6f0fb119e372"
+        openbank.tech/policy-checksum: "cbea8fe008052429"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "843e8a6581f268b5"
+    openbank.tech/policy-checksum: "4cf7944a32d8a76c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1049,6 +1049,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "843e8a6581f268b5"
+        openbank.tech/policy-checksum: "4cf7944a32d8a76c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "724d123298c17601"
+    openbank.tech/policy-checksum: "142ddf605fe0eba7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -996,6 +996,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "724d123298c17601"
+        openbank.tech/policy-checksum: "142ddf605fe0eba7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
+    openbank.tech/policy-checksum: "6910d0b913040b70"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -590,6 +590,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
+        openbank.tech/policy-checksum: "6910d0b913040b70"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b329ad74ef45c654"
+    openbank.tech/policy-checksum: "0ab9e7e93097d70e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -996,6 +996,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2413697dda1b16ff"
+    openbank.tech/policy-checksum: "0e31ccdb88e839a7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -981,6 +981,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "605a9eb03ceab393" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "28a32310acd93023" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "58c843c78ee78c17"
+        openbank.tech/policy-checksum: "e2c24e7c374848a5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "2413697dda1b16ff" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "0e31ccdb88e839a7" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ca6010977cb61fd"
+        openbank.tech/policy-checksum: "89cb08cbfd7d7fe2"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b329ad74ef45c654" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "0ab9e7e93097d70e" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1891,7 +1891,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "2435d225963ab59c" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "5c7d0402987808e2" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2281,7 +2281,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e9471b36a0ab88f8"
+        openbank.tech/policy-checksum: "b47ecf0fda6eb341"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3ca6010977cb61fd"
+    openbank.tech/policy-checksum: "89cb08cbfd7d7fe2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -954,6 +954,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "58c843c78ee78c17"
+    openbank.tech/policy-checksum: "e2c24e7c374848a5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -975,6 +975,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2435d225963ab59c"
+    openbank.tech/policy-checksum: "5c7d0402987808e2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -955,6 +955,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e9471b36a0ab88f8"
+    openbank.tech/policy-checksum: "b47ecf0fda6eb341"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -958,6 +958,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "605a9eb03ceab393"
+    openbank.tech/policy-checksum: "28a32310acd93023"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1011,6 +1011,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "4ffab805c9a8161d"
+    openbank.tech/policy-checksum: "ab5ac624edbc9d9b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -964,6 +964,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4ffab805c9a8161d"
+        openbank.tech/policy-checksum: "ab5ac624edbc9d9b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "26dea58b6d9f0279"
+    openbank.tech/policy-checksum: "6e7c0911533cdad2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -978,6 +978,25 @@ data:
           - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
         gate: threat-model
         enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+      trust_boundary_diff_change:
+        # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+        # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+        # service's trust boundaries move: new/changed inbound REST endpoints
+        # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+        # client-flavoured adapters), authn/listener/transport keys
+        # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+        # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+        detect: ["money-path <service> trust-boundary paths in the PR diff"]
+        require:
+          - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+        gate: threat-model-diff
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+        # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+        # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+        # pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
       new_service_with_outbox:
         # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
         # set openbank.outbox.dispatch-enabled=true silently never dispatches events —

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "26dea58b6d9f0279"
+        openbank.tech/policy-checksum: "6e7c0911533cdad2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/scripts/check-threat-model-diff.py
+++ b/openbank-infra/scripts/check-threat-model-diff.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Diff-aware threat-model gate for money-path services (ADR-0030 D2, issue #265).
+
+The coverage gate (check-threat-models.py) proves a threat model EXISTS; this one
+proves it is UPDATED when a PR moves a money-path service's TRUST BOUNDARIES. A
+trust-boundary change for service S is any changed file matching:
+
+  - S/src/main/**/infrastructure/rest/**           (new/changed inbound endpoints)
+  - S/src/main/**/infrastructure/client/**          (new/changed outbound edge)
+  - S/src/main/**/adapter{,s}/**.kt|.java with an HTTP/gRPC client hint in the file
+  - S/src/main/resources/application.yaml with (oidc|auth|authz|opa|http|kafka|
+    security) keys in the diff hunks                 (listeners / authn / transport)
+  - openbank-infra/gitops/components/**: S's network-policies.yaml or its
+    Deployment/Rollout manifest                      (new ingress/egress)
+
+When any of those change for a money-path service (rules.yaml:
+money_path_services, parsed by check-threat-models.py's parser) and
+docs/threat-models/<service>.md is NOT part of the same diff, emit a finding.
+
+stdlib-only; shells out to `git` unless --changed-files supplies the list.
+
+Usage:
+    check-threat-model-diff.py [--base <ref>] [--changed-files <path>] [--enforce]
+
+    --base <ref>            PR base; changed files = `git diff --name-only
+                            <ref>...HEAD` (3-dot = the actual squash delta).
+                            Default: origin/main.
+    --changed-files <path>  newline-separated changed-file list — bypasses git
+                            entirely (testable with a synthetic diff).
+
+Modes (ADR-0144 gate graduation):
+    default    advisory — findings are ::warning annotations, exit 0
+    --enforce  findings are ::error annotations, exit 1
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+REST_RE = re.compile(r"^(openbank-[^/]+)/src/main/.*/infrastructure/rest/")
+CLIENT_RE = re.compile(r"^(openbank-[^/]+)/src/main/.*/infrastructure/client/")
+ADAPTER_RE = re.compile(r"^(openbank-[^/]+)/src/main/.*/adapters?/.*\.(?:kt|java)$")
+APP_YAML_RE = re.compile(r"^(openbank-[^/]+)/src/main/resources/application\.yaml$")
+GITOPS_RE = re.compile(r"^openbank-infra/gitops/components/([^/]+)/([^/]+\.ya?ml)$")
+
+# An adapter file is an outbound trust edge only if it actually speaks HTTP/gRPC —
+# a persistence adapter is not one (same hint style as check-api-contract.py).
+CLIENT_HINT = re.compile(r"@RegisterRestClient|RestClient\b|HttpClient|WebTarget|[Gg]rpc")
+
+# application.yaml keys that move a trust boundary: authn/authz, policy engine,
+# HTTP listeners, Kafka transport, security.* — matched against diff hunk lines.
+SECURITY_KEY = re.compile(r"\b(oidc|authz?|opa|http|kafka|security)[\w.-]*\s*:", re.IGNORECASE)
+
+# Only these manifest kinds define ingress/egress or the runtime env of a service.
+GITOPS_KIND = re.compile(r"^kind:\s*(NetworkPolicy|Deployment|Rollout)\s*$", re.MULTILINE)
+
+
+def load_money_path_services() -> list[str]:
+    """Reuse check-threat-models.py's rules.yaml parser — one parser, one truth."""
+    path = pathlib.Path(__file__).resolve().parent / "check-threat-models.py"
+    spec = importlib.util.spec_from_file_location("check_threat_models", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.money_path_services()
+
+
+def changed_files(base: str) -> list[str]:
+    res = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],  # 3-dot: the squash delta
+        capture_output=True, text=True, cwd=REPO,
+    )
+    if res.returncode != 0 and "no merge base" in res.stderr:
+        # Shallow CI checkout (fetch-depth 1 + a depth-1 fetch of the PR base sha) has
+        # no merge base. In PR CI, HEAD is the fresh refs/pull/N/merge commit, so a
+        # 2-dot diff against the base sha IS the squash delta there (same reason
+        # check-api-contract.py diffs 2-dot) — fall back to it.
+        res = subprocess.run(
+            ["git", "diff", "--name-only", base, "HEAD"],
+            capture_output=True, text=True, cwd=REPO,
+        )
+    if res.returncode != 0:
+        print(f"::error::threat-model-diff gate: git diff against {base} failed: {res.stderr.strip()}")
+        sys.exit(1)
+    return [line for line in res.stdout.splitlines() if line.strip()]
+
+
+def gitops_tokens(service: str) -> set[str]:
+    """Name tokens that identify S in gitops paths (component dir or filename).
+
+    openbank-ledger-service -> {ledger-service, ledger}; openbank-sepa-payment ->
+    {sepa-payment, sepa, payment} (the shared `payments` component hosts it).
+    """
+    short = service.removeprefix("openbank-")
+    toks = {short}
+    if short.endswith("-service"):
+        toks.add(short[: -len("-service")])
+    toks.update(t for t in short.split("-") if t != "service" and len(t) > 2)
+    return toks
+
+
+def token_in(tokens: set[str], text: str) -> bool:
+    return any(
+        re.search(rf"(^|[^a-z0-9]){re.escape(t)}s?($|[^a-z0-9])", text) for t in tokens
+    )
+
+
+def yaml_security_keys_changed(base: str | None, rel: str) -> bool:
+    """True if the application.yaml diff touches a trust-boundary key.
+
+    Without git (--changed-files synthetic list) the hunks cannot be inspected —
+    be conservative and treat the touch as boundary-relevant (advisory gate).
+    """
+    if base is None:
+        return True
+    res = subprocess.run(
+        ["git", "diff", f"{base}...HEAD", "--", rel],
+        capture_output=True, text=True, cwd=REPO,
+    )
+    if res.returncode != 0 or not res.stdout:
+        return True  # can't inspect — stay conservative
+    for line in res.stdout.splitlines():
+        if line.startswith(("+++", "---")) or line[:1] not in "+-":
+            continue
+        body = line[1:].strip()
+        if not body.startswith("#") and SECURITY_KEY.search(body):
+            return True
+    return False
+
+
+def adapter_is_client(rel: str) -> bool:
+    path = REPO / rel
+    if not path.is_file():
+        return False  # deleted / synthetic — shrinking an edge is reviewed elsewhere
+    try:
+        return bool(CLIENT_HINT.search(path.read_text(encoding="utf-8", errors="replace")))
+    except OSError:
+        return False
+
+
+def gitops_hit(service: str, comp: str, fname: str) -> str | None:
+    """Reason string if this gitops file is S's NetworkPolicy or Deployment/Rollout."""
+    tokens = gitops_tokens(service)
+    if not (token_in(tokens, comp) or token_in(tokens, fname)):
+        return None
+    rel = f"openbank-infra/gitops/components/{comp}/{fname}"
+    if fname == "network-policies.yaml":
+        return f"{rel} (ingress/egress)"
+    path = REPO / rel
+    if path.is_file():
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        if GITOPS_KIND.search(text) and token_in(tokens, text):
+            return f"{rel} (Deployment/Rollout)"
+    return None
+
+
+def boundary_reasons(service: str, changed: list[str], base: str | None) -> list[str]:
+    reasons: list[str] = []
+    for rel in changed:
+        m = REST_RE.match(rel)
+        if m and m.group(1) == service:
+            reasons.append(f"{rel} (inbound REST surface)")
+            continue
+        m = CLIENT_RE.match(rel)
+        if m and m.group(1) == service:
+            reasons.append(f"{rel} (outbound client edge)")
+            continue
+        m = ADAPTER_RE.match(rel)
+        if m and m.group(1) == service and adapter_is_client(rel):
+            reasons.append(f"{rel} (HTTP/gRPC adapter)")
+            continue
+        m = APP_YAML_RE.match(rel)
+        if m and m.group(1) == service and yaml_security_keys_changed(base, rel):
+            reasons.append(f"{rel} (authn/listener/transport keys)")
+            continue
+        m = GITOPS_RE.match(rel)
+        if m:
+            hit = gitops_hit(service, m.group(1), m.group(2))
+            if hit:
+                reasons.append(hit)
+    return reasons
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="origin/main", help="PR base ref/sha (3-dot diff)")
+    ap.add_argument("--changed-files", help="file with a newline-separated changed-file list (skips git)")
+    ap.add_argument("--enforce", action="store_true")
+    args = ap.parse_args()
+
+    if args.changed_files:
+        changed = [
+            line.strip()
+            for line in pathlib.Path(args.changed_files).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        base = None
+    else:
+        changed = changed_files(args.base)
+        base = args.base
+
+    level = "error" if args.enforce else "warning"
+    services = load_money_path_services()
+    changed_set = set(changed)
+    findings: list[tuple[str, list[str]]] = []
+
+    for service in services:
+        reasons = boundary_reasons(service, changed, base)
+        if not reasons:
+            continue
+        tm_rel = f"docs/threat-models/{service}.md"
+        if tm_rel in changed_set:
+            print(f"threat-model-diff gate: {service}: trust-boundary change WITH a {tm_rel} update — OK.")
+        else:
+            findings.append((service, reasons))
+
+    for service, reasons in findings:
+        print(
+            f"::{level}::threat-model-diff gate: {service}: trust-boundary change without a "
+            f"docs/threat-models/{service}.md update — {'; '.join(reasons)} (ADR-0030 D2)"
+        )
+
+    if findings and args.enforce:
+        return 1
+    if findings:
+        print(
+            f"threat-model-diff gate: {len(findings)} finding(s) — advisory until the ADR-0144 "
+            "target_enforce_date; will become a hard gate."
+        )
+    else:
+        print("threat-model-diff gate: no money-path trust-boundary change without a threat-model update.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -175,6 +175,25 @@ change_requirements:
       - "docs/threat-models/<service>.md present/updated"   # ADR-0030 D2
     gate: threat-model
     enforced: enforce                   # check-threat-models.py live in CI; all 13 money-path services have valid threat models
+  trust_boundary_diff_change:
+    # ADR-0030 D2, diff-aware half (issue #265). The coverage gate above proves a threat
+    # model EXISTS; this one proves it is UPDATED in the same PR when a money-path
+    # service's trust boundaries move: new/changed inbound REST endpoints
+    # (infrastructure/rest/**), a new outbound HTTP/gRPC edge (infrastructure/client/**,
+    # client-flavoured adapters), authn/listener/transport keys
+    # (oidc|auth|authz|opa|http|kafka|security) in application.yaml, or the service's
+    # NetworkPolicy / Deployment/Rollout manifest under openbank-infra/gitops/components/.
+    detect: ["money-path <service> trust-boundary paths in the PR diff"]
+    require:
+      - "docs/threat-models/<service>.md updated in the SAME PR"   # ADR-0030 D2
+    gate: threat-model-diff
+    enforced: advisory
+    target_enforce_date: "2026-09-15"   # ADR-0144
+    # CI producer is LIVE (advisory): openbank-infra/scripts/check-threat-model-diff.py runs
+    # in the "Validate manifests" job on every PR, right after the coverage gate — diff-scoped
+    # (3-dot against the PR base). Findings are ::warning annotations. Flip to enforced =
+    # pass --enforce to the script in ci.yml (one-line change).
+    ci_producer: "openbank-infra/scripts/check-threat-model-diff.py"
   new_service_with_outbox:
     # A service that extends AbstractOutboxEntity / uses OutboxDispatcher but does NOT
     # set openbank.outbox.dispatch-enabled=true silently never dispatches events —


### PR DESCRIPTION
## Summary

Adds the diff-aware half of the ADR-0030 D2 threat-model gate (issue #265): the existing coverage gate proves a threat model *exists*; the new `check-threat-model-diff.py` proves it is *updated* in the same PR whenever a money-path service's trust boundaries move. Advisory-first per ADR-0144, `--enforce`-ready for graduation on 2026-09-15.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Refs #265

## Changes

- New `openbank-infra/scripts/check-threat-model-diff.py` (stdlib-only): flags a money-path service whose PR diff (3-dot vs the PR base) touches a trust boundary without touching `docs/threat-models/<service>.md`. Detection rules:
  - `S/src/main/**/infrastructure/rest/**` — inbound REST surface
  - `S/src/main/**/infrastructure/client/**` — outbound client edge
  - `S/src/main/**/adapter{,s}/**.kt|.java` carrying an HTTP/gRPC client hint
  - `S/src/main/resources/application.yaml` with `(oidc|auth|authz|opa|http|kafka|security)` keys in the diff hunks
  - `openbank-infra/gitops/components/**`: S's `network-policies.yaml` or its Deployment/Rollout manifest
- Advisory mode by default (`::warning` + exit 0), `--enforce` flips to `::error` + exit 1 (same pattern as `check-api-contract.py`); `--changed-files <file>` makes it testable without git.
- Reuses `check-threat-models.py`'s `money_path_services()` parser via importlib, and applies the same trailing-`# comment` parser fix as PR #380 — `openbank-fraud-service` / `openbank-billing-service` were silently dropped from the coverage gate; all 15 money-path services now pass it (no regression).
- `rules.yaml`: new `trust_boundary_diff_change` gate (`enforced: advisory`, `target_enforce_date: "2026-09-15"`, `ci_producer` set) — passes `check-gate-graduation.sh` (13 advisory rules, all dated).
- `ci.yml` Validate job: new PR-only step right after "threat-model coverage (ADR-0030 D2)", no `--enforce`.
- Regenerated the service OPA bundles (pid/copilot/customer-edge/notifications) that embed `rules.yaml`, with pod-roll checksums stamped; `build-bundle.sh` passes.

### Test-run evidence (synthetic `--changed-files` lists)

```
$ check-threat-model-diff.py --changed-files a.txt      # ledger .../infrastructure/rest/X.kt only
::warning::threat-model-diff gate: openbank-ledger-service: trust-boundary change without a
docs/threat-models/openbank-ledger-service.md update — ...infrastructure/rest/LedgerAdminResource.kt
(inbound REST surface) (ADR-0030 D2)                       exit=0 (advisory)

$ check-threat-model-diff.py --changed-files b.txt      # same + docs/threat-models/openbank-ledger-service.md
threat-model-diff gate: openbank-ledger-service: trust-boundary change WITH a ... update — OK.   exit=0

$ check-threat-model-diff.py --changed-files a.txt --enforce    # exit=1, ::error
$ check-threat-model-diff.py --changed-files c.txt      # party-service rest change (not money-path) → clean
$ check-threat-model-diff.py --changed-files d.txt      # ledger network-policies.yaml + sca application.yaml → 2 warnings
$ check-threat-model-diff.py --base origin/main         # this branch's real diff → clean, exit=0
```

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — N/A, CI tooling only
- [x] Unit tests added/updated. — synthetic-diff invocations above; `--changed-files` exists for testability
- [x] `python3 -m py_compile` passes on both scripts; coverage gate re-run green (15/15)
- [x] No new lint warnings (yamllint findings on rules.yaml are pre-existing line-length elsewhere in the file).
- [x] Docs updated (rules.yaml is the authoritative rule registry).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new third-party dependency (stdlib-only Python).

## Compliance impact

- [x] DORA

Strengthens the ADR-0030 D2 threat-modeling control: trust-boundary drift in money-path services now surfaces on every PR (advisory), with a dated graduation to a hard gate.

## Rollout / Rollback

- Deployment strategy: CI-only change; advisory (`::warning`, exit 0) so no PR can be blocked by it before graduation.
- Rollback plan: revert the commit (removes the step + script + rules.yaml entry; OPA bundles regenerate).
- Data migration reversible: N/A

## Reviewer notes

- The gitops→service attribution is a best-effort token match (component dir or filename + manifest kind) — deliberate: the gate is advisory, and over-attribution only ever produces a warning.
- In `--changed-files` mode `application.yaml` hunks cannot be inspected, so a touch is treated conservatively as boundary-relevant; in git mode only diff lines with the security-key regex count.
- PR #380 (still open) carries the identical one-line parser fix; whichever merges second squashes cleanly (identical hunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
