### PR TITLE
security(ci): pin agent-review actions by SHA, fix script injection in dependabot-verification-metadata

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -60,7 +60,7 @@ jobs:
     env:
       HAS_CLAUDE: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0   # need base..head for a real 3-dot diff
 
@@ -198,7 +198,7 @@ jobs:
         id: ghmodels
         if: steps.scope.outputs.skip == 'false'
         continue-on-error: true   # any failure → Claude fallback
-        uses: actions/ai-inference@v2
+        uses: actions/ai-inference@a7805884c80886efc241e94a5351df715968a0ad # v2.1.1
         with:
           model: openai/gpt-4o
           prompt-file: /tmp/prompt.txt
@@ -243,7 +243,7 @@ jobs:
           steps.scope.outputs.skip == 'false' &&
           steps.ghmodels.outcome == 'failure' &&
           env.HAS_CLAUDE == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f87768c6d25f92ae6efa7175e223ef77d4cbf97f # v1.0.166
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-verification-metadata.yml
+++ b/.github/workflows/dependabot-verification-metadata.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Push metadata diff back to the PR branch
         if: steps.tok.outputs.have == 'true'
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
           if git diff --quiet gradle/verification-metadata.xml; then
@@ -90,4 +92,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add gradle/verification-metadata.xml
           git commit -m "chore(deps): refresh dependency-verification metadata for this bump"
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git push origin "HEAD:${HEAD_REF}"


### PR DESCRIPTION
## Summary
- Pins the 3 tag-ref actions in `agent-review.yml` (`actions/checkout@v7`, `actions/ai-inference@v2`, `anthropics/claude-code-action@v1`) to their current commit SHA, matching this repo's existing SHA-pin convention used everywhere else.
- Fixes a script-injection pattern in `dependabot-verification-metadata.yml`: `github.event.pull_request.head.ref` was interpolated directly into a `run:` shell command. Moved through `env:` per GitHub's [script-injection hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

Closes the two Critical + three Medium OSSF Scorecard code-scanning findings: #292 (Dangerous-Workflow), #293, #294, #295 (Pinned-Dependencies).

## Linked issues
N/A — direct Scorecard finding remediation, no tracking issue.

## Test plan
- [ ] CI green (ktlint/build unaffected — workflow-only change)
- [ ] Scorecard re-scan clears #292-295 on next run