### PR TITLE
fix(infra): bridge agents.yaml tool-tier vocabulary into rest.rego REST actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,19 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
 - **Use explicit registry prefixes for container images** (`docker.io/library/<image>` for official
   images) so the cluster's pull-through/rewrite policies apply.
 
+### OPA / Rego policies (ADR-0031/ADR-0034)
+- **An `AI_AGENT` principal's id carries an `agent:` prefix on the REST path, but not on the
+  MCP path.** `AuthorizeInterceptor.principalType()` classifies `AI_AGENT` from a JWT `sub`
+  prefixed `agent:`, and `principal.id` is that sub verbatim — but `openbank-agent-service`
+  sets `agent` to a bare charter id (`"ui-assistant"`) directly from its own config on the MCP
+  `/tools/call` path. A charter lookup that compares `principal.id`/`input.agent` straight
+  against `agents.yaml` ids must strip the prefix first (`trim_prefix(input.agent, "agent:")`,
+  a no-op when absent) or it silently never matches for every real REST call.
+- **`rest.rego` must delegate AI-agent REST calls to `agents.allow`, never `agents.charter_allowed`
+  directly.** Only `allow` also applies `hard_denied` / `charter_denied` / `skill_ok` — calling
+  `charter_allowed` alone lets a fleet-wide hard-denied tool tier or a charter's own `tools.deny`
+  glob silently reach a REST action anyway.
+
 ### Reviewing a diff
 - **Use 3-dot diff for pre-merge review:** `git diff origin/main...origin/<branch>` is the actual
   squash delta; 2-dot includes main's post-divergence commits and makes stale branches look like

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "29ac4f7d02727915"
+    openbank.tech/policy-checksum: "bdb4e9b008e3f157"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -56,6 +56,51 @@ data:
     	some a in charter
     	some pattern in a.tools.allow
     	glob_match(pattern, input.tool)
+    }
+
+    # rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+    # AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+    # an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+    # declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+    # e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+    # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+    # relationship), so charter_allowed alone could never grant a REST read no matter how
+    # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    charter_allowed if rest_action_allowed
+
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
+    # -- the single place that already decided which REST-action service scopes each
+    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
+    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
+    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    rest_domains := {
+    	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.catalog.readonly": {"catalog"},
+    	"query.compliance.readonly": {"aml", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.interest.readonly": {"interest"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.balance.readonly": {"balance"},
+    	"query.transaction.readonly": {"transaction"},
+    }
+
+    # Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+    # however permissive matching the domain prefix alone would otherwise be.
+    rest_read_verbs := {"list", "read", "search"}
+
+    # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+    # in that tool's mapped rest_domains set AND the verb is read-only.
+    rest_action_allowed if {
+    	some a in charter
+    	some pattern in a.tools.allow
+    	some scope in rest_domains[pattern]
+    	startswith(input.tool, sprintf("%s.", [scope]))
+    	some verb in rest_read_verbs
+    	endswith(input.tool, sprintf(".%s", [verb]))
     }
 
     # run.skill is further constrained to the agent's `skills` allowlist (development plane).

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "bdb4e9b008e3f157"
+    openbank.tech/policy-checksum: "ec7ef0a24ceeb4f0"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -36,9 +36,15 @@ data:
     default allow := false
 
     # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+    # input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+    # config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+    # bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+    # AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+    # "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+    # this normalises both callers to the bare charter id without needing two lookup rules.
     charter contains a if {
     	some a in data.agents.agents
-    	a.id == input.agent
+    	a.id == trim_prefix(input.agent, "agent:")
     }
 
     # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -46,15 +52,26 @@ data:
 
     # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
     charter_denied if {
-    	some a in charter
-    	some pattern in a.tools.deny
+    	some pattern in allowed_or_denied_patterns.deny
     	glob_match(pattern, input.tool)
+    }
+
+    # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+    # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    allowed_or_denied_patterns := {
+    	"allow": {pattern |
+    		some a in charter
+    		some pattern in a.tools.allow
+    	},
+    	"deny": {pattern |
+    		some a in charter
+    		some pattern in a.tools.deny
+    	},
     }
 
     # A tool is explicitly allowed by the agent's charter allowlist.
     charter_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	glob_match(pattern, input.tool)
     }
 
@@ -66,24 +83,32 @@ data:
     # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
     # relationship), so charter_allowed alone could never grant a REST read no matter how
     # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
-    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+    # rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+    # charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+    # skips those checks.
     charter_allowed if rest_action_allowed
 
-    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
-    # -- the single place that already decided which REST-action service scopes each
-    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
-    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+    # single place that already decided which REST-action service scopes each `query.*.readonly`
+    # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+    # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
     # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
-    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+    # their entries are forward-looking and inert until that service adopts @Authorize on its
+    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+    # the bare service name, since a future read endpoint may reuse either convention and both
+    # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.catalog.readonly": {"catalog"},
-    	"query.compliance.readonly": {"aml", "sanctions"},
-    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.disputes.readonly": {"dispute"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }
@@ -95,8 +120,7 @@ data:
     # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
     # in that tool's mapped rest_domains set AND the verb is read-only.
     rest_action_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	some scope in rest_domains[pattern]
     	startswith(input.tool, sprintf("%s.", [scope]))
     	some verb in rest_read_verbs

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "29ac4f7d02727915"
+        openbank.tech/policy-checksum: "bdb4e9b008e3f157"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "bdb4e9b008e3f157"
+        openbank.tech/policy-checksum: "ec7ef0a24ceeb4f0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a95d9c7563422017"
+    openbank.tech/policy-checksum: "7ece31e94ae04dcb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -363,6 +363,51 @@ data:
     	some a in charter
     	some pattern in a.tools.allow
     	glob_match(pattern, input.tool)
+    }
+
+    # rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+    # AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+    # an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+    # declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+    # e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+    # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+    # relationship), so charter_allowed alone could never grant a REST read no matter how
+    # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    charter_allowed if rest_action_allowed
+
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
+    # -- the single place that already decided which REST-action service scopes each
+    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
+    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
+    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    rest_domains := {
+    	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.catalog.readonly": {"catalog"},
+    	"query.compliance.readonly": {"aml", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.interest.readonly": {"interest"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.balance.readonly": {"balance"},
+    	"query.transaction.readonly": {"transaction"},
+    }
+
+    # Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+    # however permissive matching the domain prefix alone would otherwise be.
+    rest_read_verbs := {"list", "read", "search"}
+
+    # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+    # in that tool's mapped rest_domains set AND the verb is read-only.
+    rest_action_allowed if {
+    	some a in charter
+    	some pattern in a.tools.allow
+    	some scope in rest_domains[pattern]
+    	startswith(input.tool, sprintf("%s.", [scope]))
+    	some verb in rest_read_verbs
+    	endswith(input.tool, sprintf(".%s", [verb]))
     }
 
     # run.skill is further constrained to the agent's `skills` allowlist (development plane).

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "7ece31e94ae04dcb"
+    openbank.tech/policy-checksum: "1b80a815c8e4459b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -55,11 +55,13 @@ data:
     	"policy_version": policy_version,
     } if {
     	count(allowed_reasons) > 0
+
     	# Defense-in-depth: a prohibited action (e.g. flipping off SCA/sanctions via a feature
     	# flag, issue #419) can never be granted by ANY reason — not even operator-on-own-tenant
     	# with a tenant-matched resource. Gating the allow head, not each reason, makes this
     	# impossible to bypass by enriching the input (the prohibition is not just surfaced).
     	not prohibited
+
     	# Pick the lexicographically smallest reason so the complete rule produces a single
     	# deterministic output even when multiple allowed_reasons rules fire simultaneously
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
@@ -83,6 +85,7 @@ data:
     allowed_reasons contains "operator-on-own-tenant" if {
     	input.principal.type == "HUMAN"
     	"ROLE_OPERATOR" in input.principal.roles
+
     	# Resource-scoped actions must target the operator's tenant; non-scoped
     	# (system-wide) actions are not granted by this rule.
     	input.resource
@@ -100,10 +103,13 @@ data:
     # duplicate the charter logic — call it through the unified package boundary.
     allowed_reasons contains "agent-charter-allows" if {
     	input.principal.type == "AI_AGENT"
-    	# Translate the REST input into the MCP input shape and reuse agents.allow.
-    	# Kept tight on purpose: only proceeds if the agent has an EXPLICIT allow
-    	# from its charter, not just absence-of-deny.
-    	data.openbank.agents.charter_allowed with input as {
+
+    	# Translate the REST input into the MCP input shape and reuse agents.allow --
+    	# NOT charter_allowed: agents.allow ALSO applies hard_denied / charter_denied /
+    	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
+    	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
+    	# tools.deny glob, silently reach a REST action anyway.
+    	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
     		"resource": input.resource,
@@ -343,9 +349,15 @@ data:
     default allow := false
 
     # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+    # input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+    # config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+    # bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+    # AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+    # "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+    # this normalises both callers to the bare charter id without needing two lookup rules.
     charter contains a if {
     	some a in data.agents.agents
-    	a.id == input.agent
+    	a.id == trim_prefix(input.agent, "agent:")
     }
 
     # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -353,15 +365,26 @@ data:
 
     # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
     charter_denied if {
-    	some a in charter
-    	some pattern in a.tools.deny
+    	some pattern in allowed_or_denied_patterns.deny
     	glob_match(pattern, input.tool)
+    }
+
+    # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+    # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    allowed_or_denied_patterns := {
+    	"allow": {pattern |
+    		some a in charter
+    		some pattern in a.tools.allow
+    	},
+    	"deny": {pattern |
+    		some a in charter
+    		some pattern in a.tools.deny
+    	},
     }
 
     # A tool is explicitly allowed by the agent's charter allowlist.
     charter_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	glob_match(pattern, input.tool)
     }
 
@@ -373,24 +396,32 @@ data:
     # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
     # relationship), so charter_allowed alone could never grant a REST read no matter how
     # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
-    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+    # rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+    # charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+    # skips those checks.
     charter_allowed if rest_action_allowed
 
-    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
-    # -- the single place that already decided which REST-action service scopes each
-    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
-    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+    # single place that already decided which REST-action service scopes each `query.*.readonly`
+    # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+    # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
     # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
-    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+    # their entries are forward-looking and inert until that service adopts @Authorize on its
+    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+    # the bare service name, since a future read endpoint may reuse either convention and both
+    # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.catalog.readonly": {"catalog"},
-    	"query.compliance.readonly": {"aml", "sanctions"},
-    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.disputes.readonly": {"dispute"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }
@@ -402,8 +433,7 @@ data:
     # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
     # in that tool's mapped rest_domains set AND the verb is read-only.
     rest_action_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	some scope in rest_domains[pattern]
     	startswith(input.tool, sprintf("%s.", [scope]))
     	some verb in rest_read_verbs

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7ece31e94ae04dcb"
+        openbank.tech/policy-checksum: "1b80a815c8e4459b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a95d9c7563422017"
+        openbank.tech/policy-checksum: "7ece31e94ae04dcb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "fab59e7557bad4ed"
+    openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -56,11 +56,13 @@ data:
     	"policy_version": policy_version,
     } if {
     	count(allowed_reasons) > 0
+
     	# Defense-in-depth: a prohibited action (e.g. flipping off SCA/sanctions via a feature
     	# flag, issue #419) can never be granted by ANY reason — not even operator-on-own-tenant
     	# with a tenant-matched resource. Gating the allow head, not each reason, makes this
     	# impossible to bypass by enriching the input (the prohibition is not just surfaced).
     	not prohibited
+
     	# Pick the lexicographically smallest reason so the complete rule produces a single
     	# deterministic output even when multiple allowed_reasons rules fire simultaneously
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
@@ -84,6 +86,7 @@ data:
     allowed_reasons contains "operator-on-own-tenant" if {
     	input.principal.type == "HUMAN"
     	"ROLE_OPERATOR" in input.principal.roles
+
     	# Resource-scoped actions must target the operator's tenant; non-scoped
     	# (system-wide) actions are not granted by this rule.
     	input.resource
@@ -101,10 +104,13 @@ data:
     # duplicate the charter logic — call it through the unified package boundary.
     allowed_reasons contains "agent-charter-allows" if {
     	input.principal.type == "AI_AGENT"
-    	# Translate the REST input into the MCP input shape and reuse agents.allow.
-    	# Kept tight on purpose: only proceeds if the agent has an EXPLICIT allow
-    	# from its charter, not just absence-of-deny.
-    	data.openbank.agents.charter_allowed with input as {
+
+    	# Translate the REST input into the MCP input shape and reuse agents.allow --
+    	# NOT charter_allowed: agents.allow ALSO applies hard_denied / charter_denied /
+    	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
+    	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
+    	# tools.deny glob, silently reach a REST action anyway.
+    	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
     		"resource": input.resource,
@@ -223,9 +229,15 @@ data:
     default allow := false
 
     # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+    # input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+    # config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+    # bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+    # AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+    # "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+    # this normalises both callers to the bare charter id without needing two lookup rules.
     charter contains a if {
     	some a in data.agents.agents
-    	a.id == input.agent
+    	a.id == trim_prefix(input.agent, "agent:")
     }
 
     # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -233,15 +245,26 @@ data:
 
     # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
     charter_denied if {
-    	some a in charter
-    	some pattern in a.tools.deny
+    	some pattern in allowed_or_denied_patterns.deny
     	glob_match(pattern, input.tool)
+    }
+
+    # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+    # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    allowed_or_denied_patterns := {
+    	"allow": {pattern |
+    		some a in charter
+    		some pattern in a.tools.allow
+    	},
+    	"deny": {pattern |
+    		some a in charter
+    		some pattern in a.tools.deny
+    	},
     }
 
     # A tool is explicitly allowed by the agent's charter allowlist.
     charter_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	glob_match(pattern, input.tool)
     }
 
@@ -253,24 +276,32 @@ data:
     # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
     # relationship), so charter_allowed alone could never grant a REST read no matter how
     # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
-    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+    # rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+    # charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+    # skips those checks.
     charter_allowed if rest_action_allowed
 
-    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
-    # -- the single place that already decided which REST-action service scopes each
-    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
-    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+    # single place that already decided which REST-action service scopes each `query.*.readonly`
+    # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+    # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
     # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
-    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+    # their entries are forward-looking and inert until that service adopts @Authorize on its
+    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+    # the bare service name, since a future read endpoint may reuse either convention and both
+    # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.catalog.readonly": {"catalog"},
-    	"query.compliance.readonly": {"aml", "sanctions"},
-    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.disputes.readonly": {"dispute"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }
@@ -282,8 +313,7 @@ data:
     # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
     # in that tool's mapped rest_domains set AND the verb is read-only.
     rest_action_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	some scope in rest_domains[pattern]
     	startswith(input.tool, sprintf("%s.", [scope]))
     	some verb in rest_read_verbs

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "68527f6b7add7bfd"
+    openbank.tech/policy-checksum: "fab59e7557bad4ed"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -243,6 +243,51 @@ data:
     	some a in charter
     	some pattern in a.tools.allow
     	glob_match(pattern, input.tool)
+    }
+
+    # rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+    # AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+    # an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+    # declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+    # e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+    # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+    # relationship), so charter_allowed alone could never grant a REST read no matter how
+    # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    charter_allowed if rest_action_allowed
+
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
+    # -- the single place that already decided which REST-action service scopes each
+    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
+    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
+    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    rest_domains := {
+    	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.catalog.readonly": {"catalog"},
+    	"query.compliance.readonly": {"aml", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.interest.readonly": {"interest"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.balance.readonly": {"balance"},
+    	"query.transaction.readonly": {"transaction"},
+    }
+
+    # Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+    # however permissive matching the domain prefix alone would otherwise be.
+    rest_read_verbs := {"list", "read", "search"}
+
+    # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+    # in that tool's mapped rest_domains set AND the verb is read-only.
+    rest_action_allowed if {
+    	some a in charter
+    	some pattern in a.tools.allow
+    	some scope in rest_domains[pattern]
+    	startswith(input.tool, sprintf("%s.", [scope]))
+    	some verb in rest_read_verbs
+    	endswith(input.tool, sprintf(".%s", [verb]))
     }
 
     # run.skill is further constrained to the agent's `skills` allowlist (development plane).

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fab59e7557bad4ed"
+        openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "68527f6b7add7bfd"
+        openbank.tech/policy-checksum: "fab59e7557bad4ed"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "68527f6b7add7bfd"
+    openbank.tech/policy-checksum: "fab59e7557bad4ed"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -243,6 +243,51 @@ data:
     	some a in charter
     	some pattern in a.tools.allow
     	glob_match(pattern, input.tool)
+    }
+
+    # rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+    # AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+    # an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+    # declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+    # e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+    # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+    # relationship), so charter_allowed alone could never grant a REST read no matter how
+    # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    charter_allowed if rest_action_allowed
+
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
+    # -- the single place that already decided which REST-action service scopes each
+    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
+    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
+    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    rest_domains := {
+    	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.catalog.readonly": {"catalog"},
+    	"query.compliance.readonly": {"aml", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.interest.readonly": {"interest"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.balance.readonly": {"balance"},
+    	"query.transaction.readonly": {"transaction"},
+    }
+
+    # Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+    # however permissive matching the domain prefix alone would otherwise be.
+    rest_read_verbs := {"list", "read", "search"}
+
+    # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+    # in that tool's mapped rest_domains set AND the verb is read-only.
+    rest_action_allowed if {
+    	some a in charter
+    	some pattern in a.tools.allow
+    	some scope in rest_domains[pattern]
+    	startswith(input.tool, sprintf("%s.", [scope]))
+    	some verb in rest_read_verbs
+    	endswith(input.tool, sprintf(".%s", [verb]))
     }
 
     # run.skill is further constrained to the agent's `skills` allowlist (development plane).

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "fab59e7557bad4ed"
+    openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -56,11 +56,13 @@ data:
     	"policy_version": policy_version,
     } if {
     	count(allowed_reasons) > 0
+
     	# Defense-in-depth: a prohibited action (e.g. flipping off SCA/sanctions via a feature
     	# flag, issue #419) can never be granted by ANY reason — not even operator-on-own-tenant
     	# with a tenant-matched resource. Gating the allow head, not each reason, makes this
     	# impossible to bypass by enriching the input (the prohibition is not just surfaced).
     	not prohibited
+
     	# Pick the lexicographically smallest reason so the complete rule produces a single
     	# deterministic output even when multiple allowed_reasons rules fire simultaneously
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
@@ -84,6 +86,7 @@ data:
     allowed_reasons contains "operator-on-own-tenant" if {
     	input.principal.type == "HUMAN"
     	"ROLE_OPERATOR" in input.principal.roles
+
     	# Resource-scoped actions must target the operator's tenant; non-scoped
     	# (system-wide) actions are not granted by this rule.
     	input.resource
@@ -101,10 +104,13 @@ data:
     # duplicate the charter logic — call it through the unified package boundary.
     allowed_reasons contains "agent-charter-allows" if {
     	input.principal.type == "AI_AGENT"
-    	# Translate the REST input into the MCP input shape and reuse agents.allow.
-    	# Kept tight on purpose: only proceeds if the agent has an EXPLICIT allow
-    	# from its charter, not just absence-of-deny.
-    	data.openbank.agents.charter_allowed with input as {
+
+    	# Translate the REST input into the MCP input shape and reuse agents.allow --
+    	# NOT charter_allowed: agents.allow ALSO applies hard_denied / charter_denied /
+    	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
+    	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
+    	# tools.deny glob, silently reach a REST action anyway.
+    	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
     		"resource": input.resource,
@@ -223,9 +229,15 @@ data:
     default allow := false
 
     # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+    # input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+    # config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+    # bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+    # AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+    # "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+    # this normalises both callers to the bare charter id without needing two lookup rules.
     charter contains a if {
     	some a in data.agents.agents
-    	a.id == input.agent
+    	a.id == trim_prefix(input.agent, "agent:")
     }
 
     # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -233,15 +245,26 @@ data:
 
     # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
     charter_denied if {
-    	some a in charter
-    	some pattern in a.tools.deny
+    	some pattern in allowed_or_denied_patterns.deny
     	glob_match(pattern, input.tool)
+    }
+
+    # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+    # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    allowed_or_denied_patterns := {
+    	"allow": {pattern |
+    		some a in charter
+    		some pattern in a.tools.allow
+    	},
+    	"deny": {pattern |
+    		some a in charter
+    		some pattern in a.tools.deny
+    	},
     }
 
     # A tool is explicitly allowed by the agent's charter allowlist.
     charter_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	glob_match(pattern, input.tool)
     }
 
@@ -253,24 +276,32 @@ data:
     # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
     # relationship), so charter_allowed alone could never grant a REST read no matter how
     # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
-    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+    # rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+    # charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+    # skips those checks.
     charter_allowed if rest_action_allowed
 
-    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
-    # -- the single place that already decided which REST-action service scopes each
-    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
-    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+    # single place that already decided which REST-action service scopes each `query.*.readonly`
+    # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+    # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
     # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
-    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+    # their entries are forward-looking and inert until that service adopts @Authorize on its
+    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+    # the bare service name, since a future read endpoint may reuse either convention and both
+    # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.catalog.readonly": {"catalog"},
-    	"query.compliance.readonly": {"aml", "sanctions"},
-    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.disputes.readonly": {"dispute"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }
@@ -282,8 +313,7 @@ data:
     # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
     # in that tool's mapped rest_domains set AND the verb is read-only.
     rest_action_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	some scope in rest_domains[pattern]
     	startswith(input.tool, sprintf("%s.", [scope]))
     	some verb in rest_read_verbs

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "fab59e7557bad4ed"
+        openbank.tech/policy-checksum: "b9e2b0d0ecfa2769"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "68527f6b7add7bfd"
+        openbank.tech/policy-checksum: "fab59e7557bad4ed"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "19cf8cdbc8ca001c"
+    openbank.tech/policy-checksum: "986ce7b8c234b184"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -302,6 +302,51 @@ data:
     	some a in charter
     	some pattern in a.tools.allow
     	glob_match(pattern, input.tool)
+    }
+
+    # rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+    # AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+    # an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+    # declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+    # e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+    # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+    # relationship), so charter_allowed alone could never grant a REST read no matter how
+    # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    charter_allowed if rest_action_allowed
+
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
+    # -- the single place that already decided which REST-action service scopes each
+    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
+    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
+    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    rest_domains := {
+    	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.catalog.readonly": {"catalog"},
+    	"query.compliance.readonly": {"aml", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.interest.readonly": {"interest"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.balance.readonly": {"balance"},
+    	"query.transaction.readonly": {"transaction"},
+    }
+
+    # Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+    # however permissive matching the domain prefix alone would otherwise be.
+    rest_read_verbs := {"list", "read", "search"}
+
+    # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+    # in that tool's mapped rest_domains set AND the verb is read-only.
+    rest_action_allowed if {
+    	some a in charter
+    	some pattern in a.tools.allow
+    	some scope in rest_domains[pattern]
+    	startswith(input.tool, sprintf("%s.", [scope]))
+    	some verb in rest_read_verbs
+    	endswith(input.tool, sprintf(".%s", [verb]))
     }
 
     # run.skill is further constrained to the agent's `skills` allowlist (development plane).

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "986ce7b8c234b184"
+    openbank.tech/policy-checksum: "ca080c5bca27b82e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -55,11 +55,13 @@ data:
     	"policy_version": policy_version,
     } if {
     	count(allowed_reasons) > 0
+
     	# Defense-in-depth: a prohibited action (e.g. flipping off SCA/sanctions via a feature
     	# flag, issue #419) can never be granted by ANY reason — not even operator-on-own-tenant
     	# with a tenant-matched resource. Gating the allow head, not each reason, makes this
     	# impossible to bypass by enriching the input (the prohibition is not just surfaced).
     	not prohibited
+
     	# Pick the lexicographically smallest reason so the complete rule produces a single
     	# deterministic output even when multiple allowed_reasons rules fire simultaneously
     	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
@@ -83,6 +85,7 @@ data:
     allowed_reasons contains "operator-on-own-tenant" if {
     	input.principal.type == "HUMAN"
     	"ROLE_OPERATOR" in input.principal.roles
+
     	# Resource-scoped actions must target the operator's tenant; non-scoped
     	# (system-wide) actions are not granted by this rule.
     	input.resource
@@ -100,10 +103,13 @@ data:
     # duplicate the charter logic — call it through the unified package boundary.
     allowed_reasons contains "agent-charter-allows" if {
     	input.principal.type == "AI_AGENT"
-    	# Translate the REST input into the MCP input shape and reuse agents.allow.
-    	# Kept tight on purpose: only proceeds if the agent has an EXPLICIT allow
-    	# from its charter, not just absence-of-deny.
-    	data.openbank.agents.charter_allowed with input as {
+
+    	# Translate the REST input into the MCP input shape and reuse agents.allow --
+    	# NOT charter_allowed: agents.allow ALSO applies hard_denied / charter_denied /
+    	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
+    	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
+    	# tools.deny glob, silently reach a REST action anyway.
+    	data.openbank.agents.allow with input as {
     		"agent": input.principal.id,
     		"tool": input.action,
     		"resource": input.resource,
@@ -282,9 +288,15 @@ data:
     default allow := false
 
     # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+    # input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+    # config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+    # bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+    # AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+    # "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+    # this normalises both callers to the bare charter id without needing two lookup rules.
     charter contains a if {
     	some a in data.agents.agents
-    	a.id == input.agent
+    	a.id == trim_prefix(input.agent, "agent:")
     }
 
     # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -292,15 +304,26 @@ data:
 
     # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
     charter_denied if {
-    	some a in charter
-    	some pattern in a.tools.deny
+    	some pattern in allowed_or_denied_patterns.deny
     	glob_match(pattern, input.tool)
+    }
+
+    # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+    # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    allowed_or_denied_patterns := {
+    	"allow": {pattern |
+    		some a in charter
+    		some pattern in a.tools.allow
+    	},
+    	"deny": {pattern |
+    		some a in charter
+    		some pattern in a.tools.deny
+    	},
     }
 
     # A tool is explicitly allowed by the agent's charter allowlist.
     charter_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	glob_match(pattern, input.tool)
     }
 
@@ -312,24 +335,32 @@ data:
     # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
     # relationship), so charter_allowed alone could never grant a REST read no matter how
     # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
-    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+    # charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+    # rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+    # charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+    # skips those checks.
     charter_allowed if rest_action_allowed
 
-    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
-    # -- the single place that already decided which REST-action service scopes each
-    # `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
-    # the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+    # rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+    # single place that already decided which REST-action service scopes each `query.*.readonly`
+    # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+    # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
     # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
-    # entries are forward-looking and inert until that service adopts @Authorize on its reads.
+    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+    # their entries are forward-looking and inert until that service adopts @Authorize on its
+    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+    # the bare service name, since a future read endpoint may reuse either convention and both
+    # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.catalog.readonly": {"catalog"},
-    	"query.compliance.readonly": {"aml", "sanctions"},
-    	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+    	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+    	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute", "complaint"},
+    	"query.disputes.readonly": {"dispute"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }
@@ -341,8 +372,7 @@ data:
     # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
     # in that tool's mapped rest_domains set AND the verb is read-only.
     rest_action_allowed if {
-    	some a in charter
-    	some pattern in a.tools.allow
+    	some pattern in allowed_or_denied_patterns.allow
     	some scope in rest_domains[pattern]
     	startswith(input.tool, sprintf("%s.", [scope]))
     	some verb in rest_read_verbs

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "986ce7b8c234b184"
+        openbank.tech/policy-checksum: "ca080c5bca27b82e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19cf8cdbc8ca001c"
+        openbank.tech/policy-checksum: "986ce7b8c234b184"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/opa/policies/agents.rego
+++ b/openbank-infra/opa/policies/agents.rego
@@ -44,6 +44,51 @@ charter_allowed if {
 	glob_match(pattern, input.tool)
 }
 
+# rest.rego's "agent-charter-allows" rule reuses this package for a REST call from an
+# AI_AGENT principal by setting input.tool := input.action -- the raw REST action string
+# an @Authorize-annotated endpoint declares (e.g. "ledger.list", "account.read"). Charters
+# declare tools.allow in the MCP tool-tier vocabulary instead (agents.yaml tool_tiers.read,
+# e.g. "query.ledger.readonly") -- a different string space. glob_match("query.ledger.readonly",
+# "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
+# relationship), so charter_allowed alone could never grant a REST read no matter how
+# clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
+# charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+charter_allowed if rest_action_allowed
+
+# rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
+# -- the single place that already decided which REST-action service scopes each
+# `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
+# the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+# query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
+# the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
+# balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
+# entries are forward-looking and inert until that service adopts @Authorize on its reads.
+rest_domains := {
+	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+	"query.catalog.readonly": {"catalog"},
+	"query.compliance.readonly": {"aml", "sanctions"},
+	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+	"query.interest.readonly": {"interest"},
+	"query.disputes.readonly": {"dispute", "complaint"},
+	"query.balance.readonly": {"balance"},
+	"query.transaction.readonly": {"transaction"},
+}
+
+# Scoped to read verbs only -- a `*.readonly` tool must never bridge into a write action,
+# however permissive matching the domain prefix alone would otherwise be.
+rest_read_verbs := {"list", "read", "search"}
+
+# A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
+# in that tool's mapped rest_domains set AND the verb is read-only.
+rest_action_allowed if {
+	some a in charter
+	some pattern in a.tools.allow
+	some scope in rest_domains[pattern]
+	startswith(input.tool, sprintf("%s.", [scope]))
+	some verb in rest_read_verbs
+	endswith(input.tool, sprintf(".%s", [verb]))
+}
+
 # run.skill is further constrained to the agent's `skills` allowlist (development plane).
 skill_ok if {
 	input.tool != "run.skill"

--- a/openbank-infra/opa/policies/agents.rego
+++ b/openbank-infra/opa/policies/agents.rego
@@ -22,9 +22,15 @@ import rego.v1
 default allow := false
 
 # Look up the calling agent's charter (from agents.yaml, loaded as data.agents.agents).
+# input.agent is bare on the MCP path (openbank-agent-service sets it directly from its own
+# config, e.g. "ui-assistant" -- AgentChatService.ASSISTANT_IDENTITY), but rest.rego's REST
+# bridge sources it from the JWT `sub` via AuthorizeInterceptor.principal.id, which for an
+# AI_AGENT is prefixed "agent:" (AuthorizeInterceptor.principalType()'s own convention, e.g.
+# "agent:onboarding" per its test). trim_prefix is a no-op when the prefix isn't present, so
+# this normalises both callers to the bare charter id without needing two lookup rules.
 charter contains a if {
 	some a in data.agents.agents
-	a.id == input.agent
+	a.id == trim_prefix(input.agent, "agent:")
 }
 
 # The hard-forbidden tier is forbidden for ALL agents, regardless of charter (agents.yaml: tool_tiers.deny).
@@ -32,15 +38,26 @@ hard_denied if input.tool in data.agents.tool_tiers.deny
 
 # A tool is explicitly denied by the agent's own charter (supports glob like "money.*", "*.write").
 charter_denied if {
-	some a in charter
-	some pattern in a.tools.deny
+	some pattern in allowed_or_denied_patterns.deny
 	glob_match(pattern, input.tool)
+}
+
+# Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
+# charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+allowed_or_denied_patterns := {
+	"allow": {pattern |
+		some a in charter
+		some pattern in a.tools.allow
+	},
+	"deny": {pattern |
+		some a in charter
+		some pattern in a.tools.deny
+	},
 }
 
 # A tool is explicitly allowed by the agent's charter allowlist.
 charter_allowed if {
-	some a in charter
-	some pattern in a.tools.allow
+	some pattern in allowed_or_denied_patterns.allow
 	glob_match(pattern, input.tool)
 }
 
@@ -52,24 +69,32 @@ charter_allowed if {
 # "ledger.list") never matches (they're unrelated strings, not even a prefix/suffix
 # relationship), so charter_allowed alone could never grant a REST read no matter how
 # clearly the charter's tools.allow / data_scope intended it -- the moment ANY service a
-# charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s.
+# charter reads flips OPA to enforce mode, every AI_AGENT read against it 403s. IMPORTANT:
+# rest.rego MUST delegate to this package's `allow` (which also applies hard_denied /
+# charter_denied / skill_ok), never to charter_allowed directly -- charter_allowed alone
+# skips those checks.
 charter_allowed if rest_action_allowed
 
-# rest_domains mirrors openbank-agent-service's own McpToolRegistry.REQUIRED_CAPABILITY map
-# -- the single place that already decided which REST-action service scopes each
-# `query.*.readonly` MCP capability is meant to cover (e.g. query.ledger.readonly also backs
-# the account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
+# rest_domains mirrors openbank-agent-service's own McpToolRegistry.capabilities map -- the
+# single place that already decided which REST-action service scopes each `query.*.readonly`
+# MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
+# account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
 # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
 # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-# balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet -- their
-# entries are forward-looking and inert until that service adopts @Authorize on its reads.
+# dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
+# their entries are forward-looking and inert until that service adopts @Authorize on its
+# reads (tracked in issue #401). Where a service's only real @Authorize action today is a
+# WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
+# sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
+# the bare service name, since a future read endpoint may reuse either convention and both
+# are inert until then anyway.
 rest_domains := {
 	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
 	"query.catalog.readonly": {"catalog"},
-	"query.compliance.readonly": {"aml", "sanctions"},
-	"query.payments.readonly": {"fx", "clearing", "sepa-instant"},
+	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
+	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
 	"query.interest.readonly": {"interest"},
-	"query.disputes.readonly": {"dispute", "complaint"},
+	"query.disputes.readonly": {"dispute"},
 	"query.balance.readonly": {"balance"},
 	"query.transaction.readonly": {"transaction"},
 }
@@ -81,8 +106,7 @@ rest_read_verbs := {"list", "read", "search"}
 # A charter tool pattern authorizes a REST action iff the action's service-scope prefix is
 # in that tool's mapped rest_domains set AND the verb is read-only.
 rest_action_allowed if {
-	some a in charter
-	some pattern in a.tools.allow
+	some pattern in allowed_or_denied_patterns.allow
 	some scope in rest_domains[pattern]
 	startswith(input.tool, sprintf("%s.", [scope]))
 	some verb in rest_read_verbs

--- a/openbank-infra/opa/policies/agents_test.rego
+++ b/openbank-infra/opa/policies/agents_test.rego
@@ -222,6 +222,57 @@ test_deny_rest_action_domain_not_in_tool_map if {
 		with input as {"agent": "rca-investigator", "tool": "ledger.list", "resource": null}
 }
 
+# rest.rego sources input.agent from the JWT `sub` via principal.id, which for a real
+# AI_AGENT is prefixed "agent:" (AuthorizeInterceptor's own convention/test uses
+# "agent:onboarding") -- agents.yaml charter ids are bare. The charter lookup strips a
+# leading "agent:" so the bridge still resolves the charter with the REAL production id
+# shape, not just the bare id agents_test.rego's other cases use.
+test_allow_rest_action_with_agent_colon_prefixed_id if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "agent:compliance-officer", "tool": "ledger.list", "resource": null}
+}
+
+# A bare id (no "agent:" prefix) still resolves too -- trim_prefix is a no-op when the
+# prefix isn't present, so the MCP path (which already passes bare ids) is unaffected.
+test_allow_rest_action_with_bare_id_unaffected if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.list", "resource": null}
+}
+
+# The fleet-wide hard-denied tier still blocks a tool reachable via the REST-action bridge:
+# agents.allow (not charter_allowed alone) must be the thing rest.rego delegates to, since
+# only allow applies hard_denied. Regression for that exact class of bug.
+test_deny_rest_action_hard_denied_via_bridge if {
+	not agents.allow with data.agents as {
+		"agents": charters.agents,
+		"tool_tiers": {"deny": ["ledger.list"]},
+	}
+		with input as {"agent": "compliance-officer", "tool": "ledger.list", "resource": null}
+	agents.decision.reason == "hard-denied tool tier" with data.agents as {
+		"agents": charters.agents,
+		"tool_tiers": {"deny": ["ledger.list"]},
+	}
+		with input as {"agent": "compliance-officer", "tool": "ledger.list", "resource": null}
+}
+
+# A charter's own tools.deny glob still blocks a tool reachable via the REST-action bridge.
+test_deny_rest_action_charter_denied_via_bridge if {
+	denying_charters := {
+		"agents": [
+			{
+				"id": "compliance-officer",
+				"plane": "control",
+				"tools": {"allow": ["query.ledger.readonly"], "deny": ["ledger.*"]},
+			},
+		],
+		"tool_tiers": {"deny": []},
+	}
+	not agents.allow with data.agents as denying_charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.list", "resource": null}
+	agents.decision.reason == "denied by charter" with data.agents as denying_charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.list", "resource": null}
+}
+
 # ---------------------------------------------------------------------------------------
 # customer-copilot (customer plane, ADR-0089). Reads the signed-in customer's own data and
 # emits PROPOSALS only; money-path tools are hard-denied and money never moves on its word.

--- a/openbank-infra/opa/policies/agents_test.rego
+++ b/openbank-infra/opa/policies/agents_test.rego
@@ -189,6 +189,40 @@ test_deny_rca_tool_not_in_allowlist if {
 }
 
 # ---------------------------------------------------------------------------------------
+# REST-action bridge (rest_domains / rest_action_allowed): rest.rego delegates an AI_AGENT
+# REST call by setting input.tool := the raw REST action string (e.g. "ledger.list"), which
+# lives in a different vocabulary than a charter's tools.allow (e.g. "query.ledger.readonly").
+# These prove the bridge grants exactly the intended REST reads and nothing more.
+# ---------------------------------------------------------------------------------------
+
+# compliance-officer's query.ledger.readonly grant bridges to a same-domain REST read action.
+test_allow_rest_action_via_readonly_tool_ledger_list if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.list", "resource": null}
+}
+
+test_allow_rest_action_via_readonly_tool_ledger_read if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.read", "resource": null}
+}
+
+# The bridge is read-only: a write verb in the same domain is NOT granted by the readonly
+# tool, even though "ledger" is in its mapped domain set.
+test_deny_rest_action_write_verb_not_bridged if {
+	not agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.create", "resource": null}
+	agents.decision.reason == "no matching allow rule" with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "ledger.create", "resource": null}
+}
+
+# A domain outside the tool's mapped set stays denied (rca-investigator only holds
+# query.observability.readonly -- no bridge to ledger.*).
+test_deny_rest_action_domain_not_in_tool_map if {
+	not agents.allow with data.agents as charters
+		with input as {"agent": "rca-investigator", "tool": "ledger.list", "resource": null}
+}
+
+# ---------------------------------------------------------------------------------------
 # customer-copilot (customer plane, ADR-0089). Reads the signed-in customer's own data and
 # emits PROPOSALS only; money-path tools are hard-denied and money never moves on its word.
 # ---------------------------------------------------------------------------------------

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -41,11 +41,13 @@ allow := {
 	"policy_version": policy_version,
 } if {
 	count(allowed_reasons) > 0
+
 	# Defense-in-depth: a prohibited action (e.g. flipping off SCA/sanctions via a feature
 	# flag, issue #419) can never be granted by ANY reason — not even operator-on-own-tenant
 	# with a tenant-matched resource. Gating the allow head, not each reason, makes this
 	# impossible to bypass by enriching the input (the prohibition is not just surfaced).
 	not prohibited
+
 	# Pick the lexicographically smallest reason so the complete rule produces a single
 	# deterministic output even when multiple allowed_reasons rules fire simultaneously
 	# (e.g. operator-on-own-tenant + operator-read-any for a tenant-scoped read).
@@ -69,6 +71,7 @@ policy_version := data.openbank.bundle.version
 allowed_reasons contains "operator-on-own-tenant" if {
 	input.principal.type == "HUMAN"
 	"ROLE_OPERATOR" in input.principal.roles
+
 	# Resource-scoped actions must target the operator's tenant; non-scoped
 	# (system-wide) actions are not granted by this rule.
 	input.resource
@@ -86,10 +89,13 @@ allowed_reasons contains "compliance-read-any" if {
 # duplicate the charter logic — call it through the unified package boundary.
 allowed_reasons contains "agent-charter-allows" if {
 	input.principal.type == "AI_AGENT"
-	# Translate the REST input into the MCP input shape and reuse agents.allow.
-	# Kept tight on purpose: only proceeds if the agent has an EXPLICIT allow
-	# from its charter, not just absence-of-deny.
-	data.openbank.agents.charter_allowed with input as {
+
+	# Translate the REST input into the MCP input shape and reuse agents.allow --
+	# NOT charter_allowed: agents.allow ALSO applies hard_denied / charter_denied /
+	# skill_ok, none of which charter_allowed alone consults. Calling charter_allowed
+	# directly would let a fleet-wide hard-denied tool tier, or an agent's own
+	# tools.deny glob, silently reach a REST action anyway.
+	data.openbank.agents.allow with input as {
 		"agent": input.principal.id,
 		"tool": input.action,
 		"resource": input.resource,

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -6,9 +6,12 @@
 #
 # Mirrors agents_test.rego patterns. Mocks the rules.yaml + bundle-version data so
 # the policy is verified in isolation, before it is shipped into a live OPA sidecar.
-# The AI_AGENT branch (which delegates to data.openbank.agents.charter_allowed) is
-# covered by agents_test.rego — repeating that surface here would just couple the
-# two suites.
+# The AI_AGENT branch's charter_allowed rule VARIATIONS (which tool bridges to which
+# domain, read-vs-write scoping) are covered by agents_test.rego — repeating that
+# surface here would just couple the two suites. What IS covered here is the
+# end-to-end wiring of that delegation through rest.allow itself (the
+# input.tool := input.action translation) — the exact integration a REST-action /
+# tool-tier vocabulary mismatch used to break silently.
 
 package openbank.rest_test
 
@@ -379,4 +382,60 @@ test_deny_service_without_role if {
 		"principal": {"id": "svc-x", "type": "SERVICE", "roles": []},
 		"action": "notification.list",
 	}
+}
+
+# ---------------------------------------------------------------------------------------
+# agent-charter-allows: an AI_AGENT principal calling a REST action directly. rest.allow
+# delegates to agents.charter_allowed by setting input.tool := input.action -- a charter
+# declaring "query.ledger.readonly" in tools.allow (the MCP tool-tier vocabulary) must
+# still grant a same-domain REST read like "ledger.list" (the @Authorize action-string
+# vocabulary), via the rest_domains bridge in agents.rego. Before that bridge existed,
+# glob_match("query.ledger.readonly", "ledger.list") never matched and every AI_AGENT
+# REST read 403'd the moment a service flipped OPA to enforce mode.
+# ---------------------------------------------------------------------------------------
+agent_charters_for_rest_bridge := {
+	"agents": [
+		{
+			"id": "ui-assistant",
+			"plane": "control",
+			"tools": {
+				"allow": ["query.ledger.readonly", "query.catalog.readonly", "draft.ticket"],
+				"deny": ["money.*", "gh.pr.*"],
+			},
+		},
+	],
+	"tool_tiers": {"deny": ["money.transfer", "money.post.ledger", "gh.pr.merge", "gh.pr.approve", "secrets.read.raw"]},
+}
+
+test_allow_ai_agent_ledger_list_via_charter_bridge if {
+	decision := rest.allow with input as {
+		"principal": {"id": "ui-assistant", "type": "AI_AGENT", "roles": []},
+		"action": "ledger.list",
+		"resource": null,
+	}
+		with data.openbank.bundle as bundle
+		with data.agents as agent_charters_for_rest_bridge
+
+	decision.allow == true
+	decision.reason == "agent-charter-allows"
+}
+
+# The bridge is read-only -- an AI_AGENT can never reach a write action through it.
+test_deny_ai_agent_ledger_create_via_charter_bridge if {
+	not rest.allow with input as {
+		"principal": {"id": "ui-assistant", "type": "AI_AGENT", "roles": []},
+		"action": "ledger.create",
+		"resource": null,
+	}
+		with data.agents as agent_charters_for_rest_bridge
+}
+
+# An AI_AGENT whose charter holds no matching tool stays denied (deny-by-default holds).
+test_deny_ai_agent_without_matching_charter_tool if {
+	not rest.allow with input as {
+		"principal": {"id": "rca-investigator", "type": "AI_AGENT", "roles": []},
+		"action": "ledger.list",
+		"resource": null,
+	}
+		with data.agents as agent_charters_for_rest_bridge
 }

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -2,7 +2,12 @@
 # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
 #
 # Unit tests for the REST authorization policy (ADR-0034 D1). Run from repo root:
-#   opa test openbank-libs/governance/policies
+#   opa test openbank-libs/governance/policies openbank-infra/opa/policies
+# (both directories: the agent-charter-allows tests below delegate into
+# data.openbank.agents, defined in openbank-infra/opa/policies/agents.rego -- running this
+# directory alone leaves that package undefined and those tests fail. build-bundle.sh
+# already runs both together; this is only a trap for `opa test` invoked by hand on just
+# this directory, as the comment on line 5 used to suggest.)
 #
 # Mirrors agents_test.rego patterns. Mocks the rules.yaml + bundle-version data so
 # the policy is verified in isolation, before it is shipped into a live OPA sidecar.
@@ -386,12 +391,19 @@ test_deny_service_without_role if {
 
 # ---------------------------------------------------------------------------------------
 # agent-charter-allows: an AI_AGENT principal calling a REST action directly. rest.allow
-# delegates to agents.charter_allowed by setting input.tool := input.action -- a charter
-# declaring "query.ledger.readonly" in tools.allow (the MCP tool-tier vocabulary) must
-# still grant a same-domain REST read like "ledger.list" (the @Authorize action-string
-# vocabulary), via the rest_domains bridge in agents.rego. Before that bridge existed,
-# glob_match("query.ledger.readonly", "ledger.list") never matched and every AI_AGENT
-# REST read 403'd the moment a service flipped OPA to enforce mode.
+# delegates to agents.allow by setting input.tool := input.action -- a charter declaring
+# "query.ledger.readonly" in tools.allow (the MCP tool-tier vocabulary) must still grant a
+# same-domain REST read like "ledger.list" (the @Authorize action-string vocabulary), via
+# the rest_domains bridge in agents.rego. Before that bridge existed, glob_match
+# ("query.ledger.readonly", "ledger.list") never matched and every AI_AGENT REST read
+# 403'd the moment a service flipped OPA to enforce mode.
+#
+# principal.id here uses the REAL production shape: AuthorizeInterceptor.principalType()
+# classifies AI_AGENT from a JWT `sub` prefixed "agent:" (its own test uses "agent:onboarding"),
+# and principal.id is that sub VERBATIM, prefix included -- agents.yaml charter ids are bare
+# ("ui-assistant"). agents.rego's charter lookup strips the prefix before comparing; these
+# tests use the prefixed form so a regression there (e.g. someone removing the trim_prefix)
+# fails here instead of only in a bare-id unit test that doesn't reflect the real JWT shape.
 # ---------------------------------------------------------------------------------------
 agent_charters_for_rest_bridge := {
 	"agents": [
@@ -409,7 +421,7 @@ agent_charters_for_rest_bridge := {
 
 test_allow_ai_agent_ledger_list_via_charter_bridge if {
 	decision := rest.allow with input as {
-		"principal": {"id": "ui-assistant", "type": "AI_AGENT", "roles": []},
+		"principal": {"id": "agent:ui-assistant", "type": "AI_AGENT", "roles": []},
 		"action": "ledger.list",
 		"resource": null,
 	}
@@ -423,7 +435,7 @@ test_allow_ai_agent_ledger_list_via_charter_bridge if {
 # The bridge is read-only -- an AI_AGENT can never reach a write action through it.
 test_deny_ai_agent_ledger_create_via_charter_bridge if {
 	not rest.allow with input as {
-		"principal": {"id": "ui-assistant", "type": "AI_AGENT", "roles": []},
+		"principal": {"id": "agent:ui-assistant", "type": "AI_AGENT", "roles": []},
 		"action": "ledger.create",
 		"resource": null,
 	}
@@ -433,9 +445,46 @@ test_deny_ai_agent_ledger_create_via_charter_bridge if {
 # An AI_AGENT whose charter holds no matching tool stays denied (deny-by-default holds).
 test_deny_ai_agent_without_matching_charter_tool if {
 	not rest.allow with input as {
-		"principal": {"id": "rca-investigator", "type": "AI_AGENT", "roles": []},
+		"principal": {"id": "agent:rca-investigator", "type": "AI_AGENT", "roles": []},
 		"action": "ledger.list",
 		"resource": null,
 	}
 		with data.agents as agent_charters_for_rest_bridge
+}
+
+# The fleet-wide hard-denied tier still blocks a REST action reachable via the bridge --
+# rest.allow MUST delegate to agents.allow (which checks hard_denied), not to
+# agents.charter_allowed alone (which doesn't). Regression coverage for that exact bug:
+# hard-denying "ledger.list" here (an artificial hard-deny entry, since no real fleet entry
+# collides with a read verb today) would otherwise still be granted by rest_action_allowed.
+test_deny_ai_agent_hard_denied_tool_via_bridge if {
+	not rest.allow with input as {
+		"principal": {"id": "agent:ui-assistant", "type": "AI_AGENT", "roles": []},
+		"action": "ledger.list",
+		"resource": null,
+	}
+		with data.agents as {
+			"agents": agent_charters_for_rest_bridge.agents,
+			"tool_tiers": {"deny": ["ledger.list"]},
+		}
+}
+
+# A charter's own tools.deny glob still blocks a REST action reachable via the bridge --
+# same regression class as the hard-denied case above, at the charter_denied layer instead.
+test_deny_ai_agent_charter_denied_tool_via_bridge if {
+	not rest.allow with input as {
+		"principal": {"id": "agent:ui-assistant", "type": "AI_AGENT", "roles": []},
+		"action": "ledger.list",
+		"resource": null,
+	}
+		with data.agents as {
+			"agents": [
+				{
+					"id": "ui-assistant",
+					"plane": "control",
+					"tools": {"allow": ["query.ledger.readonly"], "deny": ["ledger.*"]},
+				},
+			],
+			"tool_tiers": {"deny": []},
+		}
 }


### PR DESCRIPTION
## Summary

- `rest.rego`'s `agent-charter-allows` rule delegates an AI_AGENT REST call to
  `agents.charter_allowed` by setting `input.tool := input.action` (the raw REST action
  string, e.g. `ledger.list`). Charters declare `tools.allow` in the MCP tool-tier
  vocabulary instead (e.g. `query.ledger.readonly`) — an unrelated string space, so
  `glob_match("query.ledger.readonly", "ledger.list")` never matched and every AI_AGENT
  REST read would 403 the moment a service flips OPA to enforce mode. Found while
  auditing the residual risk flagged in ledger's OPA-enforce PR (refs #266).
- Fixes it with a `rest_domains` translation table in `openbank-infra/opa/policies/agents.rego`
  (mirrored from `openbank-agent-service`'s own `McpToolRegistry.capabilities` map — the
  one place that already decided which REST-action service scopes each `query.*.readonly`
  capability covers) plus a read-verb-scoped bridge rule (`rest_action_allowed`), added as
  an extra disjunct to `charter_allowed`. Scoped to `list`/`read`/`search` only, so a
  `*.readonly` tool can never bridge into a write action.

**Self-review update:** ran a 5-angle parallel code review against the first commit and it
found two real bugs in the fix itself, both fixed in the second commit:
1. The REST bridge delegated to `charter_allowed`, which skips `hard_denied` /
   `charter_denied` / `skill_ok` (only `agents.allow` applies those) — a fleet-wide
   hard-denied tool or a charter's own `tools.deny` glob would have had no effect on the
   REST path. Now delegates to `agents.allow`.
2. The charter lookup compared `input.agent` verbatim against `agents.yaml` ids, but a real
   AI_AGENT JWT's `sub` (and therefore `principal.id`) is prefixed `agent:`
   (`AuthorizeInterceptor`'s own convention), while `agents.yaml` ids are bare — so the
   bridge from the first commit was dead code against a real token. Now strips the prefix
   (`trim_prefix`, a no-op when absent, so the MCP path — which already passes bare ids —
   is unaffected).

Also corrected a comment referencing a nonexistent `McpToolRegistry` symbol, dropped an
unverified domain entry, added verified real `@Authorize` prefixes for three still-inert
domains, and factored out a duplicated charter walk. Added the two lessons to CLAUDE.md's
pitfalls per the repo's knowledge-capture convention.

Regenerated the derived OPA bundle ConfigMaps + pod-roll checksum annotations (agent, pid,
copilot, customer-edge, notifications) per the CI drift gate, twice (once per commit).

Verified with `opa eval` using the REAL `agent:`-prefixed id shape: `ledger.list` from an
AI_AGENT principal (`agent:ui-assistant`) holding a `query.ledger.readonly` charter grant
now returns `{"allow": true, "reason": "agent-charter-allows", ...}`.

## Test plan

- [x] `opa test openbank-infra/opa/policies openbank-libs/governance/policies` — 97/97
      passing (17 new regression tests total across both commits, including the
      hard_denied/charter_denied-bypass and `agent:`-prefix regressions the self-review
      surfaced).
- [x] `./openbank-infra/opa/build-bundle.sh` — `opa check --strict` + decision assertions
      pass, bundle builds.
- [x] Re-ran all four `gen-*-opa-bundle.sh` generators after each commit — idempotent, no
      further diff.
- [x] `opa eval` repro with a realistic `agent:`-prefixed principal id, not just a bare
      test id.

## Linked issues

Refs #266 (out of scope there, fixed here). Follow-up gaps found during this audit
(several services have no `@Authorize` on their read endpoints yet, so their
`rest_domains` entries are inert until they adopt it; an undeclared
`query.gl.readonly` capability; no CI drift-check between `rest_domains` and
`McpToolRegistry.capabilities`) are tracked separately in #401 rather than bundled into
this fix.

A separate, more severe finding from tracing the real request path — `openbank-agent-service`'s
downstream calls may authenticate as `HUMAN`+`ROLE_OPERATOR` rather than `AI_AGENT` at all,
via a client-credentials service account, bypassing charter scoping entirely — was filed as
a draft (unpublished) Security Advisory for a maintainer decision, not as a public issue.

## Note for reviewers

This touches the same generated OPA bundle ConfigMaps (pid/copilot/customer-edge/
notifications) as the still-open #396 (four-eyes signal wiring). The two edit
different regions of the source `.rego` files, but whichever merges second will
need to re-run the `gen-*-opa-bundle.sh` generators and push a small follow-up
commit to resolve the checksum/bundle diff — flagging so it isn't a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)