### PR TITLE
test(account): fix ktlint argument-wrapping in AccountServiceLifecycleTest

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
@@ -243,7 +243,11 @@ class AccountServiceLifecycleTest {
         assertThatThrownBy {
             runBlocking {
                 service.unfreezeAccount(
-                    UnfreezeAccountCommand(accountId = acc.id, reason = "alert cleared", requestedBy = UUID.randomUUID()),
+                    UnfreezeAccountCommand(
+                        accountId = acc.id,
+                        reason = "alert cleared",
+                        requestedBy = UUID.randomUUID(),
+                    ),
                 )
             }
         }.isInstanceOf(IllegalStateException::class.java)
@@ -260,7 +264,11 @@ class AccountServiceLifecycleTest {
         assertThatThrownBy {
             runBlocking {
                 service.unfreezeAccount(
-                    UnfreezeAccountCommand(accountId = accountId, reason = "alert cleared", requestedBy = UUID.randomUUID()),
+                    UnfreezeAccountCommand(
+                        accountId = accountId,
+                        reason = "alert cleared",
+                        requestedBy = UUID.randomUUID(),
+                    ),
                 )
             }
         }.isInstanceOf(AccountNotFoundException::class.java)


### PR DESCRIPTION
## Summary

Fixes the two ktlint violations in `AccountServiceLifecycleTest.kt` (single-line `UnfreezeAccountCommand(...)` argument lists over the 120-char limit) that keep the full-fleet lint gate red and block every code-global PR — currently #471, whose fleet rebuild trips over this unrelated latent debt.

## Type of change

- [x] chore (build / tooling) — test-source formatting only, no behavior change

## Linked issues

Closes #442

## Changes

- `openbank-account-service/src/test/.../AccountServiceLifecycleTest.kt`: wrapped the `UnfreezeAccountCommand` constructor arguments onto separate lines at both call sites (lines 246 and 263) — the standard ktlint `argument-list-wrapping` + `max-line-length` fix.

Latent-debt mechanics (known pitfall): path-scoped PR CI only lints changed files, so the violation was invisible until the fleet-lint gate and #471's code-global rebuild linted the whole module.

## Definition of Done

- [x] Hexagonal layering preserved (test formatting only).
- [ ] Unit tests added/updated — N/A (no behavior change).
- [ ] Integration / contract tests — N/A.
- [x] `:openbank-account-service:ktlintTestSourceSetCheck` passes locally (isolated Gradle home, JDK 25).
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / Avro / docs — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions, no new dependencies, no auth/crypto/payment/PII/cardholder changes.

## Compliance impact

- [x] None
