### PR TITLE
ci(dependency-graph): submit fleet Gradle dependency graph to GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# Submits the fleet's resolved Gradle/Maven dependency graph to GitHub.
+#
+# THE GAP THIS CLOSES: `gh api repos/.../dependency-graph/sbom` shows ~1100 packages, but
+# only ~2 are Maven/Gradle coordinates — every openbank-*-service's Kotlin/Java dependency
+# tree is effectively invisible to GitHub's dependency graph, because nothing in this repo
+# ever submits it (npm/pip manifests are parsed natively by GitHub; Gradle needs an explicit
+# submission step). Consequence: Dependabot security alerts report 0 open findings while
+# Scorecard's own OSV-scanner (which reads build.gradle.kts / libs.versions.toml directly,
+# independent of GitHub's graph) reports dozens of GHSA IDs with no per-package, per-fix-version
+# context — the worst of both worlds (silent Dependabot, noisy unopinionated Scorecard).
+#
+# This wires `gradle/actions/setup-gradle`'s built-in dependency-graph extractor so the graph
+# gets submitted from a real build on every relevant main push. Once populated, Dependabot
+# alerts become the authoritative, actionable, per-service view (exact vulnerable version +
+# suggested fix), and Scorecard's Vulnerabilities check should stop flying blind.
+name: Dependency submission
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/build.gradle.kts"
+      - "gradle/libs.versions.toml"
+      - "settings.gradle.kts"
+      - "gradle/wrapper/**"
+  schedule:
+    # Weekly belt-and-braces resubmission — dependency resolution can drift even without a
+    # manifest change (a transitive version moving inside a declared range).
+    - cron: "30 4 * * 1" # 04:30 UTC Monday
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-submission-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  submit:
+    name: Submit fleet dependency graph
+    runs-on: ubuntu-latest # public repo => hosted runners free+unlimited (FinOps: hosted-first)
+    timeout-minutes: 30
+    permissions:
+      contents: write # required by the dependency-submission API
+    env:
+      # Same OOM guard as fleet-lint.yml / security.yml CodeQL job: a full-fleet dependency
+      # resolution (~30 modules + the quarkus-bom) needs more than Gradle's 3 GiB default heap.
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
+      LANG: C.UTF-8
+      LC_ALL: C.UTF-8
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          distribution: temurin
+          java-version: |
+            21
+            25
+
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          dependency-graph: generate-and-submit
+
+      # assemble resolves runtimeClasspath (what actually ships); testClasses additionally
+      # resolves testCompileClasspath/testRuntimeClasspath — together the full graph the
+      # fleet depends on. No tests executed, so no Docker/Testcontainers needed.
+      # --continue: one module failing to resolve shouldn't blank out the graph for the rest.
+      - name: Resolve fleet dependency graph
+        run: ./gradlew assemble testClasses --continue --no-daemon


### PR DESCRIPTION
## Summary
- Root-causes Scorecard's Vulnerabilities finding (#298, \"63 existing vulnerabilities\"): GitHub's dependency graph has ~1100 packages but only ~2 are Maven/Gradle — the fleet's Kotlin/Java dependencies were never submitted, so Dependabot security alerts report 0 findings while Scorecard's own OSV-scanner (reading `build.gradle.kts`/`libs.versions.toml` directly) reports dozens of GHSA IDs with no per-package/fix-version context.
- Wires `gradle/actions/setup-gradle`'s built-in `dependency-graph: generate-and-submit` into a new workflow, mirroring `fleet-lint.yml`'s GRADLE_OPTS/toolchain conventions for a full-fleet `./gradlew assemble testClasses` invocation (resolves both runtime and test classpaths, no Docker/Testcontainers).
- Triggers on push to main (Gradle manifest paths) + weekly schedule + manual dispatch.

Once this lands and runs once, Dependabot's alert feed becomes the authoritative, actionable, per-service view of real Gradle CVEs (exact vulnerable version + suggested fix) — the follow-up triage of whatever it surfaces is tracked separately rather than blind-guessed from Scorecard's raw GHSA-ID dump.

## Linked issues
N/A — infra root-cause fix for #298.

## Test plan
- [ ] Workflow runs green on first push to main
- [ ] `gh api repos/JiRaska/open-bank-oss/dependency-graph/sbom` shows Maven/Gradle packages after the run
- [ ] Dependabot alerts populate (or stay at 0 if genuinely clean) within a day of the first successful submission