### PR TITLE
security(libs): remove stale domestic-payment money_path_action_prefixes override

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "b16f6cd76b4819b7"
+    openbank.tech/policy-checksum: "a89cb7daf0a3ee06"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1125,9 +1125,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b16f6cd76b4819b7"
+        openbank.tech/policy-checksum: "a89cb7daf0a3ee06"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "f2abf6e247e16621"
+    openbank.tech/policy-checksum: "94e78c23dccd8d9c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1169,9 +1169,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f2abf6e247e16621"
+        openbank.tech/policy-checksum: "94e78c23dccd8d9c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "4555643a6d6630c8"
+    openbank.tech/policy-checksum: "c25f754c13617733"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1074,9 +1074,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4555643a6d6630c8"
+        openbank.tech/policy-checksum: "c25f754c13617733"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "ab7b67a46a9c1afa"
+    openbank.tech/policy-checksum: "6b27c3206846579f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1092,9 +1092,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ab7b67a46a9c1afa"
+        openbank.tech/policy-checksum: "6b27c3206846579f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "856f14e49b072a2c"
+    openbank.tech/policy-checksum: "f40a7c7b8b76659c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1157,9 +1157,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "856f14e49b072a2c"
+        openbank.tech/policy-checksum: "f40a7c7b8b76659c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "f970d0b1c84a79e1"
+    openbank.tech/policy-checksum: "782e66223f6d06ff"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -722,9 +722,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f970d0b1c84a79e1"
+        openbank.tech/policy-checksum: "782e66223f6d06ff"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "f4638c216a66e7ab"
+    openbank.tech/policy-checksum: "22c326cc4317e94d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1085,9 +1085,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f4638c216a66e7ab"
+        openbank.tech/policy-checksum: "22c326cc4317e94d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "16d90b840a002a97"
+    openbank.tech/policy-checksum: "552f329e4d4dd51b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1122,9 +1122,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "16d90b840a002a97"
+        openbank.tech/policy-checksum: "552f329e4d4dd51b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "7b8f06a02fe7916c"
+    openbank.tech/policy-checksum: "0bea2ab27af620d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1181,9 +1181,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7b8f06a02fe7916c"
+        openbank.tech/policy-checksum: "0bea2ab27af620d5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "ab0fa27aca12e819"
+    openbank.tech/policy-checksum: "e09a2c381123a35b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1128,9 +1128,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ab0fa27aca12e819"
+        openbank.tech/policy-checksum: "e09a2c381123a35b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "f970d0b1c84a79e1"
+    openbank.tech/policy-checksum: "782e66223f6d06ff"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -722,9 +722,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "f970d0b1c84a79e1"
+        openbank.tech/policy-checksum: "782e66223f6d06ff"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1bd54a4c33f19d54"
+    openbank.tech/policy-checksum: "3b5769d9519408af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1128,9 +1128,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ff61a7459d3507a1"
+    openbank.tech/policy-checksum: "db82bb667556f78e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1113,9 +1113,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "bdc5d50e660b3d56" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "264828289580f396" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5cb81ca1562e3790"
+        openbank.tech/policy-checksum: "eaf8783527fd6f5e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ff61a7459d3507a1" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "db82bb667556f78e" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "058825c839d16414"
+        openbank.tech/policy-checksum: "c509503ab090a5b4"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1bd54a4c33f19d54" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "3b5769d9519408af" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1891,7 +1891,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3e3813f6b57a3dbc" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "d4439240554429e8" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2281,7 +2281,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c1579f0069a3814d"
+        openbank.tech/policy-checksum: "74cc69d620a1e368"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "058825c839d16414"
+    openbank.tech/policy-checksum: "c509503ab090a5b4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1086,9 +1086,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5cb81ca1562e3790"
+    openbank.tech/policy-checksum: "eaf8783527fd6f5e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1107,9 +1107,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3e3813f6b57a3dbc"
+    openbank.tech/policy-checksum: "d4439240554429e8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1087,9 +1087,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c1579f0069a3814d"
+    openbank.tech/policy-checksum: "74cc69d620a1e368"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1090,9 +1090,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bdc5d50e660b3d56"
+    openbank.tech/policy-checksum: "264828289580f396"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1143,9 +1143,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "83b354e749868851"
+    openbank.tech/policy-checksum: "ca6351e86040e776"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1096,9 +1096,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "83b354e749868851"
+        openbank.tech/policy-checksum: "ca6351e86040e776"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "e5c03e0a5981a4ce"
+    openbank.tech/policy-checksum: "dc1987a94206271b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1110,9 +1110,16 @@ data:
     money_path_action_prefixes:
       sepa-payment: [sepaPayment]
       sepa-instant: [sctInstPayment]
-      domestic-payment: [domesticPayment]
       clearing: [clearingBatch]
       sca: [device, scaChallenge]
+      # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+      # auditing issue #413). Its @Authorize actions were independently renamed from
+      # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+      # by a later change — the override entry this table used to carry (domesticPayment)
+      # had gone stale and was silently breaking the scope match again (input.action
+      # "domestic-payment.transitionStatus" no longer starts with the overridden
+      # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+      # below — do not re-add an override here unless the action prefix diverges again.
 
     # ---------------------------------------------------------------------------------------
     # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e5c03e0a5981a4ce"
+        openbank.tech/policy-checksum: "dc1987a94206271b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -45,7 +45,9 @@ rules_real := {
 	"money_path_action_prefixes": {
 		"sepa-payment": ["sepaPayment"],
 		"sepa-instant": ["sctInstPayment"],
-		"domestic-payment": ["domesticPayment"],
+		# domestic-payment intentionally absent -- its real @Authorize prefix is now
+		# domestic-payment.* (kebab-case), matching the derived scope by default
+		# (issue #413 audit found a stale override here silently re-breaking it).
 		"clearing": ["clearingBatch"],
 		"sca": ["device", "scaChallenge"],
 	},
@@ -269,9 +271,16 @@ test_four_eyes_required_sepa_instant_real_action if {
 }
 
 test_four_eyes_required_domestic_payment_real_action if {
-	# DomesticPaymentResource.kt: @Authorize(action = "domesticPayment.transitionStatus", ...)
-	rest.four_eyes_required with input as {"action": "domesticPayment.transitionStatus"}
+	# DomesticPaymentResource.kt: @Authorize(action = "domestic-payment.transitionStatus", ...)
+	# (renamed from domesticPayment.transitionStatus since the #395/#396 fix landed —
+	# now matches the derived scope directly, no override needed; issue #413 audit.)
+	rest.four_eyes_required with input as {"action": "domestic-payment.transitionStatus"}
 		with data.rules as rules_real
+}
+
+test_money_path_scopes_domestic_payment_uses_derived_name_not_stale_override if {
+	"domestic-payment" in rest.money_path_scopes with data.rules as rules_real
+	not "domesticPayment" in rest.money_path_scopes with data.rules as rules_real
 }
 
 test_four_eyes_required_clearing_real_action if {

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -307,9 +307,16 @@ review:
 money_path_action_prefixes:
   sepa-payment: [sepaPayment]
   sepa-instant: [sctInstPayment]
-  domestic-payment: [domesticPayment]
   clearing: [clearingBatch]
   sca: [device, scaChallenge]
+  # domestic-payment: intentionally NOT listed here (removed 2026-07-08, found while
+  # auditing issue #413). Its @Authorize actions were independently renamed from
+  # domesticPayment.* to domestic-payment.* (kebab-case, matching the derived scope)
+  # by a later change — the override entry this table used to carry (domesticPayment)
+  # had gone stale and was silently breaking the scope match again (input.action
+  # "domestic-payment.transitionStatus" no longer starts with the overridden
+  # "domesticPayment." scope). Now correctly covered by the default derived-name rule
+  # below — do not re-add an override here unless the action prefix diverges again.
 
 # ---------------------------------------------------------------------------------------
 # Four-eyes (dual control) for the unified OPA authz PEP (ADR-0034 D1; rest.rego reads


### PR DESCRIPTION
## Summary

Found while re-auditing all 16 money-path services for the [issue #413](https://github.com/JiRaska/open-bank-oss/issues/413) rollout: `domestic-payment`'s four-eyes scope match is broken again, on `main`, right now.

## What happened

- `domestic-payment`'s real `@Authorize` action prefix was independently renamed from `domesticPayment.*` to `domestic-payment.*` (kebab-case) by a later, unrelated change — this actually FIXES the naming to match the derived scope by default.
- But the `money_path_action_prefixes` override entry added by #396/#408 (`domestic-payment: [domesticPayment]`) was never removed.
- `rest.rego`'s override rule takes precedence over the default derived-name rule whenever an entry exists for a service — so the stale override kept forcing the scope to the now-nonexistent camelCase `domesticPayment`, silently breaking `four_eyes_required` for `domestic-payment.transitionStatus` again.

This is the exact defect class issue #395 was opened to fix, reintroduced by drift between two independently-landing changes touching the same file.

## Changes

- Removed the stale `domestic-payment` entry from `money_path_action_prefixes` — it now correctly falls through to the default derived-name rule.
- Updated `rest_test.rego`: fixed the real-action test string, added a new test pinning that `money_path_scopes` contains the derived name `domestic-payment`, not the removed override `domesticPayment`.
- Regenerated all 20 per-service + shared OPA bundle ConfigMaps (`rules.yaml` content changed) + their pod-roll checksum annotations.

## Verification

- `opa test` — 108/108 pass.
- `./openbank-infra/opa/build-bundle.sh` — full build + decision assertions green.
- Confirmed via `git diff` that every regenerated bundle ConfigMap only differs by the checksum + the `rules.yaml` content change (no unrelated drift).

## Definition of Done

- [x] Unit tests updated (`rest_test.rego`).
- [x] `opa test` / `build-bundle.sh` green locally.
- [x] No hexagonal/service code touched — pure governance policy fix.

## Security checklist

- [x] No secrets, tokens, PII.
- [x] Auth code changed → `security-review-required`.

## Compliance impact

- [x] PSD2 / SCA / RTS — restores a maker-checker control for `domestic-payment` that had silently regressed.

## Rollout / Rollback

- Deployment: rolling, via the regenerated per-service OPA bundle ConfigMap checksum annotations.
- Rollback: revert — `authz.four-eyes.enforce` is `false` everywhere still, so this only fixes the `four_eyes_required` signal, not any live enforcement.
