### PR TITLE
test(customer-edge): cover the SSRF allowlist, S2S auth and customer audit trail

### DIFF
--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/UpstreamClientTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/UpstreamClientTest.kt
@@ -10,6 +10,7 @@ import com.sun.net.httpserver.HttpServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
 
 class UpstreamClientTest {
 
@@ -38,7 +39,7 @@ class UpstreamClientTest {
             tokenResponse = """{"access_token":"test-token","expires_in":300}""",
             docBytes = pdfBytes,
             docContentType = "application/pdf",
-        ) { client, baseUrl ->
+        ) { client, baseUrl, _ ->
             val response = client.getRaw("$baseUrl/statements/s1/document", "party-1", "*/*")
 
             assertThat(response.status).isEqualTo(200)
@@ -57,7 +58,7 @@ class UpstreamClientTest {
             tokenResponse = """{"access_token":"test-token","expires_in":300}""",
             docBytes = xml.toByteArray(Charsets.UTF_8),
             docContentType = "application/xml",
-        ) { client, baseUrl ->
+        ) { client, baseUrl, _ ->
             val response = client.getRaw("$baseUrl/statements/s1/document", "party-1", "*/*")
 
             assertThat(response.status).isEqualTo(200)
@@ -66,23 +67,192 @@ class UpstreamClientTest {
         }
     }
 
+    @Test
+    fun `get sends the bearer token, party header and Accept json to the upstream`() {
+        withServer { client, baseUrl, requests ->
+            val response = client.get("$baseUrl/statements", "party-9")
+
+            assertThat(response.status).isEqualTo(200)
+            val req = requests.single { it.path == "/statements" }
+            assertThat(req.method).isEqualTo("GET")
+            assertThat(req.headers["authorization"]).isEqualTo("Bearer test-token")
+            assertThat(req.headers["x-customer-party-id"]).isEqualTo("party-9")
+            assertThat(req.headers["accept"]).isEqualTo("application/json")
+        }
+    }
+
+    @Test
+    fun `postAnonymous sends a generated Idempotency-Key and no party header`() {
+        withServer { client, baseUrl, requests ->
+            val response = client.postAnonymous("$baseUrl/parties", """{"name":"Jana"}""")
+
+            assertThat(response.status).isEqualTo(200)
+            val req = requests.single { it.path == "/parties" }
+            assertThat(req.method).isEqualTo("POST")
+            assertThat(req.body).isEqualTo("""{"name":"Jana"}""")
+            assertThat(req.headers["idempotency-key"]).isNotBlank()
+            assertThat(req.headers).doesNotContainKey("x-customer-party-id")
+        }
+    }
+
+    @Test
+    fun `patch sends no body with the party header`() {
+        withServer { client, baseUrl, requests ->
+            val response = client.patch("$baseUrl/notifications/1", "party-9")
+
+            assertThat(response.status).isEqualTo(200)
+            val req = requests.single { it.path == "/notifications/1" }
+            assertThat(req.method).isEqualTo("PATCH")
+            assertThat(req.body).isEmpty()
+            assertThat(req.headers["x-customer-party-id"]).isEqualTo("party-9")
+        }
+    }
+
+    @Test
+    fun `put forwards the body with the party header`() {
+        withServer { client, baseUrl, requests ->
+            val response = client.put("$baseUrl/savings-goal", "party-9", """{"target":1000}""")
+
+            assertThat(response.status).isEqualTo(200)
+            val req = requests.single { it.path == "/savings-goal" }
+            assertThat(req.method).isEqualTo("PUT")
+            assertThat(req.body).isEqualTo("""{"target":1000}""")
+        }
+    }
+
+    @Test
+    fun `delete sends the party header and no body`() {
+        withServer { client, baseUrl, requests ->
+            val response = client.delete("$baseUrl/standing-orders/1", "party-9")
+
+            assertThat(response.status).isEqualTo(200)
+            val req = requests.single { it.path == "/standing-orders/1" }
+            assertThat(req.method).isEqualTo("DELETE")
+        }
+    }
+
+    @Test
+    fun `post uses the caller-supplied Idempotency-Key when non-blank`() {
+        withServer { client, baseUrl, requests ->
+            client.post("$baseUrl/payments", "party-9", "{}", idempotencyKey = "client-key-1")
+
+            val req = requests.single { it.path == "/payments" }
+            assertThat(req.headers["idempotency-key"]).isEqualTo("client-key-1")
+        }
+    }
+
+    @Test
+    fun `post generates an Idempotency-Key when the caller supplies a blank one`() {
+        withServer { client, baseUrl, requests ->
+            client.post("$baseUrl/payments", "party-9", "{}", idempotencyKey = "   ")
+
+            val req = requests.single { it.path == "/payments" }
+            assertThat(req.headers["idempotency-key"]).isNotBlank().isNotEqualTo("   ")
+        }
+    }
+
+    @Test
+    fun `post with extraHeaders forwards them and applies them after the standard headers`() {
+        withServer { client, baseUrl, requests ->
+            client.post(
+                "$baseUrl/cards",
+                "party-9",
+                "{}",
+                idempotencyKey = "key-1",
+                extraHeaders = mapOf("X-Operator-Id" to "op-42"),
+            )
+
+            val req = requests.single { it.path == "/cards" }
+            assertThat(req.headers["x-operator-id"]).isEqualTo("op-42")
+            assertThat(req.headers["x-customer-party-id"]).isEqualTo("party-9")
+        }
+    }
+
+    @Test
+    fun `reuses the cached token across calls instead of re-authenticating every request`() {
+        withServer { client, baseUrl, _ ->
+            client.get("$baseUrl/a", "party-1")
+            client.get("$baseUrl/b", "party-1")
+
+            assertThat(tokenHits.get()).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `re-authenticates once the cached token is within the expiry refresh buffer`() {
+        withServer(tokenResponse = """{"access_token":"test-token","expires_in":1}""") { client, baseUrl, _ ->
+            client.get("$baseUrl/a", "party-1")
+            client.get("$baseUrl/b", "party-1")
+
+            assertThat(tokenHits.get()).isEqualTo(2)
+        }
+    }
+
+    @Test
+    fun `rejects a disallowed host without making any network call and degrades to a 502`() {
+        withServer { client, _, requests ->
+            val response = client.get("http://evil.example.com/steal", "party-1")
+
+            assertThat(response.status).isEqualTo(502)
+            assertThat(response.entity as String).contains("upstream unavailable")
+            assertThat(requests).isEmpty()
+        }
+    }
+
+    @Test
+    fun `degrades to a 502 JSON error when the upstream connection fails`() {
+        withServer { client, _, _ ->
+            // Nothing listens on this port on loopback — an allowed host per the SSRF allowlist,
+            // but the connection itself fails, exercising the outer catch block rather than validatedUri.
+            val response = client.get("http://127.0.0.1:1/unreachable", "party-1")
+
+            assertThat(response.status).isEqualTo(502)
+            assertThat(response.mediaType.toString()).isEqualTo("application/json")
+            assertThat(response.entity as String).contains("upstream unavailable")
+        }
+    }
+
+    // --- test harness ------------------------------------------------------------------
+
+    data class CapturedRequest(val method: String, val path: String, val headers: Map<String, String>, val body: String)
+
+    private val tokenHits = AtomicInteger(0)
+
     /**
      * Spins up a throwaway JDK HTTP server (HTTP/1.1, no extra test deps) that answers the
-     * client_credentials token fetch and serves the document, runs [block] against an
-     * [UpstreamClient] wired to it, and tears the server down afterwards.
+     * client_credentials token fetch and echoes every other request into the captured-request
+     * list handed to [block], and tears the server down afterwards.
      */
     private fun withServer(
-        tokenResponse: String,
-        docBytes: ByteArray,
-        docContentType: String,
-        block: (UpstreamClient, String) -> Unit,
+        tokenResponse: String = """{"access_token":"test-token","expires_in":300}""",
+        docBytes: ByteArray? = null,
+        docContentType: String = "application/json",
+        block: (UpstreamClient, String, List<CapturedRequest>) -> Unit,
     ) {
+        tokenHits.set(0)
+        val requests = mutableListOf<CapturedRequest>()
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
         server.createContext("/realms/openbank/protocol/openid-connect/token") { exchange ->
+            tokenHits.incrementAndGet()
             respond(exchange, 200, "application/json", tokenResponse.toByteArray(Charsets.UTF_8))
         }
-        server.createContext("/statements") { exchange ->
-            respond(exchange, 200, docContentType, docBytes)
+        if (docBytes != null) {
+            server.createContext("/statements") { exchange ->
+                respond(exchange, 200, docContentType, docBytes)
+            }
+        }
+        server.createContext("/") { exchange ->
+            synchronized(requests) {
+                requests.add(
+                    CapturedRequest(
+                        method = exchange.requestMethod,
+                        path = exchange.requestURI.path,
+                        headers = exchange.requestHeaders.entries.associate { (k, v) -> k.lowercase() to v.first() },
+                        body = exchange.requestBody.readBytes().toString(Charsets.UTF_8),
+                    ),
+                )
+            }
+            respond(exchange, 200, "application/json", "{}".toByteArray(Charsets.UTF_8))
         }
         server.start()
         try {
@@ -91,10 +261,10 @@ class UpstreamClientTest {
                 tokenEndpointBase = "$baseUrl/realms/openbank"
                 clientId = "openbank-edge"
                 clientSecret = "test-secret"
-                connectTimeoutMs = 5000
-                requestTimeoutMs = 5000
+                connectTimeoutMs = 2000
+                requestTimeoutMs = 2000
             }
-            block(client, baseUrl)
+            block(client, baseUrl, requests)
         } finally {
             server.stop(0)
         }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/audit/EdgeAuditPublisherTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/audit/EdgeAuditPublisherTest.kt
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.audit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.reactive.messaging.kafka.Record
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.reactive.messaging.Emitter
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.CompletableFuture
+
+/**
+ * [EdgeAuditPublisher] is the only place that records the real customer identity behind a
+ * money-moving or identity-changing action (GDPR Art. 30 / DORA Art. 17) — upstream services
+ * see only the M2M token, so a gap here is unreconstructable after the fact. It is also
+ * "best-effort BY DESIGN": a broker failure must degrade to a log line, never propagate.
+ */
+class EdgeAuditPublisherTest {
+
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-07-07T10:00:00Z"), ZoneOffset.UTC)
+    private val objectMapper = ObjectMapper()
+
+    @Suppress("UNCHECKED_CAST")
+    private fun mockEmitter(): Emitter<Record<String, String>> = mockk<Emitter<Record<String, String>>> {
+        every { send(any()) } returns CompletableFuture.completedFuture(null)
+    }
+
+    @Test
+    fun `emits a well-formed audit record with the customer as actor and aggregate`() {
+        val emitter = mockEmitter()
+        val recordSlot = slot<Record<String, String>>()
+        every { emitter.send(capture(recordSlot)) } returns CompletableFuture.completedFuture(null)
+        val publisher = EdgeAuditPublisher(objectMapper, emitter, fixedClock)
+
+        publisher.emit(
+            eventType = "customer.payment.initiated",
+            partyId = "party-123",
+            operation = "payment.sepa.created",
+            result = "SUCCESS",
+            resourceId = "payment-456",
+            details = mapOf("amount" to "100.00", "currency" to "EUR"),
+        )
+
+        assertThat(recordSlot.captured.key()).isEqualTo("party-123")
+        val payload = objectMapper.readTree(recordSlot.captured.value())
+        assertThat(payload.get("eventType").asText()).isEqualTo("customer.payment.initiated")
+        assertThat(payload.get("aggregateType").asText()).isEqualTo("CUSTOMER_ACTION")
+        assertThat(payload.get("partyId").asText()).isEqualTo("party-123")
+        assertThat(payload.get("actorId").asText()).isEqualTo("party-123")
+        assertThat(payload.get("actorType").asText()).isEqualTo("CUSTOMER")
+        assertThat(payload.get("operation").asText()).isEqualTo("payment.sepa.created")
+        assertThat(payload.get("result").asText()).isEqualTo("SUCCESS")
+        assertThat(payload.get("resourceId").asText()).isEqualTo("payment-456")
+        assertThat(payload.get("sourceService").asText()).isEqualTo("customer-edge")
+        assertThat(payload.get("occurredAt").asText()).isEqualTo("2026-07-07T10:00:00Z")
+        assertThat(payload.get("amount").asText()).isEqualTo("100.00")
+        assertThat(payload.get("currency").asText()).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `omits resourceId from the payload when absent instead of writing a null`() {
+        val emitter = mockEmitter()
+        val recordSlot = slot<Record<String, String>>()
+        every { emitter.send(capture(recordSlot)) } returns CompletableFuture.completedFuture(null)
+        val publisher = EdgeAuditPublisher(objectMapper, emitter, fixedClock)
+
+        publisher.emit(eventType = "customer.login", partyId = "party-1", operation = "auth.login", result = "SUCCESS")
+
+        val payload = objectMapper.readTree(recordSlot.captured.value())
+        assertThat(payload.has("resourceId")).isFalse()
+    }
+
+    @Test
+    fun `null detail values are dropped rather than serialised as null`() {
+        val emitter = mockEmitter()
+        val recordSlot = slot<Record<String, String>>()
+        every { emitter.send(capture(recordSlot)) } returns CompletableFuture.completedFuture(null)
+        val publisher = EdgeAuditPublisher(objectMapper, emitter, fixedClock)
+
+        publisher.emit(
+            eventType = "customer.profile.updated",
+            partyId = "party-1",
+            operation = "party.updated",
+            result = "SUCCESS",
+            details = mapOf("email" to "new@example.com", "phone" to null),
+        )
+
+        val payload = objectMapper.readTree(recordSlot.captured.value())
+        assertThat(payload.get("email").asText()).isEqualTo("new@example.com")
+        assertThat(payload.has("phone")).isFalse()
+    }
+
+    @Test
+    fun `never throws even when the emitter itself throws synchronously`() {
+        val emitter = mockk<Emitter<Record<String, String>>> {
+            every { send(any()) } throws IllegalStateException("channel closed")
+        }
+        val publisher = EdgeAuditPublisher(objectMapper, emitter, fixedClock)
+
+        publisher.emit(
+            eventType = "customer.payment.initiated",
+            partyId = "party-1",
+            operation = "x",
+            result = "FAILURE",
+        )
+
+        verify { emitter.send(any()) }
+    }
+
+    @Test
+    fun `does not throw when the emitter's returned future completes exceptionally`() {
+        val emitter = mockk<Emitter<Record<String, String>>> {
+            every { send(any()) } returns CompletableFuture<Void>().apply {
+                completeExceptionally(RuntimeException("broker unavailable"))
+            }
+        }
+        val publisher = EdgeAuditPublisher(objectMapper, emitter, fixedClock)
+
+        publisher.emit(
+            eventType = "customer.payment.initiated",
+            partyId = "party-1",
+            operation = "x",
+            result = "FAILURE",
+        )
+    }
+}

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/ratelimit/RateLimitFilterTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/ratelimit/RateLimitFilterTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.ratelimit
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.ws.rs.container.ContainerRequestContext
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.microprofile.jwt.JsonWebToken
+import org.junit.jupiter.api.Test
+
+class RateLimitFilterTest {
+
+    private fun filterWith(rateLimiter: RateLimiter, jwt: JsonWebToken, limit: Int = 100) = RateLimitFilter().apply {
+        this.rateLimiter = rateLimiter
+        this.jwt = jwt
+        this.limitPerMinute = limit
+    }
+
+    @Test
+    fun `allows the request and never touches the context when under the limit`() {
+        val jwt = mockk<JsonWebToken> {
+            every { getClaim<String>("party_id") } returns "party-1"
+        }
+        val rateLimiter = mockk<RateLimiter> { every { isAllowed("party-1", 100) } returns true }
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+
+        filterWith(rateLimiter, jwt).filter(ctx)
+
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `aborts with 429 and rate-limit headers once the party exceeds the limit`() {
+        val jwt = mockk<JsonWebToken> {
+            every { getClaim<String>("party_id") } returns "party-1"
+        }
+        val rateLimiter = mockk<RateLimiter> { every { isAllowed("party-1", 5) } returns false }
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+        val responseSlot = mutableListOf<jakarta.ws.rs.core.Response>()
+        every { ctx.abortWith(any()) } answers { responseSlot.add(firstArg()) }
+
+        filterWith(rateLimiter, jwt, limit = 5).filter(ctx)
+
+        assertThat(responseSlot).hasSize(1)
+        val response = responseSlot.first()
+        assertThat(response.status).isEqualTo(429)
+        assertThat(response.getHeaderString("X-RateLimit-Limit")).isEqualTo("5")
+        assertThat(response.getHeaderString("Retry-After")).isEqualTo("60")
+    }
+
+    @Test
+    fun `falls back to the JWT subject when party_id claim is absent`() {
+        val jwt = mockk<JsonWebToken> {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns "sub-42"
+        }
+        val rateLimiter = mockk<RateLimiter> { every { isAllowed("sub-42", 100) } returns true }
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+
+        filterWith(rateLimiter, jwt).filter(ctx)
+
+        verify { rateLimiter.isAllowed("sub-42", 100) }
+    }
+
+    @Test
+    fun `skips rate limiting entirely for anonymous requests (no party_id, no subject)`() {
+        val jwt = mockk<JsonWebToken> {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns null
+        }
+        val rateLimiter = mockk<RateLimiter>()
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+
+        filterWith(rateLimiter, jwt).filter(ctx)
+
+        verify(exactly = 0) { rateLimiter.isAllowed(any(), any()) }
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+
+    @Test
+    fun `treats a blank party_id claim as absent and falls back to subject`() {
+        val jwt = mockk<JsonWebToken> {
+            every { getClaim<String>("party_id") } returns "   "
+            every { subject } returns "sub-77"
+        }
+        val rateLimiter = mockk<RateLimiter> { every { isAllowed("sub-77", 100) } returns true }
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+
+        filterWith(rateLimiter, jwt).filter(ctx)
+
+        verify { rateLimiter.isAllowed("sub-77", 100) }
+    }
+
+    @Test
+    fun `skips rate limiting when reading the JWT claim throws (malformed token)`() {
+        val jwt = mockk<JsonWebToken> {
+            every { getClaim<String>("party_id") } throws IllegalStateException("no active request")
+        }
+        val rateLimiter = mockk<RateLimiter>()
+        val ctx = mockk<ContainerRequestContext>(relaxed = true)
+
+        filterWith(rateLimiter, jwt).filter(ctx)
+
+        verify(exactly = 0) { rateLimiter.isAllowed(any(), any()) }
+        verify(exactly = 0) { ctx.abortWith(any()) }
+    }
+}


### PR DESCRIPTION
## Summary
- `openbank-customer-edge` was the lowest-coverage service in the fleet (~38%, largest module by line count). This targets the classes with the most real risk sitting at 0-30% coverage rather than chasing the number alone:
  - `UpstreamClient` (30%) — the edge's single outbound path to every upstream service. Extends the existing loopback-server test harness to assert per-verb header/body/idempotency-key wiring (`get`/`post`/`postAnonymous`/`patch`/`put`/`delete`/`post+extraHeaders`), client_credentials token caching + refresh-on-expiry, and — the gap that mattered most — a case proving the SSRF host-allowlist actually rejects a disallowed host *before* any network call is made (this defense-in-depth check had review comments referencing 5 prior CodeQL SSRF findings, #239-241/#288/#289, but no test).
  - `EdgeAuditPublisher` (9%) — the only record of the real customer identity behind a money-moving action (GDPR Art. 30 / DORA Art. 17), since upstream services only see the M2M token. Covers payload shape, null-detail dropping, and the "never break the customer operation" best-effort contract (sync throw + async future failure).
  - `RateLimitFilter` (0%) — per-party identity resolution (`party_id` claim → `sub` fallback → anonymous bypass) and the 429 response shape.

## Test plan
- [x] `:openbank-customer-edge:test` — all new + existing tests pass (nothing regressed)
- [x] `:openbank-customer-edge:ktlintCheck` / `ktlintFormat`
- [x] `:openbank-customer-edge:detekt`
- [x] Local Kover line coverage for the module: 38% → ~56%

Linked issues: Refs #321