### PR TITLE
docs(governance): declare product-catalog T1, ADR-0083 Delivery-Status Shipped

### DIFF
--- a/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
+++ b/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-02
 Status: Accepted
-Delivery-Status: Partial
+Delivery-Status: Shipped
 Author(s): Jiri Raska
 
 > **Correction (2026-07-05).** A prior edit (#2800, 2026-06-30) marked this ADR
@@ -136,6 +136,38 @@ Author(s): Jiri Raska
 > number it accidentally shared with the (more widely referenced) outbound-oversight-webhooks
 > ADR, which keeps 0059. Historical references to "ADR-0059" in a scale-to-zero / FinOps-tier
 > context mean this document.
+
+> **Update (2026-07-07) — promotion gate measured against the live deployment; T1
+> declared, Delivery-Status: Shipped (issue #253).** The sandbox `accounts/product-catalog`
+> Deployment already runs the native image (`native-a2e14752`) with the tuned probes
+> recommended above (`startupProbe`/`readinessProbe`: `periodSeconds: 1`,
+> `failureThreshold: 10`). A 10-sample end-to-end scale-from-zero series through the KEDA
+> HTTP interceptor (force-scale to 0, wait for endpoint drain, time first byte of
+> `GET /api/v1/products`) measured:
+>
+> | | value |
+> |---|---|
+> | median TTFB | 5.29 s |
+> | avg (excl. one outlier) | 5.19 s |
+> | p95 | ~5.4 s (9.1 s including one sample that likely captured a cold node-local image pull) |
+>
+> This is marginally over the redefined **≤ 5 s p95** end-to-end target (process start
+> ≤ 500 ms p95 remains comfortably met, unchanged at ~0.2-0.3 s). Maintainer decision
+> (#253): **accept as met and declare T1.** Rationale — the miss is small (~0.3-0.4 s on
+> median), and for this specific service (non-money-path, rarely-hit admin/fees read
+> endpoint) the KEDA HTTP interceptor's entire purpose is absorbing that wait as a slow
+> first click rather than a 5xx; the FinOps trade (near-zero idle cost vs. a several-second
+> parked latency on the first request after an idle period) still holds at this margin.
+> `rules.yaml:finops_tiers.declared` now carries `openbank-product-catalog: T1` with this
+> measurement cited directly.
+>
+> **Caveat carried forward, not closed:** this is a single n=10 sample on one day, not the
+> originally-specified 48h burn-in window (Pilot plan step 5). Re-validate over a longer
+> window before treating this as permanently locked in — a real regression (e.g. from
+> cluster changes affecting admission-webhook or scheduling latency) should prompt a
+> re-measurement and, if warranted, a re-declaration (this is a non-money-path service, so
+> demoting off T1 does not need the `t0_baseline` 2-approval bar — a straightforward
+> `rules.yaml` edit with the new measurement suffices).
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,7 +91,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0080](0080-pentest-remediation-p0-p2.md) | Pentest remediation (admin.open-bank.tech) — P0/P1/P2 | Accepted | Partial | — |
 | [0081](0081-cluster-segmentation-and-container-hardening-baseline.md) | Cluster segmentation & container hardening baseline | Accepted | Shipped | — |
 | [0082](0082-ci-runner-governance.md) | CI runner governance — trust-tiered persistent pools, no human in the merge path | Superseded by ADR-0053 | N/A | — |
-| [0083](0083-t1-http-scale-to-zero-native-pilot.md) | T1 (HTTP → 0): native-image + KEDA HTTP add-on pilot on product-catalog | Accepted | Partial | — |
+| [0083](0083-t1-http-scale-to-zero-native-pilot.md) | T1 (HTTP → 0): native-image + KEDA HTTP add-on pilot on product-catalog | Accepted | Shipped | — |
 | [0084](0084-fraud-detection-bounded-context.md) | Fraud detection bounded context — real-time transaction risk scoring | Accepted | Shipped | — |
 | [0085](0085-complaints-handling.md) | Complaints handling — regulatory complaints as a first-class process | Accepted | Partial | — |
 | [0086](0086-customer-payment-non-repudiation-and-audit-chain.md) | Customer payment non-repudiation — SCA settlement gate, identity threading, audit chain | Accepted | Shipped | — |

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -772,10 +772,21 @@ finops_tiers:
     # process start ≤500ms p95 (met, ~0.2-0.3s) and end-to-end scale-from-zero with
     # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
     # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
-    # Kubernetes control-plane + admission-webhook overhead, not the image). Stays
-    # unclassified — T1 requires the live gitops Deployment to actually run the native
-    # image + tuned probes (a separate, deliberate infra cutover, not implied by this
-    # scratch measurement) plus a burn-in window per the ADR's Pilot plan steps 4-6.
+    # Kubernetes control-plane + admission-webhook overhead, not the image).
+    openbank-product-catalog: T1
+    # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
+    # already runs the native image + tuned probes (startupProbe/readinessProbe
+    # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero
+    # series through the KEDA HTTP interceptor measured median 5.29s / p95 ~5.4s
+    # (excl. one 9.1s sample that likely captured a cold node-local image pull) —
+    # marginally over the ADR's ≤5s p95 target. Accepted as met (maintainer call,
+    # #253): the miss is small, and for a non-money-path, rarely-hit admin/fees read
+    # endpoint the interceptor's whole job is absorbing that wait as a slow first
+    # click, not a 5xx — the FinOps trade (near-zero idle cost) holds. Caveat: this
+    # is a single n=10 sample on one day, not the ADR's originally-specified 48h
+    # burn-in window — re-validate over a longer window before treating T1 as
+    # permanently locked in; a regression would demote per t0_baseline's own
+    # 2-approval bar for money-path (N/A here) or a simple re-declare for non-money-path.
 
   # Keep-honest classifier: reads measured signals (HTTP rate/idle ratio, Kafka lag +
   # active fraction, CPU/replica utilisation), emits a recommended tier + realised


### PR DESCRIPTION
## Summary

Executes the maintainer decision on issue #253: accept the measured native cold-start SLO as met and declare `openbank-product-catalog: T1`.

## Type of change

- [x] docs

## Linked issues

Closes #253

## Changes

- **Measurement:** the live sandbox `accounts/product-catalog` Deployment already runs the native image (`native-a2e14752`) with the tuned probes. A 10-sample end-to-end scale-from-zero series through the KEDA HTTP interceptor measured **median 5.29s / p95 ~5.4s** — marginally over the ADR's redefined ≤5s p95 target (process start ≤500ms p95 remains comfortably met, unchanged).
- **Decision:** accept as met, declare T1. Rationale: the miss is small, and for this non-money-path, rarely-hit read endpoint the interceptor's whole job is absorbing that wait as a slow first click, not a 5xx — the FinOps trade still holds.
- `rules.yaml:finops_tiers.declared` += `openbank-product-catalog: T1`, measurement cited inline.
- ADR-0083 `Delivery-Status`: Partial → Shipped, full measurement + an explicit caveat recorded (n=10 single-day sample, not the original 48h burn-in spec — re-validate before treating this as permanently locked in; a non-money-path re-declare is cheap if it regresses).
- `docs/adr/README.md` regenerated (`gen-index.sh`).

## Definition of Done

- [x] `check-adr-registry.sh` — OK (148 ADRs, index fresh)
- [x] `check-finops-tiers.py` — no declared-side findings
- [x] No service code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)