### PR TITLE
security(ci): extract bearer token via jq instead of curl | python3 -c

### DIFF
--- a/.github/workflows/api-fuzz-authenticated.yml
+++ b/.github/workflows/api-fuzz-authenticated.yml
@@ -152,7 +152,7 @@ jobs:
             http://localhost:8080/realms/openbank/protocol/openid-connect/token \
             -d grant_type=client_credentials \
             -d client_id=openbank-services \
-            -d client_secret="${OIDC_CLIENT_SECRET}" | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')"
+            -d client_secret="${OIDC_CLIENT_SECRET}" | jq -r '.access_token')"
           if [ -z "${TOKEN:-}" ] || [ "$TOKEN" = "None" ]; then
             echo "::error::could not obtain a bearer token from Keycloak"; exit 1
           fi


### PR DESCRIPTION
## Summary
Scorecard's `downloadThenRun` heuristic (#297) flags the `curl ... | python3 -c '...'` shape used to pull the access_token out of Keycloak's response in `api-fuzz-authenticated.yml`. The python3 script is fixed/literal (`json.load(sys.stdin)`, no eval of the piped data), but the syntactic pattern still matches. Switched to `jq -r '.access_token'`, the idiomatic tool for this, which doesn't match the heuristic.

Closes #297.

## Linked issues
N/A — direct Scorecard finding remediation.

## Test plan
- [ ] `api-fuzz-authenticated.yml` still extracts a valid bearer token (behavior-identical, same JSON field)