### PR TITLE
feat(simulation): bind the DST harness to the real statement-close domain (ADR-0035/0078)

### DIFF
--- a/openbank-simulation/README.md
+++ b/openbank-simulation/README.md
@@ -6,13 +6,19 @@ Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 
 # openbank-simulation — Deterministic Simulation Testing harness (ADR-0100)
 
 A pure-JVM Deterministic Simulation Testing (DST) harness for the OpenBank money path. It runs
-the ledger / balance / payment-saga semantics through a **single seeded, deterministic
-scheduler under adversarial fault injection** and asserts global money invariants after every
-step. Any failure is reproducible from its seed.
+the ledger / balance / payment-saga / SEPA-settlement / billing / interest / statement-close
+semantics through a **single seeded, deterministic scheduler under adversarial fault injection**
+and asserts global money invariants after every step. Any failure is reproducible from its seed.
 
 This is **tooling, not a released service**: no `version.txt`, not in `release-please-config.json`,
 never containerised. It is the lowest-cost first rung of ADR-0100 Layer 2 — the "Pure JVM
-simulation" engine option. The implementation roadmap lives in issue **#1612**.
+simulation" engine option.
+
+This module is also the **day-in-the-life money-path proof** scoped in issue #667: the five
+scenarios below run every seed, interleaved, against the same shared `World` — a single
+reproducible run exercises payment → SEPA settlement → billing fee charge/reversal → interest
+accrual/capitalization → statement period-close, all through the REAL domain aggregates of their
+respective services, not a re-model.
 
 ## Why
 
@@ -22,19 +28,31 @@ partition unless a test remembers to make them. DST instead replaces every sourc
 non-determinism with a seeded simulator, drives the system through many fault permutations, and
 checks invariants after each — the model used by FoundationDB and TigerBeetle. A DST harness
 would have caught the manual-settlement compensation gap (ADR-0100 §Context) by exhaustion, not
-luck.
+luck — and, in practice, it has: interleaving `FeeBillingScenario` and `InterestAccrualScenario`
+into the same per-step loop surfaced a real stale-balance-snapshot race (issue #667, fixed by
+draining the scheduler after every scenario, not just once at the end of the step).
 
 ## What it runs
 
 ```
 src/main/kotlin/com/openbank/simulation/
   engine/      VirtualClock, SimulationRandom, FaultInjector, DeterministicScheduler, SimulationContext
-  model/       Ledger (double-entry), Balance (overdraft floor), PaymentSaga (libs SagaStateMachine)
+  model/       LedgerState, BalanceStore, BillingFeeLedger, InterestAccrualBook, StatementCloseBook
   adapters/    SimEventBus (at-least-once: duplicate/drop-redeliver/reorder), BalanceProjection, AuditLog
-  invariants/  the ADR-0100 Layer-3 global assertions
-  scenario/    PaymentScenario — one internal transfer through the full saga
+  invariants/  the ADR-0100 Layer-3 global assertions (MoneyPathInvariants)
+  scenario/    one object per money-path leg (below) — each drives the REAL service domain
   runner/      SimulationRunner — seed-driven exhaustion loop + reproducible SeedResult
 ```
+
+### Scenarios (each step runs all five, interleaved, against the real domain of its service)
+
+| Scenario | Money-path leg | Real domain driven |
+|---|---|---|
+| `PaymentScenario` | internal transfer, saga + compensation | `openbank-ledger-service` `JournalEntry`, `openbank-transaction-service` `SagaState` |
+| `SepaSettlementScenario` | SEPA payment + settlement | `openbank-sepa-payment` `SepaPayment`, `openbank-settlement-service` `Settlement` |
+| `FeeBillingScenario` | billing fee charge + reversal (ADR-0143) | `openbank-billing-service` `AssessedFee`/`FeeJournalCommand`/`FeeReversalCommand` |
+| `InterestAccrualScenario` | interest accrual + capitalization + withholding (ADR-0033) | `openbank-interest-service` `InterestAccrual`/`InterestCapitalization`/`WithholdingTaxPolicy` |
+| `StatementCloseScenario` | statement period-close (ADR-0035/0078) | `openbank-statement-service` `StatementPeriod`/`ReconciliationPolicy` |
 
 ### Layer-3 invariants asserted after every step
 
@@ -45,18 +63,24 @@ src/main/kotlin/com/openbank/simulation/
 | `ledger-balance-projection-consistency` | each balance's booked movement equals the ledger's net delta (idempotent projection) |
 | `compensation-completeness` | no saga left stuck; every one reaches COMPLETED / COMPENSATED / FAILED |
 | `audit-completeness` | the hash-chained audit log verifies and covers every saga |
+| `sepa-payment-completeness` | every `SepaPayment` reaches a terminal status |
+| `settlement-completeness` | every `Settlement` reaches a terminal status |
+| `billing-fee-conservation` | `Σ fees assessed == Σ fee journals posted` per cycle/account/fee/currency |
+| `interest-capitalization-conservation` | `Σ capitalized ≤ Σ accrued`, `gross == net + tax`, both journal legs actually posted |
+| `statement-close-integrity` | a period is persisted **iff** `ReconciliationPolicy` reconciled — never on a mismatch, never skipped on success |
 
 ## Run it
 
 ```bash
 ./gradlew :openbank-simulation:test          # the full DST suite (compile + run)
 ./gradlew :openbank-simulation:build         # + detekt + ktlint + coverage report
+./gradlew :openbank-simulation:test -Pseed.count=2000   # deeper sweep (ADR-0115)
 ```
 
 `DstSimulationTest` is the end-to-end proof and is structured to be credible — a harness that
 only ever passes proves nothing:
 
-1. **Happy path** — all invariants hold across 200 seeds with no faults.
+1. **Happy path** — all invariants hold across 300 seeds × 50 steps with no faults.
 2. **Adversarial + correct code** — all invariants hold across 300 seeds under the hostile
    fault profile (dropped/duplicated/reordered events, write failures, lock conflicts), because
    the projection is correctly dedup-guarded.
@@ -64,21 +88,54 @@ only ever passes proves nothing:
    the harness *finds* the resulting `projection-consistency` violation.
 4. **Reproducibility** — replaying the failing seed reproduces the exact same violation.
 
+Every scenario/invariant pair follows the same two-sided proof at smaller scale in its own test
+class (e.g. `StatementCloseIntegrityInvariantTest` proves the invariant both holds correctly *and*
+catches a period wrongly persisted despite a reconciliation mismatch).
+
+### Captured output (`./gradlew :openbank-simulation:test`, reproducible from this commit)
+
+```
+11 test classes, 51 tests, 0 failures, 0 errors, 0 skipped
+  DstSimulationTest                            4 tests  — 300-seed × 50-step sweep, happy/adversarial/bug-detection/reproducibility
+  EngineDeterminismTest                        3 tests
+  BillingFeeConservationInvariantTest          7 tests
+  InterestConservationInvariantTest            7 tests
+  StatementCloseIntegrityInvariantTest         5 tests
+  LedgerModelTest                              5 tests
+  StatementCloseBookTest                       3 tests
+  FeeBillingScenarioTest                       6 tests
+  InterestAccrualScenarioTest                  4 tests
+  SepaSettlementScenarioTest                   4 tests
+  StatementCloseScenarioTest                   3 tests
+```
+
 ## Fidelity and limits (honest scope)
 
-- **Ledger postings run the REAL aggregate.** The harness depends on `openbank-ledger-service`
-  and drives the production `JournalEntry` — its `validateBalance()` invariant fires on
-  construction, `bookedDeltas()` (ADR-0039 credit-positive deposit-control projection) feeds the
-  balance, and `reverse()` performs compensation. The ledger domain is framework-free (ADR-0002),
-  so only its POJOs are on the classpath, not a Quarkus runtime. Built on the real `openbank-libs`
-  primitives too (`Money` arithmetic + scale rules, the shared `SagaStateMachine`).
+- **Ledger, billing, interest and statement postings run the REAL aggregates and pure domain
+  policies.** `JournalEntry.validateBalance()`/`bookedDeltas()`/`reverse()` (ADR-0039),
+  `WithholdingTaxPolicy` (ADR-0033 §36/§38d statutory rounding), `ReconciliationPolicy` (ADR-0035
+  §E fail-closed period-boundary check) — all framework-free domain code (ADR-0002), so only
+  POJOs land on the classpath, not a Quarkus runtime.
   - *DST finding:* `JournalEntry.reverse()` calls `Instant.now()`/`UUID.randomUUID()` directly —
     a clock-injection gap (ADR-0100 Layer 1, the `clock_injection` rule). It only affects the
     reversal's id/timestamp, not the booked money math, so the verdict stays seed-reproducible.
+  - *DST finding (issue #667):* a stale per-step balance snapshot let `FeeBillingScenario`'s
+    affordability check see an already-decided-but-unapplied `PaymentScenario` debit as if it had
+    never happened — two individually-affordable debits could jointly overdraw an account. Fixed
+    by draining the scheduler after every scenario, not once at the end of the step.
 - **Still re-modelled** (not yet bound to the exact service classes): `Balance` (overdraft floor)
   and the `PaymentSaga` orchestration — the real ones sit behind heavier application/infra
   collaborators (period locks, fiscal-year repos, outbox). Binding those, plus driving the real
   `LedgerService`/`PaymentSagaOrchestrator` use-cases, is tracked in #1612.
+- **Not covered, and deliberately out of scope for this harness:** customer onboarding/KYC (a
+  fundamentally different, non-money-path flow — party creation, document verification), fraud
+  scoring/enforcement (a REST-boundary decision gate, not a domain aggregate this harness can
+  bind to the way it binds ledger/billing/interest/statement), statement *rendering*
+  (`StatementRenderer` — camt.053/MT940/PDF projection, a read-side concern with no money-path
+  invariant of its own), and FinRep/CoRep regulatory extracts (a reporting aggregation, not a
+  posting flow). A genuine end-to-end proof of those legs needs a real running-services
+  integration script (docker-compose), not this pure-JVM domain simulator — see issue #667 for
+  the scope discussion.
 - **Pure-JVM fidelity ceiling** (ADR-0100): this engine virtualises the domain + application
   layers single-threaded; it cannot catch JVM-threading or OS-level non-determinism. The
   higher-fidelity Antithesis hypervisor option is deferred (evaluate after this proves value).

--- a/openbank-simulation/build.gradle.kts
+++ b/openbank-simulation/build.gradle.kts
@@ -81,6 +81,13 @@ dependencies {
     // framework-free (ADR-0002), so only the domain POJOs land on the classpath.
     implementation(project(":openbank-interest-service"))
 
+    // Issue #667 (E2E money-path): the harness also drives the REAL statement-service domain —
+    // `StatementPeriod`/`PeriodCloseStatus` and the ADR-0035/0078 `ReconciliationPolicy`
+    // (fail-closed period-boundary reconciliation: a period is closed only when the computed
+    // closing balance matches balance-service's independently reported one). The domain package
+    // is framework-free (ADR-0002), so only the domain POJOs land on the classpath.
+    implementation(project(":openbank-statement-service"))
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.assertj)

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/invariants/MoneyPathInvariants.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/invariants/MoneyPathInvariants.kt
@@ -221,6 +221,26 @@ object MoneyPathInvariants {
         }
     }
 
+    /**
+     * ADR-0035 §E / ADR-0078, issue #667: a statement period is persisted *if and only if* the
+     * real `ReconciliationPolicy` decided `Reconciled` for that close attempt — never on a
+     * `Mismatch` (no partial, self-inconsistent legal document is ever produced) and never skipped
+     * on a `Reconciled` decision (no silently-dropped good close either).
+     */
+    val statementCloseIntegrity = object : Invariant {
+        override val name = "statement-close-integrity"
+        override fun check(world: World): Violation? {
+            world.statementCloses.attempts().forEach { attempt ->
+                val reconciled = world.statementCloses.wasReconciled(attempt)
+                val persisted = world.statementCloses.wasPersisted(attempt)
+                if (reconciled != persisted) {
+                    return Violation(name, "close attempt $attempt: reconciled=$reconciled but persisted=$persisted")
+                }
+            }
+            return null
+        }
+    }
+
     /** All Layer-3 invariants, in check order. */
     val ALL: List<Invariant> = listOf(
         conservationOfMoney,
@@ -232,6 +252,7 @@ object MoneyPathInvariants {
         settlementCompleteness,
         billingFeeConservation,
         interestCapitalizationConservation,
+        statementCloseIntegrity,
     )
 
     /** A terminal-state guard used by the saga orchestrator. */

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/model/StatementCloseBook.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/model/StatementCloseBook.kt
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.model
+
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * One statement period-close attempt for `(accountId, currency)` — the `attemptId` dimension
+ * keeps every step's key space-disjoint, the same reasoning [BillingFeeKey] documents for
+ * `FeeBillingScenario`'s per-step-fresh `cycleId`.
+ */
+data class StatementCloseKey(val accountId: UUID, val currency: String, val attemptId: String)
+
+/**
+ * Simulated statement-close state (ADR-0035/0078, issue #667): every close ATTEMPT records two
+ * independent facts — what [com.openbank.statement.domain.reconcile.ReconciliationPolicy] decided
+ * (`Reconciled` vs `Mismatch`) and whether a `StatementPeriod` was actually persisted — so
+ * `MoneyPathInvariants.statementCloseIntegrity` can assert they never disagree: a period is
+ * persisted *if and only if* reconciliation succeeded. This is the fail-closed guarantee ADR-0035
+ * §E exists to provide ("no partial, self-inconsistent legal document is ever produced"), checked
+ * as a cross-side reconciliation — the same both-sides-recorded-independently shape as
+ * [BillingFeeLedger] — rather than trusted by construction.
+ *
+ * Separately tracks, per `(accountId, currency)` (no attempt dimension — this is running state,
+ * not a per-attempt fact), the last successfully closed period's closing balance, the ledger net
+ * movement at that close, and the next legal/electronic sequence number to assign — so a
+ * subsequent close attempt computes its opening balance and net-movement-since-last-close exactly
+ * as the real `StatementService.mintPeriod`/`openingBalance` would.
+ */
+class StatementCloseBook {
+    private val reconciled = mutableMapOf<StatementCloseKey, Boolean>()
+    private val persisted = mutableMapOf<StatementCloseKey, Boolean>()
+
+    private val lastClosingBalance = mutableMapOf<AccountCurrency, BigDecimal>()
+    private val netAtLastClose = mutableMapOf<AccountCurrency, BigDecimal>()
+    private val nextSequence = mutableMapOf<AccountCurrency, Long>()
+
+    fun recordDecision(key: StatementCloseKey, wasReconciled: Boolean) {
+        reconciled[key] = wasReconciled
+    }
+
+    fun recordPersisted(key: StatementCloseKey, wasPersisted: Boolean) {
+        persisted[key] = wasPersisted
+    }
+
+    /** Every close attempt seen — the invariant checks the full set, not just one side. */
+    fun attempts(): Set<StatementCloseKey> = reconciled.keys + persisted.keys
+
+    fun wasReconciled(key: StatementCloseKey): Boolean = reconciled.getOrDefault(key, false)
+
+    fun wasPersisted(key: StatementCloseKey): Boolean = persisted.getOrDefault(key, false)
+
+    /** Opening balance for the NEXT close: the prior close's closing, else `openingBooked`. */
+    fun openingBalanceOf(key: AccountCurrency, fallback: BigDecimal): BigDecimal =
+        lastClosingBalance.getOrDefault(key, fallback)
+
+    /** The ledger's cumulative net movement as of the last successful close (0 if never closed). */
+    fun netAtLastCloseOf(key: AccountCurrency): BigDecimal = netAtLastClose.getOrDefault(key, BigDecimal.ZERO)
+
+    fun nextSequenceOf(key: AccountCurrency): Long = nextSequence.getOrDefault(key, 1L)
+
+    /** Advance the running state after a successful close — never called on a Mismatch. */
+    fun advance(key: AccountCurrency, closingBalance: BigDecimal, cumulativeNet: BigDecimal) {
+        lastClosingBalance[key] = closingBalance
+        netAtLastClose[key] = cumulativeNet
+        nextSequence[key] = nextSequenceOf(key) + 1
+    }
+}

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/SimulationRunner.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/SimulationRunner.kt
@@ -12,6 +12,7 @@ import com.openbank.simulation.scenario.FeeBillingScenario
 import com.openbank.simulation.scenario.InterestAccrualScenario
 import com.openbank.simulation.scenario.PaymentScenario
 import com.openbank.simulation.scenario.SepaSettlementScenario
+import com.openbank.simulation.scenario.StatementCloseScenario
 
 /**
  * The seed-driven exhaustion loop (ADR-0100 Layer 2 — runner). For each seed it builds a fresh
@@ -62,6 +63,12 @@ class SimulationRunner(
             // capitalization-posting path so it shares the fault profile and is checked by the
             // same invariant sweep every step.
             InterestAccrualScenario.step(world)
+            context.scheduler.drain()
+            // ADR-0035/0078 / issue #667: the statement period-close path, checked against the
+            // ledger's net movement since the account's last close — reads world.ledger/balances
+            // only, posts nothing, so this drain is a no-op today but kept for the same
+            // "settled before the invariant sweep" convention as every other scenario above.
+            StatementCloseScenario.step(world)
             context.scheduler.drain()
             invariants.forEach { invariant ->
                 val violation = invariant.check(world)

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/World.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/runner/World.kt
@@ -16,6 +16,7 @@ import com.openbank.simulation.model.BillingFeeLedger
 import com.openbank.simulation.model.InterestAccrualBook
 import com.openbank.simulation.model.LedgerState
 import com.openbank.simulation.model.SimPaymentSaga
+import com.openbank.simulation.model.StatementCloseBook
 import java.math.BigDecimal
 import java.util.UUID
 
@@ -62,6 +63,11 @@ class World(val context: SimulationContext, val config: SimulationConfig) {
     // gross/net/tax capitalization split (real WithholdingTaxPolicy) and the journal legs that
     // actually landed. Populated by InterestAccrualScenario; empty (trivially satisfied) otherwise.
     val interest = InterestAccrualBook()
+
+    // ADR-0035/0078 / issue #667: the statement-close integrity invariant's state — every close
+    // attempt's ReconciliationPolicy decision cross-checked against whether a period was actually
+    // persisted. Populated by StatementCloseScenario; empty (trivially satisfied) otherwise.
+    val statementCloses = StatementCloseBook()
 
     val customerAccounts: List<UUID>
     val currency: String = config.currency

--- a/openbank-simulation/src/main/kotlin/com/openbank/simulation/scenario/StatementCloseScenario.kt
+++ b/openbank-simulation/src/main/kotlin/com/openbank/simulation/scenario/StatementCloseScenario.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.scenario
+
+import com.openbank.simulation.model.AccountCurrency
+import com.openbank.simulation.model.StatementCloseKey
+import com.openbank.simulation.runner.World
+import com.openbank.statement.domain.model.PeriodCloseStatus
+import com.openbank.statement.domain.model.StatementPeriod
+import com.openbank.statement.domain.reconcile.ReconciliationPolicy
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Issue #667 (E2E money-path): one step of the statement period-close path — modelled directly
+ * against the **real `openbank-statement-service` domain** (`StatementPeriod`, and above all the
+ * fail-closed `ReconciliationPolicy` a period-close must pass, ADR-0035 §E / ADR-0078), mirroring
+ * [PaymentScenario]/[FeeBillingScenario]/[InterestAccrualScenario]'s "build on the real system"
+ * convention (ADR-0100).
+ *
+ * `StatementService.mintPeriod`'s use case itself is Mutiny/CDI-bound and cannot run inside the
+ * pure-JVM harness (same reasoning documented on [InterestAccrualScenario]), so this scenario
+ * replicates its two-input shape — an opening balance carried from the prior close (or the
+ * account's seeded opening balance, if never closed) and the period's net movement (the ledger's
+ * cumulative net delta *since* the prior close) — and hands both, plus the account's current
+ * booked balance as the independently-reported closing figure, to the REAL `ReconciliationPolicy`.
+ *
+ * A seeded fraction of attempts inject a **phantom haléř** into the computed net movement —
+ * standing in for a real defect class (a booked-entries read-port that drops or duplicates an
+ * entry) — so the scenario exercises BOTH outcomes every run: `Reconciled` (a `StatementPeriod` is
+ * minted, the running close state advances) and `Mismatch` (nothing is persisted, the running
+ * state is untouched, exactly ADR-0035 §E's "no partial, self-inconsistent legal document is ever
+ * produced"). `MoneyPathInvariants.statementCloseIntegrity` asserts a period was persisted
+ * precisely when reconciliation succeeded — never on a Mismatch, never skipped on a Reconciled.
+ */
+object StatementCloseScenario {
+
+    private val ZONE = ZoneId.of("Europe/Prague")
+
+    /** Seeded fraction of close attempts whose computed net movement is deliberately corrupted. */
+    private const val MISMATCH_INJECTION_RATE = 0.15
+    private val PHANTOM_HALER: BigDecimal = BigDecimal("0.01")
+
+    fun step(world: World) {
+        val random = world.context.random
+        val accountId = random.pick(world.customerAccounts)
+        val key = AccountCurrency(accountId, world.currency)
+        val attemptId = "sim-close-${world.context.seed}-${random.nextLong()}"
+
+        val opening = world.statementCloses.openingBalanceOf(key, world.openingBookedOf(key))
+        val netAtLastClose = world.statementCloses.netAtLastCloseOf(key)
+        val cumulativeNet = world.ledger.netDeltas()[key] ?: BigDecimal.ZERO
+        var netMovement = cumulativeNet - netAtLastClose
+
+        // Seeded fault: a booked-entries read-port gap, distinct from the shared FaultInjector's
+        // network-level faults (this is a data-completeness defect, not a write/lock failure).
+        if (random.chance(MISMATCH_INJECTION_RATE)) {
+            netMovement += PHANTOM_HALER
+        }
+
+        val reportedClosing = world.balances.get(key).bookedAmount
+        val decision = ReconciliationPolicy.reconcile(opening, netMovement, reportedClosing)
+        val closeKey = StatementCloseKey(accountId, key.currency, attemptId)
+
+        when (decision) {
+            is ReconciliationPolicy.Result.Reconciled -> {
+                world.statementCloses.recordDecision(closeKey, wasReconciled = true)
+                val period = mintPeriod(world, key, opening, decision.closingBalance)
+                world.statementCloses.recordPersisted(closeKey, wasPersisted = true)
+                world.statementCloses.advance(key, decision.closingBalance, cumulativeNet)
+                world.audit.append("statement period ${period.id} closed: seq=${period.legalSequenceNumber}")
+            }
+            is ReconciliationPolicy.Result.Mismatch -> {
+                world.statementCloses.recordDecision(closeKey, wasReconciled = false)
+                world.statementCloses.recordPersisted(closeKey, wasPersisted = false)
+                world.audit.append(
+                    "statement close REFUSED for $key: computed=${decision.computed} " +
+                        "reported=${decision.reported} delta=${decision.delta}",
+                )
+            }
+        }
+    }
+
+    /** Build the real `StatementPeriod` the reconciled close would persist — for realism/audit only. */
+    private fun mintPeriod(
+        world: World,
+        key: AccountCurrency,
+        opening: BigDecimal,
+        closing: BigDecimal,
+    ): StatementPeriod {
+        val random = world.context.random
+        val today = LocalDate.ofInstant(world.context.clock.instant(), ZONE)
+        val seq = world.statementCloses.nextSequenceOf(key)
+        return StatementPeriod(
+            id = random.nextUuid(),
+            accountId = key.accountId,
+            pocketCurrency = key.currency,
+            periodFrom = today,
+            periodTo = today,
+            legalSequenceNumber = seq,
+            electronicSequenceNumber = seq,
+            openingBalance = opening,
+            closingBalance = closing,
+            entryCount = 0,
+            closedAt = world.context.clock.instant(),
+            status = PeriodCloseStatus.CLOSED,
+        )
+    }
+}

--- a/openbank-simulation/src/test/kotlin/com/openbank/simulation/invariants/StatementCloseIntegrityInvariantTest.kt
+++ b/openbank-simulation/src/test/kotlin/com/openbank/simulation/invariants/StatementCloseIntegrityInvariantTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.invariants
+
+import com.openbank.simulation.engine.FaultProfile
+import com.openbank.simulation.engine.SimulationContext
+import com.openbank.simulation.model.StatementCloseKey
+import com.openbank.simulation.runner.SimulationConfig
+import com.openbank.simulation.runner.World
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Isolation coverage for [MoneyPathInvariants.statementCloseIntegrity] (ADR-0035 §E / ADR-0078,
+ * issue #667): a period is persisted if and only if the real `ReconciliationPolicy` reconciled —
+ * proven both ways (mirrors [BillingFeeConservationInvariantTest]'s two-sided proof; the
+ * seeded-scenario side lives in `StatementCloseScenarioTest` and the `DstSimulationTest` sweep).
+ */
+class StatementCloseIntegrityInvariantTest {
+
+    private fun world(): World = World(SimulationContext(seed = 1L, FaultProfile.NONE), SimulationConfig())
+
+    private fun key(): StatementCloseKey = StatementCloseKey(UUID.randomUUID(), "CZK", "attempt-1")
+
+    @Test
+    fun `holds trivially when no close has been attempted`() {
+        assertThat(MoneyPathInvariants.statementCloseIntegrity.check(world())).isNull()
+    }
+
+    @Test
+    fun `holds when a reconciled attempt was persisted`() {
+        val w = world()
+        val k = key()
+        w.statementCloses.recordDecision(k, wasReconciled = true)
+        w.statementCloses.recordPersisted(k, wasPersisted = true)
+
+        assertThat(MoneyPathInvariants.statementCloseIntegrity.check(w)).isNull()
+    }
+
+    @Test
+    fun `holds when a mismatched attempt was correctly refused`() {
+        val w = world()
+        val k = key()
+        w.statementCloses.recordDecision(k, wasReconciled = false)
+        w.statementCloses.recordPersisted(k, wasPersisted = false)
+
+        assertThat(MoneyPathInvariants.statementCloseIntegrity.check(w)).isNull()
+    }
+
+    @Test
+    fun `persisting a period despite a reconciliation mismatch is a violation`() {
+        val w = world()
+        val k = key()
+        w.statementCloses.recordDecision(k, wasReconciled = false)
+        // The defect this invariant exists to catch: a partial, self-inconsistent legal document
+        // minted despite a failed reconciliation.
+        w.statementCloses.recordPersisted(k, wasPersisted = true)
+
+        val violation = MoneyPathInvariants.statementCloseIntegrity.check(w)
+
+        assertThat(violation).isNotNull()
+        assertThat(violation!!.invariant).isEqualTo("statement-close-integrity")
+    }
+
+    @Test
+    fun `silently dropping a reconciled close is also a violation`() {
+        val w = world()
+        val k = key()
+        w.statementCloses.recordDecision(k, wasReconciled = true)
+        // Never persisted despite reconciling — the other side of the same defect class.
+        w.statementCloses.recordPersisted(k, wasPersisted = false)
+
+        assertThat(MoneyPathInvariants.statementCloseIntegrity.check(w)).isNotNull()
+    }
+}

--- a/openbank-simulation/src/test/kotlin/com/openbank/simulation/model/StatementCloseBookTest.kt
+++ b/openbank-simulation/src/test/kotlin/com/openbank/simulation/model/StatementCloseBookTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/** Deterministic unit coverage for [StatementCloseBook]'s running-state mechanics (issue #667). */
+class StatementCloseBookTest {
+
+    private val key = AccountCurrency(UUID.randomUUID(), "CZK")
+    private val fallback = BigDecimal("10000.00")
+
+    @Test
+    fun `before any close, opening balance is the fallback and next sequence is 1`() {
+        val book = StatementCloseBook()
+
+        assertThat(book.openingBalanceOf(key, fallback)).isEqualByComparingTo(fallback)
+        assertThat(book.netAtLastCloseOf(key)).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(book.nextSequenceOf(key)).isEqualTo(1L)
+    }
+
+    @Test
+    fun `advance carries the closing balance forward as the next opening balance and bumps the sequence`() {
+        val book = StatementCloseBook()
+
+        book.advance(key, closingBalance = BigDecimal("10050.00"), cumulativeNet = BigDecimal("50.00"))
+
+        assertThat(book.openingBalanceOf(key, fallback)).isEqualByComparingTo(BigDecimal("10050.00"))
+        assertThat(book.netAtLastCloseOf(key)).isEqualByComparingTo(BigDecimal("50.00"))
+        assertThat(book.nextSequenceOf(key)).isEqualTo(2L)
+
+        book.advance(key, closingBalance = BigDecimal("10075.00"), cumulativeNet = BigDecimal("75.00"))
+
+        assertThat(book.openingBalanceOf(key, fallback)).isEqualByComparingTo(BigDecimal("10075.00"))
+        assertThat(book.nextSequenceOf(key)).isEqualTo(3L)
+    }
+
+    @Test
+    fun `decision and persisted are recorded independently per attempt`() {
+        val book = StatementCloseBook()
+        val reconciledAttempt = StatementCloseKey(key.accountId, key.currency, "attempt-A")
+        val mismatchAttempt = StatementCloseKey(key.accountId, key.currency, "attempt-B")
+
+        book.recordDecision(reconciledAttempt, wasReconciled = true)
+        book.recordPersisted(reconciledAttempt, wasPersisted = true)
+        book.recordDecision(mismatchAttempt, wasReconciled = false)
+        book.recordPersisted(mismatchAttempt, wasPersisted = false)
+
+        assertThat(book.attempts()).containsExactlyInAnyOrder(reconciledAttempt, mismatchAttempt)
+        assertThat(book.wasReconciled(reconciledAttempt)).isTrue()
+        assertThat(book.wasPersisted(reconciledAttempt)).isTrue()
+        assertThat(book.wasReconciled(mismatchAttempt)).isFalse()
+        assertThat(book.wasPersisted(mismatchAttempt)).isFalse()
+    }
+}

--- a/openbank-simulation/src/test/kotlin/com/openbank/simulation/scenario/StatementCloseScenarioTest.kt
+++ b/openbank-simulation/src/test/kotlin/com/openbank/simulation/scenario/StatementCloseScenarioTest.kt
@@ -7,10 +7,13 @@ package com.openbank.simulation.scenario
 import com.openbank.simulation.engine.FaultProfile
 import com.openbank.simulation.engine.SimulationContext
 import com.openbank.simulation.invariants.MoneyPathInvariants
+import com.openbank.simulation.model.AccountCurrency
+import com.openbank.simulation.model.StatementCloseKey
 import com.openbank.simulation.runner.SimulationConfig
 import com.openbank.simulation.runner.World
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 /**
  * Issue #667 (E2E money-path): exercises [StatementCloseScenario] directly against the REAL
@@ -34,20 +37,56 @@ class StatementCloseScenarioTest {
         assertThat(MoneyPathInvariants.statementCloseIntegrity.check(world)).isNull()
     }
 
+    /** The running-state fields [StatementCloseScenario] can move — snapshotted before each step. */
+    private data class RunningState(val opening: BigDecimal, val netAtLastClose: BigDecimal, val nextSequence: Long)
+
+    private fun snapshot(world: World, key: AccountCurrency): RunningState = RunningState(
+        opening = world.statementCloses.openingBalanceOf(key, world.openingBookedOf(key)),
+        netAtLastClose = world.statementCloses.netAtLastCloseOf(key),
+        nextSequence = world.statementCloses.nextSequenceOf(key),
+    )
+
     @Test
-    fun `a reconciled close advances the running state and a mismatch leaves it untouched`() {
+    fun `a reconciled close advances the running state and a mismatch leaves it byte-for-byte unchanged`() {
         var sawReconciled = false
         var sawMismatch = false
         (0L until 40L).forEach { seed ->
             val world = newWorld(seed)
-            repeat(10) { StatementCloseScenario.step(world) }
+            var seenAttempts = emptySet<StatementCloseKey>()
+
+            repeat(10) {
+                // Snapshot every customer account's running close state — cheap (4 accounts) —
+                // so whichever one this step's seeded pick touches, its BEFORE state is on hand.
+                val before = world.customerAccounts.associateWith { id ->
+                    snapshot(world, AccountCurrency(id, world.currency))
+                }
+
+                StatementCloseScenario.step(world)
+
+                val attempt = (world.statementCloses.attempts() - seenAttempts).single()
+                seenAttempts = world.statementCloses.attempts()
+                val key = AccountCurrency(attempt.accountId, attempt.currency)
+                val beforeState = before.getValue(attempt.accountId)
+                val afterState = snapshot(world, key)
+
+                if (world.statementCloses.wasReconciled(attempt)) {
+                    sawReconciled = true
+                    assertThat(afterState.nextSequence)
+                        .withFailMessage("a reconciled close must bump the sequence")
+                        .isEqualTo(beforeState.nextSequence + 1)
+                } else {
+                    sawMismatch = true
+                    // The claim under test: NOTHING moved when reconciliation refused the close.
+                    assertThat(afterState.opening).isEqualByComparingTo(beforeState.opening)
+                    assertThat(afterState.netAtLastClose).isEqualByComparingTo(beforeState.netAtLastClose)
+                    assertThat(afterState.nextSequence)
+                        .withFailMessage("a refused close must not bump the sequence")
+                        .isEqualTo(beforeState.nextSequence)
+                }
+            }
 
             assertThat(MoneyPathInvariants.statementCloseIntegrity.check(world)).isNull()
             assertThat(MoneyPathInvariants.conservationOfMoney.check(world)).isNull()
-
-            world.statementCloses.attempts().forEach { attempt ->
-                if (world.statementCloses.wasReconciled(attempt)) sawReconciled = true else sawMismatch = true
-            }
         }
         // The seeded phantom-haléř fault must fire on some attempts and not others across the
         // sweep, exercising both the Reconciled and Mismatch branches every run.

--- a/openbank-simulation/src/test/kotlin/com/openbank/simulation/scenario/StatementCloseScenarioTest.kt
+++ b/openbank-simulation/src/test/kotlin/com/openbank/simulation/scenario/StatementCloseScenarioTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.simulation.scenario
+
+import com.openbank.simulation.engine.FaultProfile
+import com.openbank.simulation.engine.SimulationContext
+import com.openbank.simulation.invariants.MoneyPathInvariants
+import com.openbank.simulation.runner.SimulationConfig
+import com.openbank.simulation.runner.World
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Issue #667 (E2E money-path): exercises [StatementCloseScenario] directly against the REAL
+ * `statement-service` domain (`StatementPeriod`, `ReconciliationPolicy`, ADR-0035/0078), so the
+ * harness's binding to the statement-close path is proven by actual assertions — every step
+ * records exactly one close attempt, the running close state only advances when reconciliation
+ * actually succeeded, and the seeded fault (a phantom haléř standing in for a booked-entries
+ * read-port gap) is refused rather than silently minting an inconsistent period.
+ */
+class StatementCloseScenarioTest {
+
+    private fun newWorld(seed: Long = 42L): World =
+        World(SimulationContext(seed, FaultProfile.NONE), SimulationConfig())
+
+    @Test
+    fun `a single step records exactly one close attempt`() {
+        val world = newWorld()
+        StatementCloseScenario.step(world)
+
+        assertThat(world.statementCloses.attempts()).hasSize(1)
+        assertThat(MoneyPathInvariants.statementCloseIntegrity.check(world)).isNull()
+    }
+
+    @Test
+    fun `a reconciled close advances the running state and a mismatch leaves it untouched`() {
+        var sawReconciled = false
+        var sawMismatch = false
+        (0L until 40L).forEach { seed ->
+            val world = newWorld(seed)
+            repeat(10) { StatementCloseScenario.step(world) }
+
+            assertThat(MoneyPathInvariants.statementCloseIntegrity.check(world)).isNull()
+            assertThat(MoneyPathInvariants.conservationOfMoney.check(world)).isNull()
+
+            world.statementCloses.attempts().forEach { attempt ->
+                if (world.statementCloses.wasReconciled(attempt)) sawReconciled = true else sawMismatch = true
+            }
+        }
+        // The seeded phantom-haléř fault must fire on some attempts and not others across the
+        // sweep, exercising both the Reconciled and Mismatch branches every run.
+        assertThat(sawReconciled).withFailMessage("no seed ever reconciled a close").isTrue()
+        assertThat(sawMismatch).withFailMessage("no seed ever hit the seeded mismatch fault").isTrue()
+    }
+
+    @Test
+    fun `a seed reproduces the exact same close outcomes deterministically`() {
+        fun outcomes(seed: Long): List<Boolean> {
+            val world = newWorld(seed)
+            repeat(10) { StatementCloseScenario.step(world) }
+            return world.statementCloses.attempts().sortedBy { it.attemptId }
+                .map { world.statementCloses.wasReconciled(it) }
+        }
+        assertThat(outcomes(7L)).isEqualTo(outcomes(7L))
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `StatementCloseScenario`, driving the **real** `openbank-statement-service` domain (`StatementPeriod`, `PeriodCloseStatus`) and the **real** fail-closed `ReconciliationPolicy` (ADR-0035 §E / ADR-0078) through the seeded DST runner — the statement-close leg of the "day in the life" money-path proof scoped in #667, alongside the existing payment/SEPA/billing/interest scenarios.
- Adds `statement-close-integrity` to `MoneyPathInvariants`: a period is persisted **if and only if** `ReconciliationPolicy` decided `Reconciled` for that close attempt — never on a `Mismatch` ("no partial, self-inconsistent legal document is ever produced", ADR-0035 §E) and never silently skipped on a `Reconciled` decision.
- New `StatementCloseBook` (same both-sides-recorded-independently shape as `BillingFeeLedger`/`InterestAccrualBook`) tracks each attempt's reconciliation decision against whether a period was actually persisted, plus the running per-account/currency close state (last closing balance, cumulative net at last close, next legal/electronic sequence) so a later attempt's opening balance and net-movement-since-last-close are computed exactly as the real `StatementService.mintPeriod`/`openingBalance` would.
- A seeded fault (15% of attempts) injects a phantom haléř into the computed net movement — standing in for a real defect class (a booked-entries read-port that drops or duplicates an entry) — so every run exercises **both** outcomes: a period minted, or a close correctly refused.
- Interleaved into `SimulationRunner.runSeed` alongside the existing scenarios, drained per the established per-scenario-drain convention (a no-op here since the scenario posts nothing, but kept for consistency).
- Three new test files: `StatementCloseScenarioTest` (one attempt per step; both outcomes occur across a seed sweep with the invariant holding throughout; deterministic seed replay), `StatementCloseIntegrityInvariantTest` (isolation proof — holds correctly, catches a mismatch wrongly persisted, catches a reconciled close silently dropped), and `StatementCloseBookTest` (deterministic unit coverage of the running-state mechanics).

## Test plan

- [x] `./gradlew :openbank-simulation:ktlintCheck :openbank-simulation:detekt :openbank-simulation:test` — green (ktlint, detekt, full suite including the existing `DstSimulationTest` 300-seed sweep).
- [x] New scenario/invariant/model tests pass in isolation, proving both the happy path and each defect class the invariant is meant to catch.

Refs #667