### PR TITLE
feat(lending, anacredit): loan.stage_changed event integration

### DIFF
--- a/docs/adr/0037-anacredit-credit-exposure-reporting.md
+++ b/docs/adr/0037-anacredit-credit-exposure-reporting.md
@@ -108,6 +108,17 @@ dataset golden-sourcing, or the quarterly accounting dataset. Those are explicit
 **Neutral**
 - Exposure state is fed in (REST upsert) in v1 rather than consumed from `balance.overdraft.*`
   events; event ingestion + persistence is a mechanical follow-up that does not change the domain.
+  **Update (2026-07, issue #638):** the first slice of this follow-up shipped — `anacredit-service`
+  now consumes `openbank-lending-service`'s `loan.stage_changed` event (published only on a genuine
+  IFRS 9 stage transition, ADR-0028 Phase 3) via a new `LoanStageEventConsumer`
+  (`@Incoming("lending-events-in")`), and durably tracks "last known stage per loan" in a new
+  `loan_stage_projection` table — this service's **first** persisted state. The write is idempotent
+  and ordering-safe: it only applies an incoming event if its timestamp is strictly newer than the
+  projection's current value, so an out-of-order or redelivered event can never regress the stage.
+  This is intentionally narrow: the existing `CreditExposure` feed (the AnaCredit credit-dataset
+  model itself) is untouched and still in-memory/REST-fed — wiring the stage projection into the
+  rendered return (`AnaCreditReturnBuilder`, for `LOAN`-instrument-type exposures) is a separate, later
+  increment. `balance.overdraft.*` event ingestion for the overdraft side remains future work.
 
 ## Compliance impact
 

--- a/openbank-anacredit-service/CLAUDE.md
+++ b/openbank-anacredit-service/CLAUDE.md
@@ -2,8 +2,9 @@
 
 AnaCredit granular credit-exposure reporting (**ADR-0037**), port **8137**. Hexagonal per ADR-0002;
 the `domain` package has **zero** framework imports. **Derive-only**: it renders the regulatory
-credit dataset, it **moves no money and emits no events**, so it stays **off the money-path gate**
-(no threat model / 2-approval requirement under ADR-0030).
+credit dataset and **moves no money and emits no events**, so it stays **off the money-path gate**
+(no threat model / 2-approval requirement under ADR-0030) — it now **consumes** one event
+(`lending-service`'s `loan.stage_changed`, issue #638) but that is a one-way read, not a return path.
 
 ## What it does
 
@@ -29,23 +30,42 @@ audit trail** explaining every dropped instrument.
   debtor, aggregates EUR commitment, applies the policy, maps) + `AnaCreditMapper`.
 - `application/` — `AnaCreditService` + in/out ports.
 - `infrastructure/persistence/InMemoryCreditExposureRepository.kt` — v1 in-memory store
-  (the `openbank-product-catalog` pattern).
+  (the `openbank-product-catalog` pattern). **Still in-memory** — this increment does not change it.
 - `infrastructure/rest/AnaCreditResource.kt` — `POST /api/v1/anacredit/exposures` (upsert),
   `GET /api/v1/anacredit/exposures`, `GET /api/v1/anacredit/returns/{referenceDate}` (render).
+- `domain/model/LoanStageProjection.kt` + `application/port/out/LoanStageProjectionRepository.kt` +
+  `infrastructure/persistence/{entity,repository}/LoanStageProjection*` — the durable "last known IFRS
+  9 stage per loan" projection (issue #638). **The one piece of real Postgres persistence in this
+  service** — narrowly scoped to this table; `CreditExposure` itself is untouched and still in-memory.
+- `infrastructure/kafka/LoanStageEventConsumer.kt` — `@Incoming("lending-events-in")`, consumes
+  `openbank-lending-service`'s `loan.stage_changed` (topic `openbank.lending.events`) and applies it to
+  the projection via `LoanStageProjectionRepository.applyIfNewer` (idempotent, keyed on loanId +
+  strictly-newer `eventTimestamp` — an out-of-order or duplicate event can never regress the stage).
+  Same shape as `kyc-service`/`aml-service`'s `PartyEventConsumer`.
 
 ## Build / test
 
 ```
 JAVA_HOME=$(/usr/libexec/java_home -v 25) ./gradlew :openbank-anacredit-service:test --offline
 ```
-The domain tests are pure JUnit (fast, no boot); `AnaCreditResourceTest` is a `@QuarkusTest`;
-`AnaCreditContractTest` pins `openapi.yaml info.version` to `version.txt`.
+The domain tests are pure JUnit (fast, no boot); `AnaCreditResourceTest`/`AnaCreditSecurityTest` are
+`@QuarkusTest`s that do **not** need Postgres/Kafka (in-memory `CreditExposure` feed only);
+`AnaCreditContractTest` pins `openapi.yaml info.version` to `version.txt` (unaffected by this
+increment — no REST API surface change). `AnaCreditBootSmokeIT` and `LoanStageProjectionRepositoryIT`
+DO need real infra and use `PostgresRedpandaTestResource` (Testcontainers Postgres + Redpanda,
+mirrors `balance-service`/`party-service`) — `quarkus.devservices.enabled` stays `false` in `%test`
+for the fast unit/contract tests; the two Testcontainers-backed classes supply their own connection
+properties directly via `QuarkusTestResourceLifecycleManager`, bypassing Dev Services entirely.
 
 ## v1 non-goals (documented in ADR-0037)
 
 - **No ČNB submission transport** (SDMX/statistical-reporting channel) — renders only.
 - **No counterparty reference dataset** golden-sourcing; **no quarterly accounting dataset**.
-- Exposures are **fed in via REST** (v1) rather than consumed from `balance.overdraft.*` events;
-  event ingestion + persistence is a mechanical follow-up that does not touch the domain.
+- The **`CreditExposure` feed itself is still fed in via REST** and stays in-memory — this increment
+  adds a *separate*, narrowly-scoped persisted projection (`loan_stage_projection`) for lending's IFRS 9
+  stage, not a re-platform of the exposure store. Wiring that projection into
+  `AnaCreditReturnBuilder`/`CreditExposure` (so a `LOAN`-instrument-type row actually reflects real
+  overdue/stage data in the rendered return) is a separate, later increment — issue #638 lands the
+  durable, correctly-ordered projection first.
 - **EUR-equivalent commitment is supplied** (`committedAmountEur`) — FX conversion for the threshold
   is the caller's responsibility (`openbank-fx-service`).

--- a/openbank-anacredit-service/build.gradle.kts
+++ b/openbank-anacredit-service/build.gradle.kts
@@ -18,6 +18,18 @@ dependencies {
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
 
+    // Loan stage-changed event ingestion (ADR-0037 follow-up, issue #638): the projection is
+    // anacredit-service's first persisted state, scoped narrowly to `loan_stage_projection` — the
+    // existing CreditExposure feed stays in-memory in this increment.
+    implementation(libs.quarkus.smallrye.kafka)
+    implementation(libs.quarkus.hibernate.reactive.panache)
+    implementation(libs.quarkus.hibernate.reactive.panache.base)
+    implementation(libs.quarkus.reactive.pg.client)
+    implementation(libs.quarkus.flyway)
+    implementation(libs.quarkus.jdbc.postgresql)
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.reactive)
+
     implementation(project(":openbank-libs-domain"))
     implementation(project(":openbank-libs-runtime"))
     implementation(libs.quarkus.oidc)
@@ -29,6 +41,10 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.testcontainers.redpanda)
 }
 
 kover {

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/application/port/out/LoanStageProjectionRepository.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/application/port/out/LoanStageProjectionRepository.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.application.port.out
+
+import com.openbank.anacredit.domain.model.LoanStageProjection
+import java.util.UUID
+
+/**
+ * Durable "last known IFRS 9 stage per loan" read-model (ADR-0037 event-ingestion follow-up,
+ * issue #638) — anacredit-service's first persisted state; see `V1__create_loan_stage_projection.sql`.
+ *
+ * `suspend` (reactive Panache under the implementation), matching the fleet's Kafka-consumer +
+ * reactive-persistence convention (e.g. `openbank-lending-service`'s outbox repository) — the rest of
+ * `AnaCreditService`'s existing synchronous ports are untouched by this addition.
+ */
+interface LoanStageProjectionRepository {
+    suspend fun findByLoanId(loanId: UUID): LoanStageProjection?
+
+    /**
+     * Insert or update the projection for [projection.loanId], but **only** if no row exists yet or the
+     * existing row's `eventTimestamp` is strictly older than [projection.eventTimestamp]. Returns `true`
+     * if the row was written, `false` if an existing, equally-or-more-recent row made this a no-op — the
+     * idempotency guard against duplicate/out-of-order delivery (at-least-once Kafka + redelivery).
+     */
+    suspend fun applyIfNewer(projection: LoanStageProjection): Boolean
+}

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/domain/model/LoanStageProjection.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/domain/model/LoanStageProjection.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.domain.model
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * IFRS 9 stage, exactly as `openbank-lending-service` last reported it for one loan (ADR-0028 Phase 3
+ * / ADR-0037 event ingestion follow-up, issue #638).
+ *
+ * This is a **read-only projection**, not the AnaCredit credit-dataset model itself
+ * ([CreditExposure]): AnaCredit's own domain (scope test, €25k threshold, credit/financial dataset
+ * mapping) is unchanged by this addition. The projection exists so the feed can eventually enrich a
+ * `LOAN`-instrument-type [CreditExposure] with the debtor's real overdue/stage status instead of being
+ * blind to lending's book — wiring that enrichment into [com.openbank.anacredit.domain.report.AnaCreditReturnBuilder]
+ * is a separate, later increment; this lands the durable, correctly-ordered projection first.
+ *
+ * [stage] mirrors `com.openbank.libs.lending.Ifrs9Stage` by name (`STAGE_1`/`STAGE_2`/`STAGE_3`) but is
+ * declared as a plain `String` here rather than a shared dependency on `openbank-libs-lending` types —
+ * anacredit-service consumes lending's event *payload*, a stable wire contract, not its Kotlin types
+ * (services stay independently deployable, ADR-0002).
+ *
+ * [eventTimestamp] is the ordering key for idempotent consumption: a consumer only applies an incoming
+ * event if its `eventTimestamp` is strictly newer than the projection's current value, so a redelivered
+ * or out-of-order event can never regress the stage (see `LoanStageEventConsumer`).
+ */
+data class LoanStageProjection(
+    val loanId: UUID,
+    val stage: String,
+    val daysPastDue: Int,
+    val eventTimestamp: OffsetDateTime,
+    val updatedAt: OffsetDateTime,
+)

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumer.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumer.kt
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
+import com.openbank.anacredit.domain.model.LoanStageProjection
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Consumes `openbank-lending-service`'s `loan.stage_changed` event and updates the durable
+ * "last known IFRS 9 stage per loan" projection (ADR-0037 event-ingestion follow-up, issue #638), so
+ * AnaCredit's eventual `LOAN`-instrument-type exposures are no longer blind to lending's real overdue
+ * bucketing.
+ *
+ * Same shape as `kyc-service`/`aml-service`'s `PartyEventConsumer`: `suspend @Incoming` (Quarkus
+ * dispatches on the Vert.x event loop with a duplicated context, so the reactive-Panache write inside
+ * [LoanStageProjectionRepository] runs correctly), poison-pill safe (a parse/domain failure is caught,
+ * logged, and the message is acked — one malformed event must not wedge the consumer group; the
+ * canonical lending stream can be replayed).
+ *
+ * Idempotent + ordering-safe: [LoanStageProjectionRepository.applyIfNewer] only writes when the
+ * incoming event's timestamp is strictly newer than the projection's current value, so an out-of-order
+ * redelivery or a duplicate can never regress the projection to an older stage.
+ */
+@ApplicationScoped
+class LoanStageEventConsumer {
+
+    @Inject
+    lateinit var projections: LoanStageProjectionRepository
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
+    @Inject
+    lateinit var clock: Clock
+
+    private val log = Logger.getLogger(LoanStageEventConsumer::class.java)
+
+    @Incoming("lending-events-in")
+    @Suppress("TooGenericExceptionCaught") // a consumer must never die on a single bad/foreign event
+    suspend fun consume(payload: String) {
+        val node = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "[lending-events-in] Failed to parse JSON payload: %.200s", payload)
+            return
+        }
+
+        val eventType = node.path("eventType").asText()
+        if (eventType != "loan.stage_changed") return
+
+        val loanId = runCatching { UUID.fromString(node.path("loanId").asText()) }.getOrNull()
+        if (loanId == null) {
+            log.warnf("[lending-events-in] loan.stage_changed without a valid loanId, skipping: %.200s", payload)
+            return
+        }
+        val newStage = node.path("newStage").asText("").ifBlank { null }
+        if (newStage == null) {
+            log.warnf("[lending-events-in] loan.stage_changed without a newStage, skipping: %.200s", payload)
+            return
+        }
+        val daysPastDue = node.path("daysPastDue").asInt(0)
+        // asOf is the business date the transition was assessed as-of; eventTimestamp additionally falls
+        // back to "now" if the payload omits it, so a malformed/older schema never crashes the consumer.
+        val eventTimestamp = runCatching {
+            OffsetDateTime.parse(node.path("asOf").asText())
+        }.getOrDefault(OffsetDateTime.now(clock))
+
+        try {
+            val applied = projections.applyIfNewer(
+                LoanStageProjection(
+                    loanId = loanId,
+                    stage = newStage,
+                    daysPastDue = daysPastDue,
+                    eventTimestamp = eventTimestamp,
+                    updatedAt = OffsetDateTime.now(clock),
+                ),
+            )
+            if (applied) {
+                log.infof(
+                    "[lending-events-in] Applied stage projection for loan %s: %s (DPD %d)",
+                    loanId,
+                    newStage,
+                    daysPastDue,
+                )
+            } else {
+                log.infof(
+                    "[lending-events-in] Ignored stale/duplicate loan.stage_changed for loan %s " +
+                        "(existing projection is already at least as recent)",
+                    loanId,
+                )
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "[lending-events-in] Failed to apply stage projection for loan %s", loanId)
+        }
+    }
+}

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/persistence/entity/LoanStageProjectionEntity.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/persistence/entity/LoanStageProjectionEntity.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.infrastructure.persistence.entity
+
+import com.openbank.libs.domain.identifiers.Ids
+import io.quarkus.hibernate.reactive.panache.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Entity
+@Table(name = "loan_stage_projection")
+class LoanStageProjectionEntity : PanacheEntityBase() {
+    @Id
+    @Column(columnDefinition = "uuid")
+    var id: UUID = Ids.newId()
+
+    @Column(name = "loan_id", columnDefinition = "uuid")
+    var loanId: UUID = Ids.newId()
+
+    @Column(name = "stage", length = 16)
+    var stage: String = ""
+
+    @Column(name = "days_past_due")
+    var daysPastDue: Int = 0
+
+    @Column(name = "event_timestamp")
+    var eventTimestamp: OffsetDateTime = OffsetDateTime.MIN
+
+    @Column(name = "updated_at")
+    var updatedAt: OffsetDateTime = OffsetDateTime.MIN
+}

--- a/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/persistence/repository/LoanStageProjectionRepositoryImpl.kt
+++ b/openbank-anacredit-service/src/main/kotlin/com/openbank/anacredit/infrastructure/persistence/repository/LoanStageProjectionRepositoryImpl.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.anacredit.infrastructure.persistence.repository
+
+import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
+import com.openbank.anacredit.domain.model.LoanStageProjection
+import com.openbank.anacredit.infrastructure.persistence.entity.LoanStageProjectionEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+/**
+ * Reactive-Panache backing for [LoanStageProjectionRepository] (ADR-0037 event-ingestion follow-up,
+ * issue #638). [applyIfNewer] is the sole write path and is the idempotency/ordering guard: it holds
+ * the existing row (if any) for the loan, compares `eventTimestamp`, and only mutates/persists when the
+ * incoming event is strictly newer — so an out-of-order or redelivered `loan.stage_changed` can never
+ * regress the projection.
+ */
+@ApplicationScoped
+class LoanStageProjectionRepositoryImpl :
+    LoanStageProjectionRepository,
+    PanacheRepository<LoanStageProjectionEntity> {
+
+    override suspend fun findByLoanId(loanId: UUID): LoanStageProjection? = Panache.withSession {
+        find("loanId", loanId).firstResult()
+    }.awaitSuspending()?.toDomain()
+
+    override suspend fun applyIfNewer(projection: LoanStageProjection): Boolean = Panache.withTransaction {
+        find("loanId", projection.loanId).firstResult().flatMap { existing ->
+            when {
+                existing == null -> {
+                    val entity = LoanStageProjectionEntity().also {
+                        it.loanId = projection.loanId
+                        it.stage = projection.stage
+                        it.daysPastDue = projection.daysPastDue
+                        it.eventTimestamp = projection.eventTimestamp
+                        it.updatedAt = projection.updatedAt
+                    }
+                    persist(entity).map { true }
+                }
+                existing.eventTimestamp.isBefore(projection.eventTimestamp) -> {
+                    existing.stage = projection.stage
+                    existing.daysPastDue = projection.daysPastDue
+                    existing.eventTimestamp = projection.eventTimestamp
+                    existing.updatedAt = projection.updatedAt
+                    Uni.createFrom().item(true)
+                }
+                else -> {
+                    // Existing row is equally-or-more recent: stale/duplicate delivery, no-op.
+                    Uni.createFrom().item(false)
+                }
+            }
+        }
+    }.awaitSuspending()
+
+    private fun LoanStageProjectionEntity.toDomain() = LoanStageProjection(
+        loanId = loanId,
+        stage = stage,
+        daysPastDue = daysPastDue,
+        eventTimestamp = eventTimestamp,
+        updatedAt = updatedAt,
+    )
+}

--- a/openbank-anacredit-service/src/main/resources/application.yaml
+++ b/openbank-anacredit-service/src/main/resources/application.yaml
@@ -45,6 +45,47 @@ quarkus:
     host: 0.0.0.0
     root-path: /q
 
+  # Loan stage-changed projection only (ADR-0037 follow-up, issue #638) — the existing CreditExposure
+  # feed stays in-memory in this increment; this datasource backs `loan_stage_projection` alone.
+  datasource:
+    db-kind: postgresql
+    username: openbank
+    password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
+    reactive:
+      url: postgresql://localhost:5432/openbank_anacredit
+    jdbc:
+      url: jdbc:postgresql://localhost:5432/openbank_anacredit
+  flyway:
+    migrate-at-start: true
+    connect-retries: 10
+    connect-retries-interval: 2S
+  hibernate-orm:
+    database:
+      generation: none
+
+mp:
+  messaging:
+    connector:
+      smallrye-kafka:
+        security.protocol: ${KAFKA_SECURITY_PROTOCOL:PLAINTEXT}
+        ssl.keystore.location: ${KAFKA_SSL_KEYSTORE_LOCATION:}
+        ssl.keystore.type: ${KAFKA_SSL_KEYSTORE_TYPE:PKCS12}
+        ssl.keystore.password: ${KAFKA_SSL_KEYSTORE_PASSWORD:}
+        ssl.truststore.location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
+        ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
+        ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
+    incoming:
+      # loan.stage_changed -> update the durable stage projection (issue #638). earliest so a
+      # redeployed/rejoined consumer group backfills from the start of the retained topic rather than
+      # only future transitions; applyIfNewer is idempotent so replay never regresses the projection.
+      lending-events-in:
+        connector: smallrye-kafka
+        client.id: anacredit-service-lending-${quarkus.uuid}
+        group.id: anacredit-service-lending
+        topic: openbank.lending.events
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        auto.offset.reset: earliest
+
 "%test":
   quarkus:
     # No OIDC discovery at boot in tests — @TestSecurity covers auth scenarios.

--- a/openbank-anacredit-service/src/main/resources/db/migration/V1__create_loan_stage_projection.sql
+++ b/openbank-anacredit-service/src/main/resources/db/migration/V1__create_loan_stage_projection.sql
@@ -1,0 +1,23 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- anacredit-service's first persisted state (ADR-0037 event-ingestion follow-up, issue #638):
+-- a durable "last known IFRS 9 stage per loan" projection, populated by LoanStageEventConsumer from
+-- lending-service's loan.stage_changed event. This does NOT touch the existing AnaCredit credit-dataset
+-- model (CreditExposure remains in-memory in this increment) — it is a narrow, additive table scoped
+-- specifically to the stage projection.
+--
+-- Rollback: DROP TABLE loan_stage_projection;
+
+CREATE TABLE loan_stage_projection (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    loan_id             UUID NOT NULL UNIQUE,
+    stage               VARCHAR(16) NOT NULL,
+    days_past_due       INTEGER NOT NULL,
+    event_timestamp     TIMESTAMPTZ NOT NULL,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_loan_stage_projection_loan_id ON loan_stage_projection(loan_id);
+
+-- No Hibernate "<table>_seq" needed here (unlike V3 in lending-service / V6 in party-service): the
+-- entity assigns its UUID id client-side (Ids.newId()) before persist, exactly like
+-- LoanProvisioningEntity, so Panache's sequence-based id generator is never invoked.

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumerTest.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/kafka/LoanStageEventConsumerTest.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.anacredit.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.anacredit.application.port.out.LoanStageProjectionRepository
+import com.openbank.anacredit.domain.model.LoanStageProjection
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+class LoanStageEventConsumerTest {
+
+    private val projections = mockk<LoanStageProjectionRepository>()
+    private val fixedClock = Clock.fixed(Instant.parse("2026-07-01T00:00:00Z"), ZoneOffset.UTC)
+    private val consumer = LoanStageEventConsumer().also {
+        it.projections = projections
+        it.objectMapper = ObjectMapper()
+        it.clock = fixedClock
+    }
+
+    @Test
+    fun `loan stage_changed applies the projection with the parsed fields`(): Unit = runBlocking {
+        val loanId = UUID.randomUUID()
+        coEvery { projections.applyIfNewer(any()) } returns true
+
+        consumer.consume(
+            """{"eventType":"loan.stage_changed","loanId":"$loanId","previousStage":"STAGE_1",""" +
+                """"newStage":"STAGE_2","daysPastDue":40,"period":"2026-07","asOf":"2026-07-01"}""",
+        )
+
+        coVerify(exactly = 1) {
+            projections.applyIfNewer(
+                LoanStageProjection(
+                    loanId = loanId,
+                    stage = "STAGE_2",
+                    daysPastDue = 40,
+                    eventTimestamp = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+                    updatedAt = OffsetDateTime.now(fixedClock),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `a stale or duplicate event is a no-op that does not throw`(): Unit = runBlocking {
+        val loanId = UUID.randomUUID()
+        coEvery { projections.applyIfNewer(any()) } returns false
+
+        consumer.consume(
+            """{"eventType":"loan.stage_changed","loanId":"$loanId","previousStage":"STAGE_2",""" +
+                """"newStage":"STAGE_1","daysPastDue":0,"period":"2026-05","asOf":"2026-05-01"}""",
+        )
+
+        coVerify(exactly = 1) { projections.applyIfNewer(any()) }
+    }
+
+    @Test
+    fun `other lending event types are ignored`(): Unit = runBlocking {
+        consumer.consume(
+            """{"eventType":"loan.provisioned","loanId":"${UUID.randomUUID()}","stage":"STAGE_1"}""",
+        )
+
+        coVerify(exactly = 0) { projections.applyIfNewer(any()) }
+    }
+
+    @Test
+    fun `malformed payload is acked without applying a projection or throwing`(): Unit = runBlocking {
+        consumer.consume("not json")
+        consumer.consume("""{"eventType":"loan.stage_changed"}""") // no loanId
+        consumer.consume("""{"eventType":"loan.stage_changed","loanId":"${UUID.randomUUID()}"}""") // no newStage
+
+        coVerify(exactly = 0) { projections.applyIfNewer(any()) }
+    }
+
+    @Test
+    fun `a repository failure is swallowed so the consumer group is not wedged`(): Unit = runBlocking {
+        val loanId = UUID.randomUUID()
+        coEvery { projections.applyIfNewer(any()) } throws RuntimeException("db down")
+
+        // Must not throw — the message is acked and the lending stream can replay.
+        consumer.consume(
+            """{"eventType":"loan.stage_changed","loanId":"$loanId","previousStage":"STAGE_1",""" +
+                """"newStage":"STAGE_2","daysPastDue":35,"asOf":"2026-07-01"}""",
+        )
+
+        coVerify(exactly = 1) { projections.applyIfNewer(any()) }
+    }
+
+    @Test
+    fun `a missing asOf falls back to the injected clock rather than failing`(): Unit = runBlocking {
+        val loanId = UUID.randomUUID()
+        coEvery { projections.applyIfNewer(any()) } returns true
+
+        consumer.consume(
+            """{"eventType":"loan.stage_changed","loanId":"$loanId","previousStage":"STAGE_1",""" +
+                """"newStage":"STAGE_2","daysPastDue":35}""",
+        )
+
+        coVerify(exactly = 1) {
+            projections.applyIfNewer(
+                match { it.loanId == loanId && it.eventTimestamp == OffsetDateTime.now(fixedClock) },
+            )
+        }
+    }
+}

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/persistence/repository/LoanStageProjectionRepositoryIT.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/infrastructure/persistence/repository/LoanStageProjectionRepositoryIT.kt
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.anacredit.infrastructure.persistence.repository
+
+import com.openbank.anacredit.domain.model.LoanStageProjection
+import com.openbank.anacredit.it.PostgresRedpandaTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Exercises [LoanStageProjectionRepositoryImpl] against a real Postgres (Testcontainers) — the
+ * idempotent/ordering-safe `applyIfNewer` upsert is the crux of the whole `loan.stage_changed`
+ * ingestion path (ADR-0037 follow-up, issue #638) and cannot be verified with a mock.
+ *
+ * `LoanStageProjectionRepositoryImpl` is reactive (`Panache.withSession/withTransaction`), so its
+ * suspend calls must run on a Vert.x duplicated context (mirrors `openbank-ledger-service`'s
+ * `JournalPartitionMaintainerIT` — a plain `runBlocking` test thread has none).
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaTestResource::class)
+class LoanStageProjectionRepositoryIT {
+
+    @Inject
+    lateinit var repository: LoanStageProjectionRepositoryImpl
+
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    @Test
+    fun `a first-ever event for a loan is always applied`(): Unit = onVertxContext {
+        val loanId = UUID.randomUUID()
+        val applied = repository.applyIfNewer(
+            LoanStageProjection(
+                loanId = loanId,
+                stage = "STAGE_1",
+                daysPastDue = 0,
+                eventTimestamp = OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+                updatedAt = OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+            ),
+        )
+
+        assertThat(applied).isTrue()
+        val stored = repository.findByLoanId(loanId)
+        assertThat(stored?.stage).isEqualTo("STAGE_1")
+    }
+
+    @Test
+    fun `a newer event overwrites the projection`(): Unit = onVertxContext {
+        val loanId = UUID.randomUUID()
+        repository.applyIfNewer(
+            LoanStageProjection(
+                loanId = loanId,
+                stage = "STAGE_1",
+                daysPastDue = 0,
+                eventTimestamp = OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+                updatedAt = OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+            ),
+        )
+
+        val applied = repository.applyIfNewer(
+            LoanStageProjection(
+                loanId = loanId,
+                stage = "STAGE_2",
+                daysPastDue = 40,
+                eventTimestamp = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+                updatedAt = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+            ),
+        )
+
+        assertThat(applied).isTrue()
+        val stored = repository.findByLoanId(loanId)
+        assertThat(stored?.stage).isEqualTo("STAGE_2")
+        assertThat(stored?.daysPastDue).isEqualTo(40)
+    }
+
+    @Test
+    fun `an out-of-order older event is rejected and never regresses the projection`(): Unit = onVertxContext {
+        val loanId = UUID.randomUUID()
+        repository.applyIfNewer(
+            LoanStageProjection(
+                loanId = loanId,
+                stage = "STAGE_2",
+                daysPastDue = 40,
+                eventTimestamp = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+                updatedAt = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+            ),
+        )
+
+        // A stale re-delivery of an earlier (already superseded) transition.
+        val applied = repository.applyIfNewer(
+            LoanStageProjection(
+                loanId = loanId,
+                stage = "STAGE_1",
+                daysPastDue = 0,
+                eventTimestamp = OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+                updatedAt = OffsetDateTime.parse("2026-06-01T00:00:00Z"),
+            ),
+        )
+
+        assertThat(applied).isFalse()
+        val stored = repository.findByLoanId(loanId)
+        assertThat(stored?.stage).isEqualTo("STAGE_2")
+        assertThat(stored?.daysPastDue).isEqualTo(40)
+    }
+
+    @Test
+    fun `a duplicate event at the same timestamp is a no-op`(): Unit = onVertxContext {
+        val loanId = UUID.randomUUID()
+        val projection = LoanStageProjection(
+            loanId = loanId,
+            stage = "STAGE_2",
+            daysPastDue = 40,
+            eventTimestamp = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+            updatedAt = OffsetDateTime.parse("2026-07-01T00:00:00Z"),
+        )
+        repository.applyIfNewer(projection)
+
+        val appliedAgain = repository.applyIfNewer(projection)
+
+        assertThat(appliedAgain).isFalse()
+    }
+
+    @Test
+    fun `an unknown loan has no projection`(): Unit = onVertxContext {
+        assertThat(repository.findByLoanId(UUID.randomUUID())).isNull()
+    }
+}

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/integration/AnaCreditBootSmokeIT.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/integration/AnaCreditBootSmokeIT.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.anacredit.integration
 
+import com.openbank.anacredit.it.PostgresRedpandaTestResource
+import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
@@ -14,13 +16,16 @@ import org.junit.jupiter.api.Test
 /**
  * Boot smoke test guarding the "released-but-never-booted" defect class.
  *
- * anacredit-service is a released component (version.txt) with no GitOps deployment. It uses an
- * in-memory repository (no Postgres, no Kafka), so no Testcontainers resources are needed — a bare
- * @QuarkusTest is sufficient to boot the full application. This mirrors the pattern introduced for
- * lending-service (boot/config defects only surface at boot: duplicate YAML keys, missing CDI beans,
- * OIDC mis-wiring). The two assertions prove the wiring, config and OIDC override survive a real boot.
+ * anacredit-service is a released component (version.txt) with no GitOps deployment. As of the
+ * `loan.stage_changed` event-ingestion follow-up (ADR-0037, issue #638) it now boots a real Postgres
+ * datasource (Flyway `V1__create_loan_stage_projection.sql`) and a Kafka consumer
+ * (`@Incoming("lending-events-in")`), so this mirrors `balance-service`/`party-service`'s
+ * Testcontainers-backed boot smoke test rather than the old bare-`@QuarkusTest` version (which only
+ * covered the in-memory `CreditExposure` feed). The two assertions prove the wiring, config, DB
+ * migration and OIDC override all survive a real boot against live infrastructure.
  */
 @QuarkusTest
+@QuarkusTestResource(PostgresRedpandaTestResource::class)
 class AnaCreditBootSmokeIT {
 
     @Test

--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/it/PostgresRedpandaTestResource.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.anacredit.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.redpanda.RedpandaContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Isolated PostgreSQL + Redpanda (Kafka API) per test JVM (mirrors `balance-service`'s /
+ * `party-service`'s `PostgresRedpandaTestResource`, CI infra sweep #578 idiom). anacredit-service now
+ * boots the `@Incoming("lending-events-in")` consumer and the `loan_stage_projection` Flyway migration
+ * (ADR-0037 follow-up, issue #638) — a real broker + DB are needed at boot, not an in-memory switch.
+ */
+class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
+    private var postgres: PostgreSQLContainer<*>? = null
+    private var redpanda: RedpandaContainer? = null
+
+    override fun start(): Map<String, String> {
+        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+            .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_anacredit_it")
+        pg.start()
+        postgres = pg
+        val rp = RedpandaContainer(
+            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+                .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
+        )
+        rp.start()
+        redpanda = rp
+        val host = pg.host
+        val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
+        val bootstrap = rp.bootstrapServers
+        return mapOf(
+            "quarkus.datasource.reactive.url" to "vertx-reactive:postgresql://$host:$port/openbank_anacredit_it",
+            "quarkus.datasource.jdbc.url" to "jdbc:postgresql://$host:$port/openbank_anacredit_it",
+            "quarkus.datasource.username" to "openbank",
+            "quarkus.datasource.password" to "openbank_secret",
+            "kafka.bootstrap.servers" to bootstrap,
+            "mp.messaging.connector.smallrye-kafka.bootstrap.servers" to bootstrap,
+            "quarkus.devservices.enabled" to "false",
+        )
+    }
+
+    override fun stop() {
+        redpanda?.stop()
+        postgres?.stop()
+    }
+}

--- a/openbank-infra/gitops/components/anacredit/anacredit-db.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-db.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Single-owner Postgres for anacredit-service (cluster-wide CNPG operator, ADR-0009), scoped narrowly
+# to the loan.stage_changed projection (ADR-0037 follow-up, issue #638) — the existing CreditExposure
+# feed stays in-memory. Generates the anacredit-db-app secret (username/password for the `openbank`
+# owner) and an anacredit-db-rw Service the Deployment uses. Must reconcile BEFORE the anacredit image
+# that carries the datasource config deploys, else Flyway-at-start fails on a missing DB (same pattern
+# as product-catalog-db.yaml).
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: anacredit-db
+  namespace: anacredit
+spec:
+  monitoring:
+    enablePodMonitor: true
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  storage:
+    storageClass: gp3
+    size: 2Gi
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 512Mi}
+  postgresql:
+    parameters:
+      wal_keep_size: "64MB"
+  bootstrap:
+    initdb:
+      database: openbank_anacredit
+      owner: openbank

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # anacredit-service: AnaCredit regulatory reporting (ECB loan-level data, ADR-0037).
-# No DB (reads ledger/credit APIs). OIDC bearer auth via in-cluster Keycloak.
+# OIDC bearer auth via in-cluster Keycloak.
+#
+# Postgres-backed as of the loan.stage_changed event-ingestion follow-up (issue #638) — narrowly
+# scoped to the loan_stage_projection read-model; the CreditExposure feed itself is still in-memory.
+# anacredit-db (anacredit-db.yaml) must reconcile BEFORE this Deployment rolls the datasource-carrying
+# image, else Flyway-at-start fails on a missing DB (same pattern as product-catalog-db.yaml).
+# Kafka mTLS identity/ACLs: kafka-anacredit-mtls.yaml (ADR-0137 pattern) — the KafkaUser/ExternalSecrets
+# there must also land first (lower sync-wave) so the keystore Secret exists when this pod starts.
+# Probes are httpGet on /q/health/ready (not a bare tcpSocket) so Flyway-at-start failures actually
+# fail the probe instead of a false-green TCP-only check (ADR-0105 P1 lesson, product-catalog-db.yaml).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,15 +58,52 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # Datasource (issue #638) — loan_stage_projection only.
+            - name: QUARKUS_DATASOURCE_JDBC_URL
+              value: jdbc:postgresql://anacredit-db-rw.anacredit.svc:5432/openbank_anacredit
+            - name: QUARKUS_DATASOURCE_REACTIVE_URL
+              value: vertx-reactive:postgresql://anacredit-db-rw.anacredit.svc:5432/openbank_anacredit
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: anacredit-db-app
+                  key: password
+            # Kafka mTLS (ADR-0137, kafka-anacredit-mtls.yaml) — consumes loan.stage_changed only.
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA_BOOTSTRAP_SERVERS
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka-keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: anacredit-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka-truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
           startupProbe:
-            tcpSocket:
+            httpGet:
+              path: /q/health/ready
               port: management
             initialDelaySeconds: 10
             periodSeconds: 5
             failureThreshold: 30
           readinessProbe:
-            tcpSocket:
-              port: http
+            httpGet:
+              path: /q/health/ready
+              port: management
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -75,6 +121,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka-keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka-truststore
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -85,6 +137,12 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: kafka-keystore
+          secret:
+            secretName: anacredit-service-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/anacredit/kafka-anacredit-mtls.yaml
+++ b/openbank-infra/gitops/components/anacredit/kafka-anacredit-mtls.yaml
@@ -1,0 +1,91 @@
+# Kafka mTLS identity + ACLs for openbank-anacredit-service (ADR-0137 pattern, issue #638).
+#
+# anacredit-service consumes loan.stage_changed events from openbank.lending.events (group:
+# anacredit-service-lending) to keep the loan_stage_projection read-model current (ADR-0037
+# follow-up). It publishes nothing (still derive-only, ADR-0037 D/B) — no Write ACL needed.
+#
+# Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one principal for all of this
+# service's Kafka traffic. These resources live in `messaging` (where the Strimzi User Operator
+# watches); the Strimzi User Operator mints a per-user Secret of the same name there (user.crt/key/p12
+# + user.password + ca.crt). Those secrets are projected into the `anacredit` namespace by External
+# Secrets below.
+---
+# ── KafkaUser: anacredit-service ────────────────────────────────────────────
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # ADR-0137: certs (KafkaUsers -> Strimzi secrets -> ESO projection) must land before the
+    # anacredit Deployment rolls pods onto mTLS; lower waves sync first and ArgoCD blocks on
+    # ExternalSecrets reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: anacredit-service
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: openbank.lending.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: anacredit-service-lending
+          patternType: literal
+        operations: [Read]
+        host: "*"
+---
+# ── ExternalSecret: anacredit-service keystore ──────────────────────────────
+# Projects the Strimzi-minted anacredit-service Secret from `messaging` into `anacredit`.
+# `dataFrom.extract` copies every key verbatim, preserving the binary PKCS#12 payload byte-for-byte.
+# deletionPolicy: Retain so a transient store/RBAC blip never deletes a live keystore out from under
+# a running pod.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: anacredit-service-kafka-keystore
+  namespace: anacredit
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: anacredit-service-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: anacredit-service
+---
+# ── ExternalSecret: cluster CA truststore ───────────────────────────────────
+# Shared cluster-CA truststore projected into `anacredit` — identical pattern to every other
+# Kafka-connected namespace (kyc, payments, clearing, etc.).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-cluster-ca-truststore
+  namespace: anacredit
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-cluster-ca-truststore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: openbank-cluster-cluster-ca-cert

--- a/openbank-infra/gitops/components/apicurio/network-policies.yaml
+++ b/openbank-infra/gitops/components/apicurio/network-policies.yaml
@@ -94,6 +94,9 @@ spec:
               kubernetes.io/metadata.name: aml
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: anacredit
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: audit
         - namespaceSelector:
             matchLabels:

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -506,32 +506,54 @@ class LendingService(
                 expectedCreditLoss = snapshot.expectedCreditLoss,
                 createdAt = OffsetDateTime.now(clock),
             )
-            if (delta.isZero()) {
-                // Stage/ECL unchanged since the last cycle: keep the audit-trail row, post nothing.
-                provisioning.save(record).map { false }
-            } else {
-                ledger.post(
-                    LedgerPosting(
-                        "loan:${loan.id.value}:provisioning:$period",
-                        loan.partyId,
-                        delta,
-                        PostingKind.PROVISIONING,
+            // A genuine IFRS 9 stage transition (Stage 1/2/3) is a distinct signal from an ECL delta: ECL
+            // can move within the same stage (PD/EAD drift), and — first cycle aside — a stage can change
+            // with a zero-delta ECL in edge cases. Downstream consumers (e.g. AnaCredit's overdue/stage
+            // projection, issue #638) care about the transition itself, not the ledger movement, so this
+            // emits independently of whether a provisioning journal posts below.
+            val stageChanged = prior != null && prior.stage != snapshot.stage
+            val stageEvent = if (stageChanged) {
+                events.emit(
+                    LendingOutboxMessage(
+                        aggregateId = loan.id.value,
+                        eventType = "loan.stage_changed",
+                        payload = """{"loanId":"${loan.id.value}","previousStage":"${prior!!.stage}",""" +
+                            """"newStage":"${snapshot.stage}","daysPastDue":${snapshot.daysPastDue},""" +
+                            """"period":"$period","asOf":"${snapshot.asOf}"}""",
                     ),
                 )
-                    .flatMap { provisioning.save(record) }
-                    .flatMap {
-                        events.emit(
-                            LendingOutboxMessage(
-                                aggregateId = loan.id.value,
-                                eventType = "loan.provisioned",
-                                payload = """{"loanId":"${loan.id.value}","period":"$period",""" +
-                                    """"stage":"${snapshot.stage}",""" +
-                                    """"expectedCreditLoss":"${snapshot.expectedCreditLoss}",""" +
-                                    """"delta":"$delta"}""",
-                            ),
-                        )
-                    }
-                    .map { true }
+            } else {
+                Uni.createFrom().item(Unit)
+            }
+            stageEvent.flatMap {
+                if (delta.isZero()) {
+                    // ECL unchanged since the last cycle: keep the audit-trail row, post nothing to the
+                    // ledger. The stage-changed event (if any) has already been emitted above.
+                    provisioning.save(record).map { false }
+                } else {
+                    ledger.post(
+                        LedgerPosting(
+                            "loan:${loan.id.value}:provisioning:$period",
+                            loan.partyId,
+                            delta,
+                            PostingKind.PROVISIONING,
+                        ),
+                    )
+                        .flatMap { provisioning.save(record) }
+                        .flatMap {
+                            events.emit(
+                                LendingOutboxMessage(
+                                    aggregateId = loan.id.value,
+                                    eventType = "loan.provisioned",
+                                    payload = """{"loanId":"${loan.id.value}","period":"$period",""" +
+                                        """"stage":"${snapshot.stage}",""" +
+                                        """"expectedCreditLoss":"${snapshot.expectedCreditLoss}",""" +
+                                        """"delta":"$delta"}""",
+                                ),
+                            )
+                        }
+                        .map { true }
+                }
             }
         }
 

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -833,6 +833,118 @@ class LendingServiceTest {
     }
 
     @Test
+    fun `provisioning cycle emits loan stage_changed only on a genuine stage transition`() {
+        val loanId = LoanId.random()
+        val loan = Loan(
+            id = loanId,
+            applicationId = LoanApplicationId.random(),
+            partyId = partyId,
+            principal = eur("12000.00"),
+            nominalAnnualRate = BigDecimal("0.12"),
+            termPeriods = 12,
+            method = AmortizationMethod.ANNUITY,
+            firstDueDate = firstDue,
+            disbursedAt = fixedNow,
+            createdAt = fixedNow,
+        )
+        // Unpaid installment due 2026-06-30; assessed 40 days later => DPD 40 > the 30-day SICR
+        // threshold => Stage 2, whereas the prior period's record was Stage 1.
+        val schedule = listOf(
+            LoanInstallment(
+                loanId = loanId,
+                number = 1,
+                dueDate = firstDue,
+                openingBalance = eur("12000.00"),
+                principal = eur("946.19"),
+                interest = eur("120.00"),
+                payment = eur("1066.19"),
+                closingBalance = eur("11053.81"),
+            ),
+        )
+        val asOf = firstDue.plusDays(40)
+        val prior = LoanProvisioningRecord(
+            loanId = loanId,
+            period = "2026-06",
+            asOf = firstDue,
+            outstandingBalance = eur("12000.00"),
+            daysPastDue = 0,
+            bucket = com.openbank.libs.lending.DelinquencyBucket.CURRENT,
+            stage = Ifrs9Stage.STAGE_1,
+            expectedCreditLoss = eur("108.00"),
+            createdAt = fixedNow,
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findActive(any()) } returns Uni.createFrom().item(listOf(loan))
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        mockRiskParameters(loan, "0.02")
+        every { provisioning.findByLoanAndPeriod(loanId, "2026-07") } returns Uni.createFrom().nullItem()
+        every { provisioning.findLatestBefore(loanId, "2026-07") } returns Uni.createFrom().item(prior)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { provisioning.save(any()) } answers { Uni.createFrom().item(firstArg<LoanProvisioningRecord>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.runProvisioningCycle("2026-07", asOf, 500).await().indefinitely()
+
+        val stageChangedEvents = emitted.filter { it.eventType == "loan.stage_changed" }
+        assertThat(stageChangedEvents).hasSize(1)
+        val payload = stageChangedEvents.single().payload
+        assertThat(payload).contains(""""loanId":"${loanId.value}"""")
+        assertThat(payload).contains(""""previousStage":"STAGE_1"""")
+        assertThat(payload).contains(""""newStage":"STAGE_2"""")
+        assertThat(payload).contains(""""daysPastDue":40""")
+    }
+
+    @Test
+    fun `provisioning cycle does not emit loan stage_changed when the stage is unchanged`() {
+        val loanId = LoanId.random()
+        val (loan, schedule) = currentLoanWithSchedule(loanId)
+        val prior = LoanProvisioningRecord(
+            loanId = loanId,
+            period = "2026-05",
+            asOf = LocalDate.parse("2026-05-01"),
+            outstandingBalance = eur("12000.00"),
+            daysPastDue = 0,
+            bucket = com.openbank.libs.lending.DelinquencyBucket.CURRENT,
+            stage = Ifrs9Stage.STAGE_1,
+            expectedCreditLoss = eur("108.00"),
+            createdAt = fixedNow,
+        )
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findActive(any()) } returns Uni.createFrom().item(listOf(loan))
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        // Same PD as the prior period's baseline: Stage 1 -> Stage 1, zero ECL delta.
+        mockRiskParameters(loan, "0.02")
+        every { provisioning.findByLoanAndPeriod(loanId, "2026-06") } returns Uni.createFrom().nullItem()
+        every { provisioning.findLatestBefore(loanId, "2026-06") } returns Uni.createFrom().item(prior)
+        every { provisioning.save(any()) } answers { Uni.createFrom().item(firstArg<LoanProvisioningRecord>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.runProvisioningCycle("2026-06", LocalDate.parse("2026-06-01"), 500).await().indefinitely()
+
+        assertThat(emitted.filter { it.eventType == "loan.stage_changed" }).isEmpty()
+    }
+
+    @Test
+    fun `first provisioning cycle for a loan never emits loan stage_changed (no prior stage to compare)`() {
+        val loanId = LoanId.random()
+        val (loan, schedule) = currentLoanWithSchedule(loanId)
+        val emitted = mutableListOf<LendingOutboxMessage>()
+        every { loans.findActive(any()) } returns Uni.createFrom().item(listOf(loan))
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        mockRiskParameters(loan, "0.02")
+        every { provisioning.findByLoanAndPeriod(loanId, "2026-06") } returns Uni.createFrom().nullItem()
+        every { provisioning.findLatestBefore(loanId, "2026-06") } returns Uni.createFrom().nullItem()
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+        every { provisioning.save(any()) } answers { Uni.createFrom().item(firstArg<LoanProvisioningRecord>()) }
+        every { events.emit(capture(emitted)) } returns Uni.createFrom().item(Unit)
+
+        service.runProvisioningCycle("2026-06", LocalDate.parse("2026-06-01"), 500).await().indefinitely()
+
+        assertThat(emitted.filter { it.eventType == "loan.stage_changed" }).isEmpty()
+        assertThat(emitted.filter { it.eventType == "loan.provisioned" }).hasSize(1)
+    }
+
+    @Test
     fun `provisioning cycle is idempotent - a loan already provisioned this period is skipped`() {
         val loanId = LoanId.random()
         val (loan, _) = currentLoanWithSchedule(loanId)


### PR DESCRIPTION
## Summary

- `openbank-lending-service` now emits a distinct `loan.stage_changed` event (loanId, previousStage,
  newStage, daysPastDue, period, asOf) on the existing lending outbox (`openbank.lending.events`)
  whenever the scheduled IFRS 9 provisioning cycle detects a **genuine stage transition** — not on
  every tick, and not merely because the ECL delta moved (that already had its own `loan.provisioned`
  event). A loan's first-ever provisioning cycle never emits it (no prior stage to compare against).
- `openbank-anacredit-service` (ADR-0037) consumes this event via a new `LoanStageEventConsumer`
  (same `suspend @Incoming` shape as `kyc-service`/`aml-service`'s `PartyEventConsumer`) and durably
  tracks "last known stage per loan" in a new `loan_stage_projection` table — **this service's first
  real persistence**. The existing `CreditExposure` feed itself is untouched and stays in-memory;
  wiring the projection into the rendered AnaCredit return is a separate, later increment.
- Idempotent + ordering-safe: `LoanStageProjectionRepository.applyIfNewer` only writes when the
  incoming event is strictly newer than the projection's current value, so an out-of-order redelivery
  or duplicate can never regress the projection — verified against a real Postgres
  (`LoanStageProjectionRepositoryIT`, Testcontainers).

## Why this shape

ADR-0037 itself flagged this exact follow-up: *"event ingestion + persistence is a mechanical
follow-up that does not change the domain."* `CreditExposure.InstrumentType` already had a `LOAN`
case with nowhere to plug in real stage/DPD data. This lands the durable, correctly-ordered projection
first, narrowly scoped — not a re-platform of the exposure store.

## What's built vs. deferred

**Built:**
- Lending-side stage-transition detection + event, with tests covering: genuine transition (Stage 1→2),
  unchanged stage (no event), first-cycle (no prior, no event).
- AnaCredit-side consumer + idempotent/ordering-safe projection repository + Flyway migration.
- GitOps: `anacredit-db.yaml` (CNPG), `kafka-anacredit-mtls.yaml` (ADR-0137 mTLS identity, read-only
  ACL on `openbank.lending.events`), `anacredit-service.yaml` datasource/Kafka env vars, and
  `httpGet` probes (was a bare `tcpSocket` — Flyway-at-start needs the real health check).

**Deferred (explicitly out of scope):**
- Wiring `loan_stage_projection` into `AnaCreditReturnBuilder`/`CreditExposure` so a `LOAN`-instrument
  return row actually reflects the real stage/overdue data in the rendered AnaCredit return.
- `balance.overdraft.*` event ingestion for the overdraft side (unrelated, pre-existing non-goal).
- ADR-0028 Phase 3's broader AnaCredit/FINREP field-level mapping.

## Money-path / review gate

`openbank-lending-service` is money-path (`rules.yaml: money_path_services`) — the publish side
of this PR touches it, so treating the whole PR as money-path-adjacent (2 approvals). AnaCredit
itself is **not** money-path (derive-only, no money movement, no events emitted — it only consumes
one now) per its own CLAUDE.md and `rules.yaml`.

**This PR will not be merged by the agent that opened it** — opening and stopping here per explicit
instruction; no `--admin`, no self-approval, no auto-merge workaround if blocked.

## Infra note

The GitOps changes provision new cluster resources for anacredit-service (a CNPG Postgres cluster +
a Strimzi `KafkaUser`/mTLS identity) that didn't exist before — this is a real infra change, not a
same-day auto-mergeable bundle. Flagging explicitly for a deliberate review pass before rollout,
consistent with how other new-datastore additions (e.g. product-catalog's) have been reviewed.

## Test plan

- [x] `./gradlew :openbank-lending-service:test` — 26/26 pass (3 new: stage-transition emits event,
      unchanged stage does not, first cycle does not).
- [x] `./gradlew :openbank-lending-service:ktlintCheck :openbank-lending-service:detekt :openbank-lending-service:koverVerify` — pass.
- [x] `./gradlew :openbank-lending-service:quarkusBuild` — CDI wiring boots.
- [x] `./gradlew :openbank-anacredit-service:test` — 30/30 pass, including `LoanStageEventConsumerTest`
      (6 tests: apply/stale-noop/ignore-other-events/malformed-payload/repo-failure-swallowed/missing-asOf-fallback)
      and `LoanStageProjectionRepositoryIT` (5 tests against real Postgres via Testcontainers: first
      event applied, newer overwrites, out-of-order rejected, duplicate no-op, unknown loan returns null)
      and the upgraded `AnaCreditBootSmokeIT` (real Postgres + Redpanda via Testcontainers).
- [x] `./gradlew :openbank-anacredit-service:ktlintCheck :openbank-anacredit-service:detekt :openbank-anacredit-service:koverVerify` — pass.
- [x] `./gradlew :openbank-anacredit-service:quarkusBuild` — CDI wiring boots.
- [x] `.github/scripts/check-duplicate-yaml-keys.sh` — clean, 43 files checked.
- [x] `python3 openbank-infra/scripts/check-release-registration.py` — config/manifest in lockstep.
- [x] `bash docs/adr/gen-index.sh` — re-ran, no diff (Delivery-Status header unchanged).
- [ ] CI (not yet observed — PR just opened).

Closes #638