### PR TITLE
chore(gitops): auto-deploy services @ 357b9db6b0b0de507d8a2bc568696aba7d1e20dc

### DIFF
--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -36,7 +36,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: billing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-7bd7f7fd
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-357b9db6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -33,7 +33,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: fraud-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-7f06f8b1b
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-357b9db6
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8133}


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 357b9db6b0b0de507d8a2bc568696aba7d1e20dc.

**Changed services:** ["openbank-fraud-service","openbank-billing-service"]

Each image tag was updated to `sandbox-357b9db6b0b0de507d8a2bc568696aba7d1e20dc` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.