### PR TITLE
ci(admin-ui-deploy): trigger on docs/agents/** too

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -37,9 +37,10 @@ on:
     paths:
       # Admin-UI source — includes CHANGELOG.md + version.txt (release-please merge)
       - "openbank-admin-ui/**"
-      # Governance bundles baked into the image (ADRs, threat models, flags, compliance)
+      # Governance bundles baked into the image (ADRs, threat models, agent charters, flags, compliance)
       - "docs/adr/**"
       - "docs/threat-models/**"
+      - "docs/agents/**"
       - "openbank-infra/gitops/components/*/feature-flags.yaml"
       - "openbank-libs/governance/agents.yaml"
       - "openbank-libs/governance/compliance-controls.yaml"


### PR DESCRIPTION
## Summary
`docs/agents/*.md` (ADR-0156, #598) is bundled into the admin-ui image by the governance-collector Dockerfile stage, same as `docs/adr` and `docs/threat-models` — but the deploy workflow's push-path trigger list never got the matching entry. A future charter-only change (no `openbank-admin-ui/**` or `docs/adr/**` touch) would silently sit unbundled in the repo until an unrelated admin-ui push happened to rebuild the image.

Found while confirming #598-#600 actually reached a deployed sandbox image end to end.

## Test plan
- [x] YAML validated
- [x] Diffed against a fresh `origin/main` checkout

Linked issues: N/A — CI trigger-path fix, no tracked issue. Falls under the `.github/**` sensitive-scope guard (no bot review), same as #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)