### PR TITLE
fix(gitops): provision missing billing-service CNPG database

### DIFF
--- a/openbank-infra/gitops/apps/billing.yaml
+++ b/openbank-infra/gitops/apps/billing.yaml
@@ -1,7 +1,7 @@
 # ArgoCD app for billing-service (ADR-0143 phase 2c: runtime fee assessment).
-# Stateless service — no Postgres, no Kafka. Reads product, account, and balance
-# state via REST to compute fee assessments; ledger posting (outbox) is the
-# phase 2c-ii follow-up gated behind a four-eyes OPA decision.
+# Postgres-backed (billing-db.yaml, single-owner CNPG cluster) — no Kafka. Reads
+# product, account, and balance state via REST to compute fee assessments; ledger
+# posting (outbox) is the phase 2c-ii follow-up gated behind a four-eyes OPA decision.
 # The OIDC_CLIENT_SECRET Secret is delivered by ESO (billing-service-oidc).
 apiVersion: argoproj.io/v1alpha1
 kind: Application

--- a/openbank-infra/gitops/components/billing/billing-db.yaml
+++ b/openbank-infra/gitops/components/billing/billing-db.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Single-owner Postgres for billing-service (cluster-wide CNPG operator, ADR-0009). Backs the
+# fee-assessment persistence added across ADR-0143 phase 2c (#549 fee posting, #637/#672 fee
+# reversal + DST scenario): billing_cycle_assessment / assessed_fee / billing_outbox
+# (V1__init_billing.sql, V2__create_billing_outbox.sql, V3__hibernate_sequences.sql,
+# V4__add_fee_reversal.sql). Generates the billing-db-app secret (username/password for the
+# `openbank` owner) and a billing-db-rw Service the Deployment uses. Must reconcile BEFORE the
+# billing-service image that carries the datasource config deploys, else Flyway-at-start fails on
+# a missing DB (same pattern as product-catalog-db.yaml / anacredit-db.yaml).
+# NOTE: no S3 WAL/backup here yet — same gap as anacredit-db, tracked as a follow-up (#863 pattern).
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: billing-db
+  namespace: billing
+spec:
+  monitoring:
+    enablePodMonitor: true
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  storage:
+    storageClass: gp3
+    size: 2Gi
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: "1", memory: 512Mi}
+  postgresql:
+    parameters:
+      wal_keep_size: "64MB"
+  bootstrap:
+    initdb:
+      database: openbank_billing
+      owner: openbank

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -1,9 +1,11 @@
 # billing-service: runtime fee assessment and posting (ADR-0143 phase 2c).
-# Stateless — no database, no Kafka. Reads account state from account-service,
-# balance-service, and product-catalog to compute fee assessments. Phase 2c-ii
-# (ledger posting + outbox) is deploy-gated behind the four-eyes OPA gate
-# (data.openbank.billing.ledger.post.allow). OIDC bearer-token validation
-# against the Keycloak openbank realm (service-to-service client credentials).
+# Postgres-backed (billing-db.yaml, single-owner CNPG cluster) — fee posting persistence
+# landed across #549/#637/#672 (billing_cycle_assessment / assessed_fee / billing_outbox,
+# Flyway-migrated). No Kafka. Reads account state from account-service, balance-service,
+# and product-catalog to compute fee assessments. Phase 2c-ii (ledger posting + outbox) is
+# deploy-gated behind the four-eyes OPA gate (data.openbank.billing.ledger.post.allow).
+# OIDC bearer-token validation against the Keycloak openbank realm (service-to-service
+# client credentials).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -62,6 +64,21 @@ spec:
               value: http://account-service.accounts.svc:8100
             - name: BALANCE_SERVICE_URL
               value: http://balance-service.balances.svc:8103
+            # Datasource: single billing-db (billing-db.yaml). Reactive URL for the app
+            # (Panache); JDBC URL for Flyway. Both username/password variants set, matching
+            # the already-working fraud-service pattern (fraud-service.yaml).
+            - name: QUARKUS_DATASOURCE_JDBC_URL
+              value: jdbc:postgresql://billing-db-rw.billing.svc:5432/openbank_billing
+            - name: QUARKUS_DATASOURCE_REACTIVE_URL
+              value: vertx-reactive:postgresql://billing-db-rw.billing.svc:5432/openbank_billing
+            - name: QUARKUS_DATASOURCE_USERNAME
+              valueFrom: {secretKeyRef: {name: billing-db-app, key: username}}
+            - name: QUARKUS_DATASOURCE_REACTIVE_USERNAME
+              valueFrom: {secretKeyRef: {name: billing-db-app, key: username}}
+            - name: QUARKUS_DATASOURCE_PASSWORD
+              valueFrom: {secretKeyRef: {name: billing-db-app, key: password}}
+            - name: QUARKUS_DATASOURCE_REACTIVE_PASSWORD
+              valueFrom: {secretKeyRef: {name: billing-db-app, key: password}}
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://tempo.observability.svc:4317
             - name: OTEL_TRACES_SAMPLER_ARG


### PR DESCRIPTION
## Summary

`openbank-billing-service` has had real Postgres persistence since #549 (fee posting) and
#637/#672 (fee reversal + DST scenario) — `billing_cycle_assessment`, `assessed_fee`, and
`billing_outbox` entities with Flyway migrations V1-V4 — but the GitOps infra was never
provisioned:

- No CNPG `Cluster` manifest for billing (`openbank-infra/gitops/components/billing/` only had
  the Deployment/Service, namespace, network-policies, and OIDC ExternalSecret).
- No `QUARKUS_DATASOURCE_*` env vars on the Deployment container.
- The app falls back to its `localhost:5432` default and Flyway fails at boot
  (`Connection to localhost:5432 refused`), crash-looping any new rollout — confirmed live via
  `kubectl logs` on the crash-looping `billing-service-59d7c864df-*` pod in namespace `billing`.
  The old pod (pre-persistence image) is still serving traffic, so no outage, but the
  fee-posting persistence feature has never actually worked in this environment.

## Changes

- **`openbank-infra/gitops/components/billing/billing-db.yaml`** (new): single-instance CNPG
  `Cluster` (`billing-db`), `openbank_billing` database, `openbank` owner — mirrors
  `anacredit-db.yaml` / `fraud-service/postgres.yaml` conventions exactly (image tag, storage,
  resources, `monitoring.enablePodMonitor`).
- **`openbank-infra/gitops/components/billing/billing-service.yaml`**: added
  `QUARKUS_DATASOURCE_JDBC_URL` / `QUARKUS_DATASOURCE_REACTIVE_URL` (pointing at
  `billing-db-rw.billing.svc:5432/openbank_billing`) and
  `QUARKUS_DATASOURCE_{,REACTIVE_}USERNAME`/`PASSWORD` via `secretKeyRef` to the CNPG-generated
  `billing-db-app` secret — matches `fraud-service.yaml`'s exact pattern (both JDBC + reactive,
  both blocking and reactive credential vars, since `application.yaml` configures both). Also
  fixed the stale "stateless — no database, no Kafka" comment.
- **`openbank-infra/gitops/apps/billing.yaml`**: fixed the matching stale "stateless service"
  comment.

## Verification

- `kubectl apply --dry-run=client` and `--dry-run=server` both pass clean for `billing-db.yaml`
  and `billing-service.yaml` against the live cluster (CNPG CRD present, `openbank-sandbox`
  context). The one warning (`spec.monitoring.enablePodMonitor` deprecated) is pre-existing and
  identical on `anacredit-db.yaml` dry-run — not new.
- Confirmed `fraud-db-app` secret shape (`username`/`password`/`dbname` keys, CNPG's standard
  `<cluster-name>-app` naming) via `kubectl get secret -n fraud fraud-db-app`.
- Re-ran `openbank-infra/scripts/gen-network-policies.py` (the NetworkPolicy generator) —
  **zero diff anywhere in the repo**, confirming no NetworkPolicy change is needed: CNPG pods
  are operator-managed (no Deployment), so the generator doesn't select them and same-namespace
  Postgres traffic is already unaffected (same reasoning documented in the generated
  `network-policies.yaml` header).
- No ArgoCD sync-wave needed — neither `fraud` nor `anacredit`'s `Application` manifests use
  explicit waves; ordering relies on `syncPolicy.automated` + `retry.backoff`, same pattern kept
  here.
- Did **not** apply anything to the live cluster — dry-run only, per instructions. This PR is
  ready for review/merge and the live rollout should be watched once merged (new PVC + CNPG
  cluster provisioning, more consequential than a pure code fix).

## Test plan

- [ ] Reviewer applies via ArgoCD (or `kubectl apply -k` sync) and confirms `billing-db-1` pod
      becomes Ready in namespace `billing`
- [ ] Confirms `billing-db-app` secret is generated with `username`/`password` keys
- [ ] Confirms the crash-looping `billing-service` pod picks up the new env vars on next rollout
      and Flyway migrates cleanly (V1-V4 applied)
- [ ] Confirms `/q/health/ready` goes green and the old pod can be safely retired

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)