### PR TITLE
security(libs): fix four-eyes signal wiring, scope naming, and verb vocabulary

### DIFF
--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "1b80a815c8e4459b"
+    openbank.tech/policy-checksum: "04d07f3bef455f3a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -53,6 +53,7 @@ data:
     	"allow": true,
     	"reason": reason,
     	"policy_version": policy_version,
+    	"attributes": response_attributes,
     } if {
     	count(allowed_reasons) > 0
 
@@ -67,6 +68,17 @@ data:
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
     	reason := min(allowed_reasons)
     }
+
+    # Surfaced on the allow object so OpaSidecarPolicyDecisionPoint (which reads
+    # `result.attributes` generically) actually delivers it to AuthzDecision.attributes.
+    # A fleet audit (issue #395) found four_eyes_required was computed below but never
+    # reached this object — "attributes" was simply absent from the allow head — so no
+    # caller anywhere could ever have acted on it, independent of any money_path_scopes
+    # naming mismatch. Sparse on purpose: omitted (not `false`) when not required, matching
+    # this file's existing audit-attribute style (cf. default policy_version above).
+    default response_attributes := {}
+
+    response_attributes := {"four_eyes_required": true} if four_eyes_required
 
     # policy_version is audit METADATA, never a gate. Resolve it via a defaulted rule so
     # a bundle that omits openbank.bundle.version cannot turn a legitimate allow into an
@@ -172,10 +184,27 @@ data:
     # Money-path service scopes, normalised to the action namespace: money_path_services in
     # rules.yaml uses the module name (openbank-ledger-service) but an action prefix is the
     # commit scope (ledger). Strip the `openbank-` prefix and a trailing `-service` so the
-    # two align (e.g. openbank-ledger-service -> ledger; openbank-sepa-payment -> sepa-payment).
+    # two align (e.g. openbank-ledger-service -> ledger).
+    #
+    # Five services' real @Authorize action prefix does NOT match that derived name (a
+    # fleet audit, issue #395, found this silently disabled four-eyes for every one of
+    # them): sepa-payment -> sepaPayment, sepa-instant -> sctInstPayment, domestic-payment
+    # -> domesticPayment, clearing -> clearingBatch, sca -> device / scaChallenge. Two of
+    # those aren't even a casing variant of the derived name, so this uses an explicit
+    # override table (rules.yaml: money_path_action_prefixes) rather than a camelCase
+    # guess — self-documenting, and rest_test.rego pins it so a future rename can't
+    # silently drift back out of sync.
     money_path_scopes contains scope if {
     	some svc in data.rules.money_path_services
-    	scope := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	not data.rules.money_path_action_prefixes[derived]
+    	scope := derived
+    }
+
+    money_path_scopes contains scope if {
+    	some svc in data.rules.money_path_services
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	some scope in data.rules.money_path_action_prefixes[derived]
     }
 
     four_eyes_required if {
@@ -1077,12 +1106,37 @@ data:
       self_merge_forbidden_on: [CODEOWNERS_protected]
 
     # ---------------------------------------------------------------------------------------
+    # Money-path action-prefix overrides (issue #395). rest.rego derives a scope from each
+    # money_path_services entry by stripping `openbank-` and a trailing `-service`
+    # (openbank-ledger-service -> ledger) and matches it against the @Authorize action
+    # prefix (the part before the first `.`). A fleet audit found 5 services whose real
+    # prefix does not equal that derived name — two (clearing, sca) aren't even a casing
+    # variant of it — which silently disabled four_eyes_required for every one of them.
+    # List the REAL @Authorize prefix(es) here for any service where it differs; rest.rego
+    # uses this instead of the derived name for that service, and rest_test.rego pins each
+    # entry against the service's actual source so a rename can't silently drift back out
+    # of sync. Only list a service here when it diverges — everything else keeps using the
+    # derived name.
+    money_path_action_prefixes:
+      sepa-payment: [sepaPayment]
+      sepa-instant: [sctInstPayment]
+      domestic-payment: [domesticPayment]
+      clearing: [clearingBatch]
+      sca: [device, scaChallenge]
+
+    # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads
     # data.rules.four_eyes.verbs). A money-path action whose verb is listed here is flagged
     # `four_eyes_required` so the handler demands a second approver (maker-checker). This is
     # an AUGMENTATION flag, not an allow/deny on its own. NOTE: rest.rego normalises the
-    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`)
-    # to the action scope namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`,
+    # or applies the money_path_action_prefixes override above) to the action scope
+    # namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    #
+    # transfer/post/reverse/freeze/release/flip were the originally-designed vocabulary, but
+    # a fleet audit (issue #395) found real @Authorize verbs rarely spell it that way — only
+    # ledger.reverse, transaction.reverse and account.freeze literally matched. The verbs
+    # below were added to cover the real money-moving action each service actually emits.
     four_eyes:
       verbs:
         - transfer                          # outbound value movement (sepa/domestic/swift/instant)
@@ -1091,6 +1145,13 @@ data:
         - freeze                            # account freeze/unfreeze
         - release                           # release a held payment
         - flip                              # money-path feature-flag flip (ADR-0067 / issue #419)
+        - transitionStatus                  # sepa-payment / domestic-payment lifecycle transition (issue #395)
+        - recall                            # sepa-instant: recall a SETTLED payment (issue #395)
+        - settle                            # clearing: settle a clearing batch (issue #395)
+        - disburse                          # lending: loan payout (issue #395)
+        - send                              # swift: send an outbound wire message (issue #395)
+        - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
+        - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b80a815c8e4459b"
+        openbank.tech/policy-checksum: "04d07f3bef455f3a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
+    openbank.tech/policy-checksum: "64bf88316f5fce9b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -54,6 +54,7 @@ data:
     	"allow": true,
     	"reason": reason,
     	"policy_version": policy_version,
+    	"attributes": response_attributes,
     } if {
     	count(allowed_reasons) > 0
 
@@ -68,6 +69,17 @@ data:
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
     	reason := min(allowed_reasons)
     }
+
+    # Surfaced on the allow object so OpaSidecarPolicyDecisionPoint (which reads
+    # `result.attributes` generically) actually delivers it to AuthzDecision.attributes.
+    # A fleet audit (issue #395) found four_eyes_required was computed below but never
+    # reached this object — "attributes" was simply absent from the allow head — so no
+    # caller anywhere could ever have acted on it, independent of any money_path_scopes
+    # naming mismatch. Sparse on purpose: omitted (not `false`) when not required, matching
+    # this file's existing audit-attribute style (cf. default policy_version above).
+    default response_attributes := {}
+
+    response_attributes := {"four_eyes_required": true} if four_eyes_required
 
     # policy_version is audit METADATA, never a gate. Resolve it via a defaulted rule so
     # a bundle that omits openbank.bundle.version cannot turn a legitimate allow into an
@@ -173,10 +185,27 @@ data:
     # Money-path service scopes, normalised to the action namespace: money_path_services in
     # rules.yaml uses the module name (openbank-ledger-service) but an action prefix is the
     # commit scope (ledger). Strip the `openbank-` prefix and a trailing `-service` so the
-    # two align (e.g. openbank-ledger-service -> ledger; openbank-sepa-payment -> sepa-payment).
+    # two align (e.g. openbank-ledger-service -> ledger).
+    #
+    # Five services' real @Authorize action prefix does NOT match that derived name (a
+    # fleet audit, issue #395, found this silently disabled four-eyes for every one of
+    # them): sepa-payment -> sepaPayment, sepa-instant -> sctInstPayment, domestic-payment
+    # -> domesticPayment, clearing -> clearingBatch, sca -> device / scaChallenge. Two of
+    # those aren't even a casing variant of the derived name, so this uses an explicit
+    # override table (rules.yaml: money_path_action_prefixes) rather than a camelCase
+    # guess — self-documenting, and rest_test.rego pins it so a future rename can't
+    # silently drift back out of sync.
     money_path_scopes contains scope if {
     	some svc in data.rules.money_path_services
-    	scope := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	not data.rules.money_path_action_prefixes[derived]
+    	scope := derived
+    }
+
+    money_path_scopes contains scope if {
+    	some svc in data.rules.money_path_services
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	some scope in data.rules.money_path_action_prefixes[derived]
     }
 
     four_eyes_required if {
@@ -642,12 +671,37 @@ data:
       self_merge_forbidden_on: [CODEOWNERS_protected]
 
     # ---------------------------------------------------------------------------------------
+    # Money-path action-prefix overrides (issue #395). rest.rego derives a scope from each
+    # money_path_services entry by stripping `openbank-` and a trailing `-service`
+    # (openbank-ledger-service -> ledger) and matches it against the @Authorize action
+    # prefix (the part before the first `.`). A fleet audit found 5 services whose real
+    # prefix does not equal that derived name — two (clearing, sca) aren't even a casing
+    # variant of it — which silently disabled four_eyes_required for every one of them.
+    # List the REAL @Authorize prefix(es) here for any service where it differs; rest.rego
+    # uses this instead of the derived name for that service, and rest_test.rego pins each
+    # entry against the service's actual source so a rename can't silently drift back out
+    # of sync. Only list a service here when it diverges — everything else keeps using the
+    # derived name.
+    money_path_action_prefixes:
+      sepa-payment: [sepaPayment]
+      sepa-instant: [sctInstPayment]
+      domestic-payment: [domesticPayment]
+      clearing: [clearingBatch]
+      sca: [device, scaChallenge]
+
+    # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads
     # data.rules.four_eyes.verbs). A money-path action whose verb is listed here is flagged
     # `four_eyes_required` so the handler demands a second approver (maker-checker). This is
     # an AUGMENTATION flag, not an allow/deny on its own. NOTE: rest.rego normalises the
-    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`)
-    # to the action scope namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`,
+    # or applies the money_path_action_prefixes override above) to the action scope
+    # namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    #
+    # transfer/post/reverse/freeze/release/flip were the originally-designed vocabulary, but
+    # a fleet audit (issue #395) found real @Authorize verbs rarely spell it that way — only
+    # ledger.reverse, transaction.reverse and account.freeze literally matched. The verbs
+    # below were added to cover the real money-moving action each service actually emits.
     four_eyes:
       verbs:
         - transfer                          # outbound value movement (sepa/domestic/swift/instant)
@@ -656,6 +710,13 @@ data:
         - freeze                            # account freeze/unfreeze
         - release                           # release a held payment
         - flip                              # money-path feature-flag flip (ADR-0067 / issue #419)
+        - transitionStatus                  # sepa-payment / domestic-payment lifecycle transition (issue #395)
+        - recall                            # sepa-instant: recall a SETTLED payment (issue #395)
+        - settle                            # clearing: settle a clearing batch (issue #395)
+        - disburse                          # lending: loan payout (issue #395)
+        - send                              # swift: send an outbound wire message (issue #395)
+        - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
+        - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
+        openbank.tech/policy-checksum: "64bf88316f5fce9b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "c07d241ddd407abc"
+    openbank.tech/policy-checksum: "2aba9a14e3e936ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -53,18 +53,32 @@ data:
     	"allow": true,
     	"reason": reason,
     	"policy_version": policy_version,
+    	"attributes": response_attributes,
     } if {
     	count(allowed_reasons) > 0
+
     	# Defense-in-depth: a prohibited action (e.g. flipping off SCA/sanctions via a feature
     	# flag, issue #419) can never be granted by ANY reason — not even operator-on-own-tenant
     	# with a tenant-matched resource. Gating the allow head, not each reason, makes this
     	# impossible to bypass by enriching the input (the prohibition is not just surfaced).
     	not prohibited
+
     	# Pick the lexicographically smallest reason so the complete rule produces a single
     	# deterministic output even when multiple allowed_reasons rules fire simultaneously
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
     	reason := min(allowed_reasons)
     }
+
+    # Surfaced on the allow object so OpaSidecarPolicyDecisionPoint (which reads
+    # `result.attributes` generically) actually delivers it to AuthzDecision.attributes.
+    # A fleet audit (issue #395) found four_eyes_required was computed below but never
+    # reached this object — "attributes" was simply absent from the allow head — so no
+    # caller anywhere could ever have acted on it, independent of any money_path_scopes
+    # naming mismatch. Sparse on purpose: omitted (not `false`) when not required, matching
+    # this file's existing audit-attribute style (cf. default policy_version above).
+    default response_attributes := {}
+
+    response_attributes := {"four_eyes_required": true} if four_eyes_required
 
     # policy_version is audit METADATA, never a gate. Resolve it via a defaulted rule so
     # a bundle that omits openbank.bundle.version cannot turn a legitimate allow into an
@@ -83,6 +97,7 @@ data:
     allowed_reasons contains "operator-on-own-tenant" if {
     	input.principal.type == "HUMAN"
     	"ROLE_OPERATOR" in input.principal.roles
+
     	# Resource-scoped actions must target the operator's tenant; non-scoped
     	# (system-wide) actions are not granted by this rule.
     	input.resource
@@ -100,10 +115,13 @@ data:
     # duplicate the charter logic — call it through the unified package boundary.
     allowed_reasons contains "agent-charter-allows" if {
     	input.principal.type == "AI_AGENT"
-    	# Translate the REST input into the MCP input shape and reuse agents.allow.
-    	# Kept tight on purpose: only proceeds if the agent has an EXPLICIT allow
-    	# from its charter, not just absence-of-deny.
-    	data.openbank.agents.charter_allowed with input as {
+
+    	# Translate the REST input into the MCP input shape and reuse agents.allow --
+    	# NOT charter_allowed: agents.allow ALSO applies hard_denied / charter_denied /
+    	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
+    	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
+    	# tools.deny glob, silently reach a REST action anyway.
+    	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
     		"resource": input.resource,
@@ -166,10 +184,27 @@ data:
     # Money-path service scopes, normalised to the action namespace: money_path_services in
     # rules.yaml uses the module name (openbank-ledger-service) but an action prefix is the
     # commit scope (ledger). Strip the `openbank-` prefix and a trailing `-service` so the
-    # two align (e.g. openbank-ledger-service -> ledger; openbank-sepa-payment -> sepa-payment).
+    # two align (e.g. openbank-ledger-service -> ledger).
+    #
+    # Five services' real @Authorize action prefix does NOT match that derived name (a
+    # fleet audit, issue #395, found this silently disabled four-eyes for every one of
+    # them): sepa-payment -> sepaPayment, sepa-instant -> sctInstPayment, domestic-payment
+    # -> domesticPayment, clearing -> clearingBatch, sca -> device / scaChallenge. Two of
+    # those aren't even a casing variant of the derived name, so this uses an explicit
+    # override table (rules.yaml: money_path_action_prefixes) rather than a camelCase
+    # guess — self-documenting, and rest_test.rego pins it so a future rename can't
+    # silently drift back out of sync.
     money_path_scopes contains scope if {
     	some svc in data.rules.money_path_services
-    	scope := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	not data.rules.money_path_action_prefixes[derived]
+    	scope := derived
+    }
+
+    money_path_scopes contains scope if {
+    	some svc in data.rules.money_path_services
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	some scope in data.rules.money_path_action_prefixes[derived]
     }
 
     four_eyes_required if {
@@ -314,9 +349,15 @@ data:
     default allow := false
 
     # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+    # input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+    # config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+    # bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+    # AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+    # "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+    # this normalises both callers to the bare charter id without needing two lookup rules.
     charter contains a if {
     	some a in data.agents.agents
-    	a.id == input.agent
+    	a.id == trim_prefix(input.agent, "agent:")
     }
 
     # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -324,16 +365,79 @@ data:
 
     # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
     charter_denied if {
-    	some a in charter
-    	some pattern in a.tools.deny
+    	some pattern in allowed_or_denied_patterns.deny
     	glob_match(pattern, input.tool)
+    }
+
+    # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+    # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    allowed_or_denied_patterns := {
+    	"allow": {pattern |
+    		some a in charter
+    		some pattern in a.tools.allow
+    	},
+    	"deny": {pattern |
+    		some a in charter
+    		some pattern in a.tools.deny
+    	},
     }
 
     # A tool is explicitly allowed by the agent's charter allowlist.
     charter_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	glob_match(pattern, input.tool)
+    }
+
+    # rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+    # AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+    # an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+    # declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+    # e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+    # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+    # relationship), so charter_allowed alone could never grant a REST read no matter how
+    # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+    # rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+    # charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+    # skips those checks.
+    charter_allowed if rest_action_allowed
+
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+    # single place that already decided which REST-action service scopes each `query.*.readonly`
+    # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+    # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+    # their entries are forward-looking and inert until that service adopts @Authorize on its
+    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+    # the bare service name, since a future read endpoint may reuse either convention and both
+    # are inert until then anyway.
+    rest_domains := {
+    	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.catalog.readonly": {"catalog"},
+    	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
+    	"query.interest.readonly": {"interest"},
+    	"query.disputes.readonly": {"dispute"},
+    	"query.balance.readonly": {"balance"},
+    	"query.transaction.readonly": {"transaction"},
+    }
+
+    # Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+    # however permissive matching the domain prefix alone would otherwise be.
+    rest_read_verbs := {"list", "read", "search"}
+
+    # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+    # in that tool's mapped rest_domains set AND the verb is read-only.
+    rest_action_allowed if {
+    	some pattern in allowed_or_denied_patterns.allow
+    	some scope in rest_domains[pattern]
+    	startswith(input.tool, sprintf("%s.", [scope]))
+    	some verb in rest_read_verbs
+    	endswith(input.tool, sprintf(".%s", [verb]))
     }
 
     # run.skill is further constrained to the agent's `skills` allowlist (development plane).
@@ -973,12 +1077,37 @@ data:
       self_merge_forbidden_on: [CODEOWNERS_protected]
 
     # ---------------------------------------------------------------------------------------
+    # Money-path action-prefix overrides (issue #395). rest.rego derives a scope from each
+    # money_path_services entry by stripping `openbank-` and a trailing `-service`
+    # (openbank-ledger-service -> ledger) and matches it against the @Authorize action
+    # prefix (the part before the first `.`). A fleet audit found 5 services whose real
+    # prefix does not equal that derived name — two (clearing, sca) aren't even a casing
+    # variant of it — which silently disabled four_eyes_required for every one of them.
+    # List the REAL @Authorize prefix(es) here for any service where it differs; rest.rego
+    # uses this instead of the derived name for that service, and rest_test.rego pins each
+    # entry against the service's actual source so a rename can't silently drift back out
+    # of sync. Only list a service here when it diverges — everything else keeps using the
+    # derived name.
+    money_path_action_prefixes:
+      sepa-payment: [sepaPayment]
+      sepa-instant: [sctInstPayment]
+      domestic-payment: [domesticPayment]
+      clearing: [clearingBatch]
+      sca: [device, scaChallenge]
+
+    # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads
     # data.rules.four_eyes.verbs). A money-path action whose verb is listed here is flagged
     # `four_eyes_required` so the handler demands a second approver (maker-checker). This is
     # an AUGMENTATION flag, not an allow/deny on its own. NOTE: rest.rego normalises the
-    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`)
-    # to the action scope namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`,
+    # or applies the money_path_action_prefixes override above) to the action scope
+    # namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    #
+    # transfer/post/reverse/freeze/release/flip were the originally-designed vocabulary, but
+    # a fleet audit (issue #395) found real @Authorize verbs rarely spell it that way — only
+    # ledger.reverse, transaction.reverse and account.freeze literally matched. The verbs
+    # below were added to cover the real money-moving action each service actually emits.
     four_eyes:
       verbs:
         - transfer                          # outbound value movement (sepa/domestic/swift/instant)
@@ -987,6 +1116,13 @@ data:
         - freeze                            # account freeze/unfreeze
         - release                           # release a held payment
         - flip                              # money-path feature-flag flip (ADR-0067 / issue #419)
+        - transitionStatus                  # sepa-payment / domestic-payment lifecycle transition (issue #395)
+        - recall                            # sepa-instant: recall a SETTLED payment (issue #395)
+        - settle                            # clearing: settle a clearing batch (issue #395)
+        - disburse                          # lending: loan payout (issue #395)
+        - send                              # swift: send an outbound wire message (issue #395)
+        - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
+        - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c07d241ddd407abc"
+        openbank.tech/policy-checksum: "2aba9a14e3e936ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
+    openbank.tech/policy-checksum: "64bf88316f5fce9b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -54,6 +54,7 @@ data:
     	"allow": true,
     	"reason": reason,
     	"policy_version": policy_version,
+    	"attributes": response_attributes,
     } if {
     	count(allowed_reasons) > 0
 
@@ -68,6 +69,17 @@ data:
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
     	reason := min(allowed_reasons)
     }
+
+    # Surfaced on the allow object so OpaSidecarPolicyDecisionPoint (which reads
+    # `result.attributes` generically) actually delivers it to AuthzDecision.attributes.
+    # A fleet audit (issue #395) found four_eyes_required was computed below but never
+    # reached this object — "attributes" was simply absent from the allow head — so no
+    # caller anywhere could ever have acted on it, independent of any money_path_scopes
+    # naming mismatch. Sparse on purpose: omitted (not `false`) when not required, matching
+    # this file's existing audit-attribute style (cf. default policy_version above).
+    default response_attributes := {}
+
+    response_attributes := {"four_eyes_required": true} if four_eyes_required
 
     # policy_version is audit METADATA, never a gate. Resolve it via a defaulted rule so
     # a bundle that omits openbank.bundle.version cannot turn a legitimate allow into an
@@ -173,10 +185,27 @@ data:
     # Money-path service scopes, normalised to the action namespace: money_path_services in
     # rules.yaml uses the module name (openbank-ledger-service) but an action prefix is the
     # commit scope (ledger). Strip the `openbank-` prefix and a trailing `-service` so the
-    # two align (e.g. openbank-ledger-service -> ledger; openbank-sepa-payment -> sepa-payment).
+    # two align (e.g. openbank-ledger-service -> ledger).
+    #
+    # Five services' real @Authorize action prefix does NOT match that derived name (a
+    # fleet audit, issue #395, found this silently disabled four-eyes for every one of
+    # them): sepa-payment -> sepaPayment, sepa-instant -> sctInstPayment, domestic-payment
+    # -> domesticPayment, clearing -> clearingBatch, sca -> device / scaChallenge. Two of
+    # those aren't even a casing variant of the derived name, so this uses an explicit
+    # override table (rules.yaml: money_path_action_prefixes) rather than a camelCase
+    # guess — self-documenting, and rest_test.rego pins it so a future rename can't
+    # silently drift back out of sync.
     money_path_scopes contains scope if {
     	some svc in data.rules.money_path_services
-    	scope := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	not data.rules.money_path_action_prefixes[derived]
+    	scope := derived
+    }
+
+    money_path_scopes contains scope if {
+    	some svc in data.rules.money_path_services
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	some scope in data.rules.money_path_action_prefixes[derived]
     }
 
     four_eyes_required if {
@@ -642,12 +671,37 @@ data:
       self_merge_forbidden_on: [CODEOWNERS_protected]
 
     # ---------------------------------------------------------------------------------------
+    # Money-path action-prefix overrides (issue #395). rest.rego derives a scope from each
+    # money_path_services entry by stripping `openbank-` and a trailing `-service`
+    # (openbank-ledger-service -> ledger) and matches it against the @Authorize action
+    # prefix (the part before the first `.`). A fleet audit found 5 services whose real
+    # prefix does not equal that derived name — two (clearing, sca) aren't even a casing
+    # variant of it — which silently disabled four_eyes_required for every one of them.
+    # List the REAL @Authorize prefix(es) here for any service where it differs; rest.rego
+    # uses this instead of the derived name for that service, and rest_test.rego pins each
+    # entry against the service's actual source so a rename can't silently drift back out
+    # of sync. Only list a service here when it diverges — everything else keeps using the
+    # derived name.
+    money_path_action_prefixes:
+      sepa-payment: [sepaPayment]
+      sepa-instant: [sctInstPayment]
+      domestic-payment: [domesticPayment]
+      clearing: [clearingBatch]
+      sca: [device, scaChallenge]
+
+    # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads
     # data.rules.four_eyes.verbs). A money-path action whose verb is listed here is flagged
     # `four_eyes_required` so the handler demands a second approver (maker-checker). This is
     # an AUGMENTATION flag, not an allow/deny on its own. NOTE: rest.rego normalises the
-    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`)
-    # to the action scope namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`,
+    # or applies the money_path_action_prefixes override above) to the action scope
+    # namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    #
+    # transfer/post/reverse/freeze/release/flip were the originally-designed vocabulary, but
+    # a fleet audit (issue #395) found real @Authorize verbs rarely spell it that way — only
+    # ledger.reverse, transaction.reverse and account.freeze literally matched. The verbs
+    # below were added to cover the real money-moving action each service actually emits.
     four_eyes:
       verbs:
         - transfer                          # outbound value movement (sepa/domestic/swift/instant)
@@ -656,6 +710,13 @@ data:
         - freeze                            # account freeze/unfreeze
         - release                           # release a held payment
         - flip                              # money-path feature-flag flip (ADR-0067 / issue #419)
+        - transitionStatus                  # sepa-payment / domestic-payment lifecycle transition (issue #395)
+        - recall                            # sepa-instant: recall a SETTLED payment (issue #395)
+        - settle                            # clearing: settle a clearing batch (issue #395)
+        - disburse                          # lending: loan payout (issue #395)
+        - send                              # swift: send an outbound wire message (issue #395)
+        - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
+        - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
+        openbank.tech/policy-checksum: "64bf88316f5fce9b"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "ca080c5bca27b82e"
+    openbank.tech/policy-checksum: "5187b1e6418b678c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -53,6 +53,7 @@ data:
     	"allow": true,
     	"reason": reason,
     	"policy_version": policy_version,
+    	"attributes": response_attributes,
     } if {
     	count(allowed_reasons) > 0
 
@@ -67,6 +68,17 @@ data:
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
     	reason := min(allowed_reasons)
     }
+
+    # Surfaced on the allow object so OpaSidecarPolicyDecisionPoint (which reads
+    # `result.attributes` generically) actually delivers it to AuthzDecision.attributes.
+    # A fleet audit (issue #395) found four_eyes_required was computed below but never
+    # reached this object — "attributes" was simply absent from the allow head — so no
+    # caller anywhere could ever have acted on it, independent of any money_path_scopes
+    # naming mismatch. Sparse on purpose: omitted (not `false`) when not required, matching
+    # this file's existing audit-attribute style (cf. default policy_version above).
+    default response_attributes := {}
+
+    response_attributes := {"four_eyes_required": true} if four_eyes_required
 
     # policy_version is audit METADATA, never a gate. Resolve it via a defaulted rule so
     # a bundle that omits openbank.bundle.version cannot turn a legitimate allow into an
@@ -172,10 +184,27 @@ data:
     # Money-path service scopes, normalised to the action namespace: money_path_services in
     # rules.yaml uses the module name (openbank-ledger-service) but an action prefix is the
     # commit scope (ledger). Strip the `openbank-` prefix and a trailing `-service` so the
-    # two align (e.g. openbank-ledger-service -> ledger; openbank-sepa-payment -> sepa-payment).
+    # two align (e.g. openbank-ledger-service -> ledger).
+    #
+    # Five services' real @Authorize action prefix does NOT match that derived name (a
+    # fleet audit, issue #395, found this silently disabled four-eyes for every one of
+    # them): sepa-payment -> sepaPayment, sepa-instant -> sctInstPayment, domestic-payment
+    # -> domesticPayment, clearing -> clearingBatch, sca -> device / scaChallenge. Two of
+    # those aren't even a casing variant of the derived name, so this uses an explicit
+    # override table (rules.yaml: money_path_action_prefixes) rather than a camelCase
+    # guess — self-documenting, and rest_test.rego pins it so a future rename can't
+    # silently drift back out of sync.
     money_path_scopes contains scope if {
     	some svc in data.rules.money_path_services
-    	scope := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	not data.rules.money_path_action_prefixes[derived]
+    	scope := derived
+    }
+
+    money_path_scopes contains scope if {
+    	some svc in data.rules.money_path_services
+    	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+    	some scope in data.rules.money_path_action_prefixes[derived]
     }
 
     four_eyes_required if {
@@ -1016,12 +1045,37 @@ data:
       self_merge_forbidden_on: [CODEOWNERS_protected]
 
     # ---------------------------------------------------------------------------------------
+    # Money-path action-prefix overrides (issue #395). rest.rego derives a scope from each
+    # money_path_services entry by stripping `openbank-` and a trailing `-service`
+    # (openbank-ledger-service -> ledger) and matches it against the @Authorize action
+    # prefix (the part before the first `.`). A fleet audit found 5 services whose real
+    # prefix does not equal that derived name — two (clearing, sca) aren't even a casing
+    # variant of it — which silently disabled four_eyes_required for every one of them.
+    # List the REAL @Authorize prefix(es) here for any service where it differs; rest.rego
+    # uses this instead of the derived name for that service, and rest_test.rego pins each
+    # entry against the service's actual source so a rename can't silently drift back out
+    # of sync. Only list a service here when it diverges — everything else keeps using the
+    # derived name.
+    money_path_action_prefixes:
+      sepa-payment: [sepaPayment]
+      sepa-instant: [sctInstPayment]
+      domestic-payment: [domesticPayment]
+      clearing: [clearingBatch]
+      sca: [device, scaChallenge]
+
+    # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads
     # data.rules.four_eyes.verbs). A money-path action whose verb is listed here is flagged
     # `four_eyes_required` so the handler demands a second approver (maker-checker). This is
     # an AUGMENTATION flag, not an allow/deny on its own. NOTE: rest.rego normalises the
-    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`)
-    # to the action scope namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    # money_path_services entries (strips the `openbank-` prefix and a trailing `-service`,
+    # or applies the money_path_action_prefixes override above) to the action scope
+    # namespace, e.g. `openbank-ledger-service` -> `ledger`.
+    #
+    # transfer/post/reverse/freeze/release/flip were the originally-designed vocabulary, but
+    # a fleet audit (issue #395) found real @Authorize verbs rarely spell it that way — only
+    # ledger.reverse, transaction.reverse and account.freeze literally matched. The verbs
+    # below were added to cover the real money-moving action each service actually emits.
     four_eyes:
       verbs:
         - transfer                          # outbound value movement (sepa/domestic/swift/instant)
@@ -1030,6 +1084,13 @@ data:
         - freeze                            # account freeze/unfreeze
         - release                           # release a held payment
         - flip                              # money-path feature-flag flip (ADR-0067 / issue #419)
+        - transitionStatus                  # sepa-payment / domestic-payment lifecycle transition (issue #395)
+        - recall                            # sepa-instant: recall a SETTLED payment (issue #395)
+        - settle                            # clearing: settle a clearing batch (issue #395)
+        - disburse                          # lending: loan payout (issue #395)
+        - send                              # swift: send an outbound wire message (issue #395)
+        - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
+        - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ca080c5bca27b82e"
+        openbank.tech/policy-checksum: "5187b1e6418b678c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/opa/build-bundle.sh
+++ b/openbank-infra/opa/build-bundle.sh
@@ -99,8 +99,12 @@ rassert() { # desc | rule | input-json | expected (true|false)
 
 rassert "four-eyes fires for a money-path post (real long service names normalised)" \
 	four_eyes_required '{"action":"ledger.post"}' true
-rassert "four-eyes fires for a sepa-payment transfer" \
-	four_eyes_required '{"action":"sepa-payment.transfer"}' true
+# sepaPayment.transitionStatus is the REAL @Authorize action in SepaPaymentResource.kt —
+# "sepa-payment.transfer" (fixed here, issue #395) was a synthetic string no service ever
+# emits, so it silently proved nothing about whether money_path_action_prefixes actually
+# covers the fleet's real, shipped action name.
+rassert "four-eyes fires for a real sepa-payment status transition" \
+	four_eyes_required '{"action":"sepaPayment.transitionStatus"}' true
 rassert "four-eyes not required for a non-money-path update" \
 	four_eyes_required '{"action":"party.update"}' false
 rassert "four-eyes fires for a money-path feature-flag flip" \

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -39,6 +39,7 @@ allow := {
 	"allow": true,
 	"reason": reason,
 	"policy_version": policy_version,
+	"attributes": response_attributes,
 } if {
 	count(allowed_reasons) > 0
 
@@ -53,6 +54,17 @@ allow := {
 	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
 	reason := min(allowed_reasons)
 }
+
+# Surfaced on the allow object so OpaSidecarPolicyDecisionPoint (which reads
+# `result.attributes` generically) actually delivers it to AuthzDecision.attributes.
+# A fleet audit (issue #395) found four_eyes_required was computed below but never
+# reached this object — "attributes" was simply absent from the allow head — so no
+# caller anywhere could ever have acted on it, independent of any money_path_scopes
+# naming mismatch. Sparse on purpose: omitted (not `false`) when not required, matching
+# this file's existing audit-attribute style (cf. default policy_version above).
+default response_attributes := {}
+
+response_attributes := {"four_eyes_required": true} if four_eyes_required
 
 # policy_version is audit METADATA, never a gate. Resolve it via a defaulted rule so
 # a bundle that omits openbank.bundle.version cannot turn a legitimate allow into an
@@ -158,10 +170,27 @@ allowed_reasons contains "edge-service-notification" if {
 # Money-path service scopes, normalised to the action namespace: money_path_services in
 # rules.yaml uses the module name (openbank-ledger-service) but an action prefix is the
 # commit scope (ledger). Strip the `openbank-` prefix and a trailing `-service` so the
-# two align (e.g. openbank-ledger-service -> ledger; openbank-sepa-payment -> sepa-payment).
+# two align (e.g. openbank-ledger-service -> ledger).
+#
+# Five services' real @Authorize action prefix does NOT match that derived name (a
+# fleet audit, issue #395, found this silently disabled four-eyes for every one of
+# them): sepa-payment -> sepaPayment, sepa-instant -> sctInstPayment, domestic-payment
+# -> domesticPayment, clearing -> clearingBatch, sca -> device / scaChallenge. Two of
+# those aren't even a casing variant of the derived name, so this uses an explicit
+# override table (rules.yaml: money_path_action_prefixes) rather than a camelCase
+# guess — self-documenting, and rest_test.rego pins it so a future rename can't
+# silently drift back out of sync.
 money_path_scopes contains scope if {
 	some svc in data.rules.money_path_services
-	scope := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+	not data.rules.money_path_action_prefixes[derived]
+	scope := derived
+}
+
+money_path_scopes contains scope if {
+	some svc in data.rules.money_path_services
+	derived := trim_suffix(trim_prefix(svc, "openbank-"), "-service")
+	some scope in data.rules.money_path_action_prefixes[derived]
 }
 
 four_eyes_required if {

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -29,11 +29,30 @@ rules := {
 }
 
 # Mock mirroring the REAL rules.yaml shape — money_path_services uses the module name
-# (openbank-ledger-service), which rest.rego normalises to the action scope (ledger).
-# Also carries the feature_flags block (issue #419).
+# (openbank-ledger-service), which rest.rego normalises to the action scope (ledger), or
+# the money_path_action_prefixes override for the 5 services whose real @Authorize
+# prefix differs from that derived name (issue #395). Also carries the feature_flags
+# block (issue #419).
 rules_real := {
-	"money_path_services": ["openbank-ledger-service", "openbank-sepa-payment"],
-	"four_eyes": {"verbs": ["transfer", "post", "flip"]},
+	"money_path_services": [
+		"openbank-ledger-service",
+		"openbank-sepa-payment",
+		"openbank-sepa-instant",
+		"openbank-domestic-payment",
+		"openbank-clearing-service",
+		"openbank-sca-service",
+	],
+	"money_path_action_prefixes": {
+		"sepa-payment": ["sepaPayment"],
+		"sepa-instant": ["sctInstPayment"],
+		"domestic-payment": ["domesticPayment"],
+		"clearing": ["clearingBatch"],
+		"sca": ["device", "scaChallenge"],
+	},
+	"four_eyes": {"verbs": [
+		"transfer", "post", "reverse", "freeze", "release", "flip",
+		"transitionStatus", "recall", "settle", "disburse", "send", "credit", "debit",
+	]},
 	"feature_flags": {
 		"prohibited_flag_combinations": [
 			"sca-enforcement-disabled",
@@ -223,15 +242,95 @@ test_four_eyes_not_required_for_ledger_read if {
 # Name normalisation (issue #419): the REAL rules.yaml lists money_path_services as module
 # names (openbank-ledger-service); rest.rego must normalise them to the action scope so the
 # four-eyes prefix match still fires. Without normalisation these would silently not match.
+# Uses "ledger.reverse" — the actual @Authorize string in LedgerResource.kt (issue #395;
+# "ledger.post" was never a real action, so a passing test here previously proved nothing
+# about the fleet).
 # ---------------------------------------------------------------------------------------
 test_four_eyes_required_with_real_module_names if {
-	rest.four_eyes_required with input as {"action": "ledger.post"}
+	rest.four_eyes_required with input as {"action": "ledger.reverse"}
 		with data.rules as rules_real
 }
 
-test_four_eyes_required_sepa_payment_real_names if {
-	rest.four_eyes_required with input as {"action": "sepa-payment.transfer"}
+# ---------------------------------------------------------------------------------------
+# money_path_action_prefixes override (issue #395): pins each overridden service's REAL
+# @Authorize action against the actual source file, so a future rename that isn't matched
+# by an update here goes red instead of silently disabling four-eyes again.
+# ---------------------------------------------------------------------------------------
+test_four_eyes_required_sepa_payment_real_action if {
+	# SepaPaymentResource.kt: @Authorize(action = "sepaPayment.transitionStatus", ...)
+	rest.four_eyes_required with input as {"action": "sepaPayment.transitionStatus"}
 		with data.rules as rules_real
+}
+
+test_four_eyes_required_sepa_instant_real_action if {
+	# SctInstResource.kt: @Authorize(action = "sctInstPayment.recall", ...)
+	rest.four_eyes_required with input as {"action": "sctInstPayment.recall"}
+		with data.rules as rules_real
+}
+
+test_four_eyes_required_domestic_payment_real_action if {
+	# DomesticPaymentResource.kt: @Authorize(action = "domesticPayment.transitionStatus", ...)
+	rest.four_eyes_required with input as {"action": "domesticPayment.transitionStatus"}
+		with data.rules as rules_real
+}
+
+test_four_eyes_required_clearing_real_action if {
+	# ClearingResource.kt: @Authorize(action = "clearingBatch.settle", ...)
+	rest.four_eyes_required with input as {"action": "clearingBatch.settle"}
+		with data.rules as rules_real
+}
+
+# money_path_scopes uses the override prefix INSTEAD OF the derived name — the derived
+# name never appears in any real @Authorize action for these 5 services, so keeping it
+# in the set too would just be dead weight.
+test_money_path_scopes_uses_override_prefix_not_derived_name if {
+	"sepaPayment" in rest.money_path_scopes with data.rules as rules_real
+	not "sepa-payment" in rest.money_path_scopes with data.rules as rules_real
+}
+
+# A service with no override keeps using its derived name (unaffected by the override table).
+test_money_path_scopes_keeps_derived_name_when_no_override if {
+	"ledger" in rest.money_path_scopes with data.rules as rules_real
+}
+
+# sca's override lists TWO real prefixes (device, scaChallenge) — neither is a casing
+# variant of "sca", which never appears as an action prefix in the real service at all.
+test_money_path_scopes_supports_multiple_override_prefixes if {
+	"device" in rest.money_path_scopes with data.rules as rules_real
+	"scaChallenge" in rest.money_path_scopes with data.rules as rules_real
+	not "sca" in rest.money_path_scopes with data.rules as rules_real
+}
+
+# ---------------------------------------------------------------------------------------
+# End-to-end wiring (issue #395): four_eyes_required must reach the actual `allow` object
+# an OpaSidecarPolicyDecisionPoint caller receives, not just the standalone rule — the
+# bug this closes was that `allow` never carried an "attributes" key at all.
+# ---------------------------------------------------------------------------------------
+test_allow_attributes_surface_four_eyes_required if {
+	decision := rest.allow with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"], "attributes": {"tenant": "t-1"}},
+		"action": "ledger.reverse",
+		"resource": {"type": "ledger", "id": "j-1", "attributes": {"tenant": "t-1"}},
+	}
+		with data.openbank.bundle as bundle
+		with data.rules as rules_real
+
+	decision.allow == true
+	decision.attributes.four_eyes_required == true
+}
+
+# Sparse by design: no attributes key content when four-eyes isn't required.
+test_allow_attributes_empty_when_four_eyes_not_required if {
+	decision := rest.allow with input as {
+		"principal": {"id": "op-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"], "attributes": {"tenant": "t-1"}},
+		"action": "party.update",
+		"resource": {"type": "party", "id": "p-1", "attributes": {"tenant": "t-1"}},
+	}
+		with data.openbank.bundle as bundle
+		with data.rules as rules_real
+
+	decision.allow == true
+	decision.attributes == {}
 }
 
 # ---------------------------------------------------------------------------------------

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -273,12 +273,37 @@ review:
   self_merge_forbidden_on: [CODEOWNERS_protected]
 
 # ---------------------------------------------------------------------------------------
+# Money-path action-prefix overrides (issue #395). rest.rego derives a scope from each
+# money_path_services entry by stripping `openbank-` and a trailing `-service`
+# (openbank-ledger-service -> ledger) and matches it against the @Authorize action
+# prefix (the part before the first `.`). A fleet audit found 5 services whose real
+# prefix does not equal that derived name — two (clearing, sca) aren't even a casing
+# variant of it — which silently disabled four_eyes_required for every one of them.
+# List the REAL @Authorize prefix(es) here for any service where it differs; rest.rego
+# uses this instead of the derived name for that service, and rest_test.rego pins each
+# entry against the service's actual source so a rename can't silently drift back out
+# of sync. Only list a service here when it diverges — everything else keeps using the
+# derived name.
+money_path_action_prefixes:
+  sepa-payment: [sepaPayment]
+  sepa-instant: [sctInstPayment]
+  domestic-payment: [domesticPayment]
+  clearing: [clearingBatch]
+  sca: [device, scaChallenge]
+
+# ---------------------------------------------------------------------------------------
 # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads
 # data.rules.four_eyes.verbs). A money-path action whose verb is listed here is flagged
 # `four_eyes_required` so the handler demands a second approver (maker-checker). This is
 # an AUGMENTATION flag, not an allow/deny on its own. NOTE: rest.rego normalises the
-# money_path_services entries (strips the `openbank-` prefix and a trailing `-service`)
-# to the action scope namespace, e.g. `openbank-ledger-service` -> `ledger`.
+# money_path_services entries (strips the `openbank-` prefix and a trailing `-service`,
+# or applies the money_path_action_prefixes override above) to the action scope
+# namespace, e.g. `openbank-ledger-service` -> `ledger`.
+#
+# transfer/post/reverse/freeze/release/flip were the originally-designed vocabulary, but
+# a fleet audit (issue #395) found real @Authorize verbs rarely spell it that way — only
+# ledger.reverse, transaction.reverse and account.freeze literally matched. The verbs
+# below were added to cover the real money-moving action each service actually emits.
 four_eyes:
   verbs:
     - transfer                          # outbound value movement (sepa/domestic/swift/instant)
@@ -287,6 +312,13 @@ four_eyes:
     - freeze                            # account freeze/unfreeze
     - release                           # release a held payment
     - flip                              # money-path feature-flag flip (ADR-0067 / issue #419)
+    - transitionStatus                  # sepa-payment / domestic-payment lifecycle transition (issue #395)
+    - recall                            # sepa-instant: recall a SETTLED payment (issue #395)
+    - settle                            # clearing: settle a clearing batch (issue #395)
+    - disburse                          # lending: loan payout (issue #395)
+    - send                              # swift: send an outbound wire message (issue #395)
+    - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
+    - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
 
 # ---------------------------------------------------------------------------------------
 # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)


### PR DESCRIPTION
## Summary

A fleet audit (issue #395) found four-eyes (maker-checker) for money-path actions is
non-functional for three independent reasons: the computed flag never reaches the
caller, 5/15 services' real `@Authorize` prefix doesn't match the derived scope, and
most real verbs don't match the `four_eyes.verbs` vocabulary. This PR fixes the data
path for all three so the signal is accurate and actually delivered — it does not add
the enforcement action itself (see Reviewer notes).

## Type of change

- [x] security (private until disclosed)
- [x] fix (bug fix)

## Linked issues

Refs #395 (does not close it — the enforcement checkbox is intentionally left for a
follow-up, see Reviewer notes)

## Changes

- `rest.rego`: merge `four_eyes_required` into `allow.attributes` (it was computed but
  never surfaced on the `allow` object at all — `OpaSidecarPolicyDecisionPoint` reads
  `attributes` generically, so this alone was enough to make the flag unreachable
  fleet-wide, independent of any naming issue).
- `rest.rego` + `rules.yaml`: `money_path_scopes` now consults a new
  `money_path_action_prefixes` override table for the 5 services whose real
  `@Authorize` prefix isn't the module-name-derived scope (`sepa-payment` →
  `sepaPayment`, `sepa-instant` → `sctInstPayment`, `domestic-payment` →
  `domesticPayment`, `clearing` → `clearingBatch`, `sca` → `device`/`scaChallenge`).
- `rules.yaml`: extend `four_eyes.verbs` with the real fleet vocabulary
  (`transitionStatus`, `recall`, `settle`, `disburse`, `send`, `credit`, `debit`) —
  previously only `ledger.reverse`, `transaction.reverse`, and `account.freeze`
  literally matched anything in the list.
- `rest_test.rego`: the two tests claiming to validate "real module names" actually
  used synthetic actions no service emits (`ledger.post`, `sepa-payment.transfer`) —
  replaced with the real `@Authorize` strings from each service's source, plus new
  tests for the override table and an end-to-end test that `four_eyes_required`
  reaches `allow.attributes`.
- `build-bundle.sh`: same fix for its hardcoded `sepa-payment.transfer` decision
  assertion, which would otherwise fail against the real bundle now that the scope
  match is accurate.
- Regenerated the `pid`/`copilot`/`customer-edge`/`notification` OPA bundle
  ConfigMaps + pod-roll checksum annotations (`rules.yaml`/`rest.rego` content
  changed, so the committed artifacts were stale — `gen-*-opa-bundle.sh` re-run,
  verified only checksum + the new policy content differ).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — no service
      code touched.
- [x] Unit tests added/updated (`rest_test.rego`, 92/92 pass locally).
- [ ] Integration tests added/updated (if service boundary involved) — N/A, no
      service boundary changed.
- [ ] Contract tests updated (if public API changed) — N/A, no REST API changed.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` — N/A, no Kotlin changed;
      ran `./openbank-infra/opa/build-bundle.sh` instead (opa test 92/92, opa check
      --strict, decision assertions, bundle build all green).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — N/A.
- [ ] Flyway migration — N/A.
- [ ] Avro schema — N/A.
- [x] Docs updated (comments in `rules.yaml`/`rest.rego` explain the override table
      and the wiring fix; ADR-level design questions deferred, see below).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth code changed → tagging `security-review-required`.

## Compliance impact

- [x] PSD2 / SCA / RTS
- [x] AML / 5AMLD

Maker-checker (four-eyes) is a control referenced by the SCA/AML threat models for
money-path services (ADR-0030). This PR restores the *signal* (an accurate,
delivered `four_eyes_required` flag) — it does not change any existing allow/deny
outcome, and does not yet add an enforcement action that blocks a request pending a
second approver's review. No compensating control is needed for what ships here
specifically because it doesn't newly permit or newly block anything; the residual
gap (no real second-approval mechanism exists yet anywhere in the REST/human plane)
remains exactly as large as it was before this PR — this PR does not create a false
sense that it's closed.

## Rollout / Rollback

- Deployment strategy: rolling (pod-roll triggered by the checksum annotation bump
  on pid/copilot/customer-edge/notification; other money-path services pick up the
  new bundle on their normal OPA sidecar refresh).
- Rollback plan: revert this PR — `attributes` merging is additive and no existing
  `allow`/`deny` decision changes, so a revert is a clean no-op on production
  behavior.
- Data migration reversible: N/A.

## Reviewer notes

**Scope decision, please scrutinize:** I deliberately did NOT implement the actual
"require a second approver" enforcement action (blocking the request until a
distinct principal approves). A trivially-spoofable mechanism (e.g. trusting a
client-supplied "approved-by" header) would be worse than nothing — real security
theater — and a genuine implementation (a pending-approval record, a distinct
approve endpoint, principal-mismatch verification) is a new feature that deserves
its own design/ADR, not something to improvise inside a bug-fix PR. This PR restores
the *data* (`four_eyes_required` computed correctly and delivered accurately) so
that a follow-up enforcement PR has something real to consume. Issue #395 stays open
for that follow-up.

**Naming approach (rename vs. alias), please confirm:** I chose the alias/override
table (`money_path_action_prefixes`) over renaming the 5 services' shipped
`@Authorize` action strings, because a rename touches `AuditEvent` action strings
already in production audit logs and would need a per-consumer check I didn't want
to do unilaterally across 5 money-path services. If you'd prefer the rename
approach for one or more of these (clean up the action naming permanently instead
of carrying an alias table), say so and I'll follow up per-service.
