### PR TITLE
security(deps): close the 2 gaps issue #461's pins missed (tika, plexus-utils)

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -54,3 +54,18 @@ dependencies {
     // lives in [versions] of the catalog, not on this classpath.
     implementation("org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin:$ktlintPluginVersion")
 }
+
+// Security floor (issue #461 follow-up): the Quarkus Gradle plugin pulls in maven-core ->
+// plexus-utils 4.0.2 transitively (its embedded Maven resolver, used for devtools/
+// registry-client), which carries a directory-traversal vulnerability in extractFile
+// (GHSA-6fmv-xxpf-w3cw, CVE-2025-67030). gradle/osv-scanner.toml notes this couldn't be
+// forced from a *service* project's resolutionStrategy — a service's configurations.all
+// cannot reach into an already-applied Gradle plugin's own classpath. This project is
+// different: build-logic declares io.quarkus:io.quarkus.gradle.plugin as a plain
+// `implementation` dependency of *this* project (see above), so build-logic's own
+// resolutionStrategy applies directly to it.
+configurations.all {
+    resolutionStrategy {
+        force("org.codehaus.plexus:plexus-utils:4.0.3")
+    }
+}

--- a/openbank-libs/gradle/libs.versions.toml
+++ b/openbank-libs/gradle/libs.versions.toml
@@ -21,7 +21,14 @@ wiremock = "3.9.2"
 avro = "1.11.3"
 apicurio-registry = "2.6.2.Final"
 testcontainers = "1.20.4"
-pact = "4.6.17"
+# 4.7.3 (issue #461 follow-up): the only route org.apache.tika:tika-core enters the
+# project dependency graph as a real classpath dependency (pact-consumer/pact-provider
+# pull it transitively for content-type matching) — 4.6.17 resolves tika-core 2.9.1,
+# vulnerable to GHSA-f58c-gq56-vjjf (XXE, critical). 4.7.3 resolves tika-core 3.2.3.
+# Distinct from the tika-core pulled by the cyclonedx Gradle plugin's own SBOM
+# classpath (gradle/osv-scanner.toml) — that one is a separate, non-project-resolvable
+# occurrence and still needs a cyclonedx plugin version bump.
+pact = "4.7.3"
 # Static analysis (SAST gate — detekt for correctness rules, ktlint for formatting).
 # detekt 1.23.8 bundles its own kotlin-compiler-embeddable, so it parses sources
 # independently of the project Kotlin version (2.3.x here).


### PR DESCRIPTION
# security(deps): close the 2 gaps issue #461's pins missed (tika, plexus-utils)

## Context

This PR originally attempted a much broader fix (Quarkus BOM 3.33.2 → 3.37.1 + several
`force()` pins) before [#536](https://github.com/JiRaska/open-bank-oss/pull/536) — a more
conservative, already-merged sibling PR for the same alert backlog (issue #461) — landed on
`main` while this branch was in flight. #536 pins the vulnerable Netty/Jackson/postgresql/
scram/etc. transitives directly (no platform bump, avoiding any risk of desyncing from
Quarkus's tested Vert.x/Jackson combination) and is comprehensive. This PR has been **rebased
on top of #536** and reduced to only the two genuine gaps its own `gradle/osv-scanner.toml`
documents as still open, plus one bug found the hard way.

## What's left after #536

### 1. `pact` 4.6.17 → 4.7.3 — critical Tika XXE (#24, GHSA-f58c-gq56-vjjf)

`org.apache.tika:tika-core` enters this repo's dependency graph through **two independent
routes**:
- The cyclonedx Gradle plugin's own SBOM-generation classpath — not project-resolvable via
  `resolutionStrategy.force()` (a consuming project can't reach into an already-applied
  plugin's classpath). #536 correctly identified this and left it as an accepted-risk
  `osv-scanner.toml` override pending a cyclonedx plugin bump.
- **pact-consumer/pact-provider's own transitive** (content-type matching) — a genuine
  project-level test dependency, fully resolvable by bumping the `pact` version. #536 didn't
  catch this second occurrence. 4.6.17 resolves `tika-core:2.9.1`; 4.7.3 resolves
  `tika-core:3.2.3`.

### 2. `plexus-utils` 4.0.3 force in `build-logic/build.gradle.kts` — high, directory traversal (#31, GHSA-6fmv-xxpf-w3cw)

`gradle/osv-scanner.toml` (from #536) notes plexus-utils 4.0.2 "couldn't be forced from a
service project's resolutionStrategy" — correct, since the Quarkus Gradle plugin pulls it in
via its own `maven-core` dependency, and a project's `configurations.all` cannot override an
already-applied plugin's classpath. But `build-logic/build.gradle.kts` is different: it
declares `io.quarkus:io.quarkus.gradle.plugin` as a plain `implementation` dependency **of
itself** (needed to compile the precompiled convention plugins), so `build-logic`'s own
`resolutionStrategy` applies directly to it. Forcing it there should work where forcing it
from a service can't.

## What this PR deliberately does NOT touch (already covered by #536, or a landmine avoided)

- **No Quarkus BOM bump.** #536 explicitly chose to stay on 3.33.2 rather than bump to
  3.37.1, specifically to avoid desyncing from Quarkus's tested dependency combination. An
  earlier version of *this* branch tried the 3.37.1 bump anyway and broke
  `opentelemetry-api` fleet-wide (`NoClassDefFoundError: ApiUsageLogger` — forcing only the
  `api` artifact desynced it from the SDK/semconv/context artifacts still on the BOM's
  version). Reverted, then abandoned entirely in favor of #536's already-accepted, safer
  approach. `io.opentelemetry:opentelemetry-api` (#42, CVE-2026-45292) stays open — #536's
  `osv-scanner.toml` documents the same conclusion: needs a full platform bump, not a
  single-artifact force.
- No jackson/assertj/testcontainers version changes — #536 already bumped `jackson` to
  2.21.5 and `assertj` to 3.27.7 directly in `libs.versions.toml`, and force-pins
  commons-compress fleet-wide (the reason this branch originally wanted a testcontainers
  bump).
- No duplicate `scram-client`/`scram-common` force — already in
  `openbank.dependency-vulnerability-pins.gradle.kts` (#536).

## Still genuinely open after both PRs (no fix available, not attempted)

Per #536's `gradle/osv-scanner.toml`, accepted risk, each with its own reason:
- **#27 hibernate-reactive-core** — fix only in 4.2.1; even the latest Quarkus platform BOM
  (3.37.1) ships 3.4.1.Final.
- **jackson-databind GHSA-5jmj-h7xm-6q6v** — no fix on the Jackson 2.x line at all; needs
  Jackson 3.x (`tools.jackson.*` groupId), which Quarkus 3.33.2 doesn't support.
- **#42 opentelemetry-api** — needs a full OTel artifact-set bump in lockstep with a Quarkus
  platform bump (see above).
- **tika-core / plexus-utils via the cyclonedx plugin's own classpath** — needs a cyclonedx
  Gradle plugin version bump, tracked separately.

## Note on the Dependabot alert count

The live alert count (github.com/.../security/dependabot) may still show several of #536's
already-fixed packages (netty-codec, jackson-core/databind <2.21.4, commons-lang3,
commons-compress, commons-beanutils, json-smart, commons-io) as "open" — confirmed via
#536's own `gradle/verification-metadata.xml` diff that these **are** resolved to safe
versions in the actual dependency graph. Force-pin-only fixes don't reliably trigger
Dependabot's static manifest re-scan to auto-close the alert (only declared-version-string
changes reliably do, e.g. `assertj`/`postgresql` closed; most `force()`-only fixes didn't).
This is a reporting-lag/mechanism gap, not a real vulnerability gap — may need manual alert
dismissal or another scan cycle.

## Linked issues

Refs #461.
