### PR TITLE
chore(infra): stop sandbox AWS Config recording (finops)

### DIFF
--- a/openbank-infra/aws/envs/sandbox-substrate/main.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/main.tf
@@ -86,9 +86,14 @@ module "audit_baseline" {
 
   name = var.cluster_name
 
-  # Sandbox is out of prod compliance scope (and churns Karpenter nodes constantly),
-  # so record AWS Config daily instead of per-change: same resource-type coverage, no
-  # change-triggered rules depend on continuous, ~$85/mo of ConfigurationItem cost cut.
+  # Sandbox is out of prod compliance scope (and churns Karpenter nodes constantly).
+  # Even at DAILY frequency, full resource-type recording over that churn is a steady
+  # ~$140/mo with no consumer (no Config rules on this account), so the recorder is
+  # stopped entirely; CloudTrail carries the ADR-0027 tamper-evident trail on its own.
+  # All Config resources stay provisioned — re-enable is this one flag (frequency
+  # stays DAILY for when it comes back), and the openbank-config-recording-daily
+  # budget in finops-budget.tf remains as the tripwire against silent re-enable.
+  config_recording_enabled   = false
   config_recording_frequency = "DAILY"
 
   # 1-day COMPLIANCE lock keeps the sandbox destroyable; config history is short-lived.

--- a/openbank-infra/aws/envs/sandbox-substrate/main.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/main.tf
@@ -89,10 +89,16 @@ module "audit_baseline" {
   # Sandbox is out of prod compliance scope (and churns Karpenter nodes constantly).
   # Even at DAILY frequency, full resource-type recording over that churn is a steady
   # ~$140/mo with no consumer (no Config rules on this account), so the recorder is
-  # stopped entirely; CloudTrail carries the ADR-0027 tamper-evident trail on its own.
-  # All Config resources stay provisioned — re-enable is this one flag (frequency
-  # stays DAILY for when it comes back), and the openbank-config-recording-daily
-  # budget in finops-budget.tf remains as the tripwire against silent re-enable.
+  # stopped entirely. Risk boundary: what is lost is only the supplementary
+  # "what the resource looked like" state snapshots; the "who did what" audit trail —
+  # the actual ADR-0027 tamper-evident requirement — is CloudTrail (multi-region,
+  # SHA-256 digest chain, COMPLIANCE Object-Lock WORM bucket) and is untouched, so
+  # every configuration CHANGE remains attributable and tamper-evident via its API
+  # event. All Config resources stay provisioned — re-enable is this one flag
+  # (frequency stays DAILY for when it comes back), and the
+  # openbank-config-recording-daily budget in finops-budget.tf remains as the
+  # tripwire against silent re-enable. Prod-shaped environments keep the module
+  # default (enabled).
   config_recording_enabled   = false
   config_recording_frequency = "DAILY"
 

--- a/openbank-infra/aws/modules/audit-baseline/main.tf
+++ b/openbank-infra/aws/modules/audit-baseline/main.tf
@@ -433,6 +433,6 @@ resource "aws_config_delivery_channel" "audit" {
 
 resource "aws_config_configuration_recorder_status" "audit" {
   name       = aws_config_configuration_recorder.audit.name
-  is_enabled = true
+  is_enabled = var.config_recording_enabled
   depends_on = [aws_config_delivery_channel.audit]
 }

--- a/openbank-infra/aws/modules/audit-baseline/variables.tf
+++ b/openbank-infra/aws/modules/audit-baseline/variables.tf
@@ -42,6 +42,19 @@ variable "config_history_retention_days" {
   default     = 90
 }
 
+# Master switch for AWS Config recording. When false the recorder, delivery
+# channel, IAM role and history bucket all stay provisioned but the recorder is
+# stopped — zero ConfigurationItem cost, one-flag re-enable, no resource churn.
+# CloudTrail (the tamper-evident half of ADR-0027) is unaffected. Sandbox sets
+# false: it is out of prod compliance scope, has no Config rules consuming the
+# items, and a high-churn Karpenter estate makes even DAILY recording a steady
+# cost with no consumer.
+variable "config_recording_enabled" {
+  description = "Whether the AWS Config recorder actively records. False stops recording but keeps all resources in place."
+  type        = bool
+  default     = true
+}
+
 variable "config_recording_frequency" {
   description = <<-EOT
     AWS Config recording frequency: CONTINUOUS (every change) or DAILY (one snapshot


### PR DESCRIPTION
## Summary

Stops the AWS Config recorder on the sandbox: even at DAILY frequency, full resource-type recording over the Karpenter churn costs ~$140/mo (`ConfigurationItemRecordedDaily`) with no consumer — there are no Config rules on this account and the sandbox is out of prod compliance scope. CloudTrail (the tamper-evident half of ADR-0027) is unaffected.

## Type of change

- [x] chore (build / tooling)

## Linked issues

Closes #443

## Changes

- `modules/audit-baseline`: new `config_recording_enabled` master switch (default `true`, so prod-shaped consumers keep recording); wired into `aws_config_configuration_recorder_status.is_enabled`.
- `envs/sandbox-substrate`: sets `config_recording_enabled = false` with the rationale and risk boundary in-line. Recorder, delivery channel, IAM role and history bucket stay provisioned — re-enable is a one-flag flip; `config_recording_frequency` stays DAILY for when it comes back.
- The `openbank-config-recording-daily` budget (2026-07-06 drift incident) is intentionally kept as the tripwire.

## Risk assessment

**What is lost:** AWS Config's supplementary *"what the resource looked like"* point-in-time snapshots. Nothing consumes them today: zero Config rules on the account, no conformance packs, no aggregator.

**What remains (the actual ADR-0027 requirement):** the *"who did what"* audit trail — CloudTrail multi-region trail with SHA-256 log-file validation (digest chain) delivering to the COMPLIANCE Object-Lock WORM bucket. Every configuration **change** still lands there as an attributable, tamper-evident API event; only the derived state snapshot goes away. Detection of unauthorized changes therefore degrades from "state diff + API event" to "API event only", which is acceptable for a sandbox explicitly out of prod compliance scope.

**Mitigations:**
1. Module default stays `true` — any prod-shaped environment records unless it explicitly opts out.
2. All Config resources remain provisioned; re-enable is a single flag flip + apply (no rebuild, no data-loss window for future history).
3. `openbank-config-recording-daily` budget stays armed — a silent re-enable/drift shows up same-day as spend on `ConfigurationItemRecordedDaily`.
4. CloudTrail itself is guarded: trail + WORM bucket changes are management events recorded by the trail, and the digest chain makes after-the-fact tampering detectable.

## Definition of Done

- [x] Docs updated (rationale + risk boundary in-line in the env + module; no ADR change — ADR-0027's trail is CloudTrail, unchanged)
- N/A — infrastructure-only change, no service code, no API/DB/event surface.

## Ops note

Apply is manual (ADR-0060, `platform-tofu.yml` dispatch). The recorder was stopped out-of-band via `aws configservice stop-configuration-recorder` to realize the saving immediately; this PR makes the desired state match, so the next apply converges instead of re-enabling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)