### PR TITLE
fix(ci): add billing-service to auto-deploy.yml's static fleet list

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -81,9 +81,16 @@ jobs:
       - id: detect
         run: |
           set -euo pipefail
-          # Full fleet — same list as services-ci.yml (openbank-libs excluded: it has
-          # no Dockerfile, only its consumers need to be rebuilt when it changes).
-          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent'
+          # Full fleet — unlike services-ci.yml (which discovers every openbank-*/
+          # with a build.gradle.kts dynamically), this list is static and can drift:
+          # a service added to the fleet gets full CI for free but silently gets ZERO
+          # auto-deploy coverage until someone adds it here (openbank-libs excluded on
+          # purpose: it has no Dockerfile, only its consumers need rebuilding).
+          # billing-service shipped a CodeQL log-injection fix (#597/#601) that merged
+          # and released cleanly but never deployed — "Detect changed services" always
+          # printed "No deployable services changed" because the service was simply
+          # never a candidate, regardless of what changed. Re-added here.
+          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service'
 
           # Manual dispatch: rebuild the requested module(s), or the full deployable
           # fleet when no input is given. Only services that actually carry a gitops


### PR DESCRIPTION
## Summary
- `auto-deploy.yml`'s `ALL_SERVICES` list is hand-maintained, unlike `services-ci.yml` which discovers every `openbank-*/` with a `build.gradle.kts` dynamically.
- `openbank-billing-service` was never added to it, so it has had **zero auto-deploy coverage** since it joined the fleet — any change under its `src/main/**` merges and (if release-please is involved) releases cleanly, but the "Detect changed services" job always prints "No deployable services changed" regardless of what actually changed.
- Surfaced while completing deployment of #597/#601 (CodeQL log-injection fix): merged to `main`, released as `billing-service-v0.5.2`, but auto-deploy never fired a build/push/gitops-PR for it.
- Fix: add `openbank-billing-service` to the static list.

## Note — related but out of scope here
`openbank-anacredit-service` has the same gap (has a gitops manifest + `version.txt`, missing from `ALL_SERVICES`) but has no `Dockerfile`, so adding it here would break the build+push step. Needs its own investigation — not fixed in this PR.

## Test plan
- [x] Confirmed `openbank-billing-service` has a `Dockerfile`, `version.txt`, a gitops manifest (`openbank-infra/gitops/components/billing/billing-service.yaml` with an `image:sandbox-` pin), and is registered in `release-please-config.json`.
- [ ] After merge, manually trigger `workflow_dispatch` for `openbank-billing-service` to deploy the already-released `v0.5.2` fix (path-based push trigger won't retroactively fire for a past commit).
- [ ] Verify the resulting Gitops PR opens, passes CI, and merges.

Refs #597