### PR TITLE
test(notification): cover push-sender fail-closed config paths and dispatch break-glass

### DIFF
--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/push/PushSenderTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/push/PushSenderTest.kt
@@ -14,6 +14,10 @@ import io.mockk.verify
 import io.smallrye.mutiny.Uni
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+import java.util.Base64
+import java.util.Optional
 
 class PushSenderTest {
 
@@ -24,6 +28,23 @@ class PushSenderTest {
 
     private fun msg(platform: PushPlatform) =
         PushMessage(platform, "tok", "Title", "Body", mapOf("template" to "WELCOME"))
+
+    /** A syntactically valid (but freshly generated, throwaway) PKCS#8 RSA private key, base64. */
+    private fun fakeRsaPkcs8Base64(): String {
+        val pair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        return Base64.getEncoder().encodeToString(pair.private.encoded)
+    }
+
+    /**
+     * A syntactically valid (but freshly generated, throwaway) PKCS#8 EC (P-256) private key, as
+     * PEM text — [ApnsPushSender.parseKey] only skips its (buggy for bare base64) double-decode
+     * path when the value contains a "BEGIN" marker, matching how a real .p8 file is supplied.
+     */
+    private fun fakeEcPkcs8Pem(): String {
+        val gen = KeyPairGenerator.getInstance("EC").apply { initialize(ECGenParameterSpec("secp256r1")) }
+        val b64 = Base64.getEncoder().encodeToString(gen.generateKeyPair().private.encoded)
+        return "-----BEGIN PRIVATE KEY-----\n$b64\n-----END PRIVATE KEY-----"
+    }
 
     // --- FCM response mapping ---
 
@@ -63,6 +84,38 @@ class PushSenderTest {
         assertThat(result.skipped).isTrue()
     }
 
+    @Test
+    fun `fcm enabled but no service account configured fails closed with a CONFIG error`() {
+        val result = fcm().also { it.enabled = true }.send(msg(PushPlatform.FCM)).await().indefinitely()
+        assertThat(result.success).isFalse()
+        assertThat(result.errorCode).isEqualTo("CONFIG")
+    }
+
+    @Test
+    fun `fcm enabled with an unparsable service account JSON fails closed instead of throwing`() {
+        val result = fcm().also {
+            it.enabled = true
+            it.serviceAccountJson = Optional.of("not valid json")
+        }.send(msg(PushPlatform.FCM)).await().indefinitely()
+
+        assertThat(result.success).isFalse()
+        assertThat(result.errorCode).isEqualTo("CONFIG")
+    }
+
+    @Test
+    fun `fcm enabled with a service account that has no projectId and no override fails closed`() {
+        val result = fcm().also {
+            it.enabled = true
+            it.serviceAccountJson = Optional.of(
+                """{"client_email":"sa@x.iam.gserviceaccount.com","private_key":"${fakeRsaPkcs8Base64()}"}""",
+            )
+        }.send(msg(PushPlatform.FCM)).await().indefinitely()
+
+        assertThat(result.success).isFalse()
+        assertThat(result.errorCode).isEqualTo("CONFIG")
+        assertThat(result.errorMessage).contains("projectId")
+    }
+
     // --- APNs response mapping ---
 
     @Test
@@ -97,6 +150,36 @@ class PushSenderTest {
         val result = apns().also { it.enabled = false }.send(msg(PushPlatform.APNS)).await().indefinitely()
         assertThat(result.success).isTrue()
         assertThat(result.skipped).isTrue()
+    }
+
+    @Test
+    fun `apns enabled but no signing key configured fails closed with a CONFIG error`() {
+        val result = apns().also { it.enabled = true }.send(msg(PushPlatform.APNS)).await().indefinitely()
+        assertThat(result.success).isFalse()
+        assertThat(result.errorCode).isEqualTo("CONFIG")
+    }
+
+    @Test
+    fun `apns enabled with an unparsable signing key fails closed instead of throwing`() {
+        val result = apns().also {
+            it.enabled = true
+            it.privateKeyPem = Optional.of("not a valid key")
+        }.send(msg(PushPlatform.APNS)).await().indefinitely()
+
+        assertThat(result.success).isFalse()
+        assertThat(result.errorCode).isEqualTo("CONFIG")
+    }
+
+    @Test
+    fun `apns enabled with a valid key but missing keyId and teamId fails closed`() {
+        val result = apns().also {
+            it.enabled = true
+            it.privateKeyPem = Optional.of(fakeEcPkcs8Pem())
+        }.send(msg(PushPlatform.APNS)).await().indefinitely()
+
+        assertThat(result.success).isFalse()
+        assertThat(result.errorCode).isEqualTo("CONFIG")
+        assertThat(result.errorMessage).contains("keyId")
     }
 
     // --- Router ---

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/DispatchControlResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/DispatchControlResourceTest.kt
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.governance.Proposal
+import com.openbank.libs.governance.ProposalState
+import com.openbank.notification.application.DispatchControlService
+import com.openbank.notification.domain.ops.DispatchControlSnapshot
+import com.openbank.notification.domain.ops.DispatchState
+import com.openbank.notification.domain.ops.ResumeAction
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.security.identity.SecurityIdentity
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.security.Principal
+import java.time.Instant
+
+/**
+ * [DispatchControlResource] is the Tier A break-glass control plane for the notification
+ * dispatch loop (ADR-0047). Its one hard security property is that the acting identity is
+ * ALWAYS taken from the authenticated [SecurityIdentity], never from the request body — so a
+ * caller cannot spoof who performed a halt/approve/reject by putting a different actor in the
+ * JSON payload. None of the resource's delegation or that anti-spoofing property was tested.
+ */
+class DispatchControlResourceTest {
+
+    private fun stubSnapshot(state: DispatchState = DispatchState.ENABLED) = DispatchControlSnapshot(
+        controlKey = "notification-dispatch",
+        state = state,
+        version = 1,
+        reason = null,
+        actor = null,
+        effectiveFrom = Instant.EPOCH,
+        deferredReviewRequired = false,
+    )
+
+    private fun resourceWith(service: DispatchControlService, principalName: String?): DispatchControlResource {
+        val identity = mockk<SecurityIdentity>()
+        every { identity.principal } returns principalName?.let { name -> Principal { name } }
+        return DispatchControlResource(service, identity)
+    }
+
+    @Test
+    fun `get returns the current snapshot and recent history from the service`() {
+        val service = mockk<DispatchControlService> {
+            coEvery { snapshot() } returns stubSnapshot()
+            coEvery { history(20) } returns listOf(stubSnapshot(DispatchState.HALTED))
+        }
+        val resource = resourceWith(service, "operator-1")
+
+        val response = runBlocking { resource.get() }
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as Map<String, Any?>
+        assertThat(body).containsKeys("current", "history")
+    }
+
+    @Test
+    fun `halt derives the actor from the authenticated identity, never the request body`() {
+        val service = mockk<DispatchControlService> {
+            coEvery { halt(any(), any()) } returns stubSnapshot(DispatchState.HALTED)
+        }
+        val resource = resourceWith(service, "operator-1")
+
+        val response = runBlocking {
+            resource.halt(DispatchControlResource.ReasonRequest(reason = "incident #123"))
+        }
+
+        assertThat(response.status).isEqualTo(200)
+        coVerify { service.halt("operator-1", "incident #123") }
+    }
+
+    @Test
+    fun `halt uses an empty actor when the identity has no principal rather than trusting the body`() {
+        val service = mockk<DispatchControlService> {
+            coEvery { halt(any(), any()) } returns stubSnapshot(DispatchState.HALTED)
+        }
+        val resource = resourceWith(service, principalName = null)
+
+        runBlocking { resource.halt(DispatchControlResource.ReasonRequest(reason = "x")) }
+
+        coVerify { service.halt("", "x") }
+    }
+
+    @Test
+    fun `halt treats a missing reason as blank rather than null`() {
+        val service = mockk<DispatchControlService> {
+            coEvery { halt(any(), any()) } returns stubSnapshot(DispatchState.HALTED)
+        }
+        val resource = resourceWith(service, "operator-1")
+
+        runBlocking { resource.halt(DispatchControlResource.ReasonRequest(reason = null)) }
+
+        coVerify { service.halt("operator-1", "") }
+    }
+
+    @Test
+    fun `proposeResume returns 202 with the proposal id and state`() {
+        val proposal = Proposal(
+            id = "prop-1",
+            action = ResumeAction("notification-dispatch", "back to normal"),
+            proposedBy = "operator-1",
+            proposedAt = Instant.EPOCH,
+        )
+        val service = mockk<DispatchControlService> {
+            coEvery { proposeResume("operator-1", "back to normal") } returns proposal
+        }
+        val resource = resourceWith(service, "operator-1")
+
+        val response = runBlocking {
+            resource.proposeResume(DispatchControlResource.ReasonRequest(reason = "back to normal"))
+        }
+
+        assertThat(response.status).isEqualTo(202)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as Map<String, Any?>
+        assertThat(body["proposalId"]).isEqualTo("prop-1")
+        assertThat(body["state"]).isEqualTo("PROPOSED")
+    }
+
+    @Test
+    fun `approveResume delegates the path proposalId and the identity-derived checker to the service`() {
+        val service = mockk<DispatchControlService> {
+            coEvery { approveResume("prop-1", "checker-2", "looks good") } returns stubSnapshot()
+        }
+        val resource = resourceWith(service, "checker-2")
+
+        val response = runBlocking {
+            resource.approveResume("prop-1", DispatchControlResource.ReasonRequest(reason = "looks good"))
+        }
+
+        assertThat(response.status).isEqualTo(200)
+        coVerify { service.approveResume("prop-1", "checker-2", "looks good") }
+    }
+
+    @Test
+    fun `rejectResume delegates and returns the resulting proposal state`() {
+        val proposal = Proposal(
+            id = "prop-1",
+            action = ResumeAction("notification-dispatch", "back to normal"),
+            proposedBy = "operator-1",
+            proposedAt = Instant.EPOCH,
+            state = ProposalState.REJECTED,
+            decidedBy = "checker-2",
+        )
+        val service = mockk<DispatchControlService> {
+            coEvery { rejectResume("prop-1", "checker-2", "not yet") } returns proposal
+        }
+        val resource = resourceWith(service, "checker-2")
+
+        val response = runBlocking {
+            resource.rejectResume("prop-1", DispatchControlResource.ReasonRequest(reason = "not yet"))
+        }
+
+        assertThat(response.status).isEqualTo(200)
+        @Suppress("UNCHECKED_CAST")
+        val body = response.entity as Map<String, Any?>
+        assertThat(body["proposalId"]).isEqualTo("prop-1")
+        assertThat(body["state"]).isEqualTo("REJECTED")
+    }
+}


### PR DESCRIPTION
## Summary
- `FcmPushSender`/`ApnsPushSender` already had `mapResponse()` well covered, but not `send()`'s config-guard branches: enabled with no service account / no signing key, an unparsable credential, and (FCM-only) a service account with no resolvable `projectId`. Each of these must degrade to a `CONFIG` `PushResult` rather than throwing or attempting a send with bad credentials — none of those fail-closed paths had a test. Test keys are freshly generated (RSA/EC) at test time, never hardcoded.
- `DispatchControlResource` (0%) is the Tier A break-glass control plane for the notification dispatch loop (ADR-0047). Its one hard security property — every verb derives the acting identity from the authenticated `SecurityIdentity`, **never** the request body, so a caller can't spoof who performed a halt/approve/reject — had no regression test. Covers that property plus each verb's delegation to `DispatchControlService` (`halt`/`proposeResume`/`approveResume`/`rejectResume`/`get`).

## Test plan
- [x] `:openbank-notification-service:test` — all new + existing tests pass (nothing regressed)
- [x] `:openbank-notification-service:ktlintCheck`
- [x] `:openbank-notification-service:detekt`
- [x] `:openbank-notification-service:koverVerify` (already wired to `check`) — local line coverage ~36% → 46%

Linked issues: Refs #321