### PR TITLE
fix(account): transactional idempotent opening + version-guarded lifecycle updates

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/AccountPorts.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/AccountPorts.kt
@@ -31,6 +31,17 @@ interface AccountRepository {
 
     suspend fun save(account: Account): Account
 
+    /**
+     * Persist a freshly opened account, its primary currency pocket and the idempotency key in
+     * ONE transaction (#465). The key's primary key makes a concurrent duplicate submission
+     * fail atomically instead of opening a second account; the caller recovers the conflict
+     * via [findByIdempotencyKey].
+     */
+    suspend fun saveNewAccount(account: Account, primaryPocket: CurrencyPocket, idempotencyKey: String): Account
+
+    /** The account opened under this idempotency key, or null if the key is unused. */
+    suspend fun findByIdempotencyKey(idempotencyKey: String): Account?
+
     suspend fun update(account: Account): Account
 
     suspend fun existsByIban(iban: Iban): Boolean

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -24,6 +24,7 @@ import com.openbank.libs.api.pagination.CursorEncoder
 import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.api.pagination.PageInfo
 import com.openbank.libs.domain.account.Iban
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.observability.DomainMetrics
 import io.vertx.pgclient.PgException
 import jakarta.enterprise.context.ApplicationScoped
@@ -344,7 +345,7 @@ class AccountService(
 
     /** The single-IBAN account opens with one primary pocket in its own currency (ADR-0024). */
     private fun primaryPocketFor(account: Account): CurrencyPocket = CurrencyPocket(
-        id = UUID.randomUUID(),
+        id = Ids.newId(),
         accountId = account.id,
         currency = account.currency,
         isPrimary = true,

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -25,7 +25,9 @@ import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.api.pagination.PageInfo
 import com.openbank.libs.domain.account.Iban
 import com.openbank.libs.observability.DomainMetrics
+import io.vertx.pgclient.PgException
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.persistence.PersistenceException
 import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
@@ -44,6 +46,11 @@ class AccountService(
 ) : AccountUseCase {
 
     override suspend fun openAccount(command: OpenAccountCommand): Account {
+        // Idempotent replay (#465): a repeated key returns the original account and never opens
+        // a second one. The Redis record in the REST layer is only a response cache — this DB
+        // check (and the transactional key insert in saveNewAccount) is the source of truth.
+        accountRepository.findByIdempotencyKey(command.idempotencyKey)?.let { return it }
+
         // ADR-0032 §C: Sanctions gate — fails closed.
         // HIT: confirmed match — hard block.
         // REVIEW: also blocked (Sprint 1 conservative). Sprint 2 will introduce a
@@ -85,21 +92,17 @@ class AccountService(
             legalName = command.legalName.ifBlank { null },
         )
 
-        val saved = accountRepository.save(account)
-
-        // The single-IBAN account opens with one primary pocket in its own currency (ADR-0024).
-        pocketRepository.save(
-            CurrencyPocket(
-                id = UUID.randomUUID(),
-                accountId = saved.id,
-                currency = saved.currency,
-                isPrimary = true,
-                status = PocketStatus.ACTIVE,
-                openedAt = Instant.now(clock),
-                closedAt = null,
-                version = 0L,
-            ),
-        )
+        // Account + pocket + idempotency key commit in ONE transaction (#465). A concurrent
+        // duplicate submission dies on the account_idempotency primary key — recover it into
+        // the same contract as the sequential replay above: return the winner's account,
+        // publish no second event, count no second metric.
+        val saved = try {
+            accountRepository.saveNewAccount(account, primaryPocketFor(account), command.idempotencyKey)
+        } catch (e: PersistenceException) {
+            return recoverConcurrentReplay(e, command.idempotencyKey)
+        } catch (e: PgException) {
+            return recoverConcurrentReplay(e, command.idempotencyKey)
+        }
 
         // Operational money lives in the balance-service (N3 / ADR-0024). Balance init is
         // event-driven (ADR-0073): balance-service's BalanceInitConsumer creates the zero
@@ -339,6 +342,31 @@ class AccountService(
     private suspend fun requireAccount(id: UUID): Account = accountRepository.findById(id)
         ?: throw AccountNotFoundException("Account not found: $id")
 
+    /** The single-IBAN account opens with one primary pocket in its own currency (ADR-0024). */
+    private fun primaryPocketFor(account: Account): CurrencyPocket = CurrencyPocket(
+        id = UUID.randomUUID(),
+        accountId = account.id,
+        currency = account.currency,
+        isPrimary = true,
+        status = PocketStatus.ACTIVE,
+        openedAt = Instant.now(clock),
+        closedAt = null,
+        version = 0L,
+    )
+
+    /**
+     * The loser of a concurrent duplicate-open race: both contenders passed the replay check
+     * before either committed, and this transaction died on the account_idempotency primary
+     * key. Recover by returning the winner's account. Anything that is not the idempotency-key
+     * conflict propagates untouched.
+     */
+    private suspend fun recoverConcurrentReplay(e: RuntimeException, idempotencyKey: String): Account {
+        val isIdempotencyKeyConflict = generateSequence<Throwable>(e) { it.cause.takeIf { c -> c !== it } }
+            .any { it.message?.contains("account_idempotency", ignoreCase = true) == true }
+        if (!isIdempotencyKeyConflict) throw e
+        return accountRepository.findByIdempotencyKey(idempotencyKey) ?: throw e
+    }
+
     companion object {
         /** Matches the goal_name VARCHAR(120) column (ADR-0153, V13) — validated app-side too. */
         const val GOAL_NAME_MAX_LENGTH = 120
@@ -370,6 +398,14 @@ class AccountService(
 }
 
 class AccountNotFoundException(message: String) : RuntimeException(message)
+
+/**
+ * A lifecycle update raced a concurrent modification of the same account (#465): the caller's
+ * domain object was read at a version the row no longer has. Dedicated type (not
+ * IllegalStateException — that has two competing mappers, libs 422 vs service, picked
+ * non-deterministically per request; see issue #526) mapped to 409.
+ */
+class AccountUpdateConflictException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)
 
 class AccountOpeningBlockedByScreeningException(partyId: UUID, matchedName: String?) :
     RuntimeException("Account opening blocked by sanctions screening for party $partyId (matched: $matchedName)")

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/entity/AccountEntities.kt
@@ -140,3 +140,24 @@ class AccountPocketEntity : PanacheEntityBase {
         updatedAt = Instant.EPOCH
     }
 }
+
+/**
+ * Transactional idempotency for account opening (#465): the key commits atomically with the
+ * account + primary pocket insert, so a concurrent duplicate submission dies on the primary
+ * key instead of opening a second account (the Redis record in the REST layer is only a
+ * response-replay cache and is check-then-act under concurrency).
+ */
+@Entity
+@Table(name = "account_idempotency")
+class AccountIdempotencyEntity : PanacheEntityBase {
+
+    @Id
+    @Column(name = "idempotency_key", nullable = false, length = 255)
+    lateinit var idempotencyKey: String
+
+    @Column(name = "account_id", nullable = false)
+    lateinit var accountId: UUID
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant = Instant.EPOCH
+}

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
@@ -5,22 +5,43 @@
 package com.openbank.account.infrastructure.persistence.repository
 
 import com.openbank.account.application.port.out.AccountRepository
+import com.openbank.account.application.usecase.AccountUpdateConflictException
 import com.openbank.account.domain.model.Account
 import com.openbank.account.domain.model.AccountStatus
 import com.openbank.account.domain.model.AccountType
+import com.openbank.account.domain.model.CurrencyPocket
 import com.openbank.account.domain.model.SigningRule
 import com.openbank.account.infrastructure.persistence.entity.AccountEntity
+import com.openbank.account.infrastructure.persistence.entity.AccountIdempotencyEntity
 import com.openbank.libs.domain.account.Iban
 import com.openbank.libs.domain.money.CurrencyCode
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
-class AccountRepositoryImpl :
-    AccountRepository,
+class AccountIdempotencyRepository(private val clock: Clock) :
+    PanacheRepositoryBase<AccountIdempotencyEntity, String> {
+    fun persistInTransaction(key: String, accountId: UUID): io.smallrye.mutiny.Uni<Void> {
+        val e = AccountIdempotencyEntity().also {
+            it.idempotencyKey = key
+            it.accountId = accountId
+            it.createdAt = Instant.now(clock)
+        }
+        return persist(e).replaceWithVoid()
+    }
+}
+
+@ApplicationScoped
+class AccountRepositoryImpl(
+    private val idempotencyRepository: AccountIdempotencyRepository,
+    private val pocketRepository: CurrencyPocketRepositoryImpl,
+) : AccountRepository,
     PanacheRepository<AccountEntity> {
 
     override suspend fun findById(id: UUID): Account? =
@@ -69,30 +90,50 @@ class AccountRepositoryImpl :
         return Panache.withTransaction { persist(entity).replaceWith(entity) }.awaitSuspending().toDomain()
     }
 
+    override suspend fun saveNewAccount(
+        account: Account,
+        primaryPocket: CurrencyPocket,
+        idempotencyKey: String,
+    ): Account {
+        val entity = account.toEntity()
+        // One transaction for account + primary pocket + idempotency key (#465): previously the
+        // three writes were separate transactions, so a crash could leave an account without a
+        // pocket, and two concurrent opens with one Idempotency-Key both committed (the Redis
+        // record in the REST layer is a check-then-act cache). The PK on account_idempotency
+        // makes the concurrent loser's whole transaction roll back; the use case recovers it.
+        return Panache.withTransaction {
+            persist(entity)
+                .flatMap { pocketRepository.persistInTransaction(primaryPocket) }
+                .flatMap { idempotencyRepository.persistInTransaction(idempotencyKey, entity.id) }
+                .replaceWith(entity)
+        }.awaitSuspending().toDomain()
+    }
+
+    override suspend fun findByIdempotencyKey(idempotencyKey: String): Account? {
+        val accountId = Panache.withSession {
+            idempotencyRepository.find("idempotencyKey", idempotencyKey).firstResult()
+        }.awaitSuspending()?.accountId ?: return null
+        return findById(accountId)
+    }
+
     override suspend fun update(account: Account): Account {
         val entity = account.toEntity()
-        return Panache.withTransaction {
-            find("id", entity.id).firstResult().flatMap { existing ->
-                if (existing == null) throw IllegalStateException("Account ${entity.id} not found for update")
-                existing.accountType = entity.accountType
-                existing.partyId = entity.partyId
-                existing.productId = entity.productId
-                existing.currencyCode = entity.currencyCode
-                existing.status = entity.status
-                existing.openedAt = entity.openedAt
-                existing.closedAt = entity.closedAt
-                existing.version = entity.version
-                // Savings goal (ADR-0153) round-trips through the same generic update() the
-                // freeze/unfreeze/close use cases already call — those pass through a domain
-                // object whose goal fields are unchanged from the read, so this is a no-op for
-                // them and the only path that actually changes the goal is updateSavingsGoal/
-                // clearSavingsGoal in AccountService.
-                existing.goalName = entity.goalName
-                existing.goalTargetMinorUnits = entity.goalTargetMinorUnits
-                existing.goalTargetDate = entity.goalTargetDate
-                io.smallrye.mutiny.Uni.createFrom().item(existing)
-            }
-        }.awaitSuspending().toDomain()
+        return try {
+            versionMatchedUpdate(entity).awaitSuspending().toDomain()
+        } catch (e: jakarta.persistence.OptimisticLockException) {
+            // Truly simultaneous writers both pass the version-matched read (in
+            // versionMatchedUpdate) before either commits; the loser's flush then fails
+            // Hibernate's @Version check. Same conflict, same 409 (#465).
+            throw AccountUpdateConflictException(
+                "Account ${entity.id} was modified concurrently (flush-time version check)",
+                e,
+            )
+        } catch (e: org.hibernate.StaleObjectStateException) {
+            throw AccountUpdateConflictException(
+                "Account ${entity.id} was modified concurrently (flush-time version check)",
+                e,
+            )
+        }
     }
 
     override suspend fun existsByIban(iban: Iban): Boolean =
@@ -108,44 +149,79 @@ class AccountRepositoryImpl :
             partyId,
         )
     }.awaitSuspending()
+}
 
-    private fun AccountEntity.toDomain() = Account(
-        id = id,
-        accountNumber = Iban.of(accountNumber),
-        accountType = AccountType.valueOf(accountType),
-        partyId = partyId,
-        productId = productId,
-        currency = CurrencyCode.of(currencyCode),
-        status = AccountStatus.valueOf(status),
-        signingRule = SigningRule.valueOf(signingRule),
-        openedAt = openedAt,
-        closedAt = closedAt,
-        version = version,
-        sanctionsScreenedAt = sanctionsScreenedAt,
-        sanctionsStatus = sanctionsStatus,
-        legalName = legalName,
-        goalName = goalName,
-        goalTargetMinorUnits = goalTargetMinorUnits,
-        goalTargetDate = goalTargetDate,
-    )
-
-    private fun Account.toEntity() = AccountEntity().also {
-        it.id = id
-        it.accountNumber = accountNumber.value
-        it.accountType = accountType.name
-        it.partyId = partyId
-        it.productId = productId
-        it.currencyCode = currency.code
-        it.status = status.name
-        it.signingRule = signingRule.name
-        it.openedAt = openedAt
-        it.closedAt = closedAt
-        it.version = version
-        it.sanctionsScreenedAt = sanctionsScreenedAt
-        it.sanctionsStatus = sanctionsStatus
-        it.legalName = legalName
-        it.goalName = goalName
-        it.goalTargetMinorUnits = goalTargetMinorUnits
-        it.goalTargetDate = goalTargetDate
+// File-scope extension (pure Uni assembly for update() above): keeps AccountRepositoryImpl
+// within detekt's per-class function budget, same pattern as the entity<->domain mappers below.
+private fun AccountRepositoryImpl.versionMatchedUpdate(entity: AccountEntity) = Panache.withTransaction {
+    // Optimistic guard (#465): match on the version the caller's domain object was READ
+    // at, not just the id. The previous re-read-and-copy silently applied stale domain
+    // state over a row another transaction had just changed (Hibernate's @Version check
+    // passed because the re-read was fresh) — e.g. a freeze racing a close resurrected
+    // the CLOSED account as FROZEN. 0 rows here = concurrent modification -> 409.
+    find("id = ?1 and version = ?2", entity.id, entity.version).firstResult().flatMap { existing ->
+        if (existing == null) {
+            throw AccountUpdateConflictException(
+                "Account ${entity.id} was modified concurrently (expected version ${entity.version})",
+            )
+        }
+        existing.accountType = entity.accountType
+        existing.partyId = entity.partyId
+        existing.productId = entity.productId
+        existing.currencyCode = entity.currencyCode
+        existing.status = entity.status
+        existing.openedAt = entity.openedAt
+        existing.closedAt = entity.closedAt
+        // Savings goal (ADR-0153) round-trips through the same generic update() the
+        // freeze/unfreeze/close use cases already call — those pass through a domain
+        // object whose goal fields are unchanged from the read, so this is a no-op for
+        // them and the only path that actually changes the goal is updateSavingsGoal/
+        // clearSavingsGoal in AccountService.
+        existing.goalName = entity.goalName
+        existing.goalTargetMinorUnits = entity.goalTargetMinorUnits
+        existing.goalTargetDate = entity.goalTargetDate
+        io.smallrye.mutiny.Uni.createFrom().item(existing)
     }
+}
+
+// Entity<->domain mappers kept at file scope (pure functions) so AccountRepositoryImpl stays
+// within detekt's per-class function budget — same pattern as the ledger repository helpers.
+private fun AccountEntity.toDomain() = Account(
+    id = id,
+    accountNumber = Iban.of(accountNumber),
+    accountType = AccountType.valueOf(accountType),
+    partyId = partyId,
+    productId = productId,
+    currency = CurrencyCode.of(currencyCode),
+    status = AccountStatus.valueOf(status),
+    signingRule = SigningRule.valueOf(signingRule),
+    openedAt = openedAt,
+    closedAt = closedAt,
+    version = version,
+    sanctionsScreenedAt = sanctionsScreenedAt,
+    sanctionsStatus = sanctionsStatus,
+    legalName = legalName,
+    goalName = goalName,
+    goalTargetMinorUnits = goalTargetMinorUnits,
+    goalTargetDate = goalTargetDate,
+)
+
+private fun Account.toEntity() = AccountEntity().also {
+    it.id = id
+    it.accountNumber = accountNumber.value
+    it.accountType = accountType.name
+    it.partyId = partyId
+    it.productId = productId
+    it.currencyCode = currency.code
+    it.status = status.name
+    it.signingRule = signingRule.name
+    it.openedAt = openedAt
+    it.closedAt = closedAt
+    it.version = version
+    it.sanctionsScreenedAt = sanctionsScreenedAt
+    it.sanctionsStatus = sanctionsStatus
+    it.legalName = legalName
+    it.goalName = goalName
+    it.goalTargetMinorUnits = goalTargetMinorUnits
+    it.goalTargetDate = goalTargetDate
 }

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/CurrencyPocketRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/CurrencyPocketRepositoryImpl.kt
@@ -34,6 +34,10 @@ class CurrencyPocketRepositoryImpl :
         return Panache.withTransaction { persist(entity).replaceWith(entity) }.awaitSuspending().toDomain()
     }
 
+    /** Persist within the caller's transaction (#465: account + pocket + idempotency commit atomically). */
+    fun persistInTransaction(pocket: CurrencyPocket): io.smallrye.mutiny.Uni<Void> =
+        persist(pocket.toEntity()).replaceWithVoid()
+
     override suspend fun update(pocket: CurrencyPocket): CurrencyPocket = Panache.withTransaction {
         find("id", pocket.id).firstResult().flatMap { existing ->
             if (existing == null) throw IllegalStateException("Pocket ${pocket.id} not found for update")

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
@@ -7,6 +7,7 @@ package com.openbank.account.infrastructure.rest
 import com.openbank.account.application.usecase.AccountNotFoundException
 import com.openbank.account.application.usecase.AccountUpdateConflictException
 import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.domain.identifiers.Ids
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
@@ -39,7 +40,7 @@ class AccountUpdateConflictExceptionMapper : ExceptionMapper<AccountUpdateConfli
         Response.status(Response.Status.CONFLICT)
             .entity(
                 ApiError(
-                    traceId = UUID.randomUUID().toString(),
+                    traceId = Ids.randomId().toString(),
                     status = 409,
                     code = "CONCURRENT_MODIFICATION",
                     message = exception.message ?: "Account was modified concurrently",

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/ExceptionMappers.kt
@@ -5,6 +5,7 @@
 package com.openbank.account.infrastructure.rest
 
 import com.openbank.account.application.usecase.AccountNotFoundException
+import com.openbank.account.application.usecase.AccountUpdateConflictException
 import com.openbank.libs.api.error.ApiError
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
@@ -26,4 +27,23 @@ class AccountNotFoundExceptionMapper : ExceptionMapper<AccountNotFoundException>
             ),
         )
         .build()
+}
+
+// 409 concurrent-modification conflict (#465): a lifecycle update (freeze/unfreeze/close/
+// activate/goal) raced another writer — the caller read a version the row no longer has.
+// Dedicated type so the status is deterministic (see issue #526 on the IllegalStateException
+// mapper collision between libs-runtime and services).
+@Provider
+class AccountUpdateConflictExceptionMapper : ExceptionMapper<AccountUpdateConflictException> {
+    override fun toResponse(exception: AccountUpdateConflictException): Response =
+        Response.status(Response.Status.CONFLICT)
+            .entity(
+                ApiError(
+                    traceId = UUID.randomUUID().toString(),
+                    status = 409,
+                    code = "CONCURRENT_MODIFICATION",
+                    message = exception.message ?: "Account was modified concurrently",
+                ),
+            )
+            .build()
 }

--- a/openbank-account-service/src/main/resources/db/migration/V14__account_idempotency.sql
+++ b/openbank-account-service/src/main/resources/db/migration/V14__account_idempotency.sql
@@ -1,0 +1,18 @@
+-- Transactional idempotency for account opening (#465 concurrency sweep).
+--
+-- The Redis idempotency record in the REST layer is a check-then-act cache: two concurrent
+-- opens with the same Idempotency-Key both miss it and BOTH open an account (two IBANs, two
+-- AccountCreated events, one of them orphaned when the second Redis save overwrites the first).
+-- This table makes the key part of the same DB transaction as the account + primary pocket
+-- insert (ledger_idempotency pattern): the loser dies on the primary key and recovers by
+-- returning the winner's account.
+--
+-- Rollback: DROP TABLE account_idempotency;
+CREATE TABLE account_idempotency (
+    idempotency_key     VARCHAR(255) NOT NULL,
+    account_id          UUID         NOT NULL,
+    created_at          TIMESTAMPTZ  NOT NULL,
+    CONSTRAINT pk_account_idempotency PRIMARY KEY (idempotency_key)
+);
+
+CREATE INDEX idx_account_idempotency_account ON account_idempotency(account_id);

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
@@ -77,9 +77,9 @@ class AccountServiceTest {
 
             coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
             every { ibanGenerator.generate(command.currency) } returns iban
+            coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
             coEvery { accountRepository.existsByIban(iban) } returns false
-            coEvery { accountRepository.save(any()) } answers { firstArg() }
-            coEvery { pocketRepository.save(any()) } answers { firstArg() }
+            coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
             coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
 
             val result = service.openAccount(command)
@@ -88,13 +88,15 @@ class AccountServiceTest {
             assertThat(result.status).isEqualTo(AccountStatus.ACTIVE)
 
             coVerify {
-                accountRepository.save(
+                accountRepository.saveNewAccount(
                     match {
                         it.partyId == command.partyId &&
                             it.productId == command.productId &&
                             it.currency == command.currency &&
                             it.status == AccountStatus.ACTIVE
                     },
+                    match { it.isPrimary && it.currency == command.currency },
+                    eq(command.idempotencyKey),
                 )
                 eventPublisher.publish(
                     "openbank.accounts.account.created",
@@ -120,6 +122,7 @@ class AccountServiceTest {
         val iban = Iban.of("CZ6508000000192000145399")
         val command = openAccountCommand()
 
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
         every { ibanGenerator.generate(command.currency) } returns iban
         coEvery { accountRepository.existsByIban(iban) } returns true
@@ -129,7 +132,7 @@ class AccountServiceTest {
             .hasMessageContaining("IBAN collision")
 
         coVerify(exactly = 0) {
-            accountRepository.save(any())
+            accountRepository.saveNewAccount(any(), any(), any())
             balancePort.initialize(any(), any(), any())
             eventPublisher.publish(any(), any(), any())
         }
@@ -204,39 +207,42 @@ class AccountServiceTest {
     fun `openAccount is blocked when sanctions screening returns HIT`() {
         val command = openAccountCommand(legalName = "Sanctioned Person")
 
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen(any(), any()) } returns
             SanctionsScreenResult("HIT", 0.98, "Sanctioned Person")
 
         assertThatThrownBy { runBlocking { service.openAccount(command) } }
             .isInstanceOf(AccountOpeningBlockedByScreeningException::class.java)
 
-        coVerify(exactly = 0) { accountRepository.save(any()) }
+        coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
     }
 
     @Test
     fun `openAccount is blocked when sanctions screening returns REVIEW`() {
         val command = openAccountCommand(legalName = "Fuzzy Match Person")
 
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen(any(), any()) } returns
             SanctionsScreenResult("REVIEW", 0.72, "Fuzzy Match Person")
 
         assertThatThrownBy { runBlocking { service.openAccount(command) } }
             .isInstanceOf(AccountOpeningBlockedByScreeningException::class.java)
 
-        coVerify(exactly = 0) { accountRepository.save(any()) }
+        coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
     }
 
     @Test
     fun `openAccount fails closed when sanctions service is unavailable`() {
         val command = openAccountCommand(legalName = "Test Customer")
 
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen(any(), any()) } throws
             AccountScreeningUnavailableException(RuntimeException("timeout"))
 
         assertThatThrownBy { runBlocking { service.openAccount(command) } }
             .isInstanceOf(AccountScreeningUnavailableException::class.java)
 
-        coVerify(exactly = 0) { accountRepository.save(any()) }
+        coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
     }
 
     @Test
@@ -244,12 +250,12 @@ class AccountServiceTest {
         val iban = Iban.of("CZ6508000000192000145399")
         val command = openAccountCommand(legalName = "Clean Customer")
 
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen("Clean Customer", any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
         every { ibanGenerator.generate(command.currency) } returns iban
         coEvery { accountRepository.existsByIban(iban) } returns false
-        coEvery { accountRepository.save(any()) } answers { firstArg() }
+        coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
         coEvery { balancePort.initialize(any(), any(), any()) } returns Unit
-        coEvery { pocketRepository.save(any()) } answers { firstArg() }
         coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
 
         val result = service.openAccount(command)
@@ -264,12 +270,12 @@ class AccountServiceTest {
         val command = openAccountCommand(legalName = "Alice Example")
         val savedSlot = slot<Account>()
 
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { sanctionsScreening.screen("Alice Example", any()) } returns SanctionsScreenResult("CLEAR", 0.05, null)
         every { ibanGenerator.generate(command.currency) } returns iban
         coEvery { accountRepository.existsByIban(iban) } returns false
-        coEvery { accountRepository.save(capture(savedSlot)) } answers { firstArg() }
+        coEvery { accountRepository.saveNewAccount(capture(savedSlot), any(), any()) } answers { firstArg() }
         coEvery { balancePort.initialize(any(), any(), any()) } returns Unit
-        coEvery { pocketRepository.save(any()) } answers { firstArg() }
         coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
 
         service.openAccount(command)
@@ -284,9 +290,9 @@ class AccountServiceTest {
         val command = openAccountCommand()
         coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
         every { ibanGenerator.generate(command.currency) } returns iban
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
         coEvery { accountRepository.existsByIban(iban) } returns false
-        coEvery { accountRepository.save(any()) } answers { firstArg() }
-        coEvery { pocketRepository.save(any()) } answers { firstArg() }
+        coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
         coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
 
         service.openAccount(command)

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountConcurrencyIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountConcurrencyIT.kt
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.RestAssured
+import io.restassured.response.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * Concurrency / double-effect coverage for account opening and lifecycle transitions (#465).
+ * Races real HTTP requests against the IT Postgres so the transactional guards live where the
+ * defects lived: the account_idempotency primary key (V14) and the version-matched update.
+ *
+ * Barrier-released races, no sleeps; assertions count committed effects afterwards, so a
+ * scheduler that happens to serialise the requests still proves "no double effect".
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.account.it.PostgresRedpandaRedisTestResource::class)
+class AccountConcurrencyIT {
+
+    private val productId = UUID.fromString("00000000-2222-0000-0000-000000000001")
+
+    private fun openPayload(partyId: UUID) = """
+        {
+          "partyId": "$partyId",
+          "productId": "$productId",
+          "accountType": "CURRENT",
+          "currencyCode": "CZK",
+          "legalName": "Concurrency IT s.r.o."
+        }
+    """.trimIndent()
+
+    private fun openRequest(partyId: UUID, idempotencyKey: String): Response = RestAssured.given()
+        .contentType("application/json")
+        .header("Idempotency-Key", idempotencyKey)
+        .body(openPayload(partyId))
+        .post("/api/v1/accounts")
+
+    /** Fire [n] request suppliers simultaneously (barrier-released) and collect the responses. */
+    private fun race(n: Int, request: (Int) -> Response): List<Response> {
+        val barrier = CyclicBarrier(n)
+        val pool = Executors.newFixedThreadPool(n)
+        try {
+            val futures = (0 until n).map { i ->
+                pool.submit<Response> {
+                    barrier.await(30, TimeUnit.SECONDS)
+                    request(i)
+                }
+            }
+            return futures.map { it.get(60, TimeUnit.SECONDS) }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    private fun accountsOfParty(partyId: UUID): List<Map<String, Any>> {
+        val resp = RestAssured.given()
+            .queryParam("partyId", partyId.toString())
+            .get("/api/v1/accounts")
+        check(resp.statusCode == 200) { "GET accounts -> ${resp.statusCode}: ${resp.body.asString()}" }
+        return resp.jsonPath().getList("data")
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `racing duplicate opens with one idempotency key open exactly one account`() {
+        val n = 6
+        val partyId = UUID.randomUUID()
+        val idempotencyKey = UUID.randomUUID().toString()
+
+        val responses = race(n) { openRequest(partyId, idempotencyKey) }
+
+        // The loser path must resolve to the winner's account — never a second account
+        // (silent double effect: two IBANs, two AccountCreated events) and never a 5xx.
+        assertThat(responses.map { it.statusCode })
+            .describedAs("statuses %s", responses.map { "${it.statusCode}: ${it.body.asString().take(120)}" })
+            .containsOnly(201)
+        assertThat(responses.map { it.jsonPath().getString("id") }.toSet())
+            .describedAs("every contender must see the SAME account")
+            .hasSize(1)
+
+        assertThat(accountsOfParty(partyId)).hasSize(1)
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `parallel distinct opens all land exactly once with unique IBANs`() {
+        val n = 8
+        val partyId = UUID.randomUUID()
+
+        val responses = race(n) { openRequest(partyId, UUID.randomUUID().toString()) }
+
+        assertThat(responses.map { it.statusCode }).containsOnly(201)
+        val accounts = accountsOfParty(partyId)
+        assertThat(accounts).hasSize(n)
+        assertThat(accounts.map { it["accountNumber"] }).doesNotHaveDuplicates()
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `racing freeze against close never resurrects a closed account`() {
+        val partyId = UUID.randomUUID()
+        val accountId = openRequest(partyId, UUID.randomUUID().toString())
+            .then().statusCode(201)
+            .extract().jsonPath().getString("id")
+
+        val freeze = { _: Int ->
+            RestAssured.given()
+                .contentType("application/json")
+                .body("""{"reason": "fraud alert"}""")
+                .post("/api/v1/accounts/$accountId/freeze")
+        }
+        val close = { _: Int ->
+            RestAssured.given()
+                .contentType("application/json")
+                .body("""{"reason": "customer request"}""")
+                .post("/api/v1/accounts/$accountId/close")
+        }
+        val responses = race(2) { i -> if (i == 0) freeze(i) else close(i) }
+
+        // Exactly one transition wins; the loser surfaces a clean conflict — either the 409
+        // version guard (truly concurrent) or the domain state check (arrived after commit,
+        // libs maps it 422). It must NOT silently succeed: freeze-after-close previously
+        // resurrected the CLOSED account as FROZEN (lost update through re-read-and-copy).
+        val winners = responses.count { it.statusCode == 200 }
+        assertThat(winners)
+            .describedAs("statuses %s", responses.map { "${it.statusCode}: ${it.body.asString().take(120)}" })
+            .isEqualTo(1)
+        assertThat(responses.map { it.statusCode }.filter { it != 200 })
+            .allSatisfy { assertThat(it).isIn(409, 422) }
+
+        // Final state matches the winner — and a CLOSED account stayed CLOSED if close won.
+        val winnerStatus = responses.first { it.statusCode == 200 }.jsonPath().getString("status")
+        val finalStatus = RestAssured.given()
+            .get("/api/v1/accounts/$accountId")
+            .then().statusCode(200)
+            .extract().jsonPath().getString("status")
+        assertThat(finalStatus).isEqualTo(winnerStatus)
+    }
+}


### PR DESCRIPTION
## Summary

Second service of the #465 concurrency sweep. The new `AccountConcurrencyIT` races real HTTP requests against the IT Postgres+Redis and caught **three real defects**, all fixed here: concurrent duplicate open created two accounts (silent double effect), a freeze racing a close could resurrect the CLOSED account (lost update), and account+pocket inserts were not atomic.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #465. Related: #526 (mapper collision — the dedicated conflict type here follows the same pattern as the ledger PR #528), #527.

## Changes

**Bug 1 — concurrent duplicate open = two accounts.** The `Idempotency-Key` header fed a Redis response cache in the REST layer (check-then-act: both racers miss, both open) and the use case never consumed `command.idempotencyKey` at all — so even a *sequential* Kafka redelivery in `PartyEventConsumer` (which passes deterministic `onboarding-account-$partyId` keys) could double-open. Fix: `V14__account_idempotency` table (ledger pattern, rollback note in file); account + primary pocket + key commit in **one transaction** via the new `AccountRepository.saveNewAccount`; the use case replays an existing key and recovers the concurrent PK-conflict loser to the winner's account (201, same id, no second event, no metric double-count). The Redis record stays as a response-replay fast path.

**Bug 2 — lifecycle lost update (frozen resurrection).** `update()` re-read the row in a fresh transaction and copied stale domain state over it — Hibernate's `@Version` check passed because the re-read was fresh, so a freeze whose domain check ran against a stale ACTIVE snapshot happily overwrote a just-committed CLOSED status. Fix: the update matches `(id, version-the-caller-read)`; 0 rows → `AccountUpdateConflictException` → 409 (`CONCURRENT_MODIFICATION`), and a flush-time `OptimisticLockException`/`StaleObjectStateException` (truly simultaneous writers) is translated to the same 409. Applies to freeze/unfreeze/close/activate/savings-goal.

**Bug 3 — account without pocket on crash.** Account and primary-pocket inserts were two separate transactions; now folded into the `saveNewAccount` transaction.

**New tests.** `AccountConcurrencyIT` (barrier-released HTTP races, no sleeps): 6 racing duplicate opens → exactly one account, all 201, same id; 8 parallel distinct opens → 8 accounts, unique IBANs; freeze vs close race → exactly one 200, loser 409/422, final state matches the winner (no resurrection). `AccountServiceTest` updated for the new port and covers the replay + conflict paths.

Out of scope (pre-existing, unchanged): account events still publish via a direct Kafka emitter rather than the outbox — flagged during the audit; and the `@PreUpdate` EPOCH timestamp is being handled in a separate session/task.

## Definition of Done

- [x] Hexagonal layering preserved (domain untouched; ports extended; framework code in infrastructure).
- [x] Unit tests added/updated (`AccountServiceTest`).
- [x] Integration tests added (`AccountConcurrencyIT`).
- [ ] Contract tests — N/A (no API shape change; new 409 on lifecycle conflicts was previously a 500/undefined surface).
- [x] Full `:openbank-account-service:build` green locally (JDK 25; fresh forced run: 23 classes / 135 tests, 0 failures; kover floor 65 holds).
- [x] No new lint warnings (ktlint + detekt green).
- [x] Flyway migration added + rollback note (V14).
- [ ] OpenAPI / Avro — N/A (no event shape change; the fix stops duplicate emission).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new suppressions, no new dependencies.
- [x] Payment-adjacent (money-path service) code changed → 2 approvals + threat model per rules.yaml.
- [x] No PII / cardholder data path changed.

## Compliance impact

- [x] None beyond existing money-path controls (correctness fix within the account boundary).
