### PR TITLE
fix(gitops): disable image-verify cache race + fix SBOM JMESPath key

### DIFF
--- a/openbank-infra/gitops/components/kyverno/verify-images-policy.yaml
+++ b/openbank-infra/gitops/components/kyverno/verify-images-policy.yaml
@@ -58,6 +58,17 @@ spec:
           mutateDigest: false
           verifyDigest: false
           required: true
+          # useCache: false — the image-verify cache has no negative-result TTL of its
+          # own; concurrent verifyImages goroutines (this rule + the SBOM-attestation
+          # rule) race on the same ECR credential temp file ("Could not save cache: open
+          # .../.ecr/.config.json.tmp*: no such file or directory"), and whichever loses
+          # the race gets its transient failure cached as if it were a real verification
+          # result — poisoning every subsequent admission for that tag until the cache
+          # entry expires or the admission-controller pod restarts. Hit on 2026-07-09:
+          # a freshly signed, cosign-verifiable admin-ui image stayed "unverified" for
+          # 10+ retries straight because of this. Always verify fresh; correctness over
+          # the (small) admission-latency saving.
+          useCache: false
           attestors:
             - count: 1
               entries:

--- a/openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
+++ b/openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
@@ -79,12 +79,14 @@ spec:
               conditions:
                 - all:
                     # The attested predicate must actually be a CycloneDX BOM, not an empty
-                    # envelope: bomFormat is a required CycloneDX root field. cosign attest
-                    # --type cyclonedx wraps the SBOM predicate under `Data`, so the field is
-                    # {{ Data.bomFormat }} — a bare {{ bomFormat }} resolves to null and would
-                    # fail EVERY correctly-attested image (100% false Audit failures, and a
-                    # fleet-wide reject if later flipped to Enforce). Matches Kyverno's own
-                    # reference "Verify CycloneDX SBOM" policy.
-                    - key: "{{ Data.bomFormat }}"
+                    # envelope: bomFormat is a required CycloneDX root field. The predicate is
+                    # exposed to the JMESPath condition as the lowercase `data` variable — the
+                    # capitalized `{{ Data.bomFormat }}` this policy shipped with resolves to
+                    # "Unknown key \"Data\" in path" on kyverno 3.2.6 (a JMESPath query failure,
+                    # not a false/true condition result), which errors the whole verifyImages
+                    # check for every correctly-attested image. Confirmed live 2026-07-09 against
+                    # a cosign-verified admin-ui SBOM attestation. Currently Audit-only so this
+                    # was silent; would have 100%-failed the fleet if flipped to Enforce as-is.
+                    - key: "{{ data.bomFormat }}"
                       operator: Equals
                       value: "CycloneDX"


### PR DESCRIPTION
## Summary
Two live Kyverno policy bugs found while chasing the admin.open-bank.tech 503 outage (deployment stuck 0/1 behind image-verification denials, even for a freshly signed and attested image).

1. **`verify-openbank-image-signatures` (Enforce) — poisoned image-verify cache.** Concurrent `verifyImages` goroutines (this rule + the SBOM-attestation rule) race writing the same ECR credential temp file (`Could not save cache: open .../.ecr/.config.json.tmp*: no such file or directory`). Whichever loses the race gets its transient failure cached as a real verification result, blocking every subsequent admission for that tag until the cache TTL expires or the controller restarts. Reproduced: `cosign verify --key ...` succeeded locally against the exact image Kyverno kept rejecting; two admission-controller restarts only bought a few clean attempts before the race poisoned the cache again. Fix: `useCache: false` on the signature rule.
2. **`verify-openbank-image-sbom-attestation` — wrong JMESPath case.** Condition reads `{{ Data.bomFormat }}`; kyverno 3.2.6 exposes the predicate as lowercase `data`, so this errors every check (`Unknown key "Data" in path`) instead of evaluating true/false. Audit-only today so silent, but would 100%-fail the fleet the moment ADR-0144 graduates this to Enforce. Fix: lowercase to `{{ data.bomFormat }}`.

## Test plan
- [x] `cosign verify` / `cosign verify-attestation` confirmed both the signature and the SBOM attestation are valid for the image Kyverno was rejecting
- [ ] Merge, confirm ArgoCD syncs `kyverno-policies`
- [ ] Confirm admin-ui pod is admitted and reaches 1/1 ready
- [ ] Confirm `kubectl get polr -A` no longer shows the `Data.bomFormat` JMESPath error for admin-ui

## Linked issues
N/A — live incident (admin.open-bank.tech 503), continuation of #636 and #640.