### PR TITLE
docs(ledger): document journal reverse and trial-balance endpoints in openapi.yaml

### DIFF
--- a/openbank-ledger-service/src/main/resources/openapi.yaml
+++ b/openbank-ledger-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Ledger Service API
-  version: 1.5.2
+  version: 1.6.0
   description: Double-entry journal ledger — query journal entries and transaction postings.
   license:
     name: Apache-2.0
@@ -73,6 +73,77 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+
+  /api/v1/journals/{journalId}/reverse:
+    post:
+      tags: [Ledger]
+      summary: Reverse a posted journal entry
+      description: >
+        Posts a compensating journal entry (sides flipped, same amounts and entry date) that
+        nets the original to zero. The reversal is itself a journal entry with its own entry
+        number. Fails closed with 409 when the original is already reversed (or otherwise not
+        reversible) or when its entry date falls in an ATTESTED (locked) fiscal period —
+        corrections to a closed year must be booked as an adjustment in the open period.
+      operationId: reverseJournal
+      parameters:
+        - name: journalId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReverseJournalRequest'
+      responses:
+        '200':
+          description: The compensating (reversal) journal entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JournalEntryResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Journal already reversed / not reversible, or its fiscal period is ATTESTED (period lock)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /api/v1/journals/trial-balance:
+    get:
+      tags: [Ledger]
+      summary: Trial balance — debit/credit totals per GL account (must net to zero)
+      description: >
+        Aggregates POSTED journal lines per GL account as of the given date (defaults to
+        today). The double-entry invariant (sum of debits == sum of credits over the whole GL)
+        is reported as `balanced`.
+      operationId: getTrialBalance
+      parameters:
+        - name: asOf
+          in: query
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Trial balance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrialBalanceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/journals/sub-ledger-balances:
     get:
@@ -462,6 +533,18 @@ components:
             hasMore:
               type: boolean
 
+    ReverseJournalRequest:
+      type: object
+      required: [reason, reversedBy]
+      properties:
+        reason:
+          type: string
+          description: Business reason for the reversal; carried on the JournalReversed event.
+        reversedBy:
+          type: string
+          format: uuid
+          description: Operator posting the reversal.
+
     TrialBalanceLineResponse:
       type: object
       properties:
@@ -484,6 +567,25 @@ components:
         net:
           type: number
           description: totalDebit − totalCredit.
+
+    TrialBalanceResponse:
+      type: object
+      description: Point-in-time GL trial balance (all POSTED activity up to `asOf`).
+      properties:
+        asOf:
+          type: string
+          format: date
+        totalDebit:
+          type: number
+        totalCredit:
+          type: number
+        balanced:
+          type: boolean
+          description: Double-entry invariant over the whole GL — sum(debits) == sum(credits).
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrialBalanceLineResponse'
 
     TrialBalanceSectionResponse:
       type: object


### PR DESCRIPTION
## Summary

`POST /api/v1/journals/{journalId}/reverse` and `GET /api/v1/journals/trial-balance` have been live in `LedgerResource` but were missing from `openapi.yaml` — a rule #3 (ADR-0048) contract gap that predates the #465 concurrency work. This PR documents both endpoints and bumps the API-contract axis.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [x] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — spec/implementation sync caught in review; self-contained one-file spec fix, no fleet sweep or follow-up tail.

## Changes

- `openapi.yaml`: add `POST /api/v1/journals/{journalId}/reverse` (200 reversal `JournalEntryResponse`, 401/403, 404 unknown journal, 409 already-reversed / ATTESTED-period lock per `ExceptionMappers` + #869 period lock).
- `openapi.yaml`: add `GET /api/v1/journals/trial-balance?asOf=` returning the new `TrialBalanceResponse` schema (reuses existing `TrialBalanceLineResponse`).
- `openapi.yaml`: add `ReverseJournalRequest` schema (`reason`, `reversedBy`).
- `info.version` `1.5.2` → `1.6.0` — **additive** per oasdiff (verified locally with the pinned CI script: `check-api-contract.py --enforce` → "additive change, info.version 1.5.2 -> 1.6.0 — OK (required >= MINOR)"). `openbank.api.version` stays `1` (API invariant holds; release axis untouched — no hand-edit of `version.txt`).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — spec-only change
- [ ] Unit tests added/updated. — N/A, no code change
- [ ] Integration tests added/updated (if service boundary involved). — N/A
- [x] Contract tests updated (if public API changed). — no API *behavior* change (documents already-live endpoints); `LedgerSecurityContractTest` + `YearCloseSecurityContractTest` re-run locally and pass
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — no Kotlin touched; ledger security-contract tests run locally
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [ ] Docs updated (README, ADR if architectural). — N/A

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no (documentation of existing endpoints only)
- [ ] PII path changed? — no
- [ ] Cardholder data path changed? — no

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

Spec-only documentation of already-live, role-gated endpoints; no behavior, data, or control change.

## Rollout / Rollback

- Deployment strategy: rolling (spec file only, no runtime behavior change)
- Rollback plan: revert the commit
- Data migration reversible: N/A

## Reviewer notes

- Ledger is **money-path** ⇒ 2 approvals required; threat model `docs/threat-models/openbank-ledger-service.md` unchanged (no trust-boundary change — both endpoints already exist and are role-gated: reverse = `ROLE_OPERATOR`, trial-balance = SERVICE/AUDITOR/VIEWER/OPERATOR/ADMIN, locked by `LedgerSecurityContractTest`).
- Known pre-existing drift left out of scope: `POST /api/v1/journals` (postJournal) is also undocumented, and the documented `JournalEntryResponse`/`JournalLineResponse`/`listJournals` parameter shapes are stale vs. the actual DTOs — flagged separately rather than piggybacked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
