### PR TITLE
ci(governance): extend mutation testing fleet-wide + add DAST baseline scan (ADR-0030 D3)

### DIFF
--- a/.github/workflows/dast-zap-baseline.yml
+++ b/.github/workflows/dast-zap-baseline.yml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# DAST baseline scan (OWASP ZAP) — ADR-0030 D3.
+#
+# Scope decision (first cut): a full customer-edge or fleet-wide DAST run needs either the
+# real k8s cluster (customer-edge is a gitops-only Rollout/proxy, not a Gradle module with its
+# own image build in this repo) or booting all ~30 services from openbank-infra/docker-compose.yml
+# (postgres/kafka/keycloak + every service Dockerfile — too heavy for a CI job). Instead this
+# scans ONE already-defined docker-compose target: ledger-service (postgres + kafka deps only,
+# already has a health check and documented unauthenticated public paths — see
+# QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS in openbank-infra/docker-compose.yml). This is
+# unauthenticated-surface coverage, not a full authenticated crawl — the money-path service most
+# reachable from a plain HTTP client without standing up Keycloak token issuance in CI.
+#
+# Advisory / report-only for the first cut, same posture as pitest.yml: a fresh ZAP baseline
+# against a banking API is expected to surface findings that need triage (ADR-0030 D1 lifecycle),
+# not an immediate hard gate. Scheduled (not per-PR) — cost + noise.
+name: DAST baseline (ZAP)
+
+on:
+  schedule:
+    - cron: "30 4 * * 0"   # Sunday 04:30 UTC — before the pitest 03:00 UTC... run gets its own slot
+  workflow_dispatch:
+    inputs:
+      target_service:
+        description: "docker-compose service name to scan (must exist in openbank-infra/docker-compose.yml)"
+        required: false
+        default: "ledger-service"
+
+permissions:
+  contents: read
+
+jobs:
+  zap-baseline:
+    name: ZAP baseline / ledger-service
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: none
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Boot ledger-service + deps (postgres, kafka)
+        working-directory: openbank-infra
+        env:
+          # Must match the QUARKUS_DATASOURCE_PASSWORD hardcoded per-service in
+          # docker-compose.yml ("openbank_secret") — every service's datasource password is
+          # a literal there, not templated from POSTGRES_PASSWORD, so this can't be a fresh
+          # random value.
+          POSTGRES_PASSWORD: openbank_secret
+        run: |
+          docker compose up -d postgres kafka ledger-service
+          echo "Waiting for ledger-service health..."
+          for i in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:8101/api/v1/info >/dev/null 2>&1; then
+              echo "ledger-service is up"; break
+            fi
+            if [ "$i" -eq 40 ]; then
+              echo "::error::ledger-service did not become healthy in time"
+              docker compose logs ledger-service kafka postgres | tail -300
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: ZAP baseline scan (unauthenticated public surface)
+        uses: zaproxy/action-baseline@6c5a007541891231cd9e0ddec25d4f25c59c9874 # v0.15.0
+        with:
+          target: "http://127.0.0.1:8101/api/v1/journals"
+          # Report-only: never fail the job on findings (ADR-0030 D3 first cut). Findings feed
+          # the D1 vulnerability-management lifecycle for triage, not an automatic PR gate.
+          fail_action: false
+          allow_issue_writing: false
+          artifact_name: zap-baseline-ledger-service
+          cmd_options: "-a"
+
+      - name: Dump container logs on failure
+        if: failure()
+        working-directory: openbank-infra
+        run: docker compose logs ledger-service kafka postgres | tail -300
+
+      - name: Tear down stack
+        if: always()
+        working-directory: openbank-infra
+        run: docker compose down -v

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -26,6 +26,7 @@ keywords = ["openbank_secret", "admin_secret", "openbank-vault-root-token", "ope
   paths = [
     '''(^|/)openbank-[a-z0-9-]+-service/src/main/resources/application\.yaml$''',
     '''(^|/)\.github/workflows/_service-ci\.yml$''',
+    '''(^|/)\.github/workflows/dast-zap-baseline\.yml$''',
     '''(^|/)openbank-infra/docker-compose\.yml$''',
   ]
 

--- a/docs/adr/0030-supply-chain-security-and-ssdlc-hardening.md
+++ b/docs/adr/0030-supply-chain-security-and-ssdlc-hardening.md
@@ -100,6 +100,21 @@ runtime SBOM drift detection.
 - **DAST** (OWASP ZAP baseline) against ephemeral service instances in CI, seeded from each service's
   OpenAPI spec, on a scheduled cadence (not every PR — cost). Findings feed the D1 lifecycle.
 
+> **Realization (2026-07-07, mutation re-verified + DAST first cut, issue #265).** Mutation
+> testing: the fleet rollout (`.github/workflows/pitest.yml`, #317/#318) already covers 9/15
+> money-path services with substantive domain math (ledger, balance, account, transaction,
+> fx, sepa-payment, sepa-instant, domestic-payment, fraud); re-verified against a fresh
+> `origin/main` checkout that the remaining 6 (sca, consent, billing, clearing, swift,
+> lending) still have only 1-2 domain files of plain data models, so the ADR-0063
+> thin-domain exclusion still holds — no expansion needed at this time, only confirmed.
+> DAST: `.github/workflows/dast-zap-baseline.yml` runs OWASP ZAP baseline
+> (`zaproxy/action-baseline`, pinned) weekly against `openbank-ledger-service` (booted via the
+> existing `openbank-infra/docker-compose.yml`), scanning its documented unauthenticated
+> public paths. Report-only (`fail_action: false`), feeding the D1 lifecycle. Full
+> `customer-edge` (the true internet-facing edge, ADR-0065) and an authenticated crawl remain
+> follow-up — `customer-edge` is a gitops-only proxy with no Gradle/image build in this repo,
+> and fleet-wide boot is too heavy for a CI job.
+
 ### D4 — Admission control: verify provenance at deploy
 
 - The GitOps deploy path (ArgoCD, ADR-0027) gains an **admission policy** (Kyverno or OPA/Gatekeeper)

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "1b1f85a2c3e4505d"
+    openbank.tech/policy-checksum: "6a52e16c0be5ec41"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1155,15 +1155,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b1f85a2c3e4505d"
+        openbank.tech/policy-checksum: "6a52e16c0be5ec41"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "73990159182b6945"
+    openbank.tech/policy-checksum: "6f2fa52eb86f180a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1199,15 +1199,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "73990159182b6945"
+        openbank.tech/policy-checksum: "6f2fa52eb86f180a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "e8d8b9f713dde4c2"
+    openbank.tech/policy-checksum: "3e5d2c326640a9e6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1104,15 +1104,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e8d8b9f713dde4c2"
+        openbank.tech/policy-checksum: "3e5d2c326640a9e6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "7f3c57fc9d538dfb"
+    openbank.tech/policy-checksum: "db574c571fd8c97a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1122,15 +1122,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7f3c57fc9d538dfb"
+        openbank.tech/policy-checksum: "db574c571fd8c97a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "bdf0a2bd5ef91f46"
+    openbank.tech/policy-checksum: "e2aa67eadc8e291c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1187,15 +1187,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bdf0a2bd5ef91f46"
+        openbank.tech/policy-checksum: "e2aa67eadc8e291c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "f91569c95fc53d10"
+    openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -752,15 +752,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f91569c95fc53d10"
+        openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "a622c2dfc83827b3"
+    openbank.tech/policy-checksum: "9ea358b82c659aec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1115,15 +1115,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a622c2dfc83827b3"
+        openbank.tech/policy-checksum: "9ea358b82c659aec"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "bf594778e744f1af"
+    openbank.tech/policy-checksum: "3ce14b84d190e3f2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1152,15 +1152,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bf594778e744f1af"
+        openbank.tech/policy-checksum: "3ce14b84d190e3f2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "a121daa38829cef0"
+    openbank.tech/policy-checksum: "772dcf06549a6735"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1211,15 +1211,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a121daa38829cef0"
+        openbank.tech/policy-checksum: "772dcf06549a6735"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "273ab1ff910b46e9"
+    openbank.tech/policy-checksum: "d27d150e5aa63328"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1158,15 +1158,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "273ab1ff910b46e9"
+        openbank.tech/policy-checksum: "d27d150e5aa63328"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "f91569c95fc53d10"
+    openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -752,15 +752,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "f91569c95fc53d10"
+        openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a1334ad6553a8b12"
+    openbank.tech/policy-checksum: "5b9b910b50f19161"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1158,15 +1158,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1e9881796531964a"
+    openbank.tech/policy-checksum: "b38a1e12005863b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1143,15 +1143,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "323fceb2e3cf7b6e" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "7b13cd04cfc746de" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4632c2282d87aff5"
+        openbank.tech/policy-checksum: "4d74e815aaf36817"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1e9881796531964a" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "b38a1e12005863b5" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "419058562a13a90e"
+        openbank.tech/policy-checksum: "4d498aa8d5ae2fd1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a1334ad6553a8b12" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "5b9b910b50f19161" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1891,7 +1891,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1af11b73428bcbd6" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "fc0fccdf3095d101" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2281,7 +2281,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "37d694854f617127"
+        openbank.tech/policy-checksum: "56a7c357de91bdad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "419058562a13a90e"
+    openbank.tech/policy-checksum: "4d498aa8d5ae2fd1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1116,15 +1116,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4632c2282d87aff5"
+    openbank.tech/policy-checksum: "4d74e815aaf36817"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1137,15 +1137,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1af11b73428bcbd6"
+    openbank.tech/policy-checksum: "fc0fccdf3095d101"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1117,15 +1117,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "37d694854f617127"
+    openbank.tech/policy-checksum: "56a7c357de91bdad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1120,15 +1120,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "323fceb2e3cf7b6e"
+    openbank.tech/policy-checksum: "7b13cd04cfc746de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1173,15 +1173,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "88279f3f3a68a053"
+    openbank.tech/policy-checksum: "4bb84d9698ec74ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1126,15 +1126,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "88279f3f3a68a053"
+        openbank.tech/policy-checksum: "4bb84d9698ec74ef"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "7c26234ceb3da1e6"
+    openbank.tech/policy-checksum: "be0e1a9b440989da"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1140,15 +1140,33 @@ data:
         money_path_target: 70               # aspirational target; raise floor PRs as tests land
       money_path_depth:
         tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-        enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+        enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
-        # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-        # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-        # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-        # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+        ci_producer: .github/workflows/pitest.yml
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+        # only 1-2 domain files, and those files are plain data models (no branching money-movement
+        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+        # real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+      dast:
+        tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+        enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+        target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+        ci_producer: .github/workflows/dast-zap-baseline.yml
+        # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+        # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+        # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+        # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+        # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+        # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+        # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+        blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
     # ---------------------------------------------------------------------------------------
     # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7c26234ceb3da1e6"
+        openbank.tech/policy-checksum: "be0e1a9b440989da"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -354,15 +354,33 @@ coverage:
     money_path_target: 70               # aspirational target; raise floor PRs as tests land
   money_path_depth:
     tool: pitest                        # mutation testing on money-path domain math (ADR-0030 D3)
-    enforced: planned                   # weekly advisory runs are live; blocking flip pending sustained >=70%
+    enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
     target_enforce_date: "2026-09-30"   # ADR-0144
-    # Wired (pitest.yml weekly): ledger, balance, account, transaction, fx + sepa-payment,
-    # sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06). Remaining
-    # money-path services are excluded by the ADR-0063 thin-domain criterion (1-2 domain
-    # files: sca, consent, billing, clearing, swift, lending) — mutation noise, not signal.
+    ci_producer: .github/workflows/pitest.yml
+    # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
+    # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+    # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
+    # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
+    # only 1-2 domain files, and those files are plain data models (no branching money-movement
+    # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
+    # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
+    # real decision logic in its domain layer.
     # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
     # transaction 46%, balance 55%, ledger 65%, fx 73%.
     blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"
+  dast:
+    tool: "OWASP ZAP baseline (zaproxy/action-baseline)"   # ADR-0030 D3
+    enforced: advisory                  # report-only first cut; no fail_action, no PR gate
+    target_enforce_date: "2026-12-31"   # revisit once findings are triaged via the D1 lifecycle
+    ci_producer: .github/workflows/dast-zap-baseline.yml
+    # Scope decision (2026-07-07, issue #265 D3): customer-edge is the true internet-facing edge
+    # (ADR-0065) but is a gitops-only Rollout/proxy with no Gradle module or image build in this
+    # repo, and booting the full fleet (openbank-infra/docker-compose.yml: postgres/kafka/keycloak
+    # + ~30 service images) is too heavy for a CI job. First cut scans ONE already-defined
+    # docker-compose target instead: ledger-service (postgres + kafka deps only), against its
+    # documented unauthenticated public paths (QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS).
+    # Scheduled weekly, not per-PR (cost + expected finding volume on a fresh banking-API scan).
+    blocked_on: "unauthenticated-surface only; an authenticated crawl needs Keycloak token issuance wired into the CI job, and a customer-edge / fleet-wide target needs either the real cluster or a much heavier compose boot — both deferred"
 
 # ---------------------------------------------------------------------------------------
 # API deprecation policy — drives ApiVersionResponseFilter.isDeprecatedPath() (ADR-0029 D2).


### PR DESCRIPTION
## Summary

Closes out ADR-0030 D3 ("mutation testing + DAST") for issue #265, with an honest audit of
what was already done vs. what was genuinely missing.

## Type of change

- [x] chore (build / tooling)
- [x] docs

## Linked issues

Refs #265

## Changes

- **Mutation testing (Part A) — re-verified, not re-wired.** `pitest.yml` and `rules.yaml`
  already show the fleet rollout at 9/15 money-path services (ledger, balance, account,
  transaction, fx, sepa-payment, sepa-instant, domestic-payment, fraud — landed across
  #317/#318 before this PR). I re-counted domain files on a fresh `origin/main` checkout for
  the 6 excluded services (sca, consent, billing, clearing, swift, lending): each still has
  only 1-2 domain files, and those files are plain data models with no branching
  money-movement logic — the ADR-0063 thin-domain exclusion criterion still holds unchanged.
  Issue #265's D3 text ("pitest is only configured for `openbank-lending-service`") is stale;
  it predates #317/#318. I refreshed `rules.yaml: coverage.money_path_depth` to record this
  re-verification with a date stamp instead of silently leaving the impression that expansion
  is still "planned" work.
- **DAST (Part B) — net new.** Added `.github/workflows/dast-zap-baseline.yml`: a scheduled
  (weekly, Sunday 04:30 UTC) + `workflow_dispatch` job that boots `ledger-service` +
  its `postgres`/`kafka` deps via the existing `openbank-infra/docker-compose.yml`, waits for
  health, then runs `zaproxy/action-baseline` (pinned to `v0.15.0` by commit SHA) against its
  documented unauthenticated public paths (`/api/v1/journals`, see
  `QUARKUS_HTTP_AUTH_PERMISSION__PUBLIC__PATHS` in the compose file). Report-only for this
  first cut: `fail_action: false`, `allow_issue_writing: false` — findings are an artifact
  (`zap-baseline-ledger-service`) for manual triage via the ADR-0030 D1 lifecycle, not a
  merge gate.
- **`rules.yaml`**: added a `coverage.money_path_depth` refresh + a new sibling
  `coverage.dast` entry — both `enforced: advisory`, both with `ci_producer` pointing at the
  workflow that produces them, per `rules.yaml: knowledge_capture`.

## Scope decisions (explicit, not silently dropped)

- **Mutation testing**: no service was newly wired in this PR — the ADR-0063 thin-domain
  criterion, re-checked, still excludes sca/consent/billing/clearing/swift/lending. This is a
  verification, not an expansion. If any of those services grows real domain decision logic,
  revisit.
- **DAST target**: `customer-edge` (ADR-0065's true internet-facing edge) is a gitops-only
  Argo Rollout/proxy with no Gradle module or image build in this repo, so it can't be booted
  standalone in a CI job the way a service can. Standing up the *entire* fleet from
  `openbank-infra/docker-compose.yml` (postgres/kafka/keycloak + ~30 service images) was
  judged too heavy for a CI job. First cut scans **one** already-defined compose target
  (`ledger-service`) on its **unauthenticated** surface only — no Keycloak token issuance
  wired into the CI job yet. Both narrowings are recorded in `rules.yaml: coverage.dast.blocked_on`
  and in the workflow's own header comment.
- Not addressed here (explicitly out of scope for D3, tracked elsewhere in #265): D1 (VEX +
  vuln lifecycle), D2 diff-aware threat-model rule, D5 (runtime SBOM drift).

## Verification honesty note

I validated the new workflow statically (YAML parses, matches the repo's actual `yamllint`
CI config with zero new warnings beyond the pre-existing harmless `on:` truthy one that
`pitest.yml` also has, confirmed `ledger-service`'s port/public-paths/datasource-password
against `openbank-infra/docker-compose.yml`, confirmed `/api/v1/info` and `/api/v1/journals`
are real routes). I attempted a full local `docker compose up postgres kafka ledger-service`
dry run to get a real ZAP baseline output, but the local machine had several other agents'
Gradle/Docker builds running concurrently and the in-container Quarkus build stalled for
10+ minutes without completing — inconclusive due to host contention, not a sign of a defect
in the compose file or workflow (this exact compose target is the pre-existing, working local
dev stack). The workflow will get its first real execution on GitHub-hosted runners (uncontended)
on the next scheduled run or via manual `workflow_dispatch`.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — N/A, no domain code touched.
- [ ] Unit tests added/updated. — N/A, CI/governance-only change.
- [ ] Integration tests added/updated (if service boundary involved). — N/A.
- [ ] Contract tests updated (if public API changed). — N/A, no API change.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no Gradle module changed.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A.
- [ ] Flyway migration added + rollback note (if DB changed). — N/A.
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A.
- [x] Docs updated (rules.yaml).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. (The
      `POSTGRES_PASSWORD=openbank_secret` in the new workflow matches the existing
      hardcoded local-dev-only value already committed in `openbank-infra/docker-compose.yml`
      for every other service — not a new secret.)
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached. (New GitHub Action
      `zaproxy/action-baseline`, pinned by commit SHA to release `v0.15.0`, official OWASP ZAP
      project action.)
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`. — N/A, CI-only.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [x] None (governance/CI tooling only)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
