### PR TITLE
security(libs): fix unreachable SERVICE-principal rego gate (ADR-0034 Phase 5)

### DIFF
--- a/.github/scripts/check-no-service-principal-type.sh
+++ b/.github/scripts/check-no-service-principal-type.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Guard: no .rego policy (standalone or embedded as a heredoc in a
+# gen-*-opa-bundle.sh generator script, or already baked into a committed
+# *-opa-bundle.yaml ConfigMap) may gate an allow rule on
+# `principal.type == "SERVICE"`.
+#
+# AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+# ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+# client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+# client is ever granted a ROLE_SERVICE role. A rego rule gated on
+# `principal.type == "SERVICE"` is therefore structurally unreachable dead code — it
+# can never fire, silently denying the M2M caller it was meant to authorize once
+# AUTHZ_ENFORCE flips to true (found in the sca/domestic-payment ADR-0034 Phase 5 PRs,
+# issue #266, both pre-merge; the shared rest.rego edge-service-notification rule
+# carried the same defect while already deployed with AUTHZ_ENFORCE=true).
+#
+# Identify a specific M2M caller by input.principal.id (Keycloak's
+# "service-account-<clientId>" convention for a service-account token) instead —
+# ROLE_OPERATOR is shared with real human staff, so gating on HUMAN + ROLE_OPERATOR
+# alone is not equivalent and can over-grant (see rest.rego's edge-service-notification
+# rule and rules.yaml: authz_policy).
+#
+# stdlib-only (grep); no opa/rego-parser dependency. ENFORCED.
+# Usage: check-no-service-principal-type.sh [root]   (default root: .)
+set -euo pipefail
+root="${1:-.}"
+fail=0
+checked=0
+
+while IFS= read -r f; do
+  checked=$((checked + 1))
+  # Exclude comment lines (rego line-comments start with #, possibly indented) so this
+  # guard flags live rule bodies, not explanatory prose about the defect itself.
+  hits=$(grep -nE '^[[:space:]]*[^#[:space:]].*principal\.type[[:space:]]*==[[:space:]]*"SERVICE"' "$f" || true)
+  if [ -n "$hits" ]; then
+    fail=1
+    while IFS= read -r hit; do
+      lineno="${hit%%:*}"
+      echo "::error file=$f,line=$lineno::principal.type == \"SERVICE\" can never fire — AuthorizeInterceptor never emits it and no Keycloak client is ever granted ROLE_SERVICE (rules.yaml: authz_policy). Gate on input.principal.id instead."
+    done <<< "$hits"
+  fi
+done < <(find "$root" \
+  \( -name '*.rego' -o -name 'gen-*-opa-bundle*.sh' -o -name '*-opa-bundle.yaml' \) \
+  -not -path '*/build/*' -not -path '*/node_modules/*' -not -path '*/dist/*' | sort)
+
+echo "check-no-service-principal-type: $checked policy source file(s) checked, $( [ "$fail" -eq 0 ] && echo "none gate on principal.type == \"SERVICE\"." || echo "VIOLATIONS above." )"
+exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,19 @@ jobs:
       - name: "gate graduation guard (ADR-0144, enforced)"
         run: bash .github/scripts/check-gate-graduation.sh
 
+      # No dead-code SERVICE-principal rego rule (ADR-0034 Phase 5, issue #266,
+      # rules.yaml: authz_policy). AuthorizeInterceptor never emits
+      # principal.type == "SERVICE" and no Keycloak client is ever granted
+      # ROLE_SERVICE, so a rego rule gated on it can never fire — found live in the
+      # shared rest.rego edge-service-notification rule (deployed, AUTHZ_ENFORCE
+      # defaulting true) and pre-merge in the sca/domestic-payment Phase-5 PRs.
+      # Scans standalone .rego, gen-*-opa-bundle.sh generator heredocs, and
+      # committed *-opa-bundle.yaml ConfigMaps — path-unscoped so it also catches
+      # the pattern in a brand-new service's bundle, not just the four wired into
+      # opa-policy.yml. ENFORCED.
+      - name: "no dead-code SERVICE-principal rego rule (enforced)"
+        run: bash .github/scripts/check-no-service-principal-type.sh .
+
       # openbank.outbox.dispatch-enabled guard (the CLAUDE.md "outbox footgun":
       # a service whose OutboxDispatcher actually gates on this flag silently
       # never dispatches if it's left at its false default — no error,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,18 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   both pull every pact the broker holds and collide; use a single test that picks the target per
   interaction in `@BeforeEach`. Provider tests are gated on `pactbroker.url` and run only in CI.
 
+### OPA / authorization
+- **`input.principal.type == "SERVICE"` can never fire — don't write it.** `AuthorizeInterceptor`
+  only ever emits `ANONYMOUS`/`AI_AGENT`/`HUMAN`; M2M callers authenticate with a Keycloak
+  client_credentials JWT, which the interceptor classifies as `HUMAN`, and no realm client is ever
+  granted `ROLE_SERVICE`. A rego rule gated on a `SERVICE` principal type is structurally
+  unreachable dead code that silently denies its intended M2M caller once `AUTHZ_ENFORCE` flips to
+  `true` (found live in the shared `rest.rego` `edge-service-notification` rule, ADR-0034 Phase 5,
+  issue #266). Identify a specific M2M caller by `input.principal.id` (Keycloak's
+  `service-account-<clientId>` convention) instead — gating on `HUMAN` + `ROLE_OPERATOR` alone is
+  NOT equivalent, since real staff also carry `ROLE_OPERATOR` and would over-grant. Enforced by
+  `.github/scripts/check-no-service-principal-type.sh` (`rules.yaml: authz_policy`).
+
 ### GitOps / Kubernetes
 - **`strategy.type: Recreate` + Server-Side Apply = HTTP 403.** Use `RollingUpdate` with
   `maxSurge: 0 / maxUnavailable: 1` for identical zero-concurrency behaviour.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "6a52e16c0be5ec41"
+    openbank.tech/policy-checksum: "1d244119447cffc2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1299,6 +1316,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6a52e16c0be5ec41"
+        openbank.tech/policy-checksum: "1d244119447cffc2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "6f2fa52eb86f180a"
+    openbank.tech/policy-checksum: "2602d9cef2f2d216"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1343,6 +1360,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f2fa52eb86f180a"
+        openbank.tech/policy-checksum: "2602d9cef2f2d216"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "3e5d2c326640a9e6"
+    openbank.tech/policy-checksum: "91a7f1b9ce710824"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1248,6 +1265,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3e5d2c326640a9e6"
+        openbank.tech/policy-checksum: "91a7f1b9ce710824"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "db574c571fd8c97a"
+    openbank.tech/policy-checksum: "25c2f55561e417e3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1266,6 +1283,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "db574c571fd8c97a"
+        openbank.tech/policy-checksum: "25c2f55561e417e3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e2aa67eadc8e291c"
+    openbank.tech/policy-checksum: "91314d525fb75006"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1331,6 +1348,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e2aa67eadc8e291c"
+        openbank.tech/policy-checksum: "91314d525fb75006"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
+    openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -164,15 +164,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -896,6 +913,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
+        openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "9ea358b82c659aec"
+    openbank.tech/policy-checksum: "7a715a6a6bf2b480"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1259,6 +1276,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ea358b82c659aec"
+        openbank.tech/policy-checksum: "7a715a6a6bf2b480"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "3ce14b84d190e3f2"
+    openbank.tech/policy-checksum: "713d6f0fb119e372"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1296,6 +1313,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ce14b84d190e3f2"
+        openbank.tech/policy-checksum: "713d6f0fb119e372"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "772dcf06549a6735"
+    openbank.tech/policy-checksum: "843e8a6581f268b5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1355,6 +1372,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "772dcf06549a6735"
+        openbank.tech/policy-checksum: "843e8a6581f268b5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "d27d150e5aa63328"
+    openbank.tech/policy-checksum: "724d123298c17601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1302,6 +1319,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d27d150e5aa63328"
+        openbank.tech/policy-checksum: "724d123298c17601"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
+    openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -164,15 +164,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -896,6 +913,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "6a8bbf2d99d4790b"
+        openbank.tech/policy-checksum: "3f2a4cfa09b1bc65"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5b9b910b50f19161"
+    openbank.tech/policy-checksum: "b329ad74ef45c654"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1302,6 +1319,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b38a1e12005863b5"
+    openbank.tech/policy-checksum: "2413697dda1b16ff"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1287,6 +1304,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7b13cd04cfc746de" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "605a9eb03ceab393" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d74e815aaf36817"
+        openbank.tech/policy-checksum: "58c843c78ee78c17"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b38a1e12005863b5" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "2413697dda1b16ff" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d498aa8d5ae2fd1"
+        openbank.tech/policy-checksum: "3ca6010977cb61fd"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5b9b910b50f19161" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "b329ad74ef45c654" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1891,7 +1891,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "fc0fccdf3095d101" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "2435d225963ab59c" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2281,7 +2281,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "56a7c357de91bdad"
+        openbank.tech/policy-checksum: "e9471b36a0ab88f8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4d498aa8d5ae2fd1"
+    openbank.tech/policy-checksum: "3ca6010977cb61fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1260,6 +1277,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4d74e815aaf36817"
+    openbank.tech/policy-checksum: "58c843c78ee78c17"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1281,6 +1298,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "fc0fccdf3095d101"
+    openbank.tech/policy-checksum: "2435d225963ab59c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1261,6 +1278,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "56a7c357de91bdad"
+    openbank.tech/policy-checksum: "e9471b36a0ab88f8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1264,6 +1281,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7b13cd04cfc746de"
+    openbank.tech/policy-checksum: "605a9eb03ceab393"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1317,6 +1334,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "4bb84d9698ec74ef"
+    openbank.tech/policy-checksum: "4ffab805c9a8161d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1270,6 +1287,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4bb84d9698ec74ef"
+        openbank.tech/policy-checksum: "4ffab805c9a8161d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "be0e1a9b440989da"
+    openbank.tech/policy-checksum: "26dea58b6d9f0279"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,15 +163,32 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-    # above + per-handler IDOR guards) and injects the authoritative partyId query param the
-    # downstream handlers scope by — so this check only needs to recognise the edge principal.
-    # Deliberately narrow: just the notification/device families notification-service exposes;
-    # a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
+    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # scope by — so this check only needs to recognise the edge principal.
+    #
+    # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+    # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+    # client_credentials JWT (openbank-edge), which the interceptor's principalType()
+    # classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+    # ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+    # structurally unreachable dead code.
+    #
+    # Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+    # carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+    # WebAuthn device registration) — granting that to any staff member is an account-takeover
+    # primitive (an operator could enrol their own authenticator against a victim's account).
+    # test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+    #
+    # Instead, match the edge's client_credentials principal precisely by identity:
+    # AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+    # Keycloak service-account token is deterministically "service-account-<clientId>"
+    # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+    # — not forgeable by a human session, which authenticates through a different client.
     allowed_reasons contains "edge-service-notification" if {
-    	input.principal.type == "SERVICE"
-    	"ROLE_SERVICE" in input.principal.roles
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
@@ -1284,6 +1301,30 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+    # the shared OPA policy mounted in every enforcing service's bundle.
+    # ---------------------------------------------------------------------------------------
+    authz_policy:
+      principal_type_service_unreachable: true
+      # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+      # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+      # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+      # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+      # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+      # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+      # defaulting true — notification.mark-read/device.create/device.delete had NO other
+      # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+      #
+      # Identify a specific M2M caller by input.principal.id (Keycloak's
+      # "service-account-<clientId>" convention for a service-account token) instead of
+      # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+      # role-only check over-grants (e.g. it would let any operator call SCA's
+      # device.enroll — an account-takeover primitive — see rest.rego's
+      # edge-service-notification rule and rest_test.rego's
+      # test_deny_operator_read_any_does_not_cover_write).
+      ci_producer: ".github/scripts/check-no-service-principal-type.sh"
 
     # ---------------------------------------------------------------------------------------
     # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "be0e1a9b440989da"
+        openbank.tech/policy-checksum: "26dea58b6d9f0279"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/scripts/authz-coverage-report.py
+++ b/openbank-infra/scripts/authz-coverage-report.py
@@ -14,17 +14,27 @@ and classifies each action against the rest.rego reason rules:
                                   compliance-read-any (.read); party-self-service
                                   (resource-scoped read/list where id == JWT sub)
     customer.*                    customer-self-action (any authenticated HUMAN)
-    notification.* / device.*     edge-service-notification (SERVICE principal)
+    notification.* / device.*     edge-service-notification (customer-edge's
+                                  client_credentials identity, HUMAN principal.id ==
+                                  "service-account-openbank-edge" — NOT a SERVICE
+                                  principal.type; see M2M caveat below)
     other verbs WITH resource     operator-on-own-tenant ONLY (HUMAN OPERATOR whose
                                   tenant matches resource.attributes.tenant)
     other verbs WITHOUT resource  NO allow path — operator-on-own-tenant requires
                                   input.resource; nothing else matches a non-read,
                                   non-customer, non-notification action
 
-M2M caveat (the Phase-5 blocker): a SERVICE principal is only ever allowed the
-notification./device. families. Any service-to-service call to a money-path write
-endpoint (e.g. transaction-service -> ledger.create) has NO allow path today and
-will 403 under enforce. Static analysis cannot see runtime callers — check the
+M2M caveat (the Phase-5 blocker, resolved for customer-edge, open elsewhere): OPA's
+input.principal.type is NEVER "SERVICE" in this fleet — AuthorizeInterceptor.
+principalType() only ever emits ANONYMOUS/AI_AGENT/HUMAN (M2M calls carry a Keycloak
+client_credentials JWT, which the interceptor classifies as HUMAN), and no Keycloak
+client is ever granted ROLE_SERVICE. Any rego rule gated on `principal.type ==
+"SERVICE"` is dead code that can never fire. edge-service-notification was fixed to
+gate on the edge's verified principal.id instead (see rest.rego); any OTHER
+service-to-service caller (e.g. a money-path write endpoint like
+transaction-service -> ledger.create) still has NO allow path today and will 403
+under enforce unless it is verified against actual caller code and given the same
+identity-based treatment. Static analysis cannot see runtime callers — check the
 OPA advisory decision logs (AuditEvent decision_reason) before any flip.
 
 Output: a Markdown report (stdout). Not a CI gate — an analysis tool for the
@@ -63,7 +73,7 @@ def classify(action: str, resource: str) -> tuple[str, str]:
     if action.startswith("customer."):
         return "covered", "customer-self-action (any authenticated HUMAN)"
     if action.split(".", 1)[0] in ("notification", "device"):
-        return "covered", "edge-service-notification (SERVICE) + read rules"
+        return "covered", "edge-service-notification (edge identity) + read rules"
     if verb in READ_VERBS:
         scoped = " + party-self-service (resource-scoped)" if resource else ""
         return "covered", f"operator-read-any / compliance-read-any{scoped}"
@@ -120,8 +130,8 @@ def main() -> int:
           f"{totals['uncovered']} uncovered\n")
     print("> Static approximation only. Before any AUTHZ_ENFORCE flip, confirm against the "
           "OPA advisory decision logs (AuditEvent decision_reason) that no legitimate caller "
-          "hits a would-be deny — especially M2M (SERVICE) callers, which this analysis "
-          "cannot see.")
+          "hits a would-be deny — especially M2M callers, which this analysis cannot see and "
+          "which never present principal.type == \"SERVICE\" (see the M2M caveat above).")
     return 0
 
 

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -149,15 +149,32 @@ allowed_reasons contains "customer-self-action" if {
 	startswith(input.action, "customer.")
 }
 
-# The customer-edge's M2M identity (ROLE_SERVICE) calling notification-service on a
-# customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action
-# above + per-handler IDOR guards) and injects the authoritative partyId query param the
-# downstream handlers scope by — so this check only needs to recognise the edge principal.
-# Deliberately narrow: just the notification/device families notification-service exposes;
-# a blanket SERVICE allow would open every @Authorize endpoint to any M2M client.
+# The customer-edge's M2M identity calling notification-service on a customer's behalf.
+# The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
+# IDOR guards) and injects the authoritative partyId query param the downstream handlers
+# scope by — so this check only needs to recognise the edge principal.
+#
+# NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
+# produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
+# client_credentials JWT (openbank-edge), which the interceptor's principalType()
+# classifies as HUMAN (see AuthorizeInterceptor.kt), and the realm never issues a
+# ROLE_SERVICE role to any client — only ROLE_OPERATOR. A SERVICE-gated rule is therefore
+# structurally unreachable dead code.
+#
+# Gating on HUMAN + ROLE_OPERATOR alone is NOT safe here: real operator/admin staff also
+# carry ROLE_OPERATOR, and this rule's action families include device.enroll (SCA-service's
+# WebAuthn device registration) — granting that to any staff member is an account-takeover
+# primitive (an operator could enrol their own authenticator against a victim's account).
+# test_deny_operator_read_any_does_not_cover_write encodes exactly this invariant.
+#
+# Instead, match the edge's client_credentials principal precisely by identity:
+# AuthorizeInterceptor sets principal.id from the JWT's preferred_username, which for a
+# Keycloak service-account token is deterministically "service-account-<clientId>"
+# (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
+# — not forgeable by a human session, which authenticates through a different client.
 allowed_reasons contains "edge-service-notification" if {
-	input.principal.type == "SERVICE"
-	"ROLE_SERVICE" in input.principal.roles
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-edge"
 	some family in {"notification.", "device."}
 	startswith(input.action, family)
 }

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -436,12 +436,16 @@ test_operator_own_tenant_may_flip_non_prohibited if {
 }
 
 # ---------------------------------------------------------------------------------------
-# edge-service-notification: the customer-edge M2M principal (ROLE_SERVICE) may call the
-# notification/device families on the customer's behalf; anything else stays denied.
+# edge-service-notification: the customer-edge M2M caller presents a client_credentials
+# JWT that AuthorizeInterceptor classifies as HUMAN, principal.id
+# "service-account-openbank-edge" (Keycloak never issues ROLE_SERVICE, and
+# principalType() never emits "SERVICE" — see rest.rego). The rule matches on that exact
+# identity, NOT on ROLE_OPERATOR alone — a real operator/admin also carries ROLE_OPERATOR
+# and must NOT gain this rule's device.enroll reach (test_deny_operator_* below).
 # ---------------------------------------------------------------------------------------
 test_allow_service_notification_mark_read if {
 	decision := rest.allow with input as {
-		"principal": {"id": "svc-edge", "type": "SERVICE", "roles": ["ROLE_SERVICE"]},
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
 		"action": "notification.mark-read",
 		"resource": {"type": "notification", "id": "n-1"},
 	}
@@ -453,7 +457,7 @@ test_allow_service_notification_mark_read if {
 
 test_allow_service_notification_list if {
 	decision := rest.allow with input as {
-		"principal": {"id": "svc-edge", "type": "SERVICE", "roles": ["ROLE_SERVICE"]},
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
 		"action": "notification.list",
 	}
 		with data.openbank.bundle as bundle
@@ -463,7 +467,7 @@ test_allow_service_notification_list if {
 
 test_allow_service_device_list if {
 	decision := rest.allow with input as {
-		"principal": {"id": "svc-edge", "type": "SERVICE", "roles": ["ROLE_SERVICE"]},
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
 		"action": "device.list",
 	}
 		with data.openbank.bundle as bundle
@@ -471,19 +475,21 @@ test_allow_service_device_list if {
 	decision.allow == true
 }
 
-# The rule must NOT open other action families to M2M callers (deny-by-default holds).
+# The rule must NOT open other action families to the edge M2M caller (deny-by-default
+# holds) — operator-read-any also does not cover a write like party.update.
 test_deny_service_outside_notification_family if {
 	not rest.allow with input as {
-		"principal": {"id": "svc-edge", "type": "SERVICE", "roles": ["ROLE_SERVICE"]},
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
 		"action": "party.update",
 		"resource": {"type": "party", "id": "p-1"},
 	}
 }
 
-# A SERVICE principal WITHOUT ROLE_SERVICE gets nothing from this rule.
-test_deny_service_without_role if {
+# A SERVICE-typed principal (should one ever reach OPA) gets NOTHING from this rule —
+# it is intentionally HUMAN-only, matching what AuthorizeInterceptor actually emits.
+test_deny_service_typed_principal_never_matches if {
 	not rest.allow with input as {
-		"principal": {"id": "svc-x", "type": "SERVICE", "roles": []},
+		"principal": {"id": "service-account-openbank-edge", "type": "SERVICE", "roles": ["ROLE_OPERATOR"]},
 		"action": "notification.list",
 	}
 }
@@ -586,4 +592,28 @@ test_deny_ai_agent_charter_denied_tool_via_bridge if {
 			],
 			"tool_tiers": {"deny": []},
 		}
+}
+
+# A real operator/admin staff member (ROLE_OPERATOR, but NOT the edge's identity) must
+# NOT gain this rule's reach — critically, must NOT be able to device.enroll (SCA
+# WebAuthn registration is an account-takeover primitive if grantable to arbitrary staff).
+# See also test_deny_operator_read_any_does_not_cover_write above for the same invariant.
+test_deny_human_operator_who_is_not_the_edge if {
+	not rest.allow with input as {
+		"principal": {"id": "operator-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "device.enroll",
+		"resource": {"type": "device", "id": "any-party-id"},
+	}
+}
+
+# A HUMAN caller with the edge's identity but somehow missing ROLE_OPERATOR is still
+# irrelevant to this rule — it gates on identity, not role, and must still allow.
+test_allow_edge_identity_without_explicit_operator_role_check if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": []},
+		"action": "notification.list",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
 }

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -500,6 +500,30 @@ architecture:
   ci_producer: ".github/scripts/check-domain-purity.sh"
 
 # ---------------------------------------------------------------------------------------
+# REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
+# the shared OPA policy mounted in every enforcing service's bundle.
+# ---------------------------------------------------------------------------------------
+authz_policy:
+  principal_type_service_unreachable: true
+  # AuthorizeInterceptor.principalType() (openbank-libs-runtime) only ever emits
+  # ANONYMOUS/AI_AGENT/HUMAN — never SERVICE. M2M callers authenticate with a Keycloak
+  # client_credentials JWT, which the interceptor classifies as HUMAN, and no realm
+  # client is ever granted a ROLE_SERVICE role. A rego rule gated on
+  # `input.principal.type == "SERVICE"` can therefore never fire. Found live 2026-07-07
+  # in the shared rest.rego edge-service-notification rule (deployed with AUTHZ_ENFORCE
+  # defaulting true — notification.mark-read/device.create/device.delete had NO other
+  # allow path) and pre-merge in the sca/domestic-payment ADR-0034 Phase 5 PRs.
+  #
+  # Identify a specific M2M caller by input.principal.id (Keycloak's
+  # "service-account-<clientId>" convention for a service-account token) instead of
+  # principal.type or role alone — ROLE_OPERATOR is shared with real human staff, so a
+  # role-only check over-grants (e.g. it would let any operator call SCA's
+  # device.enroll — an account-takeover primitive — see rest.rego's
+  # edge-service-notification rule and rest_test.rego's
+  # test_deny_operator_read_any_does_not_cover_write).
+  ci_producer: ".github/scripts/check-no-service-principal-type.sh"
+
+# ---------------------------------------------------------------------------------------
 # Vulnerability-management lifecycle SLAs (ADR-0030 D1). Detection -> closure, in days.
 # ---------------------------------------------------------------------------------------
 vuln_management:


### PR DESCRIPTION
## Summary

While verifying the OPA-enforce PRs for issue #266, found that `AuthorizeInterceptor.principalType()` (`openbank-libs-runtime`) never produces `principal.type == "SERVICE"` — it only ever emits `ANONYMOUS`/`AI_AGENT`/`HUMAN`. M2M callers authenticate with a Keycloak client_credentials JWT (verified live against a token from the `openbank-edge` client), which the interceptor classifies as `HUMAN`, and no realm client is ever granted a `ROLE_SERVICE` role.

`rest.rego`'s `edge-service-notification` rule was gated on `input.principal.type == "SERVICE"` — structurally unreachable dead code. This rule is mounted in every enforcing service's bundle; concretely, in the **currently-deployed** customer-edge/copilot/lending/pid/notification-service bundles (`AUTHZ_ENFORCE` true or defaulting true), `notification.mark-read`, `device.create`, and `device.delete` had **no other allow path** — the customer-edge could 403 on these today.

- Fixed the rule to match the edge's verified `client_credentials` identity (`principal.id == "service-account-openbank-edge"`) instead of type/role.
- A `HUMAN` + `ROLE_OPERATOR` role-only check (my first attempt) is **not safe**: real operator/admin staff also carry `ROLE_OPERATOR`, and the rule's action families include SCA's `device.enroll` (WebAuthn device registration) — granting that to arbitrary staff is an account-takeover primitive. Caught by the existing `test_deny_operator_read_any_does_not_cover_write` invariant in `rest_test.rego`.
- Regenerated the 5 affected bundle ConfigMaps + pod-roll checksum annotations (`gen-*-opa-bundle.sh`).
- Updated `authz-coverage-report.py`'s docs — its "SERVICE principal" framing for `notification.*`/`device.*` coverage was likely the source of the same copy-pasted pattern in the open sca (#387) and domestic-payment (#393) Phase-5 PRs (both still carry `input.principal.type == "SERVICE"` gates pre-merge, flagged separately in PR review comments).
- Added `check-no-service-principal-type.sh` (Validate manifests job, fleet-wide, path-unscoped) so this pattern can't land again undetected — scans `.rego`, `gen-*-opa-bundle.sh` heredocs, and committed bundle ConfigMaps.
- Documented as an operational footgun (`CLAUDE.md`) + a checkable invariant (`rules.yaml: authz_policy`).

## Test plan
- [x] `opa test openbank-libs/governance/policies` — 35/35 (added tests for the identity-based gate + the operator-must-not-get-device.enroll invariant)
- [x] `openbank-infra/opa/build-bundle.sh` — 86/86 (full opa test suite + decision assertions)
- [x] Regenerated all 5 affected bundles via their `gen-*.sh` scripts; `git diff --exit-code` clean (matches CI's drift check)
- [x] `check-no-service-principal-type.sh` — clean on the current tree; verified it flags the actual violations in PR #387 and #393 (tested against their branch content, not committed here)
- [x] `python3 -m py_compile` on the updated `authz-coverage-report.py`

## Linked issues
Refs #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)