### PR TITLE
fix(ledger): race-safe reversal, idempotent concurrent posting, reversal line re-parenting

### DIFF
--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
@@ -34,8 +34,10 @@ import com.openbank.libs.api.pagination.PageInfo
 import com.openbank.libs.domain.money.Money
 import com.openbank.libs.observability.DomainMetrics
 import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.vertx.pgclient.PgException
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import jakarta.persistence.PersistenceException
 import java.time.Clock
 import java.time.ZoneId
 import java.util.UUID
@@ -117,31 +119,58 @@ class LedgerService(
             "Unvalidated GL account referenced in journal entry"
         }
 
-        val outbox = OutboxMessage(
-            aggregateId = entry.id,
-            eventType = JOURNAL_POSTED,
-            payload = objectMapper.writeValueAsString(
-                JournalPostedEvent(
-                    aggregateId = entry.id,
-                    version = entry.version,
-                    entryNumber = entry.entryNumber!!,
-                    transactionId = entry.transactionId,
-                    entryDate = entry.entryDate,
-                    lineCount = entry.lines.size,
-                    occurredAt = clock.instant(),
-                ),
-            ),
-        )
-
-        val saved = journalRepository.save(entry, command.idempotencyKey, listOf(outbox) + bookedChangedMessages(entry))
+        val messages = listOf(journalPostedMessage(entry)) + bookedChangedMessages(entry)
+        val saved = try {
+            journalRepository.save(entry, command.idempotencyKey, messages)
+        } catch (e: PersistenceException) {
+            return recoverConcurrentReplay(e, command.idempotencyKey)
+        } catch (e: PgException) {
+            return recoverConcurrentReplay(e, command.idempotencyKey)
+        }
         recordPostings(entry, POSTING, metrics)
         recordPostingAmounts(entry, metrics)
         return saved
     }
 
+    /**
+     * The loser of a concurrent duplicate-submission race: both contenders passed the replay
+     * check before either committed, and this transaction died on the ledger_idempotency
+     * primary key. Recover to the same contract as the sequential path — return the winner's
+     * entry (idempotent replay; no metrics, a replay is never a second posting). Anything that
+     * is not the idempotency-key conflict propagates untouched.
+     */
+    private suspend fun recoverConcurrentReplay(e: RuntimeException, idempotencyKey: String): JournalEntry {
+        val isIdempotencyKeyConflict = generateSequence<Throwable>(e) { it.cause.takeIf { c -> c !== it } }
+            .any { it.message?.contains("ledger_idempotency", ignoreCase = true) == true }
+        if (!isIdempotencyKeyConflict) throw e
+        return journalRepository.findByIdempotencyKey(idempotencyKey) ?: throw e
+    }
+
+    private fun journalPostedMessage(entry: JournalEntry): OutboxMessage = OutboxMessage(
+        aggregateId = entry.id,
+        eventType = JOURNAL_POSTED,
+        payload = objectMapper.writeValueAsString(
+            JournalPostedEvent(
+                aggregateId = entry.id,
+                version = entry.version,
+                entryNumber = entry.entryNumber!!,
+                transactionId = entry.transactionId,
+                entryDate = entry.entryDate,
+                lineCount = entry.lines.size,
+                occurredAt = clock.instant(),
+            ),
+        ),
+    )
+
     override suspend fun reverseJournal(command: ReverseJournalCommand): JournalEntry {
         val original = journalRepository.findById(command.journalId)
             ?: throw JournalNotFoundException("Journal not found: ${command.journalId}")
+
+        // Deterministic 409 for the sequential repeat; the concurrent window (both contenders
+        // read POSTED here) is closed by the conditional status flip in saveReversal.
+        if (original.status != JournalStatus.POSTED) {
+            throw JournalReversalConflictException("Journal ${original.id} is not POSTED — already reversed")
+        }
 
         // Period lock (#869): a reversal inherits the original entry's date (reverse() preserves
         // entryDate), so reversing a prior-year entry would post into that year. If that year is
@@ -326,6 +355,14 @@ private fun recordPostingAmounts(entry: JournalEntry, metrics: DomainMetrics) {
 
 class JournalNotFoundException(message: String) : RuntimeException(message)
 class GlAccountValidationException(message: String) : RuntimeException(message)
+
+/**
+ * A reversal targeted a journal that is not POSTED — repeated or concurrent reversal (#465).
+ * Dedicated type (not IllegalStateException): libs-runtime and this service both register an
+ * ExceptionMapper<IllegalStateException> (422 vs 409) and JAX-RS picks between same-type
+ * providers non-deterministically (ADR-0049 D4), so the conflict status would flip-flop.
+ */
+class JournalReversalConflictException(message: String) : RuntimeException(message)
 
 /** A posting or reversal targeted an ATTESTED (locked) fiscal period. Mapped to 409 (#869). */
 class ClosedFiscalPeriodException(message: String) : RuntimeException(message)

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/JournalEntry.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/JournalEntry.kt
@@ -77,6 +77,11 @@ data class JournalEntry(
         val reversalLines = lines.map { line ->
             line.copy(
                 id = lineIdProvider(line.id),
+                // Re-parent onto the reversal entry: leaving the original's journalId here is the
+                // V10-era bug (persistLines attached the reversal's lines to the ORIGINAL, saving
+                // the reversal with zero lines — unreadable on hydration). The V10 migration
+                // repaired the data; the code fix it references was never committed (#465).
+                journalId = reversalId,
                 side = if (line.side == JournalSide.DEBIT) JournalSide.CREDIT else JournalSide.DEBIT,
             )
         }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
@@ -5,6 +5,7 @@
 package com.openbank.ledger.infrastructure.persistence.repository
 
 import com.openbank.ledger.application.port.out.JournalRepository
+import com.openbank.ledger.application.usecase.JournalReversalConflictException
 import com.openbank.ledger.domain.model.ControlAccountTieOut
 import com.openbank.ledger.domain.model.GlAccountType
 import com.openbank.ledger.domain.model.JournalEntry
@@ -136,20 +137,32 @@ class PanacheJournalRepository(
         originalEntryDate: LocalDate,
         outbox: List<OutboxMessage>,
     ): JournalEntry = Panache.withTransaction {
-        persist(reversal.toEntity())
-            .flatMap { persistLines(reversal) }
-            .flatMap {
-                find("id = ?1 and entryDate = ?2", originalId, originalEntryDate).firstResult()
-                    .invoke { e ->
-                        if (e != null) {
-                            e.status = JournalStatus.REVERSED.name
-                            e.version += 1
-                        }
-                    }
-                    .replaceWithVoid()
+        // Status guard FIRST, as a conditional update: only a still-POSTED original may be
+        // flipped to REVERSED. Two concurrent reversals both read POSTED before either
+        // commits (the use-case check cannot see the other transaction); the row lock taken
+        // here serialises them and the loser matches 0 rows after the winner commits — so it
+        // fails BEFORE persisting a second compensation entry and its AccountBookedChanged
+        // deltas (double-credit downstream). Backstop: uq_journal_entries_reversal_of (V12).
+        update(
+            "status = ?1, version = version + 1 where id = ?2 and entryDate = ?3 and status = ?4",
+            JournalStatus.REVERSED.name,
+            originalId,
+            originalEntryDate,
+            JournalStatus.POSTED.name,
+        ).flatMap { updated ->
+            if (updated == 0) {
+                Uni.createFrom().failure(
+                    JournalReversalConflictException(
+                        "Journal $originalId is not POSTED — already reversed by a concurrent request",
+                    ),
+                )
+            } else {
+                persist(reversal.toEntity())
+                    .flatMap { persistLines(reversal) }
+                    .flatMap { persistOutbox(outbox) }
+                    .replaceWith(reversal)
             }
-            .flatMap { persistOutbox(outbox) }
-            .replaceWith(reversal)
+        }
     }.awaitSuspending()
 
     override suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLine> {

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ExceptionMappers.kt
@@ -7,6 +7,7 @@ package com.openbank.ledger.infrastructure.rest
 import com.openbank.ledger.application.usecase.ClosedFiscalPeriodException
 import com.openbank.ledger.application.usecase.GlAccountValidationException
 import com.openbank.ledger.application.usecase.JournalNotFoundException
+import com.openbank.ledger.application.usecase.JournalReversalConflictException
 import com.openbank.ledger.application.usecase.YearCloseConflictException
 import com.openbank.ledger.application.usecase.YearCloseNotFoundException
 import jakarta.ws.rs.core.MediaType
@@ -52,6 +53,18 @@ class IllegalStateExceptionMapper : ExceptionMapper<IllegalStateException> {
             .type(MediaType.APPLICATION_JSON)
             .build()
     }
+}
+
+// 409 reversal conflict (#465): repeated or concurrent reversal of the same journal entry.
+// Dedicated type so the status is deterministic — IllegalStateException has TWO registered
+// mappers (libs-runtime 422 vs this service's 409) and JAX-RS picks between same-type
+// providers non-deterministically (ADR-0049 D4).
+@Provider
+class JournalReversalConflictExceptionMapper : ExceptionMapper<JournalReversalConflictException> {
+    override fun toResponse(exception: JournalReversalConflictException): Response = Response.status(CONFLICT)
+        .entity(mapOf("error" to (exception.message ?: "Journal already reversed")))
+        .type(MediaType.APPLICATION_JSON)
+        .build()
 }
 
 @Provider

--- a/openbank-ledger-service/src/main/resources/db/migration/V12__unique_reversal_of.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V12__unique_reversal_of.sql
@@ -1,0 +1,13 @@
+-- A journal entry may be reversed at most once (#465 concurrency sweep).
+--
+-- Backstop for the transactional status guard in PanacheJournalRepository.saveReversal:
+-- even if application code regresses, a second reversal row pointing at the same original
+-- cannot commit. journal_entries is partitioned by entry_date, so the unique index must
+-- include the partition key; a reversal always inherits the original's entry_date
+-- (JournalEntry.reverse preserves it), so (reversal_of, entry_date) is equivalent to
+-- uniqueness on reversal_of alone.
+--
+-- Rollback: DROP INDEX uq_journal_entries_reversal_of;
+CREATE UNIQUE INDEX uq_journal_entries_reversal_of
+    ON journal_entries (reversal_of, entry_date)
+    WHERE reversal_of IS NOT NULL;

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceTest.kt
@@ -416,6 +416,24 @@ class LedgerServiceTest {
         }
 
         @Test
+        fun `throws a reversal conflict when the journal is already REVERSED`(): Unit = runBlocking {
+            // Deterministic 409 (#465): a dedicated conflict type, not IllegalStateException —
+            // that type has two competing mappers (libs 422 vs service 409, ADR-0049 D4).
+            val original = postedEntry().copy(status = JournalStatus.REVERSED)
+            coEvery { journalRepository.findById(original.id) } returns original
+
+            val command = ReverseJournalCommand(
+                journalId = original.id,
+                reason = "Repeat",
+                reversedBy = UUID.randomUUID(),
+            )
+
+            assertThatThrownBy { runBlocking { service.reverseJournal(command) } }
+                .isInstanceOf(JournalReversalConflictException::class.java)
+            coVerify(exactly = 0) { journalRepository.saveReversal(any(), any(), any(), any()) }
+        }
+
+        @Test
         fun `reversal of a deposit-control posting emits a negated AccountBookedChanged`(): Unit = runBlocking {
             val subAccount = UUID.randomUUID()
             val original = postedEntryWithDepositControlLeg(subAccount) // credit on subAccount = +1000

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/JournalEntryTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/JournalEntryTest.kt
@@ -290,6 +290,11 @@ class JournalEntryTest {
             assertThat(reversal.transactionId).isEqualTo(posted.transactionId)
             assertThat(reversal.entryNumber).isNull()
             assertThat(reversal.version).isEqualTo(0L)
+            // Every reversal line is re-parented onto the reversal entry. Leaving the original's
+            // journalId is the V10-era bug: persistLines then attaches the lines to the ORIGINAL
+            // and the persisted reversal has zero lines — unreadable on hydration (#465).
+            assertThat(reversal.lines).allSatisfy { assertThat(it.journalId).isEqualTo(reversalId) }
+            assertThat(reversal.lines.map { it.id }).doesNotContainAnyElementsOf(posted.lines.map { it.id })
         }
 
         @Test

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerConcurrencyIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerConcurrencyIT.kt
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Concurrency / double-spend coverage for the posting and reversal paths (#465). The domain
+ * invariants are proven single-threaded in [com.openbank.ledger.domain.model.JournalEntryTest];
+ * this suite races real HTTP requests against the IT Postgres so the transactional guards —
+ * the ledger_idempotency primary key, the POSTED→REVERSED status flip, and the
+ * uq_journal_entries_reversal_of backstop index — are exercised where they actually live.
+ *
+ * Every race uses a [CyclicBarrier] so all contenders hit the endpoint together; there is no
+ * sleeping and no timing dependence — the assertions only count committed effects afterwards,
+ * so a scheduler that happens to serialise the requests still proves "no double effect".
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
+class LedgerConcurrencyIT {
+
+    // Deterministic posting accounts seeded by V3__ledger_governance.sql (same as LedgerApiIT).
+    private val glAssetId = "a0000000-0000-0000-0000-000000000001"
+    private val glLiabilityId = "a0000000-0000-0000-0000-000000000002"
+    private val operatorId = UUID.randomUUID()
+
+    private fun journalPayload(idempotencyKey: String, transactionId: UUID, amount: String): String {
+        val today = LocalDate.now().toString()
+        return """
+            {
+              "idempotencyKey": "$idempotencyKey",
+              "transactionId": "$transactionId",
+              "entryDate": "$today",
+              "valueDate": "$today",
+              "description": "Concurrency IT posting",
+              "createdBy": "$operatorId",
+              "lines": [
+                {
+                  "glAccountId": "$glAssetId",
+                  "side": "DEBIT",
+                  "amount": "$amount",
+                  "currencyCode": "CZK",
+                  "baseAmount": "$amount",
+                  "baseCurrencyCode": "CZK"
+                },
+                {
+                  "glAccountId": "$glLiabilityId",
+                  "side": "CREDIT",
+                  "amount": "$amount",
+                  "currencyCode": "CZK",
+                  "baseAmount": "$amount",
+                  "baseCurrencyCode": "CZK"
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+
+    /** Fire [n] request suppliers simultaneously (barrier-released) and collect the responses. */
+    private fun race(n: Int, request: (Int) -> Response): List<Response> {
+        val barrier = CyclicBarrier(n)
+        val pool = Executors.newFixedThreadPool(n)
+        try {
+            val futures = (0 until n).map { i ->
+                pool.submit<Response> {
+                    barrier.await(30, TimeUnit.SECONDS)
+                    request(i)
+                }
+            }
+            return futures.map { it.get(60, TimeUnit.SECONDS) }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    private fun journalsForTransaction(transactionId: UUID): List<Map<String, Any>> {
+        val resp = RestAssured.given().get("/api/v1/journals/transaction/$transactionId")
+        check(resp.statusCode == 200) {
+            "GET journals/transaction -> ${resp.statusCode}, body: ${resp.body.asString()}, headers: ${resp.headers}"
+        }
+        return resp.jsonPath().getList("")
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `parallel distinct postings all land exactly once and the trial balance stays tied`() {
+        val n = 8
+        val transactionId = UUID.randomUUID()
+
+        val responses = race(n) { i ->
+            RestAssured.given()
+                .contentType("application/json")
+                .body(journalPayload(UUID.randomUUID().toString(), transactionId, "100.00"))
+                .post("/api/v1/journals")
+        }
+
+        assertThat(responses.map { it.statusCode }).containsOnly(201)
+
+        val entries = journalsForTransaction(transactionId)
+        assertThat(entries).hasSize(n)
+        // Entry numbers are sequence-assigned under concurrency — no duplicates.
+        assertThat(entries.map { it["entryNumber"] }).doesNotHaveDuplicates()
+
+        // Global double-entry invariant survives concurrent posting: the trial balance
+        // (which also folds in every other test's postings) still ties out to the cent.
+        val trialBalance = RestAssured.given()
+            .get("/api/v1/journals/trial-balance?asOf=${LocalDate.now()}")
+            .then().statusCode(200)
+            .extract().jsonPath()
+        assertThat(trialBalance.getBoolean("balanced")).isTrue()
+        assertThat(BigDecimal(trialBalance.getString("totalDebit")))
+            .isEqualByComparingTo(BigDecimal(trialBalance.getString("totalCredit")))
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `racing duplicate submissions with one idempotency key post exactly once`() {
+        val n = 6
+        val transactionId = UUID.randomUUID()
+        val idempotencyKey = UUID.randomUUID().toString()
+        val payload = journalPayload(idempotencyKey, transactionId, "250.00")
+
+        val responses = race(n) {
+            RestAssured.given()
+                .contentType("application/json")
+                .body(payload)
+                .post("/api/v1/journals")
+        }
+
+        // The loser path must be a clean idempotent replay of the winner's entry — the same
+        // contract the sequential replay already has — never a 5xx and never a second posting.
+        assertThat(responses.map { it.statusCode })
+            .describedAs(
+                "concurrent duplicates must all resolve to the idempotent 201, got %s",
+                responses.map {
+                    it.statusCode
+                },
+            )
+            .containsOnly(201)
+        assertThat(responses.map { it.jsonPath().getString("id") }.toSet())
+            .describedAs("every contender must see the SAME journal entry")
+            .hasSize(1)
+
+        assertThat(journalsForTransaction(transactionId)).hasSize(1)
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `racing reversals of one posted entry reverse it exactly once`() {
+        val transactionId = UUID.randomUUID()
+        val journalId = RestAssured.given()
+            .contentType("application/json")
+            .body(journalPayload(UUID.randomUUID().toString(), transactionId, "500.00"))
+            .post("/api/v1/journals")
+            .then().statusCode(201)
+            .extract().jsonPath().getString("id")
+
+        val n = 4
+        val responses = race(n) {
+            RestAssured.given()
+                .contentType("application/json")
+                .body("""{"reason": "Concurrency IT reversal", "reversedBy": "$operatorId"}""")
+                .post("/api/v1/journals/$journalId/reverse")
+        }
+
+        // Exactly one contender books the compensation; every other one must surface the
+        // conflict (409 via the IllegalStateException mapper), never a second reversal —
+        // a double reversal double-credits the counterparty downstream (AccountBookedChanged
+        // deltas are emitted per reversal).
+        val byStatus = responses.groupBy { it.statusCode }
+        assertThat(byStatus[200])
+            .describedAs("exactly one reversal must win, got statuses %s", responses.map { it.statusCode })
+            .hasSize(1)
+        assertThat(byStatus.keys - setOf(200, 409))
+            .describedAs(
+                "losers must fail with a clean 409 conflict, got %s",
+                responses.map { "${it.statusCode}: ${it.body.asString()}" },
+            )
+            .isEmpty()
+
+        // Original + exactly ONE reversal entry — never two compensations.
+        val entries = journalsForTransaction(transactionId)
+        assertThat(entries).hasSize(2)
+        assertThat(entries.count { (it["description"] as? String)?.startsWith("Reversal of entry") == true })
+            .isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## Summary

First service of the #465 concurrency sweep. The new `LedgerConcurrencyIT` races real HTTP requests against the IT Postgres and caught **three real defects**, all fixed here: a concurrent double reversal (double-credit downstream), a 500 on concurrent duplicate posting, and the V10-era reversal-line mis-parenting whose code fix was never actually committed.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #465. Related: #526 (mapper collision, fleet), #527 (post-V10 data audit/repair).

## Changes

**Bug 1 — concurrent double reversal (double-spend class).** `saveReversal` persisted the reversal first and flipped the original's status unconditionally afterwards; the domain `check(status == POSTED)` in both racers reads POSTED before either commits. Two racing `POST /journals/{id}/reverse` both booked a compensation and both emitted `AccountBookedChanged` deltas → double-credit in the balance projection. Fix: the `POSTED→REVERSED` flip is now a **conditional update executed first** — the row lock serialises contenders, the loser matches 0 rows and fails before persisting anything. `V12__unique_reversal_of.sql` adds a partial unique index on `(reversal_of, entry_date)` as a DB backstop (partition key included; rollback note in the file).

**Bug 2 — concurrent duplicate posting returned 500.** Both contenders passed the idempotent-replay check, the loser died on the `ledger_idempotency` PK. `postJournal` now recovers that specific conflict into the same contract as the sequential path: return the winner's entry (201), no metrics double-count.

**Bug 3 — reversal lines mis-parented (V10 regression-that-never-was).** `JournalEntry.reverse()` copied lines keeping the ORIGINAL's `journalId`, so `persistLines` attached every reversal's lines to the original and the reversal row persisted with **zero lines** — unreadable on hydration (`lines.size >= 2` invariant → any GET touching it fails). This is exactly what `V10__repair_misattached_reversal_lines.sql` describes; the data was repaired but `git log -S "journalId = reversalId"` shows the code fix never landed. Fixed in `reverse()`; domain test now pins line parentage. Live-data audit → #527.

**Deterministic conflict status.** The loser now surfaces as a dedicated `JournalReversalConflictException → 409`. Using `IllegalStateException` is a status lottery: libs-runtime (422 `BUSINESS_RULE_VIOLATION`) and this service (409) both register a mapper for the same type and JAX-RS picks non-deterministically per request — observed flip-flopping in the IT; fleet issue #526.

**New tests.** `LedgerConcurrencyIT` (Testcontainers Postgres, `CyclicBarrier`-released HTTP races, no sleeps): 8 parallel distinct postings → all land, entry numbers unique, trial balance ties; 6 racing duplicates with one idempotency key → exactly one entry, all 201, same id; 4 racing reversals → exactly one 200, losers 409, exactly one compensation. Plus unit tests for the use-case conflict guard and the line re-parenting invariant.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated (`LedgerServiceTest`, `JournalEntryTest`).
- [x] Integration tests added (`LedgerConcurrencyIT`).
- [ ] Contract tests — N/A (no API shape change; the reverse endpoint's missing OpenAPI documentation is being added in a separate session/task).
- [x] Full `:openbank-ledger-service:build` green locally (JDK 25, fresh forced test run: 42 test classes, 0 failures).
- [x] No new lint warnings (ktlint + detekt green).
- [ ] OpenAPI — N/A here (see above).
- [x] Flyway migration added + rollback note (V12, backstop index; includes the partitioned-table constraint rationale).
- [ ] Avro/event schema — N/A (no event shape change; the fix stops *duplicate* emission).
- [x] Docs: defect mechanics captured in code comments + issues #526/#527.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions, no new dependencies.
- [x] Payment/ledger code changed → `security-review-required` tag applies (money-path: 2 approvals + threat model per rules.yaml).
- [x] No PII / cardholder data path changed.

## Compliance impact

- [x] None beyond existing money-path controls (correctness fix within the ledger boundary).
