### PR TITLE
test(admin-ui): fix broken e2e auth + flaky locators on services-docs spec

### DIFF
--- a/openbank-admin-ui/e2e/helpers/auth.ts
+++ b/openbank-admin-ui/e2e/helpers/auth.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// E2E sign-in helper. There is no Keycloak instance in the Playwright environment
+// (webServer.env in playwright.config.ts only sets NEXTAUTH_URL/NEXTAUTH_SECRET, not
+// KEYCLOAK_*), so a real OIDC login is impossible here. src/middleware.ts gates every
+// non-auth route on a valid Auth.js session cookie with no test bypass in the
+// middleware/authOptions themselves (by design — auth bypasses don't belong in
+// production code paths, ADR-0080). Instead, mint a session-token cookie the same way
+// Auth.js itself would after a real login: encode a JWT with the exact secret/salt
+// authOptions.ts uses (@auth/core/jwt, salt = the cookie name) and inject it via
+// context.addCookies(). The middleware decodes it with the identical secret and
+// accepts it as a genuine session — no production code touched.
+import { encode } from '@auth/core/jwt'
+import type { BrowserContext } from '@playwright/test'
+
+// Must match playwright.config.ts webServer.env.NEXTAUTH_SECRET.
+const NEXTAUTH_SECRET = 'e2e-test-secret'
+// Must match authOptions.ts cookies.sessionToken.name: NEXTAUTH_URL is http://, so
+// USE_SECURE_COOKIES is false and the cookie has no `__Secure-` prefix.
+const SESSION_COOKIE_NAME = 'authjs.session-token'
+
+/** Signs the given browser context in as an operator with every role, bypassing Keycloak. */
+export async function signInAsOperator(context: BrowserContext, baseURL: string): Promise<void> {
+  const token = await encode({
+    secret: NEXTAUTH_SECRET,
+    salt: SESSION_COOKIE_NAME,
+    token: {
+      sub: 'e2e-operator',
+      name: 'E2E Operator',
+      email: 'e2e-operator@openbank.test',
+      // All route-guard roles (src/middleware.ts routeGuards) so any page renders.
+      roles: ['ROLE_ADMIN', 'ROLE_OPERATOR', 'ROLE_AUDITOR', 'ROLE_COMPLIANCE', 'ROLE_PAYMENTS'],
+      accessToken: 'e2e-fake-access-token',
+      accessTokenExpires: Date.now() + 60 * 60 * 1000,
+    },
+  })
+  await context.addCookies([{ name: SESSION_COOKIE_NAME, value: token, url: baseURL }])
+}

--- a/openbank-admin-ui/e2e/services-docs.spec.ts
+++ b/openbank-admin-ui/e2e/services-docs.spec.ts
@@ -10,6 +10,14 @@
 // intercepted via page.route() — no live services required.
 
 import { test, expect } from '@playwright/test'
+import { signInAsOperator } from './helpers/auth'
+
+// The console gates every route on an Auth.js session (src/middleware.ts); there is no
+// Keycloak in this environment, so each test signs in via a minted session cookie instead
+// of a real OIDC flow (see helpers/auth.ts for why this is safe).
+test.beforeEach(async ({ context, baseURL }) => {
+  await signInAsOperator(context, baseURL!)
+})
 
 // Minimal DocsIndex payload that satisfies hasDocs=true (items.length > 0)
 const DOCS_INDEX = {
@@ -36,10 +44,12 @@ test.describe('/services — Service Documentation page', () => {
     )
 
     await page.goto('/services')
-    // Wait for loading to finish (coverage counter should appear)
-    await expect(page.getByText(/\d+\s*\/\s*\d+/)).toBeVisible({ timeout: 10_000 })
+    // Wait for loading to finish (coverage counter should appear). Scoped to <main> —
+    // Next.js dev mode can mount a hidden error-overlay pagination badge (also "N/M"
+    // shaped) outside the app shell, which would otherwise collide in strict mode.
+    await expect(page.locator('main').getByText(/\d+\s*\/\s*\d+/)).toBeVisible({ timeout: 10_000 })
 
-    const counterText = await page.getByText(/\d+\s*\/\s*\d+/).first().textContent()
+    const counterText = await page.locator('main').getByText(/\d+\s*\/\s*\d+/).first().textContent()
     // All services documented → numerator == denominator
     const match = counterText?.match(/(\d+)\s*\/\s*(\d+)/)
     expect(match).not.toBeNull()
@@ -58,9 +68,9 @@ test.describe('/services — Service Documentation page', () => {
     )
 
     await page.goto('/services')
-    await expect(page.getByText(/\d+\s*\/\s*\d+/)).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('main').getByText(/\d+\s*\/\s*\d+/)).toBeVisible({ timeout: 10_000 })
 
-    const counterText = await page.getByText(/\d+\s*\/\s*\d+/).first().textContent()
+    const counterText = await page.locator('main').getByText(/\d+\s*\/\s*\d+/).first().textContent()
     const match = counterText?.match(/(\d+)\s*\/\s*(\d+)/)
     expect(match).not.toBeNull()
     const documented = Number(match![1])
@@ -96,8 +106,10 @@ test.describe('/services — Service Documentation page', () => {
     )
 
     await page.goto('/services')
-    // App shell rule (ADR-0076 / graceful-state guard): sidebar must be visible
-    await expect(page.locator('nav, [data-testid="sidebar"], aside')).toBeVisible({ timeout: 10_000 })
+    // App shell rule (ADR-0076 / graceful-state guard): sidebar must be visible.
+    // The Sidebar component renders <aside><nav>…, so match the outer landmark only —
+    // matching both would be a strict-mode violation (2 elements for 1 locator).
+    await expect(page.locator('aside')).toBeVisible({ timeout: 10_000 })
   })
 
   test('gracefully handles health endpoint failure (falls back to static candidates)', async ({ page }) => {
@@ -111,7 +123,7 @@ test.describe('/services — Service Documentation page', () => {
 
     await page.goto('/services')
     // Should still render without crashing — coverage counter visible (0/N with static list)
-    await expect(page.getByText(/\d+\s*\/\s*\d+/)).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('main').getByText(/\d+\s*\/\s*\d+/)).toBeVisible({ timeout: 10_000 })
     // No raw error text leaked (graceful-state rule)
     await expect(page.getByText(/HTTP 5\d\d/)).not.toBeVisible()
   })


### PR DESCRIPTION
## Summary
- `e2e/services-docs.spec.ts` never actually reached `/services` — the app middleware gates every route on an Auth.js session and there's no Keycloak in the Playwright environment, so all 5 tests silently rendered the login page. CI never caught it because the E2E step is `continue-on-error: true` (advisory only).
- Added `e2e/helpers/auth.ts` to mint a session-token cookie with the same secret/salt `authOptions.ts` uses (mirrors a real Keycloak login), wired via `test.beforeEach`.
- With auth actually working, 3 of the 5 tests hit real strict-mode locator collisions (Next dev-mode's hidden error-overlay pagination badge also matches `/\d+\/\d+/`; the Sidebar's `<aside><nav>` both matched the sidebar locator) — scoped those to `main`/`aside`.

## Type of change
- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change
- [x] test (test-only change, no `src/**` touched — no version bump per admin-ui versioning rule)

## Linked issues
N/A — ad hoc test-infra fix found while verifying e2e locally, no tracked issue.

## Changes
- `openbank-admin-ui/e2e/helpers/auth.ts` (new): mints an Auth.js session cookie for e2e sign-in.
- `openbank-admin-ui/e2e/services-docs.spec.ts`: sign in in `beforeEach`; scope 3 locators to avoid strict-mode collisions.

## Definition of Done
- [x] Unit tests: `npm test` — 410/410 passing (unaffected, no `src/**` change).
- [x] E2E: `npx playwright test` — 5/5 passing, verified stable across `--repeat-each=3` (15/15).
- [x] `npm run type-check` and `npx eslint e2e` clean.
- [ ] N/A: no DB/API/Avro change.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs (the e2e session secret is the pre-existing `NEXTAUTH_SECRET: 'e2e-test-secret'` already committed in `playwright.config.ts`, test-only, not reachable outside the Playwright-launched dev server).
- [x] No production auth/middleware code touched — the fix is entirely in `e2e/`.
- [x] No new third-party dependency (uses `@auth/core/jwt`, already a transitive dependency of `next-auth`).

## Compliance impact
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)