### PR TITLE
fix(gitops): provision missing billing-service Redis idempotency cache

### DIFF
--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -79,6 +79,8 @@ spec:
               valueFrom: {secretKeyRef: {name: billing-db-app, key: password}}
             - name: QUARKUS_DATASOURCE_REACTIVE_PASSWORD
               valueFrom: {secretKeyRef: {name: billing-db-app, key: password}}
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://redis.billing.svc:6379
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://tempo.observability.svc:4317
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/billing/network-policies.yaml
+++ b/openbank-infra/gitops/components/billing/network-policies.yaml
@@ -58,3 +58,28 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-allow-list
+  namespace: billing
+  labels:
+    app.kubernetes.io/part-of: billing
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: admin-ui
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/openbank-infra/gitops/components/billing/redis.yaml
+++ b/openbank-infra/gitops/components/billing/redis.yaml
@@ -1,0 +1,45 @@
+# Redis idempotency cache for billing-service. Ephemeral (sandbox).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: billing
+  labels: {app.kubernetes.io/name: redis, app.kubernetes.io/part-of: billing}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app.kubernetes.io/name: redis}}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: redis}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports: [{name: redis, containerPort: 6379}]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: [ALL]}
+          volumeMounts: [{name: data, mountPath: /data}]
+          readinessProbe: {tcpSocket: {port: redis}, initialDelaySeconds: 5, periodSeconds: 10}
+          resources:
+            requests: {cpu: 50m, memory: 64Mi}
+            limits: {cpu: 500m, memory: 192Mi}
+      volumes: [{name: data, emptyDir: {}}]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: billing
+  labels: {app.kubernetes.io/name: redis}
+spec:
+  selector: {app.kubernetes.io/name: redis}
+  ports: [{name: redis, port: 6379, targetPort: redis}]


### PR DESCRIPTION
## Summary
Follow-up to #683. After fixing the missing Postgres database, billing-service boots and connects to Postgres fine, but readiness still fails — health check reports the Redis idempotency-cache connection DOWN (`quarkus.redis.hosts` defaults to `localhost:6379`, same "expects an env override that was never added" gap class as the database).

Mirrors the existing per-namespace ephemeral Redis pattern (dispute-service/fx-service/interest-service/etc: `valkey:8-alpine`, no persistence, sandbox idempotency cache only):
- `openbank-infra/gitops/components/billing/redis.yaml` (new): Deployment + Service
- `billing-service.yaml`: added `QUARKUS_REDIS_HOSTS=redis://redis.billing.svc:6379`
- `network-policies.yaml`: regenerated via `gen-network-policies.py` (adds `redis-ingress-allow-list`; repo-wide regen produced zero diff elsewhere)

## Test plan
- [x] `kubectl apply --dry-run=server` clean for all three changed/new manifests
- [x] Confirmed via live `kubectl logs` on the billing-service pod that fixing the DB alone left Redis as the only remaining `DOWN` health check
- [ ] Once merged, ArgoCD should sync and billing-service's readiness should go green (will verify live after merge)

Linked issues: Refs #548