### PR TITLE
fix(ci): install trivy in admin-ui-deploy workflow

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -356,6 +356,11 @@ jobs:
             echo "::warning::prod-readiness collector failed — scorecard page will show no data"
           fi
 
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
       - name: Build, collect, push
         id: build
         run: |


### PR DESCRIPTION
## Summary
- `build-push-admin-ui.sh` silently skips SBOM attestation when `trivy` is missing from PATH.
- `admin-ui-deploy.yml` (hosted runner, no pre-baked binary) never installs trivy — unlike `auto-deploy.yml`, which hit and fixed the same gap in #224.
- Result: every admin-ui image ships unattested → Kyverno's `verify-openbank-image-sbom-attestation` policy blocks all pod admissions → `admin-ui` deployment stuck at 0/1 ready → **admin.open-bank.tech is currently down (503)**.

## Fix
Add the same `Install Trivy` step (`aquasecurity/setup-trivy` pinned to `v0.72.0`, matching the auto-deploy.yml fix) before the build/push step.

## Test plan
- [ ] Merge, re-run Admin-UI deploy workflow_dispatch
- [ ] Confirm job log shows trivy generating the SBOM (no more "trivy unavailable" WARN)
- [ ] Confirm Kyverno admits the new pod and admin-ui deployment reaches 1/1 ready
- [ ] Confirm admin.open-bank.tech serves 200

## Linked issues
N/A — live incident (admin.open-bank.tech 503), fixing directly rather than filing a tracker issue first.