### PR TITLE
docs(admin-ui): document e2e auth pattern; read NEXTAUTH_SECRET from env

### DIFF
--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -142,6 +142,24 @@ Any change under `src/**` bumps `version.txt` **and** `package.json` `version` (
 script enforces it). `feat`→minor, `fix`/`perf`→patch, `BREAKING CHANGE`→major. admin-ui is **not** a
 money-path service, so a non-breaking change is auto-merge-eligible after the independent review gate.
 
+## E2E tests (Playwright)
+
+- **Every route is gated on an Auth.js session** (`src/middleware.ts`), and there is no Keycloak in
+  the Playwright environment — a `page.goto()` without a session silently renders `/auth/login`
+  instead of the target page, so an assertion can time out (or worse, false-pass against login-page
+  markup) without anyone noticing. Sign in first via `signInAsOperator(context, baseURL)`
+  (`e2e/helpers/auth.ts`) in a `test.beforeEach` — it mints a real Auth.js session-token cookie
+  (`@auth/core/jwt` `encode()`, same secret/salt `authOptions.ts` uses) and injects it with
+  `context.addCookies()`. No production auth/middleware code is touched. Every new e2e spec needs
+  this same sign-in.
+- **Locators must not collide with Next.js dev-mode's own DOM.** `playwright.config.ts`'s
+  `webServer` runs `next dev`, and a hidden error/warning overlay can inject elements that match a
+  naive text regex (e.g. `/\d+\/\d+/` also matches the overlay's own pagination badge). Scope
+  assertions to `main` (page content) or a specific landmark rather than a bare `page.getByText`.
+- The `E2E tests (Playwright)` CI step is currently `continue-on-error: true` (advisory, not a merge
+  gate) pending full browser-dep provisioning across the runner pool — see `ci.yml` for the exact
+  condition to watch before tightening it.
+
 ## Build & verify
 
 ```

--- a/openbank-admin-ui/CLAUDE.md
+++ b/openbank-admin-ui/CLAUDE.md
@@ -151,7 +151,10 @@ money-path service, so a non-breaking change is auto-merge-eligible after the in
   (`e2e/helpers/auth.ts`) in a `test.beforeEach` — it mints a real Auth.js session-token cookie
   (`@auth/core/jwt` `encode()`, same secret/salt `authOptions.ts` uses) and injects it with
   `context.addCookies()`. No production auth/middleware code is touched. Every new e2e spec needs
-  this same sign-in.
+  this same sign-in. The `NEXTAUTH_SECRET` used to sign the cookie (`e2e-test-secret` by
+  default, overridable via env) is **test-only** — it signs a session on the ephemeral
+  `next dev` server this test run spawns, never a deployed environment; `authOptions.ts`'s
+  `requiredSecret()` already refuses any dev fallback once `NODE_ENV=production`.
 - **Locators must not collide with Next.js dev-mode's own DOM.** `playwright.config.ts`'s
   `webServer` runs `next dev`, and a hidden error/warning overlay can inject elements that match a
   naive text regex (e.g. `/\d+\/\d+/` also matches the overlay's own pagination badge). Scope

--- a/openbank-admin-ui/e2e/helpers/auth.ts
+++ b/openbank-admin-ui/e2e/helpers/auth.ts
@@ -15,8 +15,10 @@
 import { encode } from '@auth/core/jwt'
 import type { BrowserContext } from '@playwright/test'
 
-// Must match playwright.config.ts webServer.env.NEXTAUTH_SECRET.
-const NEXTAUTH_SECRET = 'e2e-test-secret'
+// Reads the same env var playwright.config.ts injects into the dev server
+// (webServer.env.NEXTAUTH_SECRET), falling back to its default — one literal instead of
+// two copies that can silently drift apart.
+const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET ?? 'e2e-test-secret'
 // Must match authOptions.ts cookies.sessionToken.name: NEXTAUTH_URL is http://, so
 // USE_SECURE_COOKIES is false and the cookie has no `__Secure-` prefix.
 const SESSION_COOKIE_NAME = 'authjs.session-token'

--- a/openbank-admin-ui/e2e/helpers/auth.ts
+++ b/openbank-admin-ui/e2e/helpers/auth.ts
@@ -17,7 +17,11 @@ import type { BrowserContext } from '@playwright/test'
 
 // Reads the same env var playwright.config.ts injects into the dev server
 // (webServer.env.NEXTAUTH_SECRET), falling back to its default — one literal instead of
-// two copies that can silently drift apart.
+// two copies that can silently drift apart. This secret only ever signs cookies for the
+// ephemeral `next dev` server Playwright spawns for this test run; it is never a
+// production value and authOptions.ts refuses this exact fallback outside NODE_ENV=production
+// (requiredSecret()), so there is no fail-fast to add here — a missing env var here just
+// means "use the same harmless test default", not a misconfigured deployment.
 const NEXTAUTH_SECRET = process.env.NEXTAUTH_SECRET ?? 'e2e-test-secret'
 // Must match authOptions.ts cookies.sessionToken.name: NEXTAUTH_URL is http://, so
 // USE_SECURE_COOKIES is false and the cookie has no `__Secure-` prefix.

--- a/openbank-admin-ui/playwright.config.ts
+++ b/openbank-admin-ui/playwright.config.ts
@@ -37,9 +37,10 @@ export default defineConfig({
     env: {
       // Point docs bundle to the repo root so libs docs are found
       OPENBANK_REPO_ROOT: '../',
-      // Disable auth for E2E tests
+      // Disable auth for E2E tests. e2e/helpers/auth.ts mints session cookies with this
+      // same secret (falls back to the same default) — keep the two in sync.
       NEXTAUTH_URL: 'http://localhost:3001',
-      NEXTAUTH_SECRET: 'e2e-test-secret',
+      NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET ?? 'e2e-test-secret',
     },
   },
 })


### PR DESCRIPTION
## Summary
Follow-up to #646, which merged before this commit synced to the PR (a race between the
push and the manual merge). #646's automated agent-review flagged that
`e2e/helpers/auth.ts`/`playwright.config.ts` each hardcoded the literal `'e2e-test-secret'`
— this closes that out.

- Both files now read `process.env.NEXTAUTH_SECRET` with that same fallback, so there's one
  source of truth instead of two copies that can silently drift.
- Documents the e2e sign-in pattern (`signInAsOperator`) and the dev-overlay-locator pitfall
  in `openbank-admin-ui/CLAUDE.md` so the next e2e spec doesn't rediscover them.
- References #653 (tracking the follow-up to flip the E2E CI step from advisory to enforced).

## Type of change
- [x] test (test-only + docs, no `src/**` touched — no version bump)

## Linked issues
Refs #653

## Changes
- `openbank-admin-ui/e2e/helpers/auth.ts`: read `NEXTAUTH_SECRET` from env.
- `openbank-admin-ui/playwright.config.ts`: same, kept in sync with the helper.
- `openbank-admin-ui/CLAUDE.md`: new "E2E tests (Playwright)" section.

## Definition of Done
- [x] `npx playwright test` — 5/5 passing.
- [x] `npm test` — 414/414 passing.
- [x] `npm run type-check` clean.

## Security checklist
- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No production auth/middleware code touched.
- [x] No new third-party dependency.

## Compliance impact
- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)