### PR TITLE
fix(account): wrap over-long argument lists in AccountServiceLifecycleTest (latent ktlint violation)

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
@@ -243,7 +243,11 @@ class AccountServiceLifecycleTest {
         assertThatThrownBy {
             runBlocking {
                 service.unfreezeAccount(
-                    UnfreezeAccountCommand(accountId = acc.id, reason = "alert cleared", requestedBy = UUID.randomUUID()),
+                    UnfreezeAccountCommand(
+                        accountId = acc.id,
+                        reason = "alert cleared",
+                        requestedBy = UUID.randomUUID(),
+                    ),
                 )
             }
         }.isInstanceOf(IllegalStateException::class.java)
@@ -260,7 +264,11 @@ class AccountServiceLifecycleTest {
         assertThatThrownBy {
             runBlocking {
                 service.unfreezeAccount(
-                    UnfreezeAccountCommand(accountId = accountId, reason = "alert cleared", requestedBy = UUID.randomUUID()),
+                    UnfreezeAccountCommand(
+                        accountId = accountId,
+                        reason = "alert cleared",
+                        requestedBy = UUID.randomUUID(),
+                    ),
                 )
             }
         }.isInstanceOf(AccountNotFoundException::class.java)


### PR DESCRIPTION
## Summary

Fixes a pre-existing, latent `argument-list-wrapping`/`max-line-length` ktlint violation in `AccountServiceLifecycleTest.kt` — two `UnfreezeAccountCommand(...)` calls exceeded 120 chars on one line with args not wrapped one-per-line.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #321

## Changes

- Wraps the two over-long argument lists across multiple lines. No behavior change.

## Why this surfaced now

Path-scoped CI never linted this file's full context until #471 (fleet `koverVerify` wiring) touched `openbank-account-service/build.gradle.kts`, triggering a full `:openbank-account-service:ktlintCheck` — the same class of footgun CLAUDE.md documents ("ktlint function-signature is latent on never-edited files... only surfaces when the whole service is rebuilt").

## Definition of Done

- [x] `ktlintTestSourceSetCheck` verified green locally on this exact fix
- [x] No behavior change — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)