### PR TITLE
docs: capture the openapi info.version merge-race footgun (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,16 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   squash delta; 2-dot includes main's post-divergence commits and makes stale branches look like
   regressions.
 
+### API contract (ADR-0048)
+- **Two racing spec PRs can both claim the same `info.version` — and both pass the gate.** The
+  api-contract gate classifies against the PR's *creation-time* base
+  (`github.event.pull_request.base.sha`), so a competing bump that merges first is invisible to
+  the second PR: it lands with new endpoints under an unchanged version (#481 vs #524 on the
+  ledger spec, corrected by #534). After any competing `openapi.yaml` change merges — including
+  when you resolve a merge conflict against `main` — re-check `info.version` against the *current*
+  `main` and re-bump; whoever lands second takes the next version. A matching version line merging
+  "cleanly" is the trap: git sees identical text, not a taken version.
+
 ## Capturing what we learn
 
 A corrected non-obvious mistake or a hard-won lesson belongs **in the repo**, where every contributor


### PR DESCRIPTION
## Summary

Captures yesterday's ledger-spec merge race as a CLAUDE.md pitfall (knowledge-capture rule): #524 and #481 both classified additive against the same 1.5.2 base, both claimed `info.version` 1.6.0, and both passed the api-contract gate — the gate diffs against the PR's creation-time `base.sha`, so the second PR landed two new endpoints under an unchanged version (corrected in #534). The gate-side fix (classify against current merge-base) is tracked separately; this documents the contributor-side imperative.

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [x] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — knowledge-capture bullet for the #481/#524/#534 merge race; the enforceable gate fix is being prepared as its own ci PR.

## Changes

- `CLAUDE.md`: new "API contract (ADR-0048)" pitfall subsection — symptom (racing spec PRs both claim the same `info.version` and both pass the gate; an identical version line merges "cleanly") + fix (after any competing `openapi.yaml` merge, re-check and re-bump against *current* `main`; whoever lands second takes the next version).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports). — docs-only
- [ ] Unit tests added/updated. — N/A
- [ ] Integration tests added/updated (if service boundary involved). — N/A
- [ ] Contract tests updated (if public API changed). — N/A
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — no code touched
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [x] Docs updated (README, ADR if architectural).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no
- [ ] PII path changed? — no
- [ ] Cardholder data path changed? — no

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

Documentation-only change to the contributor guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
