### PR TITLE
chore(infra): drop 4 low-traffic VPC interface endpoints

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/ecr-pull-through-cache.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/ecr-pull-through-cache.tf
@@ -94,80 +94,46 @@ resource "aws_ecr_pull_through_cache_rule" "ecr_public" {
 }
 
 # ---------------------------------------------------------------------------
-# CodeArtifact VPC Interface endpoint — keeps Maven Central proxy traffic
-# in-VPC so Gradle dependency downloads never hit the NAT gateway.
+# CodeArtifact VPC Interface endpoints — REMOVED (FinOps #444, 2026-07-08).
 #
-# Flow: ARC runner pod → codeartifact VPC endpoint → CodeArtifact proxy →
-#       S3 Gateway endpoint (free) → S3. Zero NAT for any dep cached in CA.
-# Estimated saving: ~$25/day (measured from NAT-Bytes cost before this fix).
+# Originally added to keep Maven Central proxy traffic in-VPC for in-cluster
+# ARC runners doing Gradle builds (flow: ARC runner pod → codeartifact VPC
+# endpoint → CodeArtifact proxy → S3 Gateway endpoint (free) → S3), avoiding
+# an estimated ~$25/day of NAT-Bytes cost.
 #
-# The endpoint was deleted 2026-06-15 (was showing 0 bytes because runner
-# image lacked aws CLI → token fetch failed → Maven Central fallback over NAT).
-# Root cause fixed: runner image digest bumped to ce7b1171 which includes
-# aws CLI; CodeArtifact endpoint restored here so both legs work.
+# Post-#198 hosted-runner migration audit: that in-cluster Gradle-build flow
+# has moved to GitHub-hosted runners, so the endpoints' own justification is
+# largely gone. CloudWatch AWS/PrivateLinkEndpoints BytesProcessed over the
+# trailing 14 days confirmed it: codeartifact.api ~0.06 GB (~$0.006/mo
+# NAT-equivalent), codeartifact.repositories showed ZERO bytes / no metric
+# data at all. Fixed cost was ~$23/mo EACH (3 AZs × $0.0105/h × 730h) — both
+# fail the keep test by a wide margin. Any residual CodeArtifact calls (e.g.
+# the arc-runners.tf codeartifact:GetAuthorizationToken IAM policy) now route
+# over NAT; that path is a small, infrequent auth-token call, not bulk dep
+# downloads. Watch openbank-nat-egress-daily; if this regresses, restore both
+# resources verbatim (see open-bank-oss#444 / git history of this file).
 # ---------------------------------------------------------------------------
-resource "aws_vpc_endpoint" "codeartifact_api" {
-  vpc_id              = local.s.vpc_id
-  service_name        = "com.amazonaws.${local.region}.codeartifact.api"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.s.private_subnet_ids
-  security_group_ids  = [local.s.node_security_group_id]
-  private_dns_enabled = true
-
-  tags = {
-    Name      = "openbank-sandbox-codeartifact-api"
-    Project   = "openbank"
-    ManagedBy = "tofu"
-  }
-}
-
-resource "aws_vpc_endpoint" "codeartifact_repositories" {
-  vpc_id              = local.s.vpc_id
-  service_name        = "com.amazonaws.${local.region}.codeartifact.repositories"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.s.private_subnet_ids
-  security_group_ids  = [local.s.node_security_group_id]
-  private_dns_enabled = true
-
-  tags = {
-    Name      = "openbank-sandbox-codeartifact-repositories"
-    Project   = "openbank"
-    ManagedBy = "tofu"
-  }
-}
 
 # ---------------------------------------------------------------------------
-# EC2 VPC Interface endpoint — eliminates NAT for aws-node (VPC CNI) EC2 API
-# calls on every cluster node.
+# EC2 VPC Interface endpoint — REMOVED (FinOps #444, 2026-07-08).
 #
-# Problem: aws-node (Amazon VPC CNI DaemonSet in kube-system) polls the EC2 API
-# continuously for ENI / IP-address management — IPAM attach/detach,
-# DescribeNetworkInterfaces, AssignPrivateIpAddresses, etc. Without this endpoint
-# every call leaves the VPC over the NAT gateway. With 15-23 nodes each polling
-# every few seconds this produces steady background NAT from kube-system that the
-# D1 FinOps detector flags as "NAT egress 2× rolling avg — kube-system".
+# Originally added to eliminate NAT for aws-node (VPC CNI) EC2 API calls
+# (IPAM attach/detach, DescribeNetworkInterfaces, AssignPrivateIpAddresses)
+# plus Karpenter (DescribeInstances/CreateFleet/TerminateInstances) and
+# ebs-csi-driver (DescribeVolumes/AttachVolume) traffic — a steady background
+# poll from kube-system that the D1 FinOps detector watches for as "NAT
+# egress 2× rolling avg — kube-system".
 #
-# Also used by: Karpenter (DescribeInstances, CreateFleet, TerminateInstances),
-# ebs-csi-driver (DescribeVolumes, AttachVolume), EKS node bootstrap.
-#
-# Fix: once private DNS resolves ec2.eu-north-1.amazonaws.com to an in-VPC IP,
-# all these components go entirely over the private endpoint — zero NAT cost.
-# ---------------------------------------------------------------------------
-resource "aws_vpc_endpoint" "ec2" {
-  vpc_id              = local.s.vpc_id
-  service_name        = "com.amazonaws.${local.region}.ec2"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.s.private_subnet_ids
-  security_group_ids  = [local.s.node_security_group_id]
-  private_dns_enabled = true
-
-  tags = {
-    Name      = "openbank-sandbox-ec2"
-    Project   = "openbank"
-    ManagedBy = "tofu"
-  }
-}
-
+# Post-#198 hosted-runner migration audit: CloudWatch AWS/PrivateLinkEndpoints
+# BytesProcessed showed a steady ~100-190 MiB/day (~4 GB/month) — NAT-equivalent
+# cost ~$0.19/month vs the ~$23/month fixed cost of the endpoint (3 AZs ×
+# $0.0105/h × 730h). The traffic is real and continuous (this is NOT an idle
+# endpoint) but far too small in absolute bytes to justify the fixed cost —
+# ~150 MiB/day of added NAT baseline is well below the 20 GB/hour /
+# 2×-rolling-avg alarm thresholds. Watch openbank-nat-egress-daily and
+# openbank-nat-egress-20gb-per-hour for a "kube-system" anomaly signature; if
+# it regresses, restore this resource verbatim (see open-bank-oss#444 / git
+# history of this file).
 # ---------------------------------------------------------------------------
 # IAM: allow Karpenter nodes to create ECR repos on first pull.
 # Pull-through cache auto-creates a private repo on first use; the node role

--- a/openbank-infra/aws/modules/network/main.tf
+++ b/openbank-infra/aws/modules/network/main.tf
@@ -252,7 +252,6 @@ locals {
   interface_endpoints = [
     "ecr.api",
     "ecr.dkr",
-    "sts",
     # ssm/ssmmessages/ec2messages removed (FinOps 2026-06-05): these were added
     # for the retired EC2 self-hosted runner model (ADR-0082). With EKS+kubectl
     # node access and ARC ephemeral runners gone, SSM Session Manager is not
@@ -269,6 +268,27 @@ locals {
     # (dominant volume = 10+ GB/day), remaining api+authenticator volume is tiny
     # and can go via NAT ($0.045/GB vs endpoint standing charge $0.72/day).
     # Fluent Bit ships to in-cluster Loki (not CloudWatch), so no other consumer.
+    #
+    # sts removed (FinOps #444, 2026-07-08): post-#198 hosted-runner migration
+    # audit. CloudWatch AWS/PrivateLinkEndpoints BytesProcessed showed ~0.23 GB
+    # over the trailing 14 days (~0.5 GB/month) — NAT-equivalent cost ~$0.02/mo
+    # vs the ~$23/mo fixed cost of the endpoint (3 AZs × $0.0105/h × 730h).
+    # IRSA/STS token exchange still works fine over the NAT path (STS is a
+    # low-volume, small-payload auth API, not a bulk-data one) — no security
+    # posture change, just no longer routed privately. Watch
+    # openbank-nat-egress-daily; if this regresses, revert is a one-line list
+    # entry (see open-bank-oss#444).
+    #
+    # ecr.api / ecr.dkr KEPT despite also being low-traffic on this measurement
+    # window (ecr.api ~0.2 GB/14d, ecr.dkr ~25.5 GB/14d but bursty up to
+    # 6-10 GB on deploy/Karpenter-churn days): both are the transport for the
+    # ECR pull-through cache (envs/sandbox-platform/ecr-pull-through-cache.tf)
+    # that every Karpenter node image pull depends on. ecr.dkr carries the
+    # actual layer bytes; ecr.api carries the paired auth/manifest calls for
+    # the same flow. Removing either pushes ALL node image pulls back onto
+    # NAT, which is the exact cost this pair was built to eliminate — traffic
+    # here scales with deploy/node-churn activity, not a flat baseline, so a
+    # quiet 14-day sample understates its long-run value.
   ]
 }
 


### PR DESCRIPTION
## Summary

Audits the 6 VPC Interface endpoints (+ 1 free S3 Gateway endpoint, always kept)
against actual traffic since #198 moved non-cluster CI jobs to GitHub-hosted
runners. Drops 4 endpoints whose measured NAT-equivalent traffic cost is far
below their fixed hourly cost; keeps 2 (`ecr.api`, `ecr.dkr`) on architectural
grounds even though their current-window traffic also undershoots the pure
cost test.

Closes #444

## Method

- Confirmed June's `VpcEndpoint-Hours` line item via Cost Explorer (grouped by
  `USAGE_TYPE` under the `Amazon Virtual Private Cloud` service, not `EC2 - Other`):
  **`EUN1-VpcEndpoint-Hours = $147.67`** (qty 14,064 hours), data-processing
  itself was only `$0.36`. This matches 6 interface endpoints × 3 AZs ×
  $0.0105/h × 730h ≈ **$138/mo fixed**, plus overlap from an endpoint removed
  mid-June.
- Verified current live endpoints: `aws ec2 describe-vpc-endpoints` (region
  `eu-north-1`) — 1 Gateway (`s3`, free) + 6 Interface (`sts`, `ecr.dkr`,
  `ecr.api`, `codeartifact.api`, `codeartifact.repositories`, `ec2`).
- Pulled 10–14 days of `AWS/PrivateLinkEndpoints` `BytesProcessed` per endpoint
  (summed across all 3 AZ subnets, since CloudWatch requires the full dimension
  set — `VPC Id` + `VPC Endpoint Id` + `Endpoint Type` + `Subnet Id` +
  `Service Name` — for `get-metric-statistics` to return data).
- Verified NAT data-processing price for `eu-north-1` via the AWS Pricing API:
  **$0.046/GB** (matches the repo's existing $0.045/GB estimate).
- Verified VPC Interface endpoint fixed price: **$0.0105/AZ-hour** →
  **~$23/mo per endpoint** (3 AZs), not the issue's simplified $7.3/mo — that
  figure appears to be a single-AZ number.

## Decision table

| Endpoint | Type | Measured window | Monthly est. bytes | NAT-equiv $/mo | Fixed $/mo | Verdict |
|---|---|---|---|---|---|---|
| `s3` | Gateway | n/a | n/a | n/a | $0 | **KEEP** (free, gateway endpoints have no hourly charge) |
| `ecr.dkr` | Interface | 14d, 25.5 GB (bursty: 150 MiB–10 GB/day) | ~55 GB | $2.52 | $23.00 | **KEEP** — see below |
| `ecr.api` | Interface | 14d, 0.20 GB | ~0.43 GB | $0.02 | $23.00 | **KEEP** — see below |
| `sts` | Interface | 14d, 0.23 GB | ~0.50 GB | $0.02 | $23.00 | **DROP** |
| `ec2` | Interface | 10d, 1.34 GB (steady ~100–190 MiB/day) | ~4.0 GB | $0.19 | $23.00 | **DROP** |
| `codeartifact.api` | Interface | 14d, 0.06 GB | ~0.13 GB | $0.006 | $23.00 | **DROP** |
| `codeartifact.repositories` | Interface | 14d, **0 bytes** (no CloudWatch metric at all) | 0 | $0 | $23.00 | **DROP** |

**Dropped this PR:** `sts`, `ec2`, `codeartifact.api`, `codeartifact.repositories`
— all fail the keep test (NAT-equivalent cost of their traffic ≪ $23/mo fixed
cost) by 2–3 orders of magnitude, and none has a compelling non-cost reason to
stay:
- `sts`: IRSA/STS token exchange is small-payload, low-volume by nature (that's
  normal for an auth API, not evidence of being "broken"); it works fine over
  NAT/public internet, so there's no security-posture change from removing the
  private path.
- `ec2`: this is genuinely continuous background traffic (aws-node/Karpenter/
  ebs-csi EC2 API polling, confirmed live via real node churn — ages 19m/57m/
  6d/28d during this audit), not an idle endpoint. But ~150 MiB/day is small
  enough that it won't trip `openbank-nat-egress-20gb-per-hour`.
- `codeartifact.api` / `codeartifact.repositories`: per the existing comment in
  `ecr-pull-through-cache.tf`, these were sized for in-cluster ARC runners
  doing Gradle builds (avoiding an estimated ~$25/day of Maven Central NAT
  traffic). That workload moved to GitHub-hosted runners under #198 — the
  near-zero measured traffic confirms the endpoints' original justification is
  gone. `codeartifact.repositories` shows literally zero bytes / no CloudWatch
  metric at all.

**Kept despite failing the raw current-traffic test:** `ecr.api`, `ecr.dkr`.
These are the transport for the ECR pull-through cache
(`openbank-infra/aws/envs/sandbox-platform/ecr-pull-through-cache.tf`) that
every Karpenter node image pull depends on (quay.io/ghcr.io/registry.k8s.io/
public.ecr.aws rewrites via Kyverno, plus native ECR/private image pulls).
`ecr.dkr` traffic in the measured window was bursty — 150–550 MiB on quiet
days, 6–10 GB on days with fleet activity (image builds/deploys) — so a quiet
14-day sample understates its long-run value; removing it would push all node
image pulls back onto NAT, which is the exact cost this endpoint (and the
whole pull-through-cache architecture) was built to avoid. `ecr.api` is the
paired auth/manifest-call sibling in the same flow and same
`local.interface_endpoints` list; removing it in isolation saves almost
nothing (its own traffic is tiny) while breaking architectural symmetry.

## Changes

- `openbank-infra/aws/modules/network/main.tf`: removed `"sts"` from
  `local.interface_endpoints` (sandbox-substrate network module).
- `openbank-infra/aws/envs/sandbox-platform/ecr-pull-through-cache.tf`: removed
  the `aws_vpc_endpoint.codeartifact_api`, `aws_vpc_endpoint.codeartifact_repositories`,
  and `aws_vpc_endpoint.ec2` resources; left explanatory comments in place of
  each (with the measured numbers) for future auditability, matching the
  existing style already used for endpoints removed in prior FinOps passes
  (`ssm`/`ssmmessages`/`ec2messages`, `eks`, `logs`).

`tofu validate` passes clean (only pre-existing, unrelated deprecation
warnings) for both `envs/sandbox-substrate` and `envs/sandbox-platform`. No
other Terraform resource references the removed endpoints or their security
group ids.

## Safety net

Per ADR-0060, this PR does **not** run `tofu apply` — that's a manual
`platform-tofu.yml` dispatch by a human after review. CI's automatic
`tofu plan (preview)` should be green on this PR.

If any of these drops turns out to matter, the traffic doesn't just fail
silently — it shows up as NAT egress instead, and the existing
`openbank-nat-egress-daily` / `openbank-nat-egress-20gb-per-hour` CloudWatch
alarms are the safety net. The fix in that case is a one-line revert (restore
the removed list entry / resource block — full previous content is in git
history of this PR's parent commit).

## Test plan

- [x] `tofu validate` clean in `envs/sandbox-substrate` and
      `envs/sandbox-platform` (pre-existing unrelated deprecation warnings only)
- [x] Confirmed no other `.tf` file references the removed endpoint resources
      or reuses their security-group/subnet locals exclusively
- [ ] CI `tofu plan (preview)` on this PR — should show only the 4 endpoint
      deletions (`sts` in the substrate network module's `for_each`,
      `codeartifact_api`/`codeartifact_repositories`/`ec2` in sandbox-platform)
- [ ] Human review + manual `platform-tofu.yml` dispatch to actually apply
- [ ] Watch `openbank-nat-egress-daily` for one week post-apply for a
      regression signature on any of the 4 dropped endpoints
