### PR TITLE
ci(spike): diagnose dead Claude fallback in agent-review.yml [DO NOT MERGE]

### DIFF
--- a/.github/workflows/debug-claude-oauth-test.yml
+++ b/.github/workflows/debug-claude-oauth-test.yml
@@ -1,0 +1,26 @@
+# TEMPORARY diagnostic workflow — see issue investigating the dead Claude
+# fallback in agent-review.yml. Isolated from agent-review.yml's own scope
+# gate (which would otherwise mark any .github/* change "sensitive" and skip
+# the very step being tested). Delete this file once the fallback is fixed.
+name: Debug Claude OAuth
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Claude OAuth probe
+        uses: anthropics/claude-code-action@f87768c6d25f92ae6efa7175e223ef77d4cbf97f # v1.0.166
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          prompt: "Reply with exactly the word: PONG. Do not use any tools."


### PR DESCRIPTION
## Summary
- Throwaway diagnostic workflow to capture the real error behind agent-review.yml's dead Claude fallback (`is_error: true`, `num_turns: 1`, `total_cost_usd: 0` on every run — see run 29018611507 on PR #682).
- Standalone `.github/workflows/debug-claude-oauth-test.yml`, isolated from agent-review.yml's own scope gate so this actually runs.
- **Not intended to merge** — will be closed and the branch deleted once root cause is found.

## Test plan
- [ ] Confirm the workflow runs on this PR
- [ ] Capture the real SDK error via `show_full_output: true`
- [ ] Close this PR after diagnosis

Linked issues: N/A — throwaway diagnostic spike, not a tracked change.