### PR TITLE
fix(finrep): regenerate ADR index and fix bare image ref in the Deployment

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -105,7 +105,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0094](0094-eudi-native-identity-hub.md) | EUDI-native identity hub — eIDAS 2.0 wallet onboarding, probabilistic record linkage, and durable orchestration | Accepted | Partial | — |
 | [0095](0095-qrlesspay-ble-proximity-spayd-payments.md) | QRlessPay — BLE proximity SPAYD payments | Accepted | Partial | openbank-app |
 | [0096](0096-entity-level-statutory-accounting-close.md) | Entity-level statutory accounting close (GL period freeze, attested trial balance, financial statements, EoY) | Accepted | Planned | — |
-| [0097](0097-supervisory-prudential-returns-finrep-corep.md) | Supervisory / prudential returns (FINREP / COREP) derived from the attested close | Accepted | Planned | — |
+| [0097](0097-supervisory-prudential-returns-finrep-corep.md) | Supervisory / prudential returns (FINREP / COREP) derived from the attested close | Accepted | Partial | — |
 | [0098](0098-progressive-delivery-argo-rollouts.md) | Progressive Delivery for Money-Path Services via Argo Rollouts | Accepted | Shipped | — |
 | [0099](0099-automated-secret-rotation.md) | Automated secret rotation: OpenBao dynamic credentials + CronJob rotator | Accepted | Partial | — |
 | [0100](0100-deterministic-simulation-testing.md) | Deterministic Simulation Testing for the banking core | Accepted | Partial | — |

--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -1,3 +1,10 @@
+# finrep-service has never been built/pushed via openbank-infra/scripts/build-push-service.sh
+# (this is its first ArgoCD registration, ADR-0097). The image tag below is a placeholder,
+# following the same first-registration pattern as developer-portal's `sandbox-sec1` — it
+# does NOT point at a real pushed image yet. Run `build-push-service.sh finrep --bump` (or the
+# CI auto-deploy pipeline) to build+push the real `sandbox-<git-sha>` image and rewrite this
+# tag before relying on this Deployment actually coming up (ArgoCD will otherwise report
+# ImagePullBackOff — see PR #547 reviewer notes).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: finrep-service
-          image: openbank-finrep-service:0.1.0
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-init
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

Follow-up fix to #547 (already merged), which registered `finrep-service` with ArgoCD but
merged before two review findings on that PR were addressed. #547 merged at the pre-fix
commit, so both issues are currently live on `main` — this PR lands the fix directly.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [x] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #530

## Changes

- **`docs/adr/README.md`**: regenerated via `bash docs/adr/gen-index.sh` — was stale after
  #547's ADR-0097 `Delivery-Status: Planned -> Partial` edit (derived data must be
  regenerated, never hand-left behind; this is what `check-adr-registry.sh` gates on).
- **`openbank-infra/gitops/components/finrep/finrep-service.yaml`**: fixed a bare,
  unqualified image reference. It had `image: openbank-finrep-service:0.1.0` — no registry
  — which defaults to Docker Hub, where this image does not exist. Now that #547 has
  registered finrep-service with ArgoCD (`selfHeal: true`), the next reconcile will
  actually try to pull this image and hit `ImagePullBackOff`. Fixed to the fleet's real
  convention: `265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-init`
  (matches the ECR path shape every other deployed service uses, per
  `build-push-service.sh`). Added an explicit comment: finrep-service has never actually
  been built/pushed through that pipeline, so `sandbox-init` is a placeholder (same
  precedent as developer-portal's pre-pipeline `sandbox-sec1`) — a real
  `build-push-service.sh finrep --bump` (or the CI auto-deploy pipeline) is still required
  before this Deployment comes up healthy. This PR fixes the wrong-registry defect (would
  silently pull from Docker Hub) but does not by itself guarantee a successful first sync.

## What was verified locally

- `bash .github/scripts/check-adr-registry.sh` → `OK — 149 ADRs, unique numbers, headings
  match filenames, index fresh.` (exit 0).
- `kubectl apply --dry-run=client -f openbank-infra/gitops/components/finrep/finrep-service.yaml`
  → structurally valid (`configured (dry run)`); confirmed nothing was actually applied to
  the live cluster.
- 3-dot diff against `origin/main` is exactly these 2 files, 9 insertions / 2 deletions —
  no unrelated changes picked up.

## Definition of Done

- [x] Hexagonal layering preserved — no domain code changed.
- [ ] Unit tests added/updated — N/A, gitops/docs-only change.
- [ ] Integration tests — N/A.
- [ ] Contract tests — N/A, no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` — N/A, no Kotlin changed in this PR.
- [x] No new lint warnings.
- [ ] OpenAPI spec — N/A.
- [ ] Flyway migration — N/A.
- [ ] Avro schema — N/A.
- [x] Docs updated (regenerated ADR index).

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth/crypto/payment code changed — No.
- [ ] PII path changed — No.
- [ ] Cardholder data path changed — No.

## Compliance impact

- [x] CNB reporting (ADR-0097) — this PR only fixes the deployment registration's
      correctness; no change to reporting logic or compliance surface.

## Rollout / Rollback

- Deployment strategy: same ArgoCD automated sync as #547.
- Rollback plan: revert this PR — reverts to the bare image ref (worse) and stale index;
  not a functional regression risk beyond what #547 already introduced.
- Data migration reversible: N/A.

## Reviewer notes

- `finrep-service` is not in `rules.yaml: money_path_services` — no threat model / 2-approval
  gate applies; this is a normal-review gitops/governance fix.
- I have **not** merged this PR and will not — leaving for human review per repo process.