### PR TITLE
fix(infra): self-heal AWS Config recorder if left stopped by an apply

### DIFF
--- a/openbank-infra/aws/envs/sandbox-substrate/config-recorder-selfheal.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/config-recorder-selfheal.tf
@@ -1,0 +1,144 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# AWS Config recorder self-heal (2026-07-06/07/08 incidents)
+# ─────────────────────────────────────────────────────────────────────────────
+# The Config recorder has been left fully STOPPED (not just drifted to
+# CONTINUOUS recording_mode) three times by an apply that recreates or replaces
+# the recorder and gets interrupted (cancelled/failed) before its start step
+# runs — most recently by repeated `tofu apply` iterations against this same
+# stack from a separate in-flight CI-pipeline change. Each recurrence cost
+# $60-90 extra in a single day once a human noticed and restarted it, because a
+# stopped-then-restarted recorder can also lose its DAILY recording_mode and
+# briefly record CONTINUOUS again before the mode is re-applied.
+#
+# This closes the gap with two layers, event-driven + periodic backstop:
+#  1. EventBridge rule matching CloudTrail's StopConfigurationRecorder call —
+#     fires within ~1 minute of the recorder stopping, any cause.
+#  2. A 15-minute schedule as a backstop in case the CloudTrail event is ever
+#     missed (event delivery is best-effort, not guaranteed).
+# Both invoke the same Lambda, which is idempotent — restarting an already-
+# running recorder is a no-op checked before any AWS API call.
+# ─────────────────────────────────────────────────────────────────────────────
+
+data "aws_partition" "current" {}
+
+data "archive_file" "config_recorder_healer" {
+  type        = "zip"
+  source_dir  = "${path.module}/lambda/config-recorder-healer"
+  output_path = "${path.module}/lambda/config-recorder-healer.zip"
+}
+
+data "aws_iam_policy_document" "config_recorder_healer_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "config_recorder_healer" {
+  name               = "${var.cluster_name}-config-recorder-healer"
+  assume_role_policy = data.aws_iam_policy_document.config_recorder_healer_assume.json
+}
+
+data "aws_iam_policy_document" "config_recorder_healer" {
+  statement {
+    sid = "HealRecorder"
+    actions = [
+      "config:DescribeConfigurationRecorderStatus",
+      "config:DescribeConfigurationRecorders",
+      "config:StartConfigurationRecorder",
+      "config:PutConfigurationRecorder",
+    ]
+    resources = ["*"] # Config recorder actions are not resource-scopable
+  }
+  statement {
+    sid       = "PassRecorderRole"
+    actions   = ["iam:PassRole"]
+    resources = [module.audit_baseline.config_role_arn]
+  }
+  statement {
+    sid = "Logs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["arn:${data.aws_partition.current.partition}:logs:${var.region}:*:log-group:/aws/lambda/${var.cluster_name}-config-recorder-healer*"]
+  }
+}
+
+resource "aws_iam_role_policy" "config_recorder_healer" {
+  name   = "heal-recorder"
+  role   = aws_iam_role.config_recorder_healer.id
+  policy = data.aws_iam_policy_document.config_recorder_healer.json
+}
+
+resource "aws_lambda_function" "config_recorder_healer" {
+  function_name    = "${var.cluster_name}-config-recorder-healer"
+  role              = aws_iam_role.config_recorder_healer.arn
+  handler           = "handler.handler"
+  runtime           = "python3.13"
+  timeout           = 30
+  memory_size       = 128
+  filename          = data.archive_file.config_recorder_healer.output_path
+  source_code_hash  = data.archive_file.config_recorder_healer.output_base64sha256
+
+  environment {
+    variables = {
+      RECORDER_NAME       = module.audit_baseline.config_recorder_name
+      RECORDING_FREQUENCY = "DAILY"
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "config_recorder_healer" {
+  name              = "/aws/lambda/${aws_lambda_function.config_recorder_healer.function_name}"
+  retention_in_days = 14
+}
+
+# Layer 1: event-driven, fires within ~1 minute of the stop.
+resource "aws_cloudwatch_event_rule" "config_recorder_stopped" {
+  name = "${var.cluster_name}-config-recorder-stopped"
+  event_pattern = jsonencode({
+    source      = ["aws.config"]
+    detail-type = ["AWS API Call via CloudTrail"]
+    detail = {
+      eventSource = ["config.amazonaws.com"]
+      eventName   = ["StopConfigurationRecorder"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "config_recorder_stopped" {
+  rule = aws_cloudwatch_event_rule.config_recorder_stopped.name
+  arn  = aws_lambda_function.config_recorder_healer.arn
+}
+
+resource "aws_lambda_permission" "config_recorder_stopped" {
+  statement_id  = "AllowEventBridgeStoppedEvent"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.config_recorder_healer.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.config_recorder_stopped.arn
+}
+
+# Layer 2: periodic backstop in case the CloudTrail event is ever missed.
+resource "aws_cloudwatch_event_rule" "config_recorder_healer_schedule" {
+  name                = "${var.cluster_name}-config-recorder-healer-schedule"
+  schedule_expression = "rate(15 minutes)"
+}
+
+resource "aws_cloudwatch_event_target" "config_recorder_healer_schedule" {
+  rule = aws_cloudwatch_event_rule.config_recorder_healer_schedule.name
+  arn  = aws_lambda_function.config_recorder_healer.arn
+}
+
+resource "aws_lambda_permission" "config_recorder_healer_schedule" {
+  statement_id  = "AllowEventBridgeSchedule"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.config_recorder_healer.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.config_recorder_healer_schedule.arn
+}

--- a/openbank-infra/aws/envs/sandbox-substrate/lambda/config-recorder-healer/handler.py
+++ b/openbank-infra/aws/envs/sandbox-substrate/lambda/config-recorder-healer/handler.py
@@ -1,0 +1,55 @@
+"""Self-heal the AWS Config recorder if it is ever left in a stopped state.
+
+Triggered by an EventBridge rule matching the CloudTrail `StopConfigurationRecorder`
+API call. A `tofu apply` that recreates `aws_config_configuration_recorder.audit`
+(e.g. a provider bump, or an apply interrupted mid-recreate) stops the old recorder
+as part of the destroy step; if the apply is cancelled or fails before the new
+recorder's start step runs, the recorder is left off with zero audit coverage
+until someone notices (a 15-hour gap on 2026-07-07, repeated 2026-07-08 during
+active CI iteration on the substrate apply pipeline — each recurrence also cost
+$60-80/day once restarted mid-CONTINUOUS-window before the DAILY mode re-applied).
+
+This does not replace fixing the underlying apply reliability — it is a backstop
+so a stopped recorder is a same-minute self-correction, not a multi-hour human-
+detected compliance and cost gap.
+"""
+
+import os
+
+import boto3
+
+RECORDER_NAME = os.environ["RECORDER_NAME"]
+RECORDING_FREQUENCY = os.environ.get("RECORDING_FREQUENCY", "DAILY")
+
+
+def handler(event, context):
+    client = boto3.client("config")
+
+    status = client.describe_configuration_recorder_status(
+        ConfigurationRecorderNames=[RECORDER_NAME]
+    )["ConfigurationRecordersStatus"]
+
+    if not status:
+        print(f"No recorder named {RECORDER_NAME} found — nothing to heal.")
+        return {"healed": False, "reason": "recorder_not_found"}
+
+    if status[0]["recording"]:
+        print(f"{RECORDER_NAME} is already recording — no action needed.")
+        return {"healed": False, "reason": "already_recording"}
+
+    print(f"{RECORDER_NAME} is stopped — restarting.")
+    client.start_configuration_recorder(ConfigurationRecorderName=RECORDER_NAME)
+
+    # Belt-and-braces: also re-assert the DAILY recording_mode in case the same
+    # apply that stopped the recorder also dropped recordingMode (the original
+    # 2026-07-06 incident — CONTINUOUS drift, not just a stopped recorder).
+    recorder = client.describe_configuration_recorders(
+        ConfigurationRecorderNames=[RECORDER_NAME]
+    )["ConfigurationRecorders"][0]
+    mode = recorder.get("recordingMode", {}).get("recordingFrequency")
+    if mode != RECORDING_FREQUENCY:
+        print(f"recordingMode was {mode!r}, resetting to {RECORDING_FREQUENCY!r}.")
+        recorder["recordingMode"] = {"recordingFrequency": RECORDING_FREQUENCY}
+        client.put_configuration_recorder(ConfigurationRecorder=recorder)
+
+    return {"healed": True}

--- a/openbank-infra/aws/envs/sandbox-substrate/versions.tf
+++ b/openbank-infra/aws/envs/sandbox-substrate/versions.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.7"
+    }
   }
 
   # Separate state from the runner stack so the EKS lifecycle never disturbs the

--- a/openbank-infra/aws/modules/audit-baseline/outputs.tf
+++ b/openbank-infra/aws/modules/audit-baseline/outputs.tf
@@ -20,6 +20,10 @@ output "config_recorder_name" {
   value = aws_config_configuration_recorder.audit.name
 }
 
+output "config_role_arn" {
+  value = aws_iam_role.config.arn
+}
+
 output "audit_kms_key_arn" {
   value = aws_kms_key.audit.arn
 }


### PR DESCRIPTION
## Summary
- Config recorder has been left fully stopped 3× (2026-07-06, 07, 08) by an interrupted `tofu apply` that recreates it — up to 15h of zero audit coverage, plus $60-90/day extra cost each time (recorder briefly re-records CONTINUOUS before a human manually restarts it and re-applies DAILY mode).
- Adds `config-recorder-selfheal.tf`: a small Lambda that restarts the recorder and re-asserts `recordingMode=DAILY` if it's ever found stopped. Two triggers — EventBridge rule on CloudTrail's `StopConfigurationRecorder` (event-driven, ~1min) + a 15-minute schedule as backstop.
- **Verified live**: manually stopped the recorder, self-healed in 21 seconds via the event-driven path.

## Also fixed (discovered during apply)
- A stale S3 state lock (16+ hours old, from a cancelled 2026-07-08T13:47 UTC `tofu apply` run on this same stack) was blocking ALL applies against `sandbox/substrate.tfstate` — including this PR's own plan and any concurrent CI-pipeline work. Verified the owning GitHub Actions run was `completed`/`cancelled` (not in-flight) before `tofu force-unlock`.

## Test plan
- [x] `tofu validate` clean (pre-existing unrelated deprecation warning only)
- [x] `tofu plan` targeted to only the new resources — 10 to add, 0 to change, 0 to destroy (excluded an unrelated pending fck-nat instance replace already in the plan from prior work, deliberately not touched here)
- [x] `tofu apply` (targeted) succeeded
- [x] Live verification: `stop_configuration_recorder` → recorder auto-restarted in 21s, `recordingMode` confirmed DAILY post-heal

Linked issues: N/A — FinOps/compliance incident remediation, no tracked issue opened yet