### PR TITLE
build(governance): wire koverVerify into check fleet-wide + first measured floors

### DIFF
--- a/build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts
+++ b/build-logic/src/main/kotlin/openbank.quarkus-service.gradle.kts
@@ -100,13 +100,13 @@ tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
     setSchemaVersion("1.5")
 }
 
-// koverVerify is intentionally NOT wired to check here. Coverage enforcement
-// is a per-service decision: only services with an explicit
-//   tasks.named("check") { dependsOn("koverVerify") }
-// block (e.g. the 13 money-path services from #338) gate their build on coverage.
-// Wiring it fleet-wide from the convention plugin would fail services whose
-// coverage has not yet been measured / baselined.
-//
-// Kover 0.7+ auto-wires koverVerify to the check task when a verify{} block is
-// present. Disable it here so only services that explicitly depend on it run it.
-tasks.matching { it.name == "koverVerify" }.configureEach { enabled = false }
+// Coverage gate (ADR-0020, ratchet-only — sweep #466). koverVerify is wired into
+// check fleet-wide: a module with a kover verify{} rule gets its floor enforced, a
+// module without rules passes trivially — so a module cannot silently opt out of
+// the ratchet. The previous default here DISABLED koverVerify and required
+// per-service re-enable boilerplate; that made "ungated" and "gated with floor 0"
+// indistinguishable from a real gate in a green build. Floors live in each module's
+// build.gradle.kts and only ever go up.
+tasks.named("check") {
+    dependsOn("koverVerify")
+}

--- a/openbank-agent-service/build.gradle.kts
+++ b/openbank-agent-service/build.gradle.kts
@@ -59,23 +59,18 @@ dependencies {
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
 }
 
+// Coverage floor (ADR-0020, ratchet-only — sweep #466: was a placebo minValue = 0
+// gate that could never fail). Measured 75.8% LINE coverage (1344/1772) at
+// introduction, no filter excludes; floor set at 70, raise-only from here.
 kover {
     reports {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    minValue = 70
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }
         }
     }
-}
-
-tasks.named("koverVerify") {
-    enabled = true
-}
-
-tasks.named("check") {
-    dependsOn(tasks.named("koverVerify"))
 }

--- a/openbank-customer-edge/build.gradle.kts
+++ b/openbank-customer-edge/build.gradle.kts
@@ -34,3 +34,26 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
 }
+
+// Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO
+// koverVerify gate at all). Floor = measured LINE coverage at introduction minus ~5 pt
+// headroom; raise-only from here. Same excludes rationale as ledger/billing: thin REST
+// adapters are covered by API ITs, reflection DTOs are data holders.
+kover {
+    reports {
+        filters {
+            excludes {
+                annotatedBy("jakarta.ws.rs.Path")
+                annotatedBy("io.quarkus.runtime.annotations.RegisterForReflection")
+            }
+        }
+        verify {
+            rule {
+                bound {
+                    minValue = 37 // measured 41.8% (223/534) at introduction
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
+}

--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -40,3 +40,26 @@ dependencies {
     testImplementation(libs.rest.assured.kotlin)
     testImplementation(libs.testcontainers.postgresql)
 }
+
+// Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO
+// koverVerify gate at all). Floor = measured LINE coverage at introduction minus ~5 pt
+// headroom; raise-only from here. Same excludes rationale as ledger/billing: thin REST
+// adapters are covered by API ITs, reflection DTOs are data holders.
+kover {
+    reports {
+        filters {
+            excludes {
+                annotatedBy("jakarta.ws.rs.Path")
+                annotatedBy("io.quarkus.runtime.annotations.RegisterForReflection")
+            }
+        }
+        verify {
+            rule {
+                bound {
+                    minValue = 90 // measured 95.4% (1315/1379) at introduction
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
+}

--- a/openbank-security-scanner/build.gradle.kts
+++ b/openbank-security-scanner/build.gradle.kts
@@ -33,3 +33,26 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
 }
+
+// Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO
+// koverVerify gate at all). Floor = measured LINE coverage at introduction minus ~5 pt
+// headroom; raise-only from here. Same excludes rationale as ledger/billing: thin REST
+// adapters are covered by API ITs, reflection DTOs are data holders.
+kover {
+    reports {
+        filters {
+            excludes {
+                annotatedBy("jakarta.ws.rs.Path")
+                annotatedBy("io.quarkus.runtime.annotations.RegisterForReflection")
+            }
+        }
+        verify {
+            rule {
+                bound {
+                    minValue = 15 // measured 20.2% (98/485) at introduction
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Flips the convention-plugin default so `koverVerify` is wired into `check` fleet-wide (no module can silently opt out of the ADR-0020 coverage ratchet), and lands the first four real, measured floors from the #466 sweep: the 3 ungated convention modules and the worst placebo (`minValue = 0`) gate.

## Type of change

- [x] chore (build / tooling)
- [ ] feat / fix / refactor / perf / docs / security / breaking change

## Linked issues

Refs #466

## Changes

- `build-logic/openbank.quarkus-service.gradle.kts`: the plugin previously **disabled** `koverVerify` globally and required per-service re-enable boilerplate — which is how 5 modules ended up with no gate and 17 with a floor of 0 while `rules.yaml: coverage.ratchet_only` claims enforcement. Now `check` depends on `koverVerify` for every module applying the convention; modules without verify rules pass trivially, so this cannot break an unbaselined module.
- `openbank-customer-edge`: first gate — measured 41.8% LINE (223/534, with the standard `@Path`/`@RegisterForReflection` excludes) → floor **37**.
- `openbank-product-catalog`: first gate — measured 95.4% LINE (1315/1379) → floor **90**.
- `openbank-security-scanner`: first gate — measured 20.2% LINE (98/485) → floor **15** (honest baseline; raising it is follow-up test work under #466).
- `openbank-agent-service`: placebo `minValue = 0` → measured 75.8% LINE (1344/1772, no excludes) → floor **70**; dropped the now-redundant `enabled = true` + `check dependsOn` boilerplate (new convention default covers it).

All floors follow the account-service baseline pattern: measured value minus ~5 pt headroom, raise-only from here.

Not in this PR (tracked in #466): the remaining 16 `minValue = 0` modules, analytics-sink (kover plugin not applied), simulation (DST tooling — exemption decision pending), and removing the redundant boilerplate from the ~25 already-gated services.

## Definition of Done

- [x] Hexagonal layering preserved (build config only, no source changes).
- [ ] Unit tests added/updated — N/A (no behavior change; gates verified by running them).
- [ ] Integration tests — N/A.
- [ ] Contract tests — N/A (no API change).
- [x] `koverVerify` passes for all four touched modules (run locally, JDK 25); `:openbank-ledger-service:check -m` confirms the fleet-wide wiring.
- [x] No new lint warnings (`ktlintCheck` green on all four modules).
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs: rationale captured in the convention-plugin comment + sweep issue #466.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `@Suppress`.
- [x] No new third-party dependency.
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed.
- [x] No cardholder data path changed.

## Compliance impact

- [x] None
