### PR TITLE
fix(gitops): tolerate stale runner image + fix can-i-deploy failure miscount

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -607,8 +607,13 @@ jobs:
               # in this environment", the counterpart service has simply not been deployed to
               # sandbox yet and therefore cannot break any contract expectation. Treat it the
               # same as a 404 pacticipant (not a Pacticipant → trivially deployable).
-              elif [ "$(echo "$cid_out" | grep -c "no verified pact\|Computer says no" || true)" -gt 0 ] && \
-                   [ "$(echo "$cid_out" | grep -c "no version is currently recorded" || true)" -ge "$(echo "$cid_out" | grep -c "no verified pact\|Computer says no" || true)" ]; then
+              # Count only the per-pair "There is no verified pact..." explanation lines, NOT
+              # the one-time "Computer says no" banner the CLI prints regardless of how many
+              # pairs failed — folding the banner into the count made a single real failure
+              # look like two, so the >= comparison below could never hold for exactly one
+              # failing pair (issue surfaced by fraud-service/transaction-service, 2026-07-09).
+              elif [ "$(echo "$cid_out" | grep -c "There is no verified pact" || true)" -gt 0 ] && \
+                   [ "$(echo "$cid_out" | grep -c "no version is currently recorded" || true)" -ge "$(echo "$cid_out" | grep -c "There is no verified pact" || true)" ]; then
                 echo "::warning::can-i-deploy: ${svc} has counterpart(s) not yet recorded in sandbox — treating as deployable (ADR-0092)"
               else
                 echo "::error::can-i-deploy: ${svc} NOT deployable — deployment blocked (ADR-0092)"

--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -213,7 +213,12 @@ locals {
       cache_root="/mnt/k8s-disks/0/runner-tool-cache/Java_Temurin-Hotspot_jdk"
       preload_root="/opt/openbank-jdk-preload/Java_Temurin-Hotspot_jdk"
       mkdir -p "$cache_root"
+      if [ ! -d "$preload_root" ]; then
+        echo "jdk toolcache: preload_root $preload_root not present in this runner image (stale/rebuilt image?) - skipping preload, actions/setup-java will download on demand"
+        exit 0
+      fi
       for version_dir in "$preload_root"/*/; do
+        [ -d "$version_dir" ] || continue
         version="$(basename "$version_dir")"
         dst="$cache_root/$version/arm64"
         if [ -e "$dst.complete" ]; then


### PR DESCRIPTION
## Summary
- `openbank-build` ARC runner pods were crash-looping (`Init:Error`) for 4+ hours: `init-jdk-toolcache-preload` assumed `/opt/openbank-jdk-preload/` always exists in the pinned runner image digest, but that digest predates the preload feature. Fix: guard on directory existence, skip cleanly (falls back to normal `actions/setup-java` download).
- `can-i-deploy`'s ADR-0092 "counterpart never deployed to sandbox" carve-out double-counted the one-time "Computer says no" banner alongside the real per-pair failure line, so a single genuine failure could never satisfy the `-ge` comparison. Fix: count only the `There is no verified pact` line.

Both were caught live while getting fraud-service (#635) and billing-service (#672) redeployed today — verified the runner fix via a live `kubectl patch` to the AutoScalingRunnerSet (pods now 2/2 Running) before committing it here so the next `tofu apply` doesn't regress it.

## Test plan
- [x] Live-verified: patched `AutoScalingRunnerSet/openbank-build` in-cluster, confirmed new pods reach `2/2 Running`
- [x] Reproduced the can-i-deploy miscount from actual `auto-deploy` run logs (fraud-service vs transaction-service, run 29014201492) and confirmed the corrected grep pattern would classify it as deployable
- [ ] Next `auto-deploy` workflow_dispatch for fraud-service/billing-service should pass `can-i-deploy` cleanly once this merges

Linked issues: N/A — operational CI/infra fix found and fixed inline while chasing deployment of #635/#672, no tracking issue