### PR TITLE
test(libs-runtime): cover security/audit/error-mapping plumbing shared by the fleet

### DIFF
--- a/openbank-libs-runtime/build.gradle.kts
+++ b/openbank-libs-runtime/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
+    testImplementation("jakarta.persistence:jakarta.persistence-api:3.2.0")
     testImplementation("io.quarkus:quarkus-security:3.33.2")
     testImplementation("org.jboss.resteasy:resteasy-core:6.2.12.Final")
     testImplementation("org.jboss.logging:jboss-logging:3.6.2.Final")
@@ -82,7 +83,7 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 20
+                    minValue = 50
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/api/error/CommonExceptionMappersTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/api/error/CommonExceptionMappersTest.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.api.error
+
+import jakarta.ws.rs.WebApplicationException
+import org.assertj.core.api.Assertions.assertThat
+import org.jboss.logging.MDC
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class CommonExceptionMappersTest {
+
+    @AfterEach
+    fun clearMdc() {
+        MDC.remove("correlationId")
+    }
+
+    @Test
+    fun `IllegalArgumentException maps to 400 VALIDATION_ERROR`() {
+        val response = IllegalArgumentExceptionMapper().toResponse(IllegalArgumentException("bad amount"))
+        val body = response.entity as ApiError
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat(body.code).isEqualTo(ErrorCode.VALIDATION_ERROR.code)
+        assertThat(body.message).isEqualTo("bad amount")
+    }
+
+    @Test
+    fun `IllegalArgumentException falls back to a generic message when none is set`() {
+        val body = IllegalArgumentExceptionMapper().toResponse(IllegalArgumentException()).entity as ApiError
+        assertThat(body.message).isEqualTo("Invalid request")
+    }
+
+    @Test
+    fun `IllegalStateException maps to 422 BUSINESS_RULE_VIOLATION`() {
+        val response = IllegalStateExceptionMapper().toResponse(IllegalStateException("account frozen"))
+        val body = response.entity as ApiError
+
+        assertThat(response.status).isEqualTo(422)
+        assertThat(body.code).isEqualTo("BUSINESS_RULE_VIOLATION")
+        assertThat(body.message).isEqualTo("account frozen")
+    }
+
+    @Test
+    fun `NoSuchElementException maps to 404 NOT_FOUND`() {
+        val response = NoSuchElementExceptionMapper().toResponse(NoSuchElementException("account 123"))
+        val body = response.entity as ApiError
+
+        assertThat(response.status).isEqualTo(404)
+        assertThat(body.code).isEqualTo(ErrorCode.NOT_FOUND.code)
+        assertThat(body.message).isEqualTo("account 123")
+    }
+
+    @Test
+    fun `WebApplicationException maps known statuses to their ErrorCode`() {
+        val mapper = WebApplicationExceptionMapper()
+
+        val unauthorized = WebApplicationException("nope", 401)
+        assertThat((mapper.toResponse(unauthorized).entity as ApiError).code)
+            .isEqualTo(ErrorCode.UNAUTHORIZED.code)
+
+        val forbidden = WebApplicationException("forbidden", 403)
+        assertThat((mapper.toResponse(forbidden).entity as ApiError).code).isEqualTo(ErrorCode.FORBIDDEN.code)
+
+        val conflict = WebApplicationException("conflict", 409)
+        assertThat((mapper.toResponse(conflict).entity as ApiError).code).isEqualTo(ErrorCode.CONFLICT.code)
+    }
+
+    @Test
+    fun `WebApplicationException falls back to HTTP_ prefixed code for unmapped statuses`() {
+        val response = WebApplicationExceptionMapper().toResponse(WebApplicationException("teapot", 418))
+        val body = response.entity as ApiError
+
+        assertThat(response.status).isEqualTo(418)
+        assertThat(body.code).isEqualTo("HTTP_418")
+    }
+
+    @Test
+    fun `GenericExceptionMapper never leaks the original exception message`() {
+        val secret = IllegalStateException("SELECT * FROM parties WHERE ssn = '990101/1234'")
+        val response = GenericExceptionMapper().toResponse(secret)
+        val body = response.entity as ApiError
+
+        assertThat(response.status).isEqualTo(500)
+        assertThat(body.code).isEqualTo(ErrorCode.INTERNAL_ERROR.code)
+        assertThat(body.message).doesNotContain("SELECT").doesNotContain("ssn")
+        assertThat(body.message).contains(body.traceId)
+    }
+
+    @Test
+    fun `traceId reuses the MDC correlation id set by CorrelationIdRequestFilter when present`() {
+        MDC.put("correlationId", "corr-from-request")
+
+        val body = NoSuchElementExceptionMapper().toResponse(NoSuchElementException("x")).entity as ApiError
+
+        assertThat(body.traceId).isEqualTo("corr-from-request")
+    }
+
+    @Test
+    fun `traceId falls back to a fresh id when no correlation id is in MDC`() {
+        val body = NoSuchElementExceptionMapper().toResponse(NoSuchElementException("x")).entity as ApiError
+        assertThat(body.traceId).isNotBlank()
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/audit/AuditEventPublisherTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/audit/AuditEventPublisherTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.audit
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+/**
+ * [LoggingAuditEventPublisher] is the DORA Art. 17 fallback that guarantees an audit event
+ * is always recorded even when no durable (Kafka) publisher is wired up — so this must never
+ * throw regardless of which optional fields are absent.
+ */
+class AuditEventPublisherTest {
+
+    private val publisher: AuditEventPublisher = LoggingAuditEventPublisher()
+
+    @Test
+    fun `publishes a fully populated event without throwing`(): Unit = runBlocking {
+        publisher.publish(
+            AuditEvent(
+                actorId = "party-123",
+                actorType = "CUSTOMER",
+                operation = "account.party.created",
+                resourceType = "account",
+                resourceId = "acc-456",
+                ipAddress = "203.0.113.7",
+                userAgent = "openbank-app/1.0",
+                result = AuditResult.SUCCESS,
+                traceId = "trace-789",
+            ),
+        )
+    }
+
+    @Test
+    fun `publishes an event with absent optional fields without throwing`(): Unit = runBlocking {
+        publisher.publish(
+            AuditEvent(
+                actorId = "system",
+                actorType = "SERVICE",
+                operation = "payment.sepa.recalled",
+                resourceType = "payment",
+                resourceId = null,
+                result = AuditResult.DENIED,
+                traceId = null,
+            ),
+        )
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/domain/identifiers/IdConvertersTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/domain/identifiers/IdConvertersTest.kt
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.domain.identifiers
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Every typesafe-ID JPA converter must round-trip through the raw [UUID] column type and
+ * must pass `null` through unchanged — Hibernate calls these converters on nullable
+ * foreign-key columns, so a converter that NPEs on null breaks persistence fleet-wide.
+ */
+class IdConvertersTest {
+
+    @Test
+    fun `AccountIdConverter round-trips and passes null through`() {
+        val converter = AccountIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(AccountId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(AccountId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `TransactionIdConverter round-trips and passes null through`() {
+        val converter = TransactionIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(TransactionId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(TransactionId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `PartyIdConverter round-trips and passes null through`() {
+        val converter = PartyIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(PartyId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(PartyId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `CardIdConverter round-trips and passes null through`() {
+        val converter = CardIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(CardId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(CardId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `DisputeIdConverter round-trips and passes null through`() {
+        val converter = DisputeIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(DisputeId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(DisputeId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `OrderIdConverter round-trips and passes null through`() {
+        val converter = OrderIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(OrderId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(OrderId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `ConsentIdConverter round-trips and passes null through`() {
+        val converter = ConsentIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(ConsentId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(ConsentId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `PaymentIdConverter round-trips and passes null through`() {
+        val converter = PaymentIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(PaymentId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(PaymentId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `CaseIdConverter round-trips and passes null through`() {
+        val converter = CaseIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(CaseId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(CaseId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `LoanApplicationIdConverter round-trips and passes null through`() {
+        val converter = LoanApplicationIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(LoanApplicationId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(LoanApplicationId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `LoanIdConverter round-trips and passes null through`() {
+        val converter = LoanIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(LoanId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(LoanId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+
+    @Test
+    fun `CollateralIdConverter round-trips and passes null through`() {
+        val converter = CollateralIdConverter()
+        val id = UUID.randomUUID()
+        assertThat(converter.convertToDatabaseColumn(CollateralId(id))).isEqualTo(id)
+        assertThat(converter.convertToEntityAttribute(id)).isEqualTo(CollateralId(id))
+        assertThat(converter.convertToDatabaseColumn(null)).isNull()
+        assertThat(converter.convertToEntityAttribute(null)).isNull()
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/BearerTokenClientHeadersFactoryTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/security/BearerTokenClientHeadersFactoryTest.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.security
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.enterprise.inject.Instance
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class BearerTokenClientHeadersFactoryTest {
+
+    private fun factoryWith(tokenProvider: Instance<ServiceTokenProvider>): BearerTokenClientHeadersFactory =
+        BearerTokenClientHeadersFactory().apply { this.tokenProvider = tokenProvider }
+
+    private fun unresolvableProvider(): Instance<ServiceTokenProvider> = mockk { every { isResolvable } returns false }
+
+    @Test
+    fun `prefers the CDI ServiceTokenProvider when one is resolvable`() {
+        val provider = mockk<ServiceTokenProvider> { every { getToken() } returns "s2s-token" }
+        val tokenProvider = mockk<Instance<ServiceTokenProvider>> {
+            every { isResolvable } returns true
+            every { get() } returns provider
+        }
+        val incoming = MultivaluedHashMap<String, String>().apply {
+            putSingle("Authorization", "Bearer end-user-token")
+        }
+        val outgoing = MultivaluedHashMap<String, String>()
+
+        val result = factoryWith(tokenProvider).update(incoming, outgoing)
+
+        assertThat(result.getFirst("Authorization")).isEqualTo("Bearer s2s-token")
+    }
+
+    @Test
+    fun `falls back to passing through the inbound Authorization header (act-as flow)`() {
+        val incoming = MultivaluedHashMap<String, String>().apply {
+            putSingle("Authorization", "Bearer end-user-token")
+        }
+        val outgoing = MultivaluedHashMap<String, String>()
+
+        val result = factoryWith(unresolvableProvider()).update(incoming, outgoing)
+
+        assertThat(result.getFirst("Authorization")).isEqualTo("Bearer end-user-token")
+    }
+
+    @Test
+    fun `sends no Authorization header when neither a provider nor an inbound header exists`() {
+        val incoming = MultivaluedHashMap<String, String>()
+        val outgoing = MultivaluedHashMap<String, String>()
+
+        val result = factoryWith(unresolvableProvider()).update(incoming, outgoing)
+
+        assertThat(result.containsKey("Authorization")).isFalse()
+    }
+
+    @Test
+    fun `never overwrites an Authorization header already set on the outgoing request`() {
+        val provider = mockk<ServiceTokenProvider> { every { getToken() } returns "s2s-token" }
+        val tokenProvider = mockk<Instance<ServiceTokenProvider>> {
+            every { isResolvable } returns true
+            every { get() } returns provider
+        }
+        val incoming = MultivaluedHashMap<String, String>()
+        val outgoing = MultivaluedHashMap<String, String>().apply { putSingle("Authorization", "Bearer preset") }
+
+        val result = factoryWith(tokenProvider).update(incoming, outgoing)
+
+        assertThat(result.getFirst("Authorization")).isEqualTo("Bearer preset")
+    }
+
+    @Test
+    fun `propagates correlation and request ids from inbound to outgoing`() {
+        val incoming = MultivaluedHashMap<String, String>().apply {
+            putSingle("X-Correlation-ID", "corr-1")
+            putSingle("X-Request-ID", "req-1")
+        }
+        val outgoing = MultivaluedHashMap<String, String>()
+
+        val result = factoryWith(unresolvableProvider()).update(incoming, outgoing)
+
+        assertThat(result.getFirst("X-Correlation-ID")).isEqualTo("corr-1")
+        assertThat(result.getFirst("X-Request-ID")).isEqualTo("req-1")
+    }
+
+    @Test
+    fun `does not overwrite correlation ids already present on the outgoing request`() {
+        val incoming = MultivaluedHashMap<String, String>().apply { putSingle("X-Correlation-ID", "corr-inbound") }
+        val outgoing = MultivaluedHashMap<String, String>().apply { putSingle("X-Correlation-ID", "corr-outgoing") }
+
+        val result = factoryWith(unresolvableProvider()).update(incoming, outgoing)
+
+        assertThat(result.getFirst("X-Correlation-ID")).isEqualTo("corr-outgoing")
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/CorrelationIdFilterTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/CorrelationIdFilterTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.web
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import org.assertj.core.api.Assertions.assertThat
+import org.jboss.logging.MDC
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class CorrelationIdFilterTest {
+
+    @AfterEach
+    fun clearMdc() {
+        MDC.remove(MDC_CORRELATION_ID)
+        MDC.remove(MDC_REQUEST_ID)
+    }
+
+    private fun requestWith(correlationId: String?, requestId: String?): ContainerRequestContext =
+        mockk(relaxed = true) {
+            every { getHeaderString(HEADER_CORRELATION_ID) } returns correlationId
+            every { getHeaderString(HEADER_REQUEST_ID) } returns requestId
+        }
+
+    @Test
+    fun `propagates inbound correlation and request ids into properties and MDC`() {
+        val req = requestWith(correlationId = "corr-123", requestId = "req-456")
+
+        CorrelationIdRequestFilter().filter(req)
+
+        verify { req.setProperty(ApiVersionResponseFilter.CORRELATION_ID_KEY, "corr-123") }
+        verify { req.setProperty(MDC_REQUEST_ID, "req-456") }
+        assertThat(MDC.get(MDC_CORRELATION_ID)).isEqualTo("corr-123")
+        assertThat(MDC.get(MDC_REQUEST_ID)).isEqualTo("req-456")
+    }
+
+    @Test
+    fun `generates fresh ids when the client sent none`() {
+        val req = requestWith(correlationId = null, requestId = null)
+
+        CorrelationIdRequestFilter().filter(req)
+
+        val generatedCorrelationId = MDC.get(MDC_CORRELATION_ID) as String
+        val generatedRequestId = MDC.get(MDC_REQUEST_ID) as String
+        assertThat(generatedCorrelationId).isNotBlank()
+        assertThat(generatedRequestId).isNotBlank()
+        assertThat(generatedCorrelationId).isNotEqualTo(generatedRequestId)
+    }
+
+    @Test
+    fun `response filter clears the MDC so it never leaks across requests`() {
+        MDC.put(MDC_CORRELATION_ID, "leftover-corr")
+        MDC.put(MDC_REQUEST_ID, "leftover-req")
+        val req = mockk<ContainerRequestContext>(relaxed = true)
+        val resp = mockk<ContainerResponseContext>(relaxed = true)
+
+        CorrelationIdResponseFilter().filter(req, resp)
+
+        assertThat(MDC.get(MDC_CORRELATION_ID)).isNull()
+        assertThat(MDC.get(MDC_REQUEST_ID)).isNull()
+    }
+}

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/RateLimitFilterTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/web/RateLimitFilterTest.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.web
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.ws.rs.container.ContainerRequestContext
+import jakarta.ws.rs.container.ContainerResponseContext
+import jakarta.ws.rs.core.MultivaluedHashMap
+import jakarta.ws.rs.core.UriInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RateLimitFilterTest {
+
+    private fun requestFor(path: String): ContainerRequestContext {
+        val uriInfo = mockk<UriInfo> { every { this@mockk.path } returns path }
+        return mockk(relaxed = true) { every { this@mockk.uriInfo } returns uriInfo }
+    }
+
+    @Test
+    fun `disabled filter never touches the request`() {
+        val filter = RateLimitFilter(maxConcurrent = 1, enabled = false)
+        val req = requestFor("/api/v1/accounts")
+
+        filter.filter(req)
+
+        verify(exactly = 0) { req.abortWith(any()) }
+        verify(exactly = 0) { req.setProperty(any(), any()) }
+    }
+
+    @Test
+    fun `health endpoints under q are exempt from the limit`() {
+        val filter = RateLimitFilter(maxConcurrent = 1, enabled = true)
+        val first = requestFor("/q/health")
+        val second = requestFor("/q/metrics")
+
+        filter.filter(first)
+        filter.filter(second)
+
+        verify(exactly = 0) { first.abortWith(any()) }
+        verify(exactly = 0) { second.abortWith(any()) }
+    }
+
+    @Test
+    fun `acquires a permit and marks the request when under the limit`() {
+        val filter = RateLimitFilter(maxConcurrent = 2, enabled = true)
+        val req = requestFor("/api/v1/accounts")
+
+        filter.filter(req)
+
+        verify(exactly = 0) { req.abortWith(any()) }
+        verify { req.setProperty("rate-limit-acquired", true) }
+    }
+
+    @Test
+    fun `rejects with 429 once concurrent capacity is exhausted`() {
+        val filter = RateLimitFilter(maxConcurrent = 1, enabled = true)
+        filter.filter(requestFor("/api/v1/accounts")) // consumes the only permit
+
+        val overflow = requestFor("/api/v1/transactions")
+        val responseSlot = mutableListOf<jakarta.ws.rs.core.Response>()
+        every { overflow.abortWith(any()) } answers { responseSlot.add(firstArg()) }
+
+        filter.filter(overflow)
+
+        assertThat(responseSlot).hasSize(1)
+        val response = responseSlot.first()
+        assertThat(response.status).isEqualTo(429)
+        assertThat(response.getHeaderString("Retry-After")).isEqualTo("1")
+        assertThat(response.getHeaderString("X-RateLimit-Remaining")).isEqualTo("0")
+        verify(exactly = 0) { overflow.setProperty("rate-limit-acquired", true) }
+    }
+
+    @Test
+    fun `response filter releases the permit and reports remaining capacity`() {
+        val filter = RateLimitFilter(maxConcurrent = 3, enabled = true)
+        val req = requestFor("/api/v1/accounts")
+        filter.filter(req)
+        every { req.getProperty("rate-limit-acquired") } returns true
+
+        val headers = MultivaluedHashMap<String, Any>()
+        val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
+        filter.filter(req, resp)
+
+        assertThat(headers.getFirst("X-RateLimit-Limit")).isEqualTo(3)
+        assertThat(headers.getFirst("X-RateLimit-Remaining")).isEqualTo(3)
+    }
+
+    @Test
+    fun `response filter is a no-op when no permit was acquired`() {
+        val filter = RateLimitFilter(maxConcurrent = 1, enabled = false)
+        val req = requestFor("/api/v1/accounts")
+        every { req.getProperty("rate-limit-acquired") } returns null
+
+        val headers = MultivaluedHashMap<String, Any>()
+        val resp = mockk<ContainerResponseContext> { every { this@mockk.headers } returns headers }
+        filter.filter(req, resp)
+
+        assertThat(headers).isEmpty()
+    }
+}


### PR DESCRIPTION
## Summary
- `openbank-libs-runtime` sat at ~29% coverage (Codecov) with several security- and audit-critical classes at literally 0%: `RateLimitFilter`, `CorrelationIdFilter`, `BearerTokenClientHeadersFactory`, `CommonExceptionMappers`, `LoggingAuditEventPublisher`, and every typesafe-ID JPA converter — all shared transitively by every service in the fleet.
- Adds real unit tests for the meaningful branches: concurrent-request permit acquisition/429/release, S2S bearer-token resolution order (CDI `ServiceTokenProvider` → inbound pass-through act-as flow → none), correlation-ID propagation into MDC across request/response, PII/SQL-safe sanitisation on `GenericExceptionMapper` (the DORA-relevant "never leak the raw exception message" contract), and null-safety round-trips on every ID converter.
- Ratchets `koverVerify` floor for the module 20% → 50% (line coverage now ~55% locally) so it can't silently regress.

## Test plan
- [x] `:openbank-libs-runtime:test` — all new + existing tests pass
- [x] `:openbank-libs-runtime:ktlintCheck` / `ktlintFormat`
- [x] `:openbank-libs-runtime:detekt`
- [x] `:openbank-libs-runtime:koverVerify` at the raised 50% floor

Linked issues: Refs #321