### PR TITLE
test(governance): measured kover floors for all remaining zero-floor and ungated modules

### DIFF
--- a/openbank-aml-service/build.gradle.kts
+++ b/openbank-aml-service/build.gradle.kts
@@ -50,7 +50,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 41.3% (228/552) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 36
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-anacredit-service/build.gradle.kts
+++ b/openbank-anacredit-service/build.gradle.kts
@@ -36,7 +36,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 94.3% (183/194) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 89
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-analytics-sink/build.gradle.kts
+++ b/openbank-analytics-sink/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.allopen)
     alias(libs.plugins.quarkus)
     alias(libs.plugins.cyclonedx)
+    alias(libs.plugins.kover)
     // Static analysis gate (detekt + ktlint, ratchet via baselines) — same
     // convention the services get through openbank.quarkus-service.
     id("openbank.static-analysis")
@@ -79,4 +80,21 @@ tasks.named<org.cyclonedx.gradle.CycloneDxTask>("cyclonedxBom") {
     setSkipConfigs(listOf("testCompileClasspath", "testRuntimeClasspath", "annotationProcessor", "kapt"))
     setProjectType("application")
     setSchemaVersion("1.5")
+}
+
+// Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had no kover
+// plugin at all). Measured 56.7% LINE (538/949) at introduction, no filter excludes;
+// ~5 pt headroom, raise-only from here. Kover auto-wires koverVerify into check when a
+// verify{} rule is present (this module does not apply openbank.quarkus-service).
+kover {
+    reports {
+        verify {
+            rule {
+                bound {
+                    minValue = 51
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
 }

--- a/openbank-analytics-sink/build.gradle.kts
+++ b/openbank-analytics-sink/build.gradle.kts
@@ -12,7 +12,8 @@ plugins {
     // convention the services get through openbank.quarkus-service.
     id("openbank.static-analysis")
 }
-group = "com.openbank"; version = "0.1.0-SNAPSHOT"
+group = "com.openbank"
+version = "0.1.0-SNAPSHOT"
 repositories {
     // GCS mirror of Maven Central first (#849) — shared NAT egress IP gets
     // 429-throttled by Central during fleet-wide build storms; 404 falls through.

--- a/openbank-audit-service/build.gradle.kts
+++ b/openbank-audit-service/build.gradle.kts
@@ -43,7 +43,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 26.9% (125/465) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 22
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-card-issuance-service/build.gradle.kts
+++ b/openbank-card-issuance-service/build.gradle.kts
@@ -50,7 +50,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 48.7% (190/390) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 43
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-copilot-service/build.gradle.kts
+++ b/openbank-copilot-service/build.gradle.kts
@@ -51,7 +51,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 46.8% (597/1275) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 41
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-devops-agent/build.gradle.kts
+++ b/openbank-devops-agent/build.gradle.kts
@@ -56,7 +56,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 24.3% (145/597) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 19
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-finops-agent/build.gradle.kts
+++ b/openbank-finops-agent/build.gradle.kts
@@ -45,7 +45,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 8.5% (28/328) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 5
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -50,7 +50,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 49.4% (326/660) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 44
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-kyc-service/build.gradle.kts
+++ b/openbank-kyc-service/build.gradle.kts
@@ -43,7 +43,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 45.4% (227/500) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 40
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -53,7 +53,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 40.3% (424/1052) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 35
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-onboarding-service/build.gradle.kts
+++ b/openbank-onboarding-service/build.gradle.kts
@@ -45,7 +45,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 43.4% (144/332) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 38
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-sdd-service/build.gradle.kts
+++ b/openbank-sdd-service/build.gradle.kts
@@ -49,7 +49,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 43.8% (219/500) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 38
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-simulation/build.gradle.kts
+++ b/openbank-simulation/build.gradle.kts
@@ -80,3 +80,20 @@ tasks.test {
     // property the test falls back to its built-in default, so a plain `:test` stays reproducible.
     providers.gradleProperty("seed.count").orNull?.let { systemProperty("seed.count", it) }
 }
+
+// Coverage floor (ADR-0020, ratchet-only — sweep #466). The DST harness is tooling, but its
+// invariant checkers ARE the safety net for the money-path domain semantics — an untested
+// checker is a checker that silently stops checking. Measured 96.0% LINE (457/476) at
+// introduction; floor 90, raise-only from here.
+kover {
+    reports {
+        verify {
+            rule {
+                bound {
+                    minValue = 90
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
+                }
+            }
+        }
+    }
+}

--- a/openbank-standing-order-service/build.gradle.kts
+++ b/openbank-standing-order-service/build.gradle.kts
@@ -48,7 +48,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 39.3% (154/392) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 34
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-statement-service/build.gradle.kts
+++ b/openbank-statement-service/build.gradle.kts
@@ -52,7 +52,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 48.2% (486/1009) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 43
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }

--- a/openbank-tpp-registry-service/build.gradle.kts
+++ b/openbank-tpp-registry-service/build.gradle.kts
@@ -51,7 +51,9 @@ kover {
         verify {
             rule {
                 bound {
-                    minValue = 0
+                    // Ratchet floor (ADR-0020, sweep #466): measured 31.2% (113/362) LINE at introduction,
+                    // ~5 pt headroom, raise-only from here.
+                    minValue = 26
                     coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.LINE
                 }
             }


### PR DESCRIPTION
## Summary

Second tranche of the #466 sweep: every remaining zero-floor (`minValue = 0`) module and both previously unmeasurable modules get a **real, measured** kover ratchet floor. After this PR the only module without a floor is `openbank-libs` (umbrella, no sources — documented exemption, enforced per sub-module).

## Type of change

- [x] chore (build / tooling) — build-config floors only, no source changes

## Linked issues

Refs #466

## Changes

Floors = measured LINE coverage at introduction minus ~5 pt headroom (account-service baseline pattern), raise-only from here. Measured per module with its existing kover filter config, sequentially (parallel @QuarkusTest JVMs collide on the fixed test port 8081):

| Module | Measured | Floor |
|---|---|---|
| aml-service | 41.3% | 36 |
| anacredit-service | 94.3% | 89 |
| audit-service | 26.9% | 22 |
| card-issuance-service | 48.7% | 43 |
| copilot-service | 46.8% | 41 |
| devops-agent | 24.3% | 19 |
| finops-agent | 8.5% | 5 |
| interest-service | 49.4% | 44 |
| kyc-service | 45.4% | 40 |
| notification-service | 40.3% | 35 |
| onboarding-service | 43.4% | 38 |
| sdd-service | 43.8% | 38 |
| standing-order-service | 39.3% | 34 |
| statement-service | 48.2% | 43 |
| tpp-registry-service | 31.2% | 26 |
| analytics-sink (new gate + kover plugin) | 56.7% | 51 |
| simulation (new gate) | 96.0% | 90 |

- `openbank-analytics-sink`: did not apply the kover plugin at all — added `alias(libs.plugins.kover)` + verify rule (it does not use the `openbank.quarkus-service` convention, so it relies on Kover's own koverVerify→check auto-wiring; verified in the gate run).
- `openbank-simulation`: DST harness — tooling, but its invariant checkers are the safety net for money-path semantics, so it gets a floor rather than an exemption.
- `openbank-libs`: left at the documented exemption (umbrella module, zero sources; coverage enforced per sub-module) — ticking it in #466 with that note.
- The low floors (audit 22, devops-agent 19, finops-agent 5) are deliberately honest baselines, not targets — raising them is follow-up test work under #466/#321; a low real floor beats a placebo 0 because it can only go up.

## Definition of Done

- [x] Hexagonal layering preserved (build config only).
- [ ] Unit tests added/updated — N/A (no behavior change; gates verified by running them).
- [x] `koverVerify` green for all touched modules (run locally, JDK 25, sequential).
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / Avro / contract tests — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions; the only new dependency edge is the kover Gradle plugin applied to analytics-sink (already in the version catalog).
- [x] No auth / crypto / payment / PII / cardholder changes.

## Compliance impact

- [x] None
