### PR TITLE
fix(infra): pass --platform to trivy SBOM scan in build-push-admin-ui.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,13 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   `maxSurge: 0 / maxUnavailable: 1` for identical zero-concurrency behaviour.
 - **Use explicit registry prefixes for container images** (`docker.io/library/<image>` for official
   images) so the cluster's pull-through/rewrite policies apply.
+- **`trivy image` defaults to `linux/amd64` for remote scans, regardless of host arch.** Once a build
+  moves to a native `linux/arm64` builder (sandbox nodes, arm64 hosted runners), a plain
+  `trivy image ... "${IMAGE}"` against the pushed (arm64-only) image fails with `no child with
+  platform linux/amd64 in index` — silently, if the caller only checks the exit code. Pass
+  `--platform` explicitly, matching the arch the image was actually built for. A skipped SBOM
+  attestation here means Kyverno's `verify-openbank-image-sbom-attestation` policy blocks every pod
+  admission for that image (admin-ui outage, 2026-07-09).
 
 ### OPA / Rego policies (ADR-0031/ADR-0034)
 - **An `AI_AGENT` principal's id carries an `agent:` prefix on the REST path, but not on the

--- a/openbank-infra/scripts/build-push-admin-ui.sh
+++ b/openbank-infra/scripts/build-push-admin-ui.sh
@@ -370,7 +370,7 @@ if [ -n "${COSIGN_BIN:-}" ]; then
   # the push): trivy generates the image SBOM, cosign attest binds it with the same KMS key.
   if command -v trivy >/dev/null 2>&1; then
     AUI_SBOM="${TMPDIR:-/tmp}/openbank-admin-ui.cdx.json"
-    if trivy image --format cyclonedx --output "${AUI_SBOM}" "${IMAGE}" 2>/dev/null; then
+    if trivy image --platform "${PLATFORM}" --format cyclonedx --output "${AUI_SBOM}" "${IMAGE}" 2>/dev/null; then
       echo "==> cosign attest (cyclonedx) ${IMAGE}"
       COSIGN_YES=true "$COSIGN_BIN" attest --key "${COSIGN_KEY}" --type cyclonedx \
         --predicate "${AUI_SBOM}" "${IMAGE}" \


### PR DESCRIPTION
## Summary
- Follow-up to #636. Trivy now installs, but the SBOM scan still failed: `trivy image` defaults to `linux/amd64` for remote scans regardless of host arch, and admin-ui builds `linux/arm64`-only (sandbox node arch). Reproduced locally: `no child with platform linux/amd64 in index`.
- The script only checks the exit code (stderr is suppressed), so this failed silently as a generic "trivy image SBOM generation failed" WARN — image still pushed unsigned-for-SBOM, Kyverno keeps blocking pod admission, **admin.open-bank.tech still 503 after #636**.
- Pass `--platform "${PLATFORM}"` (the same var the `docker buildx build` call already uses) so trivy scans the arch that was actually built.
- Added a CLAUDE.md pitfall bullet under GitOps/Kubernetes for the next time this bites (e.g. a service or runner-image build moving to arm64).

## Test plan
- [x] Reproduced the failure locally against the live ECR image and confirmed `--platform linux/arm64` fixes it (`trivy image --platform linux/arm64 ...` succeeds, generates SBOM)
- [ ] Merge, re-run Admin-UI deploy
- [ ] Confirm job log shows `cosign attest` succeeding (no more "trivy image SBOM generation failed")
- [ ] Confirm Kyverno admits the new pod, admin-ui reaches 1/1 ready, admin.open-bank.tech serves 200

## Linked issues
N/A — live incident (admin.open-bank.tech 503), continuation of #636.