### PR TITLE
security(billing): inline log sanitization so CodeQL actually recognizes it

### DIFF
--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/application/usecase/BillingCycleService.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/application/usecase/BillingCycleService.kt
@@ -36,13 +36,19 @@ class BillingCycleService(
 ) {
     private val log = Logger.getLogger(BillingCycleService::class.java)
 
+    // cycleId/accountId/currency below trace back to caller input (the REST POST /fees/post
+    // endpoint and the scheduled cycle trigger's account list) and are logged with the CR/LF
+    // stripped inline (CodeQL java/log-injection, CWE-117 log forging) rather than through a
+    // shared helper: CodeQL's log-injection sanitizer check is a local syntactic match on the
+    // replace() call at the sink itself, not an interprocedural summary, so a wrapper function
+    // is an opaque call to it and leaves the alert open (confirmed against this exact file).
     suspend fun assessAndPost(cycleId: String, accountId: String, currency: String): BillingAssessment {
         repository.findExisting(cycleId, accountId, currency)?.let {
             log.debugf(
                 "billing cycle %s account %s currency %s already assessed — returning existing (idempotent replay)",
-                cycleId.sanitizeForLog(),
-                accountId.sanitizeForLog(),
-                currency.sanitizeForLog(),
+                cycleId.replace('\n', '_').replace('\r', '_'),
+                accountId.replace('\n', '_').replace('\r', '_'),
+                currency.replace('\n', '_').replace('\r', '_'),
             )
             return it
         }
@@ -65,17 +71,12 @@ class BillingCycleService(
                     log.errorf(
                         ex,
                         "billing cycle %s account %s currency %s failed — continuing with the rest of the batch",
-                        cycleId.sanitizeForLog(),
-                        accountId.sanitizeForLog(),
-                        currency.sanitizeForLog(),
+                        cycleId.replace('\n', '_').replace('\r', '_'),
+                        accountId.replace('\n', '_').replace('\r', '_'),
+                        currency.replace('\n', '_').replace('\r', '_'),
                     )
                 }
         }
         return processed
     }
 }
-
-// CodeQL java/log-injection: cycleId/accountId/currency ultimately trace back to caller input
-// (the REST POST /fees/post endpoint and the scheduled cycle trigger's account list). Strip
-// CR/LF so an attacker-controlled value can't forge additional log lines (log forging, CWE-117).
-private fun String?.sanitizeForLog(): String = (this ?: "-").replace('\n', '_').replace('\r', '_')


### PR DESCRIPTION
## What

PR #588 "fixed" CodeQL alerts #299/#300/#301 (`java/log-injection`) by wrapping the
CR/LF strip in a private `sanitizeForLog()` extension function. That did **not**
actually work: verified directly against this file — CodeQL's log-injection sanitizer
check is a **local syntactic match** on the `replace()`/`replaceAll()` call at the sink
node itself (see `java/ql/lib/semmle/code/java/security/LogInjection.qll` on
`github/codeql`). It does no interprocedural summarization of arbitrary user-defined
methods, so the wrapper function was an opaque call to it and the taint never cleared.

Proof: a rescan of a later `main` commit (which already included the wrapper) opened
**three brand-new alerts** (#302/#303/#304) at the exact same two locations.
#299-301 only auto-closed because the code text (fingerprint) changed, not because
CodeQL agreed the value was actually sanitized.

## Fix

Inline `cycleId/accountId/currency.replace('\n', '_').replace('\r', '_')` directly at
each `log.debugf`/`log.errorf` call, matching the pattern CodeQL's query recognizes
(confirmed against the QL source + `github/codeql` discussions #10702/#12641).
Duplicated 3× per log call instead of factored into a shared helper — the duplication
*is* the fix here; a shared function defeats the local check again.

## Flagging (not fixed here — needs its own follow-up)

The same `sanitizeForLog()`-style wrapper pattern is referenced in ~8 other services'
commit messages as a prior fix for this exact CodeQL rule. None of those alerts show up
in this repo's code-scanning alert history as ever having reached `fixed` state —
strongly suggesting they have the same live gap, just never verified against an actual
CodeQL rescan. Worth a fleet sweep issue to audit and re-fix with the inline pattern.

## Linked issues

N/A — direct correction of a change in #588; no tracking issue existed for the original
finding.