### PR TITLE
feat(domestic-payment): enforce fraud verdict on cleared payments (ADR-0084 §4.2)

### DIFF
--- a/docs/adr/0084-fraud-detection-bounded-context.md
+++ b/docs/adr/0084-fraud-detection-bounded-context.md
@@ -68,6 +68,24 @@ Author(s): Jiří Raška
 > unmapped currency whenever `isNewPayee` is true. Still shadow mode only; no payment surface honours
 > the verdict yet.
 
+> **Update 2026-07-09 — §4.2: first payment surface honours the verdict (issue #667).**
+> `openbank-domestic-payment` gains an enforcement mode for the fraud gate, flag-gated by
+> `openbank.domestic.fraud.enforcement-enabled` (default `false` — a deliberate runbook-gated
+> rollout flip, same convention as the four-eyes `authz.four-eyes.enforce` toggle; see the
+> "these are first-pass, non-calibrated figures... pending risk-team input" disclosure on the v3/v4
+> thresholds above — enforcement stays off until that calibration happens). With the flag on:
+> `DomesticPaymentService.applyFraudGate` runs for every screening-cleared payment; a REVIEW or
+> CHALLENGE verdict holds the payment in `RECEIVED` (opens a `FRAUD_REVIEW` case via the existing
+> `AmlCasePort`/aml-service case store, mirroring the shape of an AML `REVIEW` hold — no new
+> case-management system) for manual release; DECLINE rejects the payment outright with the new
+> `DomesticRejectReason.FRAUD_SUSPECTED`. ALLOW — and the flag-off shadow path — validate exactly as
+> before. The `FraudScoringAdapter` fail-open contract is unchanged: an unreachable fraud-service
+> still scores ALLOW, so this gate can only ever add friction, never remove availability. Threat
+> model updated (`docs/threat-models/openbank-domestic-payment.md`); no new trust boundary or data
+> flow, same `fraud-service` call as the 2026-06-17 shadow wiring. The other three scored surfaces
+> (sepa-payment, sepa-instant, fx) remain shadow-only — extending enforcement to them is a follow-up,
+> not bundled with this increment.
+
 ## Context
 
 The platform has a **regulatory screening gate** (ADR-0032: synchronous sanctions/AML screening

--- a/docs/threat-models/openbank-domestic-payment.md
+++ b/docs/threat-models/openbank-domestic-payment.md
@@ -143,3 +143,19 @@ not change any existing request's outcome until explicitly flipped.
   both via `api()`). Pure Gradle dependency-graph change — no source import changed, no new transitive
   dependency introduced, no behavior change. Attack surface, trust boundaries, and STRIDE rows above are
   unaffected. No DB change; rollback = revert the commit.
+- **2026-07-09** — ADR-0084 §4.2 (issue #667): the `domestic-payment → fraud-service` edge added
+  2026-06-17 gains an ENFORCEMENT mode, flag-gated by `openbank.domestic.fraud.enforcement-enabled`
+  (off by default — same runbook-gated-rollout posture as `authz.four-eyes.enforce`). With the flag
+  on, a non-ALLOW verdict now has a real effect: REVIEW/CHALLENGE hold the payment in RECEIVED (a
+  `FRAUD_REVIEW` case is opened via the existing `AmlCasePort`/aml-service case store — reused, not a
+  new case-management system) for manual release; DECLINE rejects the payment outright
+  (`DomesticRejectReason.FRAUD_SUSPECTED`). With the flag off, or verdict ALLOW, behavior is
+  byte-for-byte identical to the shadow-only path. **No new trust boundary or data flow** — the same
+  `fraud-service` call, same fail-open adapter contract (an unreachable fraud-service still scores
+  ALLOW, so this gate can only ever add friction, never remove availability). **Risk class = integrity**
+  (a miscalibrated non-ALLOW verdict can hold or reject a legitimate payment) — mitigated by the
+  default-off flag: ADR-0084 itself discloses the v3/v4 thresholds as "first-pass, non-calibrated
+  figures... pending shadow-mode data and risk-team input", so enforcement stays a deliberate,
+  separately-reviewed flip, not bundled with this change. No DB schema change (the AML case store's
+  `alertCode` column already accepts arbitrary values); rollback = flip the flag back to `false` or
+  revert the commit.

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentService.kt
@@ -69,6 +69,8 @@ class DomesticPaymentService(
     private val temporalTaskQueue: String,
     @ConfigProperty(name = "openbank.domestic.scheme-submission.enabled", defaultValue = "false")
     private val schemeSubmissionEnabled: Boolean,
+    @ConfigProperty(name = "openbank.domestic.fraud.enforcement-enabled", defaultValue = "false")
+    private val fraudEnforcementEnabled: Boolean,
     private val workflowClient: WorkflowClient,
     private val clock: Clock,
 ) : DomesticPaymentUseCase {
@@ -90,11 +92,13 @@ class DomesticPaymentService(
         temporalTaskQueue: String,
         @ConfigProperty(name = "openbank.domestic.scheme-submission.enabled", defaultValue = "false")
         schemeSubmissionEnabled: Boolean,
+        @ConfigProperty(name = "openbank.domestic.fraud.enforcement-enabled", defaultValue = "false")
+        fraudEnforcementEnabled: Boolean,
         workflowClient: WorkflowClient,
     ) : this(
         paymentRepository, eventPublisher, screeningPort, amlCasePort, fraudScoringPort,
         schemeGatewayPort, settlementPort, accountLookupPort, metrics, temporalEnabled, temporalTaskQueue,
-        schemeSubmissionEnabled, workflowClient, Clock.systemUTC(),
+        schemeSubmissionEnabled, fraudEnforcementEnabled, workflowClient, Clock.systemUTC(),
     )
 
     private val log = Logger.getLogger(DomesticPaymentService::class.java)
@@ -106,6 +110,7 @@ class DomesticPaymentService(
         private const val ALERT_SANCTIONS_HIT = "SANCTIONS_HIT"
         private const val ALERT_AML_HOLD = "AML_HOLD"
         private const val ALERT_SCREENING_UNAVAILABLE = "SCREENING_UNAVAILABLE"
+        private const val ALERT_FRAUD_REVIEW = "FRAUD_REVIEW"
 
         private const val OWN_BANK_CODE = "0000"
     }
@@ -165,12 +170,10 @@ class DomesticPaymentService(
         }
 
         // ADR-0032: screening is the first processing step, run synchronously after the RECEIVED row
-        // is durably persisted (so the payment is never lost if screening then fails).
+        // is durably persisted (so the payment is never lost if screening then fails). Fraud scoring
+        // (ADR-0084 §4.2) is the second gate, consulted only for a payment screening has cleared —
+        // see applyScreening's CLEAR branch.
         val screened = applyScreening(received)
-
-        // ADR-0084 §4.1 (SHADOW): score for fraud alongside screening, log the verdict, and IGNORE it —
-        // the payment proceeds on its screening outcome. Fail-open via the adapter (never blocks/holds).
-        scoreFraudShadow(screened)
 
         return submitToScheme(screened)
     }
@@ -281,11 +284,18 @@ class DomesticPaymentService(
     }
 
     /**
-     * Fraud scoring in SHADOW mode (ADR-0084 §1/§4.1): the verdict is observed (logged here; metered +
-     * audited by fraud-service), never enforced. A non-ALLOW verdict is logged for the RTS Art. 18
-     * baseline; ALLOW is silent. The adapter is fail-open, so this can never affect the payment.
+     * The fraud gate for a payment screening has cleared (ADR-0084 §4.2). Always scores — the
+     * verdict is metered + audited by fraud-service regardless of enforcement — but only ACTS on
+     * it when `openbank.domestic.fraud.enforcement-enabled` is true (default false, a
+     * runbook-gated rollout flip, same convention as the four-eyes `enforce` toggle). With
+     * enforcement off, or verdict ALLOW, this persists VALIDATED exactly like the pre-Phase-2
+     * shadow path. REVIEW/CHALLENGE hold the payment in RECEIVED (same shape as an AML REVIEW
+     * hold: a case is opened, no further transition, a human releases it) rather than persisting
+     * anything — mirrors [applyScreening]'s own hold-vs-persist split. DECLINE rejects outright.
+     * The adapter is fail-open (`FraudScoringAdapter`), so an unreachable fraud-service always
+     * scores ALLOW here — this gate can only ever add friction, never remove availability.
      */
-    private suspend fun scoreFraudShadow(payment: DomesticPayment) {
+    private suspend fun applyFraudGate(payment: DomesticPayment): DomesticPayment {
         val outcome = fraudScoringPort.score(
             FraudScoreCommand(
                 amount = payment.amount,
@@ -295,14 +305,36 @@ class DomesticPaymentService(
                 counterpartyId = null,
             ),
         )
-        if (outcome.verdict != FraudVerdict.ALLOW) {
-            log.infof(
-                "Fraud SHADOW verdict %s (score=%d, rules=%s) for payment %s — observed, not enforced",
-                outcome.verdict,
-                outcome.score,
-                outcome.ruleVersion,
-                payment.id,
-            )
+        if (outcome.verdict == FraudVerdict.ALLOW) {
+            return persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
+        }
+
+        val mode = if (fraudEnforcementEnabled) "ENFORCED" else "SHADOW"
+        log.infof(
+            "Fraud %s verdict %s (score=%d, rules=%s, reasons=%s) for payment %s",
+            mode,
+            outcome.verdict,
+            outcome.score,
+            outcome.ruleVersion,
+            outcome.reasons,
+            payment.id,
+        )
+        if (!fraudEnforcementEnabled) {
+            return persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
+        }
+
+        val detail = "verdict=${outcome.verdict} score=${outcome.score} rules=${outcome.ruleVersion} " +
+            "reasons=${outcome.reasons.joinToString()}"
+        return when (outcome.verdict) {
+            FraudVerdict.DECLINE -> {
+                openCaseQuietly(payment, AmlCaseRiskLevel.CRITICAL, ALERT_FRAUD_REVIEW, detail, null)
+                persistTransition(payment, DomesticPaymentStatus.REJECTED, DomesticRejectReason.FRAUD_SUSPECTED, detail)
+            }
+            FraudVerdict.REVIEW, FraudVerdict.CHALLENGE -> {
+                openCaseQuietly(payment, AmlCaseRiskLevel.HIGH, ALERT_FRAUD_REVIEW, detail, null)
+                payment
+            }
+            FraudVerdict.ALLOW -> persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
         }
     }
 
@@ -334,8 +366,7 @@ class DomesticPaymentService(
         }
 
         return when (ScreeningPolicy.decide(results)) {
-            ScreeningDecision.CLEAR ->
-                persistTransition(payment, DomesticPaymentStatus.VALIDATED, null, null)
+            ScreeningDecision.CLEAR -> applyFraudGate(payment)
 
             ScreeningDecision.REVIEW -> {
                 results.filter {

--- a/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DomesticPayment.kt
+++ b/openbank-domestic-payment/src/main/kotlin/com/openbank/domestic/domain/model/DomesticPayment.kt
@@ -31,6 +31,7 @@ enum class DomesticRejectReason {
     AMOUNT_LIMIT_EXCEEDED,
     AML_HOLD,
     SANCTIONS_HIT,
+    FRAUD_SUSPECTED,
     TECHNICAL_ERROR,
 }
 

--- a/openbank-domestic-payment/src/main/resources/application.yaml
+++ b/openbank-domestic-payment/src/main/resources/application.yaml
@@ -153,6 +153,12 @@ openbank:
     scheme-submission:
       # ADR-0104 D4 Czech clearing pilot. OFF by default; when off, behaviour is exactly as before.
       enabled: ${DOMESTIC_SCHEME_SUBMISSION_ENABLED:false}
+    fraud:
+      # ADR-0084 §4.2: flips the fraud verdict from SHADOW (observed, logged, ignored) to
+      # ENFORCED (REVIEW/CHALLENGE hold the payment for manual release; DECLINE rejects it).
+      # OFF by default — a deliberate runbook-gated rollout flip, same convention as the
+      # four-eyes `enforce` toggle below. ALLOW always validates regardless of this flag.
+      enforcement-enabled: ${DOMESTIC_FRAUD_ENFORCEMENT_ENABLED:false}
   temporal:
     enabled: false
     server-url: temporal-frontend.temporal.svc.cluster.local:7233

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/application/usecase/DomesticPaymentServiceTest.kt
@@ -71,21 +71,9 @@ class DomesticPaymentServiceTest {
         workflowClient = mockk()
         // temporalEnabled = false: these tests cover the synchronous screening/fraud path
         // (ADR-0101 P2 delegates to Temporal only when enabled), so workflowClient is unused.
-        service = DomesticPaymentService(
-            paymentRepository,
-            eventPublisher,
-            screeningPort,
-            amlCasePort,
-            fraudScoringPort,
-            schemeGatewayPort,
-            settlementPort,
-            accountLookupPort,
-            metrics,
-            temporalEnabled = false,
-            temporalTaskQueue = "openbank-domestic-payments",
-            schemeSubmissionEnabled = false,
-            workflowClient = workflowClient,
-        )
+        // fraudEnforcementEnabled = false here — the shadow-mode default; enforcement-specific
+        // tests rebuild the service with it on.
+        service = buildService(fraudEnforcementEnabled = false)
 
         // Account lookup for server-side transferScope derivation: default to null (INTERNAL_CLIENT).
         coEvery { accountLookupPort.findPartyByIban(any()) } returns null
@@ -100,6 +88,40 @@ class DomesticPaymentServiceTest {
         every { eventPublisher.statusChangedPayload(any(), any()) } returns "{\"event\":\"status-changed\"}"
         coJustRun { amlCasePort.openCase(any()) }
     }
+
+    private fun buildService(fraudEnforcementEnabled: Boolean): DomesticPaymentService = DomesticPaymentService(
+        paymentRepository,
+        eventPublisher,
+        screeningPort,
+        amlCasePort,
+        fraudScoringPort,
+        schemeGatewayPort,
+        settlementPort,
+        accountLookupPort,
+        metrics,
+        temporalEnabled = false,
+        temporalTaskQueue = "openbank-domestic-payments",
+        schemeSubmissionEnabled = false,
+        fraudEnforcementEnabled = fraudEnforcementEnabled,
+        workflowClient = workflowClient,
+    )
+
+    private fun buildServiceWithScheme(): DomesticPaymentService = DomesticPaymentService(
+        paymentRepository,
+        eventPublisher,
+        screeningPort,
+        amlCasePort,
+        fraudScoringPort,
+        schemeGatewayPort,
+        settlementPort,
+        accountLookupPort,
+        metrics,
+        temporalEnabled = false,
+        temporalTaskQueue = "openbank-domestic-payments",
+        schemeSubmissionEnabled = true,
+        fraudEnforcementEnabled = false,
+        workflowClient = workflowClient,
+    )
 
     private fun clear(role: ScreeningRole) = ScreeningResult("name", role, ScreeningMatchStatus.CLEAR, 0.0, null)
 
@@ -152,6 +174,75 @@ class DomesticPaymentServiceTest {
 
         assertThat(result.status).isEqualTo(DomesticPaymentStatus.VALIDATED)
         coVerify(exactly = 1) { fraudScoringPort.score(any()) }
+    }
+
+    @Test
+    fun `enforced DECLINE verdict rejects the payment and opens a CRITICAL fraud case`(): Unit = runBlocking {
+        val enforced = buildService(fraudEnforcementEnabled = true)
+        val command = createCommand()
+        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
+        coEvery { fraudScoringPort.score(any()) } returns
+            FraudScoreOutcome(FraudVerdict.DECLINE, 99, "v4", listOf("velocity-cap"))
+
+        val result = enforced.createPayment(command)
+
+        assertThat(result.status).isEqualTo(DomesticPaymentStatus.REJECTED)
+        assertThat(result.rejectReason).isEqualTo(DomesticRejectReason.FRAUD_SUSPECTED)
+        coVerify {
+            amlCasePort.openCase(
+                match { it.riskLevel == AmlCaseRiskLevel.CRITICAL && it.alertCode == "FRAUD_REVIEW" },
+            )
+        }
+    }
+
+    @Test
+    fun `enforced REVIEW verdict holds the payment in RECEIVED and opens a HIGH fraud case`(): Unit = runBlocking {
+        val enforced = buildService(fraudEnforcementEnabled = true)
+        val command = createCommand()
+        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
+        coEvery { fraudScoringPort.score(any()) } returns
+            FraudScoreOutcome(FraudVerdict.REVIEW, 60, "v4", listOf("new-payee-high-amount"))
+
+        val result = enforced.createPayment(command)
+
+        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
+        coVerify {
+            amlCasePort.openCase(
+                match { it.riskLevel == AmlCaseRiskLevel.HIGH && it.alertCode == "FRAUD_REVIEW" },
+            )
+        }
+        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
+    }
+
+    @Test
+    fun `enforced CHALLENGE verdict also holds the payment for manual release`(): Unit = runBlocking {
+        val enforced = buildService(fraudEnforcementEnabled = true)
+        val command = createCommand()
+        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
+        coEvery { fraudScoringPort.score(any()) } returns
+            FraudScoreOutcome(FraudVerdict.CHALLENGE, 40, "v4", listOf("velocity-h1"))
+
+        val result = enforced.createPayment(command)
+
+        assertThat(result.status).isEqualTo(DomesticPaymentStatus.RECEIVED)
+        coVerify(exactly = 0) { paymentRepository.update(any(), any()) }
+    }
+
+    @Test
+    fun `enforced ALLOW verdict validates the payment exactly like shadow mode`(): Unit = runBlocking {
+        val enforced = buildService(fraudEnforcementEnabled = true)
+        val command = createCommand()
+        coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
+        coEvery { screeningPort.screen(any(), any(), any()) } returns clear(ScreeningRole.DEBTOR)
+        coEvery { fraudScoringPort.score(any()) } returns FraudScoreOutcome(FraudVerdict.ALLOW, 0, "v4", emptyList())
+
+        val result = enforced.createPayment(command)
+
+        assertThat(result.status).isEqualTo(DomesticPaymentStatus.VALIDATED)
+        coVerify(exactly = 0) { amlCasePort.openCase(any()) }
     }
 
     @Test
@@ -321,21 +412,7 @@ class DomesticPaymentServiceTest {
 
     @Test
     fun `scheme ACSC followed by successful settlement transitions payment to SETTLED`(): Unit = runBlocking {
-        val serviceWithScheme = DomesticPaymentService(
-            paymentRepository,
-            eventPublisher,
-            screeningPort,
-            amlCasePort,
-            fraudScoringPort,
-            schemeGatewayPort,
-            settlementPort,
-            accountLookupPort,
-            metrics,
-            temporalEnabled = false,
-            temporalTaskQueue = "openbank-domestic-payments",
-            schemeSubmissionEnabled = true,
-            workflowClient = workflowClient,
-        )
+        val serviceWithScheme = buildServiceWithScheme()
         val command = createCommand()
         coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
         coEvery {
@@ -351,21 +428,7 @@ class DomesticPaymentServiceTest {
 
     @Test
     fun `settlement unavailable holds payment in SENT_TO_CLEARING`(): Unit = runBlocking {
-        val serviceWithScheme = DomesticPaymentService(
-            paymentRepository,
-            eventPublisher,
-            screeningPort,
-            amlCasePort,
-            fraudScoringPort,
-            schemeGatewayPort,
-            settlementPort,
-            accountLookupPort,
-            metrics,
-            temporalEnabled = false,
-            temporalTaskQueue = "openbank-domestic-payments",
-            schemeSubmissionEnabled = true,
-            workflowClient = workflowClient,
-        )
+        val serviceWithScheme = buildServiceWithScheme()
         val command = createCommand()
         coEvery { paymentRepository.findByIdempotencyKey(command.idempotencyKey) } returns null
         coEvery {


### PR DESCRIPTION
## Summary

- Fraud-service has computed real verdicts (v4 rule set: velocity, large-amount, new-payee+high-amount) since 2026-06-17, but no payment surface ever acted on them — pure shadow mode. Issue #667's scope explicitly calls this out: "decision actually consulted by at least one payment service, not just deployed."
- Wires `openbank-domestic-payment` as that first surface. `applyFraudGate` (replacing `scoreFraudShadow`) runs for every screening-cleared payment and, when `openbank.domestic.fraud.enforcement-enabled=true`:
  - **REVIEW/CHALLENGE** → hold the payment in `RECEIVED`, open a `FRAUD_REVIEW` case via the existing `AmlCasePort`/aml-service case store — same shape as an AML `REVIEW` hold (a human releases it), reusing the existing case store rather than building a new one.
  - **DECLINE** → reject outright with the new `DomesticRejectReason.FRAUD_SUSPECTED`.
  - **ALLOW** → validates exactly as before.
- **Default is `false`** — a deliberate runbook-gated rollout flip, same convention as `authz.four-eyes.enforce`. ADR-0084 itself discloses the v3/v4 thresholds as "first-pass, non-calibrated figures... pending shadow-mode data and risk-team input", so flipping this to `true` is a separate, deliberate decision, not bundled here.
- `FraudScoringAdapter`'s fail-open contract is untouched — an unreachable fraud-service still scores `ALLOW`, so this gate can only ever add friction, never remove availability.
- No new trust boundary or data flow — same `fraud-service` call as the 2026-06-17 shadow wiring. Threat model (`docs/threat-models/openbank-domestic-payment.md`) and ADR-0084 updated with delivery notes.
- The other three scored surfaces (sepa-payment, sepa-instant, fx) remain shadow-only; extending enforcement to them is a follow-up.

## Test plan

- [x] `./gradlew :openbank-domestic-payment:ktlintCheck :openbank-domestic-payment:detekt :openbank-domestic-payment:test` — green.
- [x] New unit tests: enforced DECLINE rejects + opens a CRITICAL case; enforced REVIEW holds in RECEIVED + opens a HIGH case; enforced CHALLENGE also holds; enforced ALLOW validates normally with no case opened.
- [x] Existing shadow-mode tests (`fraud shadow verdict is observed but never enforced`, screening REVIEW/BLOCK/unavailable paths) pass unchanged — default-off enforcement preserves current behavior byte-for-byte.

## Money-path

`openbank-domestic-payment` is a money-path service (`rules.yaml: money_path_services`) — this PR needs 2 approvals + the updated threat model per ADR-0030. I have not merged or attempted to merge this myself.

Refs #667