### PR TITLE
feat(infra): off-hours scale-down of the sandbox app-plane

### DIFF
--- a/openbank-infra/gitops/apps/finops-scaledown.yaml
+++ b/openbank-infra/gitops/apps/finops-scaledown.yaml
@@ -1,0 +1,35 @@
+# ArgoCD app for the off-hours app-plane scale-down (issue #446, ADR-0057
+# "coarse backstop"). Two CronJobs (22:00 / 07:00 Europe/Prague) that scale
+# the Deployments/Rollouts listed in configmap-allowlist.yaml to 0/1
+# replicas. Namespace-scoped RBAC only (rbac.yaml) — this Application does
+# NOT touch any other Application's resources; it only reads its own
+# manifests here and, at runtime, patches the `scale` subresource of the
+# workloads named in the allowlist ConfigMap.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: finops-scaledown
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: git@github.com:JiRaska/open-bank-oss.git
+    targetRevision: main
+    path: openbank-infra/gitops/components/finops-scaledown
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: finops-scaledown
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 15s
+        factor: 2
+        maxDuration: 5m
+    syncOptions:
+      - CreateNamespace=false

--- a/openbank-infra/gitops/components/finops-scaledown/configmap-allowlist.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/configmap-allowlist.yaml
@@ -1,0 +1,108 @@
+# Explicit, human-reviewable allowlist/denylist for the off-hours scale-down
+# (issue #446). This ConfigMap is the single source of truth both CronJobs
+# read from — edit THIS file to add/remove a target, never the CronJob
+# command inline. RBAC (rbac.yaml) is the actual enforcement boundary: a
+# namespace added here without a matching RoleBinding will just fail closed
+# (kubectl returns Forbidden, the job logs it and moves on — see
+# concurrencyPolicy/errexit notes in the CronJobs).
+#
+# KEEP-ALIVE (never listed in DOWNSCALE_TARGETS below), and why:
+#   - admin-ui           : task requirement — the demo's own front door.
+#   - customer-edge      : task requirement — sole internet->cluster path for
+#                          the retail-app showcase (ADR-0065).
+#   - iam (Keycloak)      : both of the above do a live OIDC handshake against
+#                          it on every login; scaling it down 500s every
+#                          "browsable" claim above it.
+#   - observability       : Prometheus/Grafana/Loki/Tempo/Alertmanager run on
+#                          their OWN dedicated on-demand NodePool already
+#                          (components/observability/nodepool-observability.yaml)
+#                          precisely so they are never subject to spot/
+#                          consolidation churn — scaling them down here would
+#                          fight that isolation for a stack that is already
+#                          FinOps-lean (single replica, 12h retention) and is
+#                          what makes the demo "look alive" in the first place.
+#                          Deliberately whole-namespace excluded rather than
+#                          cherry-picking Helm-generated Deployment names,
+#                          which are chart-version-fragile.
+#
+# ALSO EXCLUDED (not app-plane, or already self-managing scale-to-zero):
+#   - product-catalog, interest-service, sdd-service, card-issuance-service:
+#     already KEDA HTTPScaledObject-managed (ADR-0057 T1). A CronJob forcing
+#     replicas=0 would race the KEDA-managed HPA that owns their replica
+#     count; excluded so the two controllers never fight over the same field.
+#   - notification-service: KEDA ScaledObject with minReplicaCount:1 (the
+#     customer-edge notification feed is a synchronous read) — same reason.
+#   - Kafka (Strimzi KafkaNodePool), Temporal (Helm release), CNPG Postgres
+#     clusters: stateful, operator-managed, NOT a plain Deployment/Rollout —
+#     `kubectl scale` does not apply the same way, and a broker/DB restart
+#     risk (WAL replay, Multi-Attach EBS, per ADR-0082's own postmortem on
+#     the observability NodePool) outweighs the modest saving here. Left for
+#     a future, deliberate change (KEDA Kafka-lag scaling per ADR-0057 T2),
+#     not a blunt cron.
+#   - pact-broker, reposilite, registry-cache, gradle-build-cache: CI-adjacent
+#     caches that a CI run may need at any hour (contract verification,
+#     dependency resolution), independent of EU daytime demo traffic.
+#   - external-dns, external-secrets, kyverno, argo-rollouts (controllers):
+#     cluster platform plumbing, not app-plane; near-zero idle cost and other
+#     components' reconciliation depends on them being up continuously.
+#
+# SCALE-DOWN TARGETS: every remaining app-plane service, INCLUDING every
+# money-path service in openbank-libs/governance/rules.yaml:money_path_services
+# (ledger, transaction, account, balance, sepa-payment, sepa-instant,
+# domestic-payment, clearing, swift, fx, lending, sca, consent, fraud,
+# billing, settlement). This is deliberate per issue #446: the sandbox has
+# NO SLA (ADR-0057) and no real money moves through it, so the same
+# money-path services that need 2 approvals + a threat model to touch in
+# rules.yaml are explicitly fine to scale to zero overnight here — the
+# ADR-0030 threat-model gate governs CODE/CONFIG changes to these services,
+# not a sandbox's off-hours compute floor.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: finops-scaledown-allowlist
+  namespace: finops-scaledown
+  labels:
+    app.kubernetes.io/part-of: finops-scaledown
+data:
+  # Format: one "<namespace>/<kind>/<name>" entry per line. <kind> is
+  # "deployment" or "rollout" (both support the `scale` subresource, so
+  # `kubectl scale <kind>/<name> -n <namespace> --replicas=N` works
+  # identically for either — ADR-0098 notes Rollout is a drop-in
+  # Deployment replacement including the scale subresource).
+  DOWNSCALE_TARGETS: |
+    accounts/rollout/account-service
+    aml/deployment/aml-service
+    anacredit/deployment/anacredit-service
+    audit/deployment/audit-service
+    balances/rollout/balance-service
+    billing/deployment/billing-service
+    consent/rollout/consent-service
+    developer-portal/deployment/developer-portal
+    dispute/deployment/dispute-service
+    finrep/deployment/finrep-service
+    fraud/rollout/fraud-service
+    fx/rollout/fx-service
+    kyc/rollout/kyc-service
+    ledger/rollout/ledger-service
+    lending/rollout/lending-service
+    onboarding/rollout/onboarding-service
+    party/rollout/party-service
+    payments/rollout/transaction-service
+    payments/rollout/sepa-payment
+    payments/rollout/domestic-payment
+    payments/rollout/sepa-instant
+    payments/rollout/clearing-service
+    payments/deployment/standing-order-service
+    payments/rollout/settlement-service
+    payments/deployment/clearing-simulator
+    payments/rollout/swift-service
+    pid/deployment/pid-service
+    psd2/deployment/psd2-service
+    sanctions/rollout/sanctions-service
+    sca/rollout/sca-service
+    statements/deployment/statement-service
+    tpp-registry/deployment/tpp-registry-service
+    platform/deployment/agent-service
+    platform/deployment/copilot-service
+    devops-agent/deployment/devops-agent
+    finops-agent/deployment/finops-agent

--- a/openbank-infra/gitops/components/finops-scaledown/configmap-allowlist.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/configmap-allowlist.yaml
@@ -24,6 +24,57 @@
 #                          Deliberately whole-namespace excluded rather than
 #                          cherry-picking Helm-generated Deployment names,
 #                          which are chart-version-fragile.
+#   - ledger-service, transaction-service, account-service, balance-service:
+#     added after PR review (issue #446 follow-up). standing-order-service's
+#     StandingOrderExecutionScheduler runs a REAL, enabled-by-default batch
+#     job at a FIXED time — 03:00 UTC (openbank.scheduler.execution-cron,
+#     openbank-standing-order-service/src/main/resources/application.yaml)
+#     — that posts due standing-order payments through exactly this chain.
+#     03:00 UTC = 04:00 Prague (CET) / 05:00 Prague (CEST): squarely inside
+#     the 22:00-07:00 down window, every single night. A once-daily FIXED
+#     cron (unlike a `*/30` or hourly one) has no graceful degradation: if
+#     standing-order-service itself is at 0 replicas when its one daily tick
+#     is due, the tick is simply never scheduled — Quarkus doesn't queue a
+#     missed cron for next boot, so the sweep would silently never run,
+#     indefinitely (weekday wake-up at 07:00 Prague is itself well past the
+#     day's only window, and the following night's 03:00 UTC is back inside
+#     the down period again). Rather than fight cron timing, standing-order-
+#     service AND the "core" chain nearly everything transitively depends on
+#     (ledger, transaction, account, balance) stay up continuously. This
+#     still captures most of the saving: the payment-scheme-specific
+#     services (sepa-payment, sepa-instant, domestic-payment, clearing,
+#     swift, fx, lending, sca, consent, fraud, billing, settlement) are
+#     still scaled down.
+#
+# OTHER SCHEDULED-JOB / DOWN-WINDOW COLLISIONS CHECKED (grep for
+# `@Scheduled(cron` across every service), not exempted:
+#   - onboarding-service AbandonedRegistrationCleaner: real, unconditional,
+#     fixed cron at 02:00 UTC (0 0 2 * * ?) — same "fixed once-daily inside
+#     the window" shape as standing-order-service above, but NOT exempted:
+#     the job only suspends registrations stuck >=30 days in early KYC, a
+#     housekeeping sweep with no money movement, fully idempotent, and
+#     reversible by an operator from the admin-UI (ADR-0068). Missing a
+#     night (or every night, worst case) delays a 30-day-stale cleanup by a
+#     few hours to a day — judged acceptable for a no-SLA sandbox, unlike a
+#     payment-execution job. Flagged here for visibility, not fixed.
+#   - agent-service OversightService (agent.oversight.cron, sandbox default
+#     `*/30 * * * *`) and consent-service ConsentExpirationJob (`0 5 * * *`,
+#     hourly): both are RECURRING (every 30 min / every hour), not a single
+#     fixed daily window, so scaling to 0 overnight just pauses the ticks —
+#     they resume on schedule once the pod is back at replicas=1. This is
+#     the intended, graceful degradation the whole PR relies on, not a bug.
+#   - notification-service NotificationOutboxDeadLetterJanitorJob (02:00
+#     UTC) and DeviceTokenSweepJob (03:00 UTC): both real fixed-time crons,
+#     but notification-service is already KEDA-managed with
+#     minReplicaCount: 1 (see below) — never at 0 replicas, no collision.
+#   - statement-service PeriodCloseScheduler and sdd-service
+#     MandateExpiryScheduler: confirmed DISABLED by default
+#     (openbank.statement.scheduled-close.enabled / openbank.sdd.expiry.enabled,
+#     both default "false", not overridden in gitops) — dead code today, no
+#     live collision.
+#   - analytics-sink ReconciliationJob: the service has no
+#     openbank-infra/gitops component/Application at all — not deployed to
+#     the sandbox cluster, so not in scope.
 #
 # ALSO EXCLUDED (not app-plane, or already self-managing scale-to-zero):
 #   - product-catalog, interest-service, sdd-service, card-issuance-service:
@@ -46,16 +97,19 @@
 #     cluster platform plumbing, not app-plane; near-zero idle cost and other
 #     components' reconciliation depends on them being up continuously.
 #
-# SCALE-DOWN TARGETS: every remaining app-plane service, INCLUDING every
-# money-path service in openbank-libs/governance/rules.yaml:money_path_services
-# (ledger, transaction, account, balance, sepa-payment, sepa-instant,
-# domestic-payment, clearing, swift, fx, lending, sca, consent, fraud,
-# billing, settlement). This is deliberate per issue #446: the sandbox has
-# NO SLA (ADR-0057) and no real money moves through it, so the same
-# money-path services that need 2 approvals + a threat model to touch in
-# rules.yaml are explicitly fine to scale to zero overnight here — the
-# ADR-0030 threat-model gate governs CODE/CONFIG changes to these services,
-# not a sandbox's off-hours compute floor.
+# SCALE-DOWN TARGETS: every remaining app-plane service, INCLUDING most of
+# openbank-libs/governance/rules.yaml:money_path_services (sepa-payment,
+# sepa-instant, domestic-payment, clearing, swift, fx, lending, sca,
+# consent, fraud, billing, settlement) — EXCEPT ledger, transaction,
+# account and balance, which moved to the keep-alive list above (see the
+# standing-order-service cron-collision note). This is still deliberate per
+# issue #446: the sandbox has NO SLA (ADR-0057) and no real money moves
+# through it, so money-path services that need 2 approvals + a threat model
+# to touch in rules.yaml are explicitly fine to scale to zero overnight here
+# — the ADR-0030 threat-model gate governs CODE/CONFIG changes to these
+# services, not a sandbox's off-hours compute floor. The four exempted
+# services are kept alive purely for the cron-correctness reason above, not
+# because they're money-path (that would have been true of ALL thirteen).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -70,11 +124,9 @@ data:
   # identically for either — ADR-0098 notes Rollout is a drop-in
   # Deployment replacement including the scale subresource).
   DOWNSCALE_TARGETS: |
-    accounts/rollout/account-service
     aml/deployment/aml-service
     anacredit/deployment/anacredit-service
     audit/deployment/audit-service
-    balances/rollout/balance-service
     billing/deployment/billing-service
     consent/rollout/consent-service
     developer-portal/deployment/developer-portal
@@ -83,16 +135,13 @@ data:
     fraud/rollout/fraud-service
     fx/rollout/fx-service
     kyc/rollout/kyc-service
-    ledger/rollout/ledger-service
     lending/rollout/lending-service
     onboarding/rollout/onboarding-service
     party/rollout/party-service
-    payments/rollout/transaction-service
     payments/rollout/sepa-payment
     payments/rollout/domestic-payment
     payments/rollout/sepa-instant
     payments/rollout/clearing-service
-    payments/deployment/standing-order-service
     payments/rollout/settlement-service
     payments/deployment/clearing-simulator
     payments/rollout/swift-service

--- a/openbank-infra/gitops/components/finops-scaledown/configmap-allowlist.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/configmap-allowlist.yaml
@@ -45,21 +45,39 @@
 #     services (sepa-payment, sepa-instant, domestic-payment, clearing,
 #     swift, fx, lending, sca, consent, fraud, billing, settlement) are
 #     still scaled down.
+#   - kyc-service: same fixed-once-daily-cron bug, found during the same
+#     audit that caught standing-order-service above. KycRetentionScheduler
+#     enforces the AML Act §16 5-year KYC-case hard-delete retention policy,
+#     `enabled=true` by default (openbank.retention.kyc.enabled), fixed cron
+#     at 03:30 UTC (openbank.retention.kyc.cron) — inside the down window
+#     every night, same silent-never-fires risk as standing-order-service,
+#     except this one is a REGULATORY retention control (ADR-0118 SS5), not
+#     just a demo feature. Unlike standing-order-service, kyc-service has no
+#     synchronous cross-service dependency for this job (it only touches its
+#     own Postgres), so no dependency chain needed — kyc-service alone moves
+#     to keep-alive. It was the only scale-down target in the `kyc`
+#     namespace, so that RoleBinding was removed entirely (same as
+#     accounts/balances/ledger above).
 #
-# OTHER SCHEDULED-JOB / DOWN-WINDOW COLLISIONS CHECKED (grep for
-# `@Scheduled(cron` across every service), not exempted:
+# OTHER SCHEDULED-JOB / DOWN-WINDOW COLLISIONS CHECKED (grepped for every
+# `@Scheduled` in the fleet, not just the single-line `@Scheduled(cron`
+# pattern — the multi-line annotation form used by most of these was missed
+# by the first pass), not exempted:
 #   - onboarding-service AbandonedRegistrationCleaner: real, unconditional,
 #     fixed cron at 02:00 UTC (0 0 2 * * ?) — same "fixed once-daily inside
-#     the window" shape as standing-order-service above, but NOT exempted:
-#     the job only suspends registrations stuck >=30 days in early KYC, a
-#     housekeeping sweep with no money movement, fully idempotent, and
-#     reversible by an operator from the admin-UI (ADR-0068). Missing a
-#     night (or every night, worst case) delays a 30-day-stale cleanup by a
-#     few hours to a day — judged acceptable for a no-SLA sandbox, unlike a
-#     payment-execution job. Flagged here for visibility, not fixed.
+#     the window" shape as standing-order-service/kyc-service above, but
+#     NOT exempted: the job only suspends registrations stuck >=30 days in
+#     early KYC, a housekeeping sweep with no money movement, fully
+#     idempotent, and reversible by an operator from the admin-UI
+#     (ADR-0068). Missing a night (or every night, worst case) delays a
+#     30-day-stale cleanup by a few hours to a day — judged acceptable for
+#     a no-SLA sandbox, unlike a payment-execution or regulatory-retention
+#     job. Flagged here for visibility, not fixed.
 #   - agent-service OversightService (agent.oversight.cron, sandbox default
-#     `*/30 * * * *`) and consent-service ConsentExpirationJob (`0 5 * * *`,
-#     hourly): both are RECURRING (every 30 min / every hour), not a single
+#     `*/30 * * * *`), consent-service ConsentExpirationJob (`0 5 * * *`,
+#     hourly), lending-service InterestAccrualScheduler and
+#     ProvisioningCycleScheduler (both `every = ...`, fixed-RATE not
+#     fixed-cron): all RECURRING (every N minutes/hours), not a single
 #     fixed daily window, so scaling to 0 overnight just pauses the ticks —
 #     they resume on schedule once the pod is back at replicas=1. This is
 #     the intended, graceful degradation the whole PR relies on, not a bug.
@@ -67,6 +85,32 @@
 #     UTC) and DeviceTokenSweepJob (03:00 UTC): both real fixed-time crons,
 #     but notification-service is already KEDA-managed with
 #     minReplicaCount: 1 (see below) — never at 0 replicas, no collision.
+#   - card-issuance-service CardPiiRetentionScheduler (03:00 UTC,
+#     enabled=true, AML Act SS16 card-PII anonymisation — same regulatory
+#     shape as kyc-service's job above): already on the keep-alive list
+#     because it's KEDA HTTPScaledObject-managed (T1), so THIS CronJob
+#     never touches it — no collision from this PR. (KEDA's own
+#     scale-to-zero-on-idle is a separate, pre-existing mechanism outside
+#     this PR's scope; not introduced or changed here.)
+#   - ledger-service TieOutScheduler (06:00 UTC) and FxRevaluationScheduler
+#     (15:00 UTC), balance-service BalanceReconciliationScheduler (23:30
+#     UTC): all real fixed-time crons, but ledger-service and
+#     balance-service are BOTH already on the keep-alive list (the
+#     standing-order-service fix above) — no collision.
+#   - fx-service CnbRateIngestionScheduler (14:40 UTC): real fixed-time
+#     cron, but 14:40 UTC (15:40/16:40 Prague) falls OUTSIDE the 22:00-07:00
+#     down window entirely — no collision regardless of fx-service being
+#     scaled down.
+#   - billing-service BillingCycleScheduler (monthly, 03:00 UTC on the 1st):
+#     confirmed DISABLED by default (openbank.billing.scheduler.enabled
+#     defaults to "false", not overridden in gitops; the KDoc explains the
+#     account-batch has no fleet-wide account-discovery port yet) — dead
+#     code today, no live collision.
+#   - audit-service SessionLogRetentionScheduler (04:00 UTC): confirmed
+#     DISABLED by default (openbank.retention.session-log.enabled defaults
+#     to "false", deliberately — the KDoc says merging must not itself
+#     cause any deletion against a brand-new table) — dead code today, no
+#     live collision.
 #   - statement-service PeriodCloseScheduler and sdd-service
 #     MandateExpiryScheduler: confirmed DISABLED by default
 #     (openbank.statement.scheduled-close.enabled / openbank.sdd.expiry.enabled,
@@ -102,14 +146,17 @@
 # sepa-instant, domestic-payment, clearing, swift, fx, lending, sca,
 # consent, fraud, billing, settlement) — EXCEPT ledger, transaction,
 # account and balance, which moved to the keep-alive list above (see the
-# standing-order-service cron-collision note). This is still deliberate per
-# issue #446: the sandbox has NO SLA (ADR-0057) and no real money moves
-# through it, so money-path services that need 2 approvals + a threat model
-# to touch in rules.yaml are explicitly fine to scale to zero overnight here
-# — the ADR-0030 threat-model gate governs CODE/CONFIG changes to these
-# services, not a sandbox's off-hours compute floor. The four exempted
-# services are kept alive purely for the cron-correctness reason above, not
-# because they're money-path (that would have been true of ALL thirteen).
+# standing-order-service cron-collision note), and EXCEPT kyc-service
+# (its own, separate cron-collision note just above). This is still
+# deliberate per issue #446: the sandbox has NO SLA (ADR-0057) and no real
+# money moves through it, so money-path services that need 2 approvals + a
+# threat model to touch in rules.yaml are explicitly fine to scale to zero
+# overnight here — the ADR-0030 threat-model gate governs CODE/CONFIG
+# changes to these services, not a sandbox's off-hours compute floor. The
+# exempted services are kept alive purely for the cron-correctness reason
+# above, not because they're money-path (kyc-service isn't even on the
+# money-path list; that reasoning would have applied to all thirteen
+# money-path services otherwise).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -134,7 +181,6 @@ data:
     finrep/deployment/finrep-service
     fraud/rollout/fraud-service
     fx/rollout/fx-service
-    kyc/rollout/kyc-service
     lending/rollout/lending-service
     onboarding/rollout/onboarding-service
     party/rollout/party-service

--- a/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-down.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-down.yaml
@@ -1,0 +1,124 @@
+# Off-hours scale-DOWN CronJob (issue #446, ~$100-200/mo target).
+#
+# SCHEDULE / TIMEZONE (ADR-0100 discipline: do the DST math explicitly, don't
+# assume UTC==local): the cluster runs Kubernetes 1.34 (see
+# components/admin-ui/cost-collector.yaml), and CronJob `spec.timeZone` has
+# been GA since 1.27 — so, like cost-collector, we set `timeZone` directly
+# instead of hand-converting CET/CEST to a UTC offset. The kube-controller-
+# manager evaluates `schedule` in the given IANA zone and follows its DST
+# transitions automatically (Europe/Prague observes the same CET/CEST
+# transitions as the rest of the EU). Concretely:
+#   - "0 22 * * *" @ Europe/Prague = 22:00 local every day.
+#     - CET  (winter, UTC+1): 22:00 local = 21:00 UTC.
+#     - CEST (summer, UTC+2): 22:00 local = 20:00 UTC.
+#   The whole point of `timeZone` over a hardcoded UTC cron is that we do
+#   NOT have to hand-re-derive that UTC offset twice a year — the field
+#   owns the seasonal drift so 22:00 stays 22:00 local across the
+#   March/October changeovers, which a bare UTC schedule cannot do.
+# Weekends: scale-down re-runs every night including Fri/Sat/Sun, and
+# scale-up (cronjob-scale-up.yaml) is skipped Sat/Sun (see its schedule) —
+# so the fleet also stays down for the whole weekend, per the issue's
+# "nights + weekends are ~70% of wall-clock hours" framing, without a
+# separate weekend-specific schedule.
+#
+# The allowlist ConfigMap (configmap-allowlist.yaml) is the single source of
+# truth for WHAT gets scaled — this CronJob only mounts and iterates it.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: finops-scale-down
+  namespace: finops-scaledown
+  labels:
+    app.kubernetes.io/part-of: finops-scaledown
+    app.kubernetes.io/component: scale-down
+spec:
+  # 22:00 Europe/Prague, every day (nights + the whole weekend).
+  schedule: "0 22 * * *"
+  timeZone: "Europe/Prague"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 900
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: finops-scale-down
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: finops-scaledown
+          automountServiceAccountToken: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: scale-down
+              # alpine/k8s ships BOTH `kubectl` and a real shell (bash/coreutils) on a
+              # proper semver tag (1.34.9 tracks the cluster's 1.34 minor). The
+              # official `rancher/kubectl` image was tried first and rejected: it is
+              # kubectl-only with no shell at all (exec: "/bin/sh": no such file or
+              # directory), so it cannot run the loop below. `bitnami/kubectl` was
+              # also tried and rejected: Bitnami's "Secure Images" migration removed
+              # every semver tag from the free tier — only `latest` (mutable) and
+              # content-addressed sha256 tags remain, which fights this repo's
+              # pin-everything discipline (ADR-0121 / Scorecard Pinned-Dependencies).
+              image: docker.io/alpine/k8s:1.34.9
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: TARGET_REPLICAS
+                  value: "0"
+                - name: HOME
+                  value: /tmp
+              volumeMounts:
+                - name: allowlist
+                  mountPath: /etc/finops-scaledown
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -uo pipefail
+                  fail=0
+                  while IFS='/' read -r ns kind name; do
+                    # Skip blank lines / stray whitespace from the ConfigMap.
+                    [ -z "$ns" ] && continue
+                    echo "{\"event\":\"scale-down\",\"namespace\":\"${ns}\",\"kind\":\"${kind}\",\"name\":\"${name}\",\"replicas\":${TARGET_REPLICAS}}"
+                    if ! kubectl scale "${kind}/${name}" -n "${ns}" --replicas="${TARGET_REPLICAS}"; then
+                      echo "{\"event\":\"scale-down-error\",\"namespace\":\"${ns}\",\"kind\":\"${kind}\",\"name\":\"${name}\"}"
+                      fail=1
+                    fi
+                  done < /etc/finops-scaledown/DOWNSCALE_TARGETS
+                  # Don't let one missing/renamed workload fail the whole job silently —
+                  # but DO surface a non-zero exit so failedJobsHistoryLimit/alerting
+                  # can catch a persistent drift between the allowlist and the cluster.
+                  exit $fail
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: allowlist
+              configMap:
+                name: finops-scaledown-allowlist
+            - name: tmp
+              emptyDir: {}
+          nodeSelector:
+            workload: observability
+          tolerations:
+            - key: workload
+              operator: Equal
+              value: observability
+              effect: NoSchedule

--- a/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-up.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/cronjob-scale-up.yaml
@@ -1,0 +1,109 @@
+# Off-hours scale-UP CronJob (issue #446) — the counterpart to
+# cronjob-scale-down.yaml. Restores every DOWNSCALE_TARGETS workload to its
+# GitOps-declared replica count (1 — every target in the allowlist is a
+# single-replica Deployment/Rollout, confirmed against each component's own
+# manifest) so the fleet is warm again for EU business hours.
+#
+# SCHEDULE / TIMEZONE: same Europe/Prague `timeZone` field as the scale-down
+# job (see its comment for the CET/CEST UTC-offset table) — 07:00 local,
+# Monday-Friday only. Weekday-only is deliberate: per the issue's plan
+# ("22:00-07:00 CET + weekends"), the fleet should ALSO stay down through
+# Saturday/Sunday, not just wake up every morning including weekends. The
+# scale-down job (schedule "0 22 * * *") still runs every night including
+# Fri/Sat/Sun nights, so Saturday and Sunday simply never get a matching
+# scale-up and the fleet rides at the downscaled floor until Monday 07:00.
+#
+# Argo Rollouts caveat: scaling a Rollout back up from 0->1 starts a fresh
+# rollout at the CURRENT `stable` revision (no canary/analysis re-run for a
+# pure replica-count change — that only triggers on a new pod template
+# hash), so this is a plain capacity restore, not a redeploy.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: finops-scale-up
+  namespace: finops-scaledown
+  labels:
+    app.kubernetes.io/part-of: finops-scaledown
+    app.kubernetes.io/component: scale-up
+spec:
+  # 07:00 Europe/Prague, Monday-Friday only (see comment above for why
+  # weekends are deliberately excluded).
+  schedule: "0 7 * * 1-5"
+  timeZone: "Europe/Prague"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 900
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: finops-scale-up
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: finops-scaledown
+          automountServiceAccountToken: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: scale-up
+              # See cronjob-scale-down.yaml for why alpine/k8s (not rancher/kubectl
+              # or bitnami/kubectl) is the image here — needs a real shell + kubectl
+              # on a pinned semver tag, which neither alternative offers today.
+              image: docker.io/alpine/k8s:1.34.9
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: TARGET_REPLICAS
+                  value: "1"
+                - name: HOME
+                  value: /tmp
+              volumeMounts:
+                - name: allowlist
+                  mountPath: /etc/finops-scaledown
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -uo pipefail
+                  fail=0
+                  while IFS='/' read -r ns kind name; do
+                    [ -z "$ns" ] && continue
+                    echo "{\"event\":\"scale-up\",\"namespace\":\"${ns}\",\"kind\":\"${kind}\",\"name\":\"${name}\",\"replicas\":${TARGET_REPLICAS}}"
+                    if ! kubectl scale "${kind}/${name}" -n "${ns}" --replicas="${TARGET_REPLICAS}"; then
+                      echo "{\"event\":\"scale-up-error\",\"namespace\":\"${ns}\",\"kind\":\"${kind}\",\"name\":\"${name}\"}"
+                      fail=1
+                    fi
+                  done < /etc/finops-scaledown/DOWNSCALE_TARGETS
+                  exit $fail
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+          volumes:
+            - name: allowlist
+              configMap:
+                name: finops-scaledown-allowlist
+            - name: tmp
+              emptyDir: {}
+          nodeSelector:
+            workload: observability
+          tolerations:
+            - key: workload
+              operator: Equal
+              value: observability
+              effect: NoSchedule

--- a/openbank-infra/gitops/components/finops-scaledown/namespace.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/namespace.yaml
@@ -1,0 +1,22 @@
+# Off-hours app-plane scale-down (issue #446, ADR-0057 "coarse backstop").
+#
+# ADR-0057 classifies services into T0-T3 FinOps tiers and explicitly names a
+# blunt scheduled scale-down as a REJECTED *primary* mechanism ("does not
+# generalise to per-service bursty load") but calls it out as "useful only as
+# a coarse backstop, subsumed by per-service scale-to-zero." That is exactly
+# what this component is: a time-based floor for services that have NOT (yet)
+# been given a KEDA ScaledObject/HTTPScaledObject, sitting alongside — not
+# instead of — the per-service T1/T2 scale-to-zero already shipped for
+# product-catalog, interest-service, sdd-service, card-issuance-service and
+# notification-service (see cronjob-scale-down.yaml's exclusion list).
+#
+# This is a sandbox/demo-only cost lever (no SLA, ADR-0057 workload tiers) —
+# it deliberately scales money-path services to zero overnight/weekends,
+# which would NEVER be acceptable in a real production tier (ADR-0030).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: finops-scaledown
+  labels:
+    app.kubernetes.io/part-of: finops-scaledown
+    app.kubernetes.io/managed-by: argocd

--- a/openbank-infra/gitops/components/finops-scaledown/rbac.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/rbac.yaml
@@ -37,12 +37,13 @@ rules:
 # ServiceAccount even if they were accidentally added to the ConfigMap —
 # RBAC is the authoritative boundary, the ConfigMap is the readable summary.
 #
-# NOTE: `accounts`, `balances` and `ledger` namespaces intentionally have NO
-# RoleBinding — account-service, balance-service and ledger-service moved to
-# the keep-alive allowlist (see configmap-allowlist.yaml's standing-order-
-# service cron-collision note) and each of those three namespaces had no
-# other scale-down target, so the whole RoleBinding was removed rather than
-# left dangling and unused.
+# NOTE: `accounts`, `balances`, `ledger` and `kyc` namespaces intentionally
+# have NO RoleBinding — account-service, balance-service, ledger-service
+# (standing-order-service cron-collision note) and kyc-service (its own,
+# separate cron-collision note) all moved to the keep-alive allowlist in
+# configmap-allowlist.yaml, and each of those four namespaces had no other
+# scale-down target, so the whole RoleBinding was removed rather than left
+# dangling and unused.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -156,18 +157,6 @@ kind: RoleBinding
 metadata:
   name: finops-scaledown
   namespace: fx
-  labels: { app.kubernetes.io/part-of: finops-scaledown }
-roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
-subjects:
-  - kind: ServiceAccount
-    name: finops-scaledown
-    namespace: finops-scaledown
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: finops-scaledown
-  namespace: kyc
   labels: { app.kubernetes.io/part-of: finops-scaledown }
 roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
 subjects:

--- a/openbank-infra/gitops/components/finops-scaledown/rbac.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/rbac.yaml
@@ -36,18 +36,13 @@ rules:
 # DOWNSCALE_TARGETS. Namespaces NOT listed here cannot be touched by this
 # ServiceAccount even if they were accidentally added to the ConfigMap —
 # RBAC is the authoritative boundary, the ConfigMap is the readable summary.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: finops-scaledown
-  namespace: accounts
-  labels: { app.kubernetes.io/part-of: finops-scaledown }
-roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
-subjects:
-  - kind: ServiceAccount
-    name: finops-scaledown
-    namespace: finops-scaledown
----
+#
+# NOTE: `accounts`, `balances` and `ledger` namespaces intentionally have NO
+# RoleBinding — account-service, balance-service and ledger-service moved to
+# the keep-alive allowlist (see configmap-allowlist.yaml's standing-order-
+# service cron-collision note) and each of those three namespaces had no
+# other scale-down target, so the whole RoleBinding was removed rather than
+# left dangling and unused.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -77,18 +72,6 @@ kind: RoleBinding
 metadata:
   name: finops-scaledown
   namespace: audit
-  labels: { app.kubernetes.io/part-of: finops-scaledown }
-roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
-subjects:
-  - kind: ServiceAccount
-    name: finops-scaledown
-    namespace: finops-scaledown
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: finops-scaledown
-  namespace: balances
   labels: { app.kubernetes.io/part-of: finops-scaledown }
 roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
 subjects:
@@ -185,18 +168,6 @@ kind: RoleBinding
 metadata:
   name: finops-scaledown
   namespace: kyc
-  labels: { app.kubernetes.io/part-of: finops-scaledown }
-roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
-subjects:
-  - kind: ServiceAccount
-    name: finops-scaledown
-    namespace: finops-scaledown
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: finops-scaledown
-  namespace: ledger
   labels: { app.kubernetes.io/part-of: finops-scaledown }
 roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
 subjects:

--- a/openbank-infra/gitops/components/finops-scaledown/rbac.yaml
+++ b/openbank-infra/gitops/components/finops-scaledown/rbac.yaml
@@ -1,0 +1,361 @@
+# Least-privilege identity for the scale-down/scale-up CronJobs (issue #446).
+#
+# The ClusterRole only grants `get`/`list`/`patch` on the `scale` subresource
+# of Deployments and Argo Rollouts (ADR-0098 — money-path services use
+# Rollout, not Deployment, as their workload kind) — no exec, no secrets, no
+# writes to the pod spec itself. Same pattern as admin-ui-discovery
+# (components/admin-ui/admin-ui.yaml): the ClusterRole is defined once and
+# bound with a per-namespace RoleBinding, never a ClusterRoleBinding, so a
+# compromised ServiceAccount cannot scale workloads outside the namespaces
+# explicitly listed below. Adding a namespace to the scale-down set is a
+# reviewed two-line change: a RoleBinding here AND an entry in the
+# allowlist ConfigMap's DOWNSCALE_TARGETS.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: finops-scaledown
+  namespace: finops-scaledown
+  labels:
+    app.kubernetes.io/part-of: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: finops-scaledown
+  labels:
+    app.kubernetes.io/part-of: finops-scaledown
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/scale"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts", "rollouts/scale"]
+    verbs: ["get", "list", "patch"]
+---
+# One RoleBinding per namespace that appears in the allowlist ConfigMap's
+# DOWNSCALE_TARGETS. Namespaces NOT listed here cannot be touched by this
+# ServiceAccount even if they were accidentally added to the ConfigMap —
+# RBAC is the authoritative boundary, the ConfigMap is the readable summary.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: accounts
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: aml
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: anacredit
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: audit
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: balances
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: billing
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: consent
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: developer-portal
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: dispute
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: finrep
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: fraud
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: fx
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: kyc
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: ledger
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: lending
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: onboarding
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: party
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: payments
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: pid
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: psd2
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: sanctions
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: sca
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: statements
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: tpp-registry
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: platform
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: devops-agent
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: finops-scaledown
+  namespace: finops-agent
+  labels: { app.kubernetes.io/part-of: finops-scaledown }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: finops-scaledown }
+subjects:
+  - kind: ServiceAccount
+    name: finops-scaledown
+    namespace: finops-scaledown


### PR DESCRIPTION
## Summary

Adds two CronJobs that scale the sandbox app-plane's Deployments/Rollouts to
zero replicas overnight (22:00 CET) and back to 1 on weekday mornings (07:00
CET), leaving them at the downscaled floor through the whole weekend.
Karpenter consolidates the now-empty spot nodes on its own — this PR only
manages replica counts, never node counts directly.

**Update after review:** ledger-service, transaction-service, account-service,
balance-service and kyc-service were moved from the scale-down list to
keep-alive — see "Post-review fix" below for why.

## Type of change

- [x] feat (new functionality)

## Linked issues

Closes #446

## Changes

- `openbank-infra/gitops/components/finops-scaledown/namespace.yaml` — new
  `finops-scaledown` namespace.
- `.../rbac.yaml` — least-privilege `ServiceAccount` + `ClusterRole` (get/
  list/patch on `deployments`, `deployments/scale`, `rollouts`,
  `rollouts/scale` only — no exec, no secrets) bound via one `RoleBinding`
  per target namespace (23 total after the post-review fixes), same
  per-namespace-binding pattern as `admin-ui-discovery`. RBAC is the
  enforcement boundary, not just the ConfigMap below.
- `.../configmap-allowlist.yaml` — the visible, single-source-of-truth
  allowlist (`DOWNSCALE_TARGETS`), with the keep-alive/exclusion reasoning
  written out in full as comments.
- `.../cronjob-scale-down.yaml` / `cronjob-scale-up.yaml` — the two
  scheduled jobs; both read-only mount the ConfigMap and loop
  `kubectl scale <kind>/<name> -n <ns> --replicas=N` per line, emitting
  structured JSON logs and a non-zero exit if any target fails (so
  `failedJobsHistoryLimit` surfaces a persistent allowlist/cluster drift
  instead of failing silently).
- `openbank-infra/gitops/apps/finops-scaledown.yaml` — the ArgoCD
  Application wiring it in (picked up automatically by root-app's
  `directory.recurse: true`, no other file needs editing).

### The exact schedule + timezone reasoning

- Scale-down: `schedule: "0 22 * * *"`, `timeZone: "Europe/Prague"` — every
  night including Friday/Saturday/Sunday.
- Scale-up: `schedule: "0 7 * * 1-5"`, `timeZone: "Europe/Prague"` —
  weekday mornings only, so the fleet stays down through the whole weekend
  rather than waking up Saturday/Sunday morning too.
- Cluster runs Kubernetes 1.34 (per the existing `cost-collector.yaml`
  comment) and `CronJob.spec.timeZone` has been GA since 1.27, so both jobs
  set `timeZone` directly instead of a hand-converted UTC schedule — the
  field owns the CET/CEST seasonal drift (22:00 local = 21:00 UTC in
  winter, 20:00 UTC in summer) automatically across the March/October
  changeovers, matching this repo's existing `cost-collector`/
  `infra-vuln-scanner` CronJobs.

## Post-review fix: two fixed-time crons collided with the down window

Review caught a real correctness bug in the first version of this PR:
`standing-order-service`'s `StandingOrderExecutionScheduler` runs a real,
enabled-by-default batch job at a **fixed** `03:00 UTC` daily
(`openbank.scheduler.execution-cron`, confirmed live — not gated behind a
disabled flag) that posts due standing-order payments through the
ledger/transaction/account/balance chain. `03:00 UTC` = `04:00` (CET) /
`05:00` (CEST) Prague — squarely inside the `22:00–07:00` down window,
**every single night**. Unlike a recurring cron (every 30 min / hourly),
Quarkus does not queue a missed fixed-cron tick for the next boot — if
standing-order-service is at 0 replicas at its one daily trigger time, the
sweep silently never runs that day, and on the current schedule that would
have been *every* day indefinitely (weekday wake-up at 07:00 Prague is
already past the day's only window).

**Fix 1:** `ledger-service`, `transaction-service`, `account-service`,
`balance-service` and `standing-order-service` moved to the keep-alive
allowlist — kept alive purely for this cron-correctness reason, not
because they're money-path (every other money-path service still scales
down). Their now-single-purpose RoleBindings (`accounts`, `balances`,
`ledger` namespaces each only had one scale-down target) were removed from
`rbac.yaml`; `payments` keeps its binding since sepa-payment,
domestic-payment, sepa-instant, clearing, settlement, clearing-simulator
and swift are still scale-down targets there.

While auditing the rest of the fleet for the same shape (see below), I
found a **second, independent occurrence**: `kyc-service`'s
`KycRetentionScheduler` enforces the AML Act §16 5-year KYC-case
hard-delete retention policy (ADR-0118 §5), `enabled=true` by default,
fixed cron at `03:30 UTC` — also inside the down window every night, and
also a regulatory retention control rather than a demo feature.

**Fix 2:** `kyc-service` moved to keep-alive too. Unlike standing-order,
this job has no synchronous cross-service dependency (only its own
Postgres), so no dependency chain was needed — kyc-service alone. It was
the only scale-down target in the `kyc` namespace, so that RoleBinding was
removed as well.

**Audited every `@Scheduled` in the fleet for the same fixed-time-inside-
window shape** (the first pass had only grepped the single-line
`@Scheduled(cron` form and missed the multi-line annotations most of these
use — documented inline in `configmap-allowlist.yaml`):
- `onboarding-service` `AbandonedRegistrationCleaner` (`02:00 UTC`, real,
  unconditional) has the same shape but is judged acceptable to leave
  scaled down: it's an idempotent, non-money, 30-day-threshold housekeeping
  sweep (suspends abandoned KYC registrations, reversible by an operator)
  — missing a night delays cleanup by hours, nothing more. Flagged for
  visibility, not exempted.
- `agent-service` `OversightService` (`*/30 * * * *` in the sandbox),
  `consent-service` `ConsentExpirationJob` (`0 5 * * *`, hourly), and
  `lending-service`'s `InterestAccrualScheduler` /
  `ProvisioningCycleScheduler` (both fixed-**rate** `every = ...`, not
  fixed-cron) are all recurring, not fixed-once-daily — scaling to 0
  overnight just pauses the ticks, which resume once the pod is back up.
  This is the intended degradation the whole PR relies on, not a bug.
- `notification-service`'s two fixed-cron jobs (`02:00`/`03:00 UTC`) never
  collide because notification-service is already KEDA-managed with
  `minReplicaCount: 1` — never at 0 replicas.
- `card-issuance-service`'s `CardPiiRetentionScheduler` (`03:00 UTC`,
  `enabled=true`, same AML §16 regulatory shape as kyc-service's job): no
  collision from this PR because card-issuance-service is already on
  keep-alive as a KEDA `HTTPScaledObject` target (T1) — this CronJob never
  touches it. (KEDA's own idle scale-to-zero is a separate, pre-existing
  mechanism, out of this PR's scope.)
- `ledger-service`'s `TieOutScheduler` (`06:00 UTC`) and
  `FxRevaluationScheduler` (`15:00 UTC`), `balance-service`'s
  `BalanceReconciliationScheduler` (`23:30 UTC`): real fixed-time crons,
  but both services are already keep-alive from Fix 1 — no collision.
- `fx-service`'s `CnbRateIngestionScheduler` (`14:40 UTC` = `15:40`/`16:40`
  Prague) falls entirely outside the down window — no collision regardless
  of fx-service scaling down.
- `billing-service`'s `BillingCycleScheduler` (monthly) and
  `audit-service`'s `SessionLogRetentionScheduler`: confirmed **disabled by
  default**, not overridden in gitops — dead code today.
- `statement-service` `PeriodCloseScheduler` and `sdd-service`
  `MandateExpiryScheduler`: confirmed **disabled by default** in
  `application.yaml`, not overridden in gitops — dead code today.
- `analytics-sink` `ReconciliationJob`: the service has no
  `openbank-infra/gitops` component/Application at all — not deployed to
  the sandbox, out of scope.

### The keep-alive allowlist (never scaled down)

- `admin-ui`, `customer-edge` — task/issue requirement, the demo's own
  front door and the sole internet-facing showcase path (ADR-0065).
- Keycloak (`iam` namespace) — both of the above do a live OIDC handshake
  against it on every login; without it "demo pages still respond" fails
  for any authenticated flow.
- The whole `observability` namespace (Prometheus/Grafana/Loki/Tempo/
  Alertmanager/Pyrra/etc.) — it already runs on its own dedicated
  **on-demand** Karpenter NodePool specifically so it's never subject to
  spot/consolidation churn (`components/observability/
  nodepool-observability.yaml`), and is what makes the demo "look alive."
  Excluded as a whole namespace rather than cherry-picking Helm-generated
  Deployment names, which are chart-version-fragile.
- **`ledger-service`, `transaction-service`, `account-service`,
  `balance-service`, `standing-order-service`** — added in the post-review
  fix above, for the `StandingOrderExecutionScheduler` fixed-cron
  correctness reason, not because they're money-path.
- **`kyc-service`** — added in the second post-review fix, for the
  `KycRetentionScheduler` AML §16 retention-cron correctness reason.
- `product-catalog`, `interest-service`, `sdd-service`,
  `card-issuance-service` — already KEDA `HTTPScaledObject`-managed
  (ADR-0057 T1); forcing `replicas=0` here would race the HPA KEDA already
  owns for these.
- `notification-service` — KEDA `ScaledObject` with `minReplicaCount: 1`
  (the customer-edge notification feed is a synchronous read); same
  reasoning.
- Kafka (Strimzi), Temporal, CNPG Postgres clusters — stateful,
  operator-managed, not a plain Deployment/Rollout; `kubectl scale` doesn't
  apply the same way and a broker/DB restart risk outweighs the modest
  saving. Left for a deliberate future change (KEDA Kafka-lag scaling per
  ADR-0057 T2), not a blunt cron.
- `pact-broker`, `reposilite`, `registry-cache`, `gradle-build-cache` — CI
  may need these at any hour, independent of EU daytime demo traffic.
- `external-dns`, `external-secrets`, `kyverno`, `argo-rollouts`
  (controllers) — cluster platform plumbing other components'
  reconciliation depends on.

### Everything else is a scale-down candidate — including most money-path services

Per the issue's explicit framing, this **includes most of
`rules.yaml: money_path_services`** (sepa-payment, sepa-instant,
domestic-payment, clearing, swift, fx, lending, sca, consent, fraud,
billing, settlement — everything except the four exempted above for the
cron-correctness reason) plus every other non-excluded app-plane service
(aml, anacredit, audit, developer-portal, dispute, finrep, onboarding,
party, pid, psd2, sanctions, statements, tpp-registry, agent-service,
copilot-service, devops-agent, finops-agent). Note `kyc-service` is no
longer in this list (moved to keep-alive, see above). The sandbox has no
SLA (ADR-0057) and no real money moves through it — the ADR-0030
threat-model gate governs *code/config changes* to these services, not a
sandbox's off-hours compute floor, so this is explicitly acceptable per
the issue.

## Validation performed (no live-cluster changes made)

- `kubectl apply --dry-run=client -f <file>` — clean for every manifest,
  re-verified after the post-review fix.
- `yamllint` with the same ruleset `ci.yml`'s "Validate manifests" job
  uses — clean, before and after the fix.
- `shellcheck -S warning` on the inline CronJob scripts — clean.
- `python3 openbank-infra/scripts/gen-network-policies.py` re-run locally —
  zero diff, both before and after the fix (this component makes no
  Deployment-env/Ingress/ScaledObject edges for the generator to pick up).
- `python3 openbank-infra/scripts/check-finops-tiers.py` — unaffected
  (this PR does not touch `rules.yaml`).
- Verified the `DOWNSCALE_TARGETS` namespace set has an exact 1:1 match
  with the `RoleBinding` namespaces in `rbac.yaml` (no gaps, no excess
  grants) via a scripted diff — re-verified after each post-review fix
  (23 namespaces on both sides, final state).
- Ran the actual loop script inside `docker.io/alpine/k8s:1.34.9` against a
  stubbed `kubectl` to confirm parsing, per-line logging, and
  continue-past-failure/non-zero-exit behavior all work as written.
- Image choice: `docker.io/alpine/k8s:1.34.9` — tried `rancher/kubectl`
  first (kubectl-only, no shell, can't run the loop) and `bitnami/kubectl`
  second (Bitnami's Secure Images migration removed semver tags from the
  free tier, only mutable `latest` remains); `alpine/k8s` ships both a
  real shell and `kubectl` on a proper 1.34.x tag.
- Grepped every `@Scheduled` (both single-line and multi-line annotation
  forms) across the fleet and checked each one's resolved UTC time, its
  `enabled` default, and its host service's scale-down/keep-alive status
  against the down window (see "Post-review fix" above).
- Re-ran `kubectl apply --dry-run=client`, `yamllint`, and
  `gen-network-policies.py` (zero diff) after each of the two post-review
  fixes, not just the first.

**This PR does not touch the live cluster.** ArgoCD (`root` app-of-apps,
`directory.recurse: true` over `gitops/apps/`) will pick up the new
Application once this merges to `main` and syncs — that sync is a separate,
human-observed step, not part of this change.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — N/A, infra-only.
- [ ] Unit tests added/updated — N/A, no application code.
- [ ] Integration tests added/updated — N/A.
- [ ] Contract tests updated — N/A, no API change.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, no Gradle module touched.
- [x] No new lint warnings (yamllint/shellcheck clean, see Validation above).
- [ ] OpenAPI spec regenerated — N/A.
- [ ] Flyway migration added — N/A.
- [ ] Avro schema versioned — N/A.
- [x] Docs updated — allowlist/denylist reasoning, including the cron-collision audit, is inline in the ConfigMap and CronJob comments (this is the "visible list" the issue asked for).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress` — N/A, no Kotlin.
- [x] No new third-party dependency beyond a public container image
      (`docker.io/alpine/k8s:1.34.9`, routed through the existing
      ECR-pull-through Kyverno policy like every other `docker.io/*` image
      in gitops).
- [ ] Auth / crypto / payment code changed? — No code changed, only replica
      counts of existing, already-reviewed workloads.
- [ ] PII path changed? — No.
- [ ] Cardholder data path changed? — No.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None — this is a sandbox/demo-only operational cost lever (ADR-0057
      workload tiers explicitly separate prod-mandated continuity from a
      no-SLA sandbox); it does not change any service's `rules.yaml` tier
      declaration or any production posture.

## Rollout / Rollback

- Deployment strategy: ArgoCD auto-sync on merge (`syncPolicy.automated`,
  same as every other component here).
- Rollback plan: revert this PR (or delete the `finops-scaledown`
  Application) — the two CronJobs and their RBAC/namespace are the only
  new resources; deleting them stops all future scale actions and does not
  affect any other component. If the fleet is mid-scale-down when rolled
  back, manually run the scale-up loop once (`kubectl scale <kind>/<name>
  --replicas=1` per `DOWNSCALE_TARGETS` line) to restore capacity
  immediately rather than waiting for the next scheduled window.
- Data migration reversible: N/A, no data migration.

## Reviewer notes

- This PR intentionally does **not** apply anything to the live cluster —
  per the task, that's left to ArgoCD after merge + a human-observed sync.
- The allowlist is deliberately a flat ConfigMap (not Kustomize
  components/vars) to match this repo's existing `gitops/components/*`
  convention, which uses plain-directory ArgoCD sync
  (`directory.recurse: true`), not real Kustomize overlays.
- Happy to split the RBAC into fewer, wildcard-scoped bindings if
  preferred, but kept it 1:1 with the ConfigMap's namespace list to make
  the "what can this SA touch" boundary trivially auditable against the
  visible allowlist.
- The standing-order-service fix (see above) was caught in review, not by
  me initially. Re-auditing with a broader grep (every `@Scheduled`, not
  just the single-line form) turned up a second, independent instance
  (kyc-service) that I'd missed the first time — worth a skeptical second
  look at the full audit list in "Post-review fix" above in case a third
  one slipped through.
