### PR TITLE
ci(agent-review): skip the admin-ui-deploy GitOps PR, not just release-please

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -50,10 +50,29 @@ permissions:
 jobs:
   agent-review:
     # Skip drafts; skip the release-please bot (its PRs are machine-generated and
-    # gated separately). Everything else is evaluated.
+    # gated separately); skip the admin-ui-deploy GitOps PR (also machine-generated
+    # — image-tag bump plus a regenerated derived catalog, ADR-0029 Layer B).
+    #
+    # The admin-ui-deploy skip is branch-pattern-based, not actor-based like the
+    # release-please one: that pipeline opens its PR via GITOPS_PR_TOKEN (a PAT
+    # under the repo owner's own account, so further workflows actually trigger),
+    # so `github.actor` here is the owner, not a bot — the actor check alone can't
+    # tell "automated deploy" apart from "a human's PR". Real-world cost of that
+    # gap (2026-07-08): three deploy PRs (#596, #608, #609) piled up unmerged
+    # because the reviewer kept flagging the SAME false positive on every one —
+    # reviewing cluster-topology.json/infra-lifecycle.json (CI-regenerated
+    # governance-as-code catalogs, not hand-authored) as if a namespace/role entry
+    # appearing in the derived report were a new infra decision this PR made,
+    # when the only substantive diff line is the image tag in admin-ui.yaml. That
+    # silently broke the "auto-merged once CI is green, no human step" promise
+    # documented in admin-ui-deploy.yml — required_status_checks (all-green,
+    # Validate manifests, Gitleaks, issue-hygiene) already gate every merge, same
+    # as a release-please PR; this workflow doesn't need to gate a second time on
+    # a mechanical GitOps bump it has no code-judgment basis to review.
     if: >-
       github.event.pull_request.draft == false &&
-      github.actor != 'github-actions[bot]'
+      github.actor != 'github-actions[bot]' &&
+      !startsWith(github.head_ref, 'chore/admin-ui-deploy-')
     runs-on: ubuntu-latest
     # secrets context isn't available in a step-level `if:` — expose it as a
     # job-level boolean env so the Claude fallback can gate on its presence.


### PR DESCRIPTION
## Summary
Today's PR backlog investigation found the root cause of a recurring pile-up: `admin-ui-deploy.yml`'s auto-generated GitOps PRs (image-tag bump + regenerated derived catalog) were getting a false-positive `CHANGES_REQUESTED` from `agent-review` on every single deploy, because the reviewer has no way to tell "mechanically regenerated governance-as-code catalog" apart from "a new infra decision". That silently broke the documented "auto-merged once CI is green, no human step" promise (admin-ui-deploy.yml header comment) — three snapshots (#596, #608, #609) piled up unmerged behind the same complaint before I closed them as superseded and dismissed the (also false-positive) reviews on the current one (#611) by hand.

- Extends the existing release-please skip (`github.actor != 'github-actions[bot]'`) with a branch-name check for `chore/admin-ui-deploy-*`, since that pipeline opens its PR via `GITOPS_PR_TOKEN` (a PAT under the repo owner's account, not a bot actor) — so the actor check alone can't distinguish it from a human's PR.
- No change to the sensitive-scope guard (money-path, governance, `.github/**`, release wiring, threat models, ADR, DB migrations) — those still always defer to a human, unaffected.
- `required_status_checks` (`all-green`, `Validate manifests`, `Gitleaks`, `issue-hygiene`) already gates every merge; this removes a redundant LLM-judgment pass that had no code-judgment basis to review a version-bump PR anyway.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid YAML
- [x] Diff reviewed against a fresh `origin/main` checkout, not a stale local copy (this file had already gained a test/coverage-only carve-out and pinned-SHA action refs I didn't have locally — re-applied the change against the real current content instead of overwriting it)
- [ ] Real end-to-end confirmation is the next admin-ui-deploy PR merging without a bot review appearing at all — will know within a day given the deploy frequency

Linked issues: N/A — CI/governance fix, no tracked issue. This PR itself falls under the sensitive-scope guard it's editing (`.github/**`), so it will not get an agent-review approval — expected, not a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)