### PR TITLE
ci(governance): widen agent-review to skip test-only and coverage-ratchet-only files

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -12,6 +12,13 @@
 #     wiring, threat model) is deliberately deferred to a human — the job posts a
 #     note and exits WITHOUT approving. Money-path still needs 2 human approvals +
 #     a threat model per rules.yaml (ADR-0030); this workflow must never weaken that.
+#     One narrow carve-out (added to cut review backlog without weakening any of
+#     the above): a changed file does NOT count toward "money-path service change"
+#     if it's a test file (**/src/test/**), or a build.gradle.kts hunk that ONLY
+#     raises a kover `minValue` coverage floor (ratchet-only, per rules.yaml's own
+#     "coverage never lowers" invariant) — see is_test_or_coverage_only_file below.
+#     A PR that touches src/main, config, or anything else in a money-path service
+#     still defers to a human exactly as before.
 #   * NON-BLOCKING. This job is NOT a required check. If the model is down, the PR
 #     is from a fork (read-only token), or the change is sensitive, it simply adds
 #     no approval and a human reviews as before. It can only ever *add* signal.
@@ -75,9 +82,34 @@ jobs:
           MP="$(yq -r '.money_path_services[]' openbank-libs/governance/rules.yaml)"
           MP_RE="$(echo "$MP" | paste -sd'|' -)"
 
+          # A file is safe to skip entirely (doesn't count toward ANY sensitivity
+          # bucket below, including money-path) if it's a test file, or a
+          # build.gradle.kts hunk that ONLY raises a kover coverage floor. Both are
+          # inherently no-behavior-change: a test file can't alter runtime
+          # authorization/business logic, and a ratchet-only minValue increase can
+          # only make CI stricter, never weaker (rules.yaml: coverage never lowers).
+          # Anything else in the file (a dependency bump, a different DSL block)
+          # falls through to the normal per-file rules below.
+          is_test_or_coverage_only_file() {
+            local f="$1"
+            case "$f" in
+              */src/test/*) return 0 ;;
+              */build.gradle.kts|build.gradle.kts)
+                local filediff other_changes old_val new_val
+                filediff="$(git diff "origin/${BASE_REF}...HEAD" -- "$f")"
+                other_changes="$(echo "$filediff" | grep -E '^[+-][^+-]' | grep -vE '^[+-][[:space:]]*(//|minValue = [0-9]+[[:space:]]*$)')"
+                old_val="$(echo "$filediff" | grep -oE '^-[[:space:]]*minValue = [0-9]+' | grep -oE '[0-9]+$' | tail -1)"
+                new_val="$(echo "$filediff" | grep -oE '^\+[[:space:]]*minValue = [0-9]+' | grep -oE '[0-9]+$' | tail -1)"
+                [ -z "$other_changes" ] && [ -n "$old_val" ] && [ -n "$new_val" ] && [ "$new_val" -ge "$old_val" ]
+                ;;
+              *) return 1 ;;
+            esac
+          }
+
           sensitive=""
           while IFS= read -r f; do
             [ -z "$f" ] && continue
+            is_test_or_coverage_only_file "$f" && continue
             case "$f" in
               .github/*) sensitive="CI / automation change ($f)";;
               openbank-libs/governance/*) sensitive="governance rules change ($f)";;


### PR DESCRIPTION
## Summary

- The open-PR backlog is dominated by `REVIEW_REQUIRED` PRs — most legitimately
  money-path/governance/CI changes that should stay human-reviewed — but a specific,
  identifiable subset (#382, #384, #386: coverage-floor-ratchet PRs) touch **only** test
  files plus a `build.gradle.kts` hunk that raises a `kover` `minValue`, yet get deferred
  to a human anyway solely because they sit inside a money-path service directory.
- Adds `is_test_or_coverage_only_file` to `.github/workflows/agent-review.yml`'s scope
  classifier: a changed file stops counting toward "money-path service change" (or any
  other sensitivity bucket) if it's under `**/src/test/**`, or if its only
  `build.gradle.kts` hunk raises a `kover` coverage floor (never lowers it — checked from
  the diff itself). Anything else in the file — a dependency bump, an actual `src/main`
  change, any other DSL edit — still falls through to the existing rules unchanged.
- Governance (`openbank-libs/governance/*`), CI/automation (`.github/*`), DB migrations,
  threat models, ADRs, release wiring, and any money-path `src/main` change are completely
  untouched by this carve-out and still always defer to a human, per the workflow's own
  documented non-negotiable design guardrail (see the header comment).

## Test plan

- [x] Extracted the classifier logic and ran it locally against the real diffs of 5 open
      PRs (fetched via `gh`, `git diff origin/main...<pr-head>`):
  - #386 (account coverage), #384 (lending coverage), #382 (sepa-instant coverage) — now
    clear as non-sensitive (previously deferred).
  - #411 (ledger OPA-enforce, touches `src/main`) — still correctly deferred
    (`threat-model change`, since it also touches `docs/threat-models/*`).
  - #402 (this session's own governance policy fix) — still correctly deferred
    (`governance rules change`).
- [x] YAML validity checked (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Linked issues

N/A — direct backlog-throughput fix requested in session, no existing tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)