### PR TITLE
ci(governance): resolve env-var-default syntax in dispatch-enabled check

### DIFF
--- a/.github/scripts/check-outbox-dispatch-enabled.sh
+++ b/.github/scripts/check-outbox-dispatch-enabled.sh
@@ -27,7 +27,17 @@
 # AbstractOutboxDispatcher. A module without such a dispatcher (no gated
 # outbox, or no outbox at all) has nothing to guard and is skipped.
 #
-# stdlib-only (awk); no PyYAML/yamllint dependency, matching
+# Value resolution: the raw YAML value is judged as "enabled" if it is the
+# bare literal true/"true", OR the SmallRye env-var-with-default syntax
+# ${VAR:true}/"${VAR:true}" whose default term is true. Everything else fails
+# closed: a bare false, ${VAR:false}, an env-var with NO default (${VAR} —
+# we refuse to guess what that resolves to at deploy time), or a missing key
+# entirely. (Fixed in open-bank-oss#620 — the original literal-only match
+# false-negatived on the ${VAR:true} form, which is this repo's normal
+# pattern for a soft-toggle elsewhere, e.g. notification-service's
+# `enabled: ${SLACK_WEBHOOK_ENABLED:false}`.)
+#
+# stdlib-only (awk + shell); no PyYAML/yamllint dependency, matching
 # check-app-version-override.sh. ENFORCED — as of this script's introduction,
 # every in-scope service already sets dispatch-enabled: true (0 violations on
 # origin/main), so this is a regression guard, not a fleet-sweep-in-waiting.
@@ -67,9 +77,31 @@ while IFS= read -r moddir; do
     END { if (!found) print "MISSING" }
   ' "$yml")
 
-  if [ "$value" != "true" ] && [ "$value" != "\"true\"" ]; then
+  # Strip a single layer of surrounding double-quotes, if present, e.g.
+  # "${OPENBANK_OUTBOX_DISPATCH_ENABLED:true}" -> ${OPENBANK_OUTBOX_DISPATCH_ENABLED:true}.
+  unquoted="$value"
+  case "$unquoted" in
+    \"*\") unquoted="${unquoted#\"}"; unquoted="${unquoted%\"}" ;;
+  esac
+
+  # Resolve SmallRye env-var-with-default syntax: ${VAR:default} -> default.
+  # A bare literal (true/false/MISSING) is left untouched by this pattern and
+  # falls through to the plain comparison below. ${VAR} with NO ':default' at
+  # all does not match this case either — it stays as-is and is judged (and
+  # rejected) as an ambiguous, non-"true" value, same as today: we refuse to
+  # guess what an env-var-with-no-default resolves to at deploy time.
+  resolved="$unquoted"
+  case "$unquoted" in
+    '${'*:*'}')
+      body="${unquoted#\$\{}"   # strip leading ${
+      body="${body%\}}"          # strip trailing }
+      resolved="${body#*:}"      # everything after the first ':' is the default
+      ;;
+  esac
+
+  if [ "$resolved" != "true" ]; then
     fail=1
-    echo "::error file=$yml::$moddir has a dispatch-gated $(basename "$disp") but openbank.outbox.dispatch-enabled is '$value', not true — this service will never dispatch outbox events at runtime (no error, attempt_count stays 0). Set 'openbank: outbox: dispatch-enabled: true' in application.yaml."
+    echo "::error file=$yml::$moddir has a dispatch-gated $(basename "$disp") but openbank.outbox.dispatch-enabled is '$value' (resolves to '$resolved'), not true — this service will never dispatch outbox events at runtime (no error, attempt_count stays 0). Set 'openbank: outbox: dispatch-enabled: true' (or an env-var default that resolves to true) in application.yaml."
   fi
 done < <(
   find "$root" -maxdepth 1 -type d -name 'openbank-*' -not -path '*/.claude/*' \


### PR DESCRIPTION
## Summary

- Fixes a false-negative in `check-outbox-dispatch-enabled.sh`: it only recognized a bare
  `true`/`"true"` literal for `openbank.outbox.dispatch-enabled`, so a service using this repo's
  normal `${VAR:default}` SmallRye syntax (e.g.
  `dispatch-enabled: "${OPENBANK_OUTBOX_DISPATCH_ENABLED:true}"`) got flagged as a violation even
  though the default correctly resolves to `true`.
- Discovered live in PR #549 (`openbank-billing-service`): the author had to hardcode a bare
  `true` instead of the idiomatic env-var-toggle form used elsewhere in the fleet
  (`openbank-notification-service`'s `enabled: ${SLACK_WEBHOOK_ENABLED:false}`,
  `openbank-agent-service`'s `global-enabled: ${AGENT_KILL_SWITCH_GLOBAL_ENABLED:true}`), purely
  to satisfy this script's literal-only match.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #620

## Before / after parsing logic

**Before:**
```sh
if [ "$value" != "true" ] && [ "$value" != "\"true\"" ]; then
  fail=1
  ...
fi
```
`$value` is the raw extracted YAML scalar. If the config was
`dispatch-enabled: "${OPENBANK_OUTBOX_DISPATCH_ENABLED:true}"`, `$value` is literally that string
— never equal to `true`/`"true"` — so the check fails even though the effective default is `true`.

**After:** strip one layer of surrounding quotes, then — only for the shape `${VAR:default}` —
extract `default` (everything after the first `:` inside the braces) and judge *that* value
against `true`. A bare literal (`true`/`false`/`MISSING`) doesn't match the `${...}` pattern and
falls through unchanged, so existing behavior for the literal case is untouched.

```sh
resolved="$unquoted"
case "$unquoted" in
  '${'*:*'}')
    body="${unquoted#\$\{}"
    body="${body%\}}"
    resolved="${body#*:}"
    ;;
esac
if [ "$resolved" != "true" ]; then
  fail=1
  ...
fi
```

`${VAR}` with no `:default` does **not** match the `${'*:*'}` glob (no `:` inside the braces), so
it is left as-is and correctly still fails — we refuse to guess what an env-var with no default
resolves to at deploy time. A missing key still resolves to the sentinel `MISSING` and still fails.

## Manual verification (6 required cases)

No bats/shell-test convention exists in this repo for `.github/scripts/*.sh` (checked — only
inline scripts + workflow invocation), so verified with fixture directories mirroring the
`openbank-*` scope shape (`version.txt` + `*OutboxDispatcher.kt` referencing
`AbstractOutboxDispatcher` + `application.yaml`):

| Case | Config value | Result |
|---|---|---|
| (a) bare `true` | `dispatch-enabled: true` | **pass** |
| (b) bare `false` | `dispatch-enabled: false` | **fail** |
| (c) `${VAR:true}` | `dispatch-enabled: "${OPENBANK_OUTBOX_DISPATCH_ENABLED:true}"` (and unquoted form) | **pass** |
| (d) `${VAR:false}` | `dispatch-enabled: ${OPENBANK_OUTBOX_DISPATCH_ENABLED:false}` | **fail** |
| (e) `${VAR}` no default, key present | `dispatch-enabled: ${OPENBANK_OUTBOX_DISPATCH_ENABLED}` | **fail** (ambiguous, correctly not silently passed) |
| (f) key entirely missing | (no `dispatch-enabled` key at all) | **fail** (the original footgun case — still caught) |

All six matched the required behavior exactly.

## Fleet sweep result

Ran the fixed script against every current service in the repo:

```
check-outbox-dispatch-enabled: 28 dispatch-gated service(s) checked, 3 skipped (no gated dispatcher), all set dispatch-enabled: true.
```

- **0 violations** — every currently-merged dispatch-gated service already uses the bare `true`
  literal (confirmed by grepping every `openbank-*-service/src/main/resources/application.yaml`
  for `dispatch-enabled` beforehand), so **no other service was silently mis-flagged by the old
  bug** — the false negative only affected the in-flight PR #549, not anything on `main` today.
- For comparison, the **old** (unfixed) script against `origin/main` reports `27 checked, ...
  all set dispatch-enabled: true` (one fewer, since billing-service's dispatcher doesn't exist on
  `main` yet) — confirming this fix causes **zero behavior change** for the existing fleet and is
  purely additive in what it accepts.

## Definition of Done

- [x] This is a CI/governance script change, not application code — no `version.txt` bump
      applies (no service's `src/main/**` touched).
- [x] Manually verified against all 6 fixture cases + full fleet sweep (see above).
- [ ] Contract tests — N/A.
- [ ] Flyway/Avro — N/A.
- [x] Docs: updated the script's own header comment to describe the new resolution rule and link
      back to this fix.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress` — N/A (shell script).
- [ ] Auth/crypto/payment code — N/A, this is a governance CI script, not application code.

## Compliance impact

- N/A — CI governance tooling only, not a money-path service change.

## Note on process

This PR is **not** self-merged and no `--admin`/override flag was used or will be used. Opening
for review and stopping here.