### PR TITLE
fix(infra): add the LLVMFuzzerTestOneInput marker to generated fuzz wrappers

### DIFF
--- a/fuzz/ossfuzz/ossfuzz-build.sh
+++ b/fuzz/ossfuzz/ossfuzz-build.sh
@@ -24,13 +24,25 @@ cd "$SRC/open-bank-oss"
 cp fuzz/ossfuzz/build/libs/ossfuzz-all.jar "$OUT/openbank.jar"
 
 for fuzzer in Pacs008ReaderFuzzer RodneCisloFuzzer; do
+  # The "LLVMFuzzerTestOneInput" comment below is a REQUIRED magic marker, not doc:
+  # OSS-Fuzz/CIFuzz recognizes a file in $OUT as a fuzz target only if its CONTENT
+  # contains that string (infra/utils.py is_fuzz_target_local, FUZZ_TARGET_SEARCH_STRING)
+  # — without it check_build fails with "No fuzz targets found". Same canonical wrapper
+  # (incl. the ASan-headroom -Xmx/-Xss settings) as google/oss-fuzz JVM projects.
   cat > "$OUT/$fuzzer" <<SH
 #!/usr/bin/env bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
 this_dir=\$(dirname "\$0")
+if [[ "\$@" =~ (^| )-runs=[0-9]+(\$| ) ]]; then
+  mem_settings='-Xmx1900m:-Xss900k'
+else
+  mem_settings='-Xmx2048m:-Xss1024k'
+fi
 LD_LIBRARY_PATH="\$JVM_LD_LIBRARY_PATH" \\
   "\$this_dir/jazzer_driver" --agent_path="\$this_dir/jazzer_agent_deploy.jar" \\
   --cp="\$this_dir/openbank.jar" \\
   --target_class=com.openbank.fuzz.$fuzzer \\
+  --jvm_args="\$mem_settings" \\
   "\$@"
 SH
   chmod +x "$OUT/$fuzzer"


### PR DESCRIPTION
## Summary

The first live ClusterFuzzLite run (PR #450) failed `check_build` with `No fuzz targets found in out dir`: OSS-Fuzz/CIFuzz recognizes a file in `$OUT` as a fuzz target only if its content contains `LLVMFuzzerTestOneInput` (`infra/utils.py` `is_fuzz_target_local`), and our generated Jazzer wrappers lacked the canonical magic-comment marker. The eventual google/oss-fuzz onboarding of the #330 package would fail identically — the new lane caught a real latent bug on its first run.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #455

## Changes

- `fuzz/ossfuzz/ossfuzz-build.sh`: generate the canonical OSS-Fuzz JVM wrapper — `# LLVMFuzzerTestOneInput for fuzzer detection.` marker line + the standard `--jvm_args` ASan-headroom memory settings (`-Xmx2048m:-Xss1024k`, reduced under `-runs=`), with a comment explaining the marker is load-bearing.
- Wrapper generation verified locally (heredoc expansion, `bash -n`, marker present).
- This PR touches `fuzz/**`, so the ClusterFuzzLite lane runs on it — the live end-to-end validation.

## Definition of Done

- [x] Hexagonal layering preserved. — N/A (build script)
- [x] Unit tests added/updated. — N/A; validated by the cflite lane on this PR + local wrapper-generation check
- [x] Integration/contract tests, OpenAPI, Flyway, Avro — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no Kotlin change
- [x] No new lint warnings.
- [x] Docs updated. — inline comment in the build script