### PR TITLE
fix(account): stamp audit timestamps on the transactional open path

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
@@ -105,6 +105,11 @@ class AccountRepositoryImpl(
         idempotencyKey: String,
     ): Account {
         val entity = account.toEntity()
+        // Audit timestamps come from the injected Clock here, same as save() (ADR-0100 / #540):
+        // the column DEFAULT never applies because Hibernate writes every insertable column.
+        val now = clock.instant()
+        entity.createdAt = now
+        entity.updatedAt = now
         // One transaction for account + primary pocket + idempotency key (#465): previously the
         // three writes were separate transactions, so a crash could leave an account without a
         // pocket, and two concurrent opens with one Idempotency-Key both committed (the Redis

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/CurrencyPocketRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/CurrencyPocketRepositoryImpl.kt
@@ -41,8 +41,14 @@ class CurrencyPocketRepositoryImpl(private val clock: Clock) :
     }
 
     /** Persist within the caller's transaction (#465: account + pocket + idempotency commit atomically). */
-    fun persistInTransaction(pocket: CurrencyPocket): io.smallrye.mutiny.Uni<Void> =
-        persist(pocket.toEntity()).replaceWithVoid()
+    fun persistInTransaction(pocket: CurrencyPocket): io.smallrye.mutiny.Uni<Void> {
+        val entity = pocket.toEntity()
+        // Same Clock stamping as save() (ADR-0100 / #540) — this path bypasses save() entirely.
+        val now = clock.instant()
+        entity.createdAt = now
+        entity.updatedAt = now
+        return persist(entity).replaceWithVoid()
+    }
 
     override suspend fun update(pocket: CurrencyPocket): CurrencyPocket = Panache.withTransaction {
         find("id", pocket.id).firstResult().flatMap { existing ->


### PR DESCRIPTION
## Summary

Fixes red `main`: #540 was merged with the account-service build failing. The #540 × #541 merge resolution fixed the `versionMatchedUpdate` compile error (`internal val clock`) but left the **new transactional open path unstamped** — `saveNewAccount()` and `CurrencyPocketRepositoryImpl.persistInTransaction()` persist entities with their EPOCH defaults, reintroducing the exact bug #540 fixed on the primary account-open path. The `ReconciliationSummaryIT` since-window regression test from #540 correctly catches it, which is what is failing on `main` now.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #533

## Changes

- `saveNewAccount()`: stamp `createdAt`/`updatedAt` from the injected `Clock`, same as `save()`.
- `CurrencyPocketRepositoryImpl.persistInTransaction()`: ditto — this path bypasses `save()` entirely.

## Notes for reviewers

- No new test needed: the #540 regression test (`ReconciliationSummaryIT` — a freshly opened account must fall inside a `?since=` reconciliation window) exercises exactly this path since #541 switched `openAccount` to `saveNewAccount`. It fails on current `main` and passes with this fix.
- Verified locally: ktlintCheck + `ReconciliationSummaryIT` (5/5), `AccountConcurrencyIT` (3/3), `AccountApiIT` (12/12).
- Process note: #540's head was merged with `all-green: failure` (zero reviews, admin bypass) — that is how this landed on `main`; see the PR conversation for the timeline.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated. — covered by the existing #540 regression test
- [x] Integration tests added/updated (if service boundary involved). — existing ITs cover the path
- [ ] Contract tests updated (if public API changed). — N/A
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. (targeted local run; full suite in CI)
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A
- [ ] Flyway migration added + rollback note (if DB changed). — N/A
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A
- [ ] Docs updated (README, ADR if architectural). — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)