### PR TITLE
docs(governance): assurance case + maintainer-continuity mechanism

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -46,6 +46,24 @@ The target model (to be formalized in a future governance ADR):
 4. **Technical Steering Committee (TSC)** — for large architectural decisions, once the contributor
    base exceeds ~10 regular contributors.
 
+## Continuity if the maintainer is incapacitated
+
+The project is designed to survive the loss of its single maintainer with minimal interruption
+(OpenSSF Best Practices `access_continuity`):
+
+1. **Credential continuity.** A designated trusted contact holds emergency access to the
+   maintainer's credential vault (a time-delayed grant via the vault provider's emergency-access
+   mechanism). The vault contains everything needed to assume the Maintainer role: repository owner
+   account access and recovery codes, and the release-signing key material. The identity of the
+   contact and vault specifics are deliberately not published.
+2. **No manual release machinery.** Releases are fully automated (release-please; see
+   [Release process](#release-process)) — the successor only needs merge rights to cut releases,
+   close issues, and accept changes. All CI/CD, infrastructure definitions, and governance rules
+   live in this repository as code; there are no undocumented manual steps.
+3. **Fork backstop.** Everything required to continue the project — source, documentation, CI
+   definitions, infrastructure-as-code, governance rules — is public under Apache-2.0, so the
+   community can continue the project from a fork even in the worst case.
+
 ## Decision-making
 
 - **Architectural decisions** are recorded as ADRs in `docs/adr/` (see [README](docs/adr/README.md)).

--- a/docs/assurance-case.md
+++ b/docs/assurance-case.md
@@ -1,0 +1,112 @@
+# OpenBank security assurance case
+
+This document is the project's **assurance case** (OpenSSF Best Practices, Silver
+`assurance_case`): a structured argument, with links to evidence, for why OpenBank's
+security requirements are met. It ties together the artifacts that already govern the
+platform — the STRIDE threat models, the machine-enforced rules in
+[`openbank-libs/governance/rules.yaml`](../openbank-libs/governance/rules.yaml), the
+architecture ADRs, and the CI gates — into one place.
+
+It follows the claim → argument → evidence structure. Sections: security requirements
+(§1), threat model (§2), trust boundaries (§3), secure-design argument (§4),
+common-weaknesses argument (§5), residual risks (§6).
+
+## 1. Security requirements (claims)
+
+OpenBank is a retail-banking platform reference implementation. Its top-level security
+claims, from which everything below derives:
+
+- **C1 — Money movement is correct and authorized.** No payment, posting, or card
+  operation happens without an authenticated principal, an authorization decision, and
+  (for money-path changes) four-eyes control. Double-entry invariants hold.
+- **C2 — The platform is tamper-evident.** Every security-relevant action is recorded
+  in an audit trail whose integrity is cryptographically verifiable.
+- **C3 — Personal and financial data are protected.** Access is deny-by-default and
+  scoped per principal type (customer, operator, AI agent, service).
+- **C4 — The supply chain is trustworthy.** What runs in production is provably built
+  from reviewed source with known dependencies.
+
+## 2. Threat model
+
+Threat modeling is per-service and CI-enforced, not a one-off document:
+
+- **33 STRIDE threat models** live in [`docs/threat-models/`](threat-models/), one per
+  service, each with data-flow diagram, trust-boundary inventory, and mitigations.
+- For every **money-path service** (the list is machine-readable in
+  [`rules.yaml: money_path_services`](../openbank-libs/governance/rules.yaml)) a threat
+  model is **required by CI** before changes merge (ADR-0030); such PRs additionally
+  need two approvals.
+- Platform-level threat actors considered: external customers (PSU), third-party
+  providers (TPP, PSD2 surface), operators, **AI agents** (first-class, least-privileged
+  principal type — ADR-0034), inbound clearing counterparties (untrusted ISO 20022 XML),
+  and a compromised CI or dependency (supply chain).
+
+## 3. Trust boundaries
+
+The platform's trust boundaries, each with its enforcement mechanism:
+
+| # | Boundary | Enforcement |
+|---|----------|-------------|
+| B1 | Internet → edge | TLS everywhere; OIDC via Keycloak; PSD2 SCA flows (sca-service) |
+| B2 | Between principal types (USER / OPERATOR / AI_AGENT / SERVICE) | Central **deny-by-default OPA policy** for both REST and MCP surfaces ([ADR-0034](adr/0034-unified-opa-authz-mcp-and-rest.md)); per-service Rego with CI coverage reporting |
+| B3 | Service → service | Kubernetes NetworkPolicies generated from declared config (default-deny); mTLS in-cluster; per-service DB credentials (no shared schemas) |
+| B4 | Inbound clearing files → domain | Typed parsers with totality guarantees; **fuzzed continuously** (Jazzer targets for `Pacs008Reader`, identity parsers — `fuzz/ossfuzz/`, ClusterFuzzLite on PRs) |
+| B5 | Event bus | Outbox pattern (no dual writes), versioned backward-compatible schemas (rule #4 in [CONTRIBUTING.md](../CONTRIBUTING.md)) |
+| B6 | Source → production (supply chain) | Signed commits (ruleset-enforced), PR-only merges, SLSA provenance + cosign-signed SBOM per release, digest-pinned images |
+
+## 4. Secure design principles applied (argument for C1–C3)
+
+- **Least privilege & complete mediation.** Authorization is centralized in OPA and
+  deny-by-default: an endpoint without an explicit allow rule returns 403. AI agents are
+  a separate, narrower principal class rather than inheriting operator rights
+  (ADR-0034). CI workflow tokens follow least privilege (Scorecard Token-Permissions
+  10/10).
+- **Separation of concerns / economy of mechanism.** Hexagonal architecture per service
+  ([ADR-0002](adr/0002-hexagonal-architecture-per-service.md)); the domain layer has
+  **zero framework imports** (CI-enforced purity gate), so business invariants —
+  double-entry balance, idempotency, four-eyes — are testable in isolation from any
+  transport concern.
+- **Defense in depth for money movement (C1).** A money-path change passes: 2 human
+  approvals + threat model (CI gate) → OPA authz at runtime → four-eyes approval flow on
+  money verbs → idempotency keys against replay → double-entry ledger invariants →
+  tamper-evident audit record.
+- **Tamper evidence (C2).** The audit trail is a hash-chained, verifiable log
+  ([ADR-0133](adr/0133-tamper-evident-audit-chain.md)); release evidence bundles (SBOM,
+  SLSA provenance, VEX) are cosign-signed and attached to every GitHub release.
+- **Fail-safe defaults.** Deny-by-default authz (B2); default-deny NetworkPolicies
+  (B3); new services must opt *in* to event dispatch and coverage floors rather than
+  silently opting out.
+
+## 5. Common implementation weaknesses countered (argument for C1–C4)
+
+| Weakness class | Countermeasure (with evidence) |
+|---|---|
+| Injection, SSRF, deserialization, path traversal | CodeQL SAST on **all** commits (Scorecard SAST 10/10); Jazzer sanitizers (SQLi, LDAP, SSRF, deserialization hooks) run against the parser boundary in CI fuzzing |
+| Malformed-input crashes (XXE, entity expansion, stack overflow) | Continuous fuzzing of untrusted-input parsers (B4); parser totality is an asserted property, not an assumption |
+| Known-vulnerable dependencies | Dependabot (7 ecosystems, weekly) + dependency-review gate + Trivy image scans + OSV over the committed dependency graph (`gradle/verification-metadata.xml`) — 0 known vulnerabilities at last scan (Scorecard Vulnerabilities 10/10) |
+| Dependency tampering | Gradle dependency verification (SHA-256 checksums committed); digest-pinned container images; SHA-pinned GitHub Actions (Scorecard Pinned-Dependencies) |
+| Secret leakage | Gitleaks CI gate + GitHub push protection; secrets live in AWS Secrets Manager / OpenBao, never in the repo |
+| Weak cryptography | No home-grown crypto: OIDC/JWT via Keycloak (RS256), cosign/KMS (ECDSA P-256, SHA-256) for signing, GPG-signed commits; no SHA-1/CBC-mode dependence in project defaults |
+| Regression of fixed bugs | Ratchet-only coverage rule (coverage may never drop, rule #5); Pact contract tests broker-verified in CI; mutation testing lane (pitest) |
+| Unreviewed changes | PR-only merges to `main` (ruleset), Conventional-Commit-driven release notes, independent LLM reviewer + human review, 2 approvals on money path |
+
+## 6. Residual risks and roadmap
+
+Known, openly tracked gaps (honesty is part of the assurance argument):
+
+- **Fleet statement coverage is ~59 %**, below the 80 % Silver bar; the ratchet
+  roadmap (issue #321) raises per-service floors quarterly, money-path first.
+- **Bus factor 1.** Mitigated by the continuity mechanism in
+  [GOVERNANCE.md](../GOVERNANCE.md#continuity-if-the-maintainer-is-incapacitated); a
+  second maintainer remains the target (GOVERNANCE.md, "Path to distributed
+  governance").
+- **Reproducible builds** are not yet bit-for-bit verified (jar timestamps); candidate
+  follow-up tracked in the SSDLC audit backlog.
+
+## Maintenance
+
+This assurance case is updated whenever a new ADR changes a trust boundary or a
+mitigation, and reviewed as part of each periodic security audit (ADR-0030). Evidence
+links intentionally point at CI-enforced artifacts (rules.yaml, workflows, threat-model
+gate) rather than prose, so drift between the argument and reality is caught by the
+same machinery it describes.

--- a/docs/openssf-silver-assessment.md
+++ b/docs/openssf-silver-assessment.md
@@ -14,7 +14,7 @@ Legend: **Met** — paste the justification; **Unmet** — the honest gap and wh
 |---|---|---|
 | `governance` | **Met** | GOVERNANCE.md documents the decision model: single-maintainer beta with ADRs (docs/adr/, 140+) as the binding decision mechanism, 2-approval rule for money-path code, 24-hour PR hold, and the documented path to distributed governance. |
 | `roles_responsibilities` | **Met** | GOVERNANCE.md + CODEOWNERS define maintainer duties; money-path services require maintainer + external technical reviewer (2 approvals). |
-| `access_continuity` | **Unmet** (honest) | Bus factor 1 is stated openly in GOVERNANCE.md and ADR-0146. Closing requires a second maintainer with owner access — tracked as the top governance follow-up of the 2026-07 SSDLC audit. |
+| `access_continuity` | **Met** (2026-07-08) | GOVERNANCE.md § "Continuity if the maintainer is incapacitated": a designated trusted contact holds time-delayed emergency access to the maintainer's credential vault (repo owner account + recovery codes + signing keys); releases are fully automated (release-please), so merge rights alone suffice to release; public Apache-2.0 repo is the fork backstop. |
 | `bus_factor` | **Unmet** (honest) | Same as `access_continuity`; the criterion needs ≥2 significant contributors. |
 | `documentation_roadmap` | **Met** | Governance follow-ups live as labeled GitHub issues (ADR-0052 backlog discipline); the coverage/mutation roadmap is issue #321; rules.yaml `target_enforce_date` fields (ADR-0144) are the enforcement roadmap, machine-readable. |
 | `documentation_architecture` | **Met** | docs/adr/ — 140+ Architecture Decision Records with status + delivery tracking; per-service CLAUDE.md; hexagonal architecture spec in ADR-0002. |
@@ -48,7 +48,7 @@ Legend: **Met** — paste the justification; **Unmet** — the honest gap and wh
 | `regression_tests_added50` | **Met** | Bug-class regressions get dedicated CI guards (duplicate-YAML-keys, outbox dispatch flag, DomainEvent ctor, runBlocking Unit…) — regression tests are the house style. |
 | `test_policy_mandated` | **Met** | CONTRIBUTING.md DoD: "Test the new behavior"; coverage is ratchet-only (never lower), enforced by koverVerify per service. |
 | `test_most` | **Met** | Coverage ratchet + per-service floors (e.g. transaction 85, fraud 85, domestic-payment 75); mutation testing (pitest) on 9 money-path services weekly. |
-| `test_statement_coverage80` / `test_branch_coverage80` / `test_statement_coverage90` | **Unmet** (honest) | Fleet-wide 80% statement coverage is not yet reached; the ratchet roadmap (#321) drives money-path floors to ≥70% and beyond, quarterly. |
+| `test_statement_coverage80` / `test_branch_coverage80` / `test_statement_coverage90` | **Unmet** (honest) | Fleet-wide statement coverage is 58.7% (codecov, 2026-07-08) — below the 80% bar. The ratchet roadmap (#321) drives money-path floors to ≥70% and beyond, quarterly. This is the single remaining Silver blocker (98% cap until closed). |
 | `coding_standards` / `coding_standards_enforced` | **Met** | detekt (maxIssues=0 vs baseline) + ktlint wired into `check`; path-scoped CI enforces on every PR. |
 | `build_standard_variables` / `build_non_recursive` | **Met** | Standard Gradle conventions; convention plugins in build-logic/; no recursive make. |
 | `build_preserve_debug` | **Met** | JVM bytecode retains debug info by default; fast-jar packaging does not strip. |
@@ -73,7 +73,7 @@ Legend: **Met** — paste the justification; **Unmet** — the honest gap and wh
 | `crypto_verification_private` | **Met** | Private keys never in repo (gitleaks custom rules + push protection); signing via cloud KMS only. |
 | `security_review` | **Met** | External pen-test performed (P0–P2 findings remediated, README); continuous CodeQL + Trivy + weekly Scorecard; threat models per money-path service. |
 | `hardening` | **Met** | Non-root containers, digest-pinned bases, Kyverno admission (signature Enforce, SBOM attestation Audit), NetworkPolicies generated from declared edges (ADR-0081), least-privilege workflow tokens. |
-| `assurance_case` | **Unmet** (honest) | No single assurance-case document yet. Candidate: docs/assurance-case.md tying threat models + gates + evidence bundles into one argument. Most raw material exists. |
+| `assurance_case` | **Met** (2026-07-08) | docs/assurance-case.md — claim→argument→evidence: security requirements, STRIDE threat-model inventory (33 models, CI-gated on money path), trust-boundary table (B1–B6), secure-design argument (deny-by-default OPA, hexagonal domain purity, defense-in-depth on money verbs, tamper-evident audit), common-weaknesses table (SAST, fuzzing, dependency posture, secrets, crypto). |
 | `copyright_per_file` / `license_per_file` | **Met** | SPDX headers fleet-wide (`SPDX-License-Identifier` in every source file). |
 
 ## Gold-only (listed for completeness)


### PR DESCRIPTION
## Summary

Repo-side artifacts for the two OpenSSF Silver MUST criteria that were honestly Unmet: a real **assurance case** (claim→argument→evidence over the threat models, rules.yaml gates and ADRs) and a documented **maintainer-continuity mechanism** (time-delayed vault emergency access for a designated trusted contact — identity deliberately unpublished; automated releases mean merge rights suffice; public repo as fork backstop). Assessment doc refreshed with the honest coverage number (58.7% — the single remaining Silver blocker).

## Type of change

- [x] docs

## Linked issues

Closes #589

## Changes

- `docs/assurance-case.md` — new: security requirements C1–C4, threat-model inventory, trust boundaries B1–B6, secure-design argument, common-weaknesses table, residual risks.
- `GOVERNANCE.md` — new section "Continuity if the maintainer is incapacitated".
- `docs/openssf-silver-assessment.md` — `assurance_case` + `access_continuity` → Met with pointers; coverage row gets the measured 58.7%.

## Definition of Done

- [x] Docs-only change — build/test/OpenAPI/Flyway/Avro N/A.
- [x] No new lint warnings.