### PR TITLE
chore(gitops): auto-deploy services @ 16d2556934fe5238fd98ad33da8472e257a1f014

### DIFF
--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: billing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-357b9db6
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-16d25569
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 16d2556934fe5238fd98ad33da8472e257a1f014.

**Changed services:** ["openbank-billing-service"]

Each image tag was updated to `sandbox-16d2556934fe5238fd98ad33da8472e257a1f014` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.