### PR TITLE
fix(audit-service): fix silent Kafka group.id/auto.offset.reset config bug

### DIFF
--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -85,13 +85,26 @@ mp:
         ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
         ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
     incoming:
+      # group.id / auto.offset.reset are deliberately NOT set as YAML keys here — see
+      # openbank-infra/gitops/components/audit/audit-service-msg-override.yaml (a properties-file
+      # override loaded via QUARKUS_CONFIG_LOCATIONS) for where they're set instead. Summary:
+      # SmallRye Config's YAML source unconditionally quotes any leaf map key containing a literal
+      # dot (`group.id` registers as the literal property name `"group.id"`, quotes included,
+      # regardless of whether the YAML key itself is quoted), so
+      # KafkaConnectorIncomingConfiguration's plain lookup never finds it. group.id then silently
+      # fell back to Quarkus's default (quarkus.application.name = openbank-audit-service), which
+      # the audit-service KafkaUser ACL (kafka-audit-mtls.yaml) does NOT grant Read on (only
+      # "audit-service" is granted) — every consumer poll got a silent
+      # org.apache.kafka.common.errors.GroupAuthorizationException. A properties file (not an env
+      # var) is used because this channel name is hyphenated (audit-events-in): SmallRye's env-var
+      # reverse-mapping for hyphenated/dotted channel names is ambiguous and previously broke
+      # transaction-service's payment-scheme-accepted channel this way (reverted, #2649→#2659); a
+      # properties file carries the exact property name unambiguously. See issue #686.
       audit-events-in:
         connector: smallrye-kafka
         client.id: audit-service-${quarkus.uuid}
-        group.id: audit-service
         topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
 "%dev":
   quarkus:
     log:

--- a/openbank-infra/gitops/components/audit/audit-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service-msg-override.yaml
@@ -1,0 +1,36 @@
+# Kafka `group.id` / `auto.offset.reset` override for audit-service's audit-events-in channel
+# (issue #686).
+#
+# Why this exists: Quarkus's YAML config source unconditionally quotes any leaf map key
+# containing a literal dot when registering it as a MicroProfile Config property, so
+# `group.id: audit-service` / `auto.offset.reset: earliest` written as plain YAML keys under
+# `mp.messaging.incoming.audit-events-in` in application.yaml silently register only as the
+# literal property name `"group.id"` (quotes included) — a name
+# KafkaConnectorIncomingConfiguration's getters never look up. group.id then silently falls back
+# to Quarkus's default (quarkus.application.name = openbank-audit-service), which the
+# audit-service KafkaUser ACL (kafka-audit-mtls.yaml) does NOT grant Read on (only the group
+# "audit-service" is granted) — every consumer poll gets a silent
+# org.apache.kafka.common.errors.GroupAuthorizationException.
+#
+# Why a properties FILE and not env vars: SmallRye discovers messaging channels by scanning
+# config property NAMES, and the env-var form (MP_MESSAGING_INCOMING_AUDIT_EVENTS_IN_*)
+# reverse-maps ambiguously for a hyphenated channel name like audit-events-in → a broken channel
+# → startup crash (this exact approach was tried for transaction-service's hyphenated
+# payment-scheme-accepted channel and reverted, #2649→#2659). A properties file carries the EXACT
+# hyphenated/dotted property name unambiguously, so discovery is unambiguous.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml (~254). Loaded via
+# QUARKUS_CONFIG_LOCATIONS on the Deployment (audit-service.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit-service-msg-override
+  namespace: audit
+  labels:
+    app.kubernetes.io/name: audit-service
+    app.kubernetes.io/part-of: audit
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.audit-events-in.group.id=audit-service
+    mp.messaging.incoming.audit-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -81,6 +81,14 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # issue #686: load the audit-events-in group.id / auto.offset.reset override
+            # (audit-service-msg-override ConfigMap, mounted below) as an external Quarkus config
+            # source, since these keys can't be set via the dotted YAML key in application.yaml
+            # (SmallRye Config silently drops it) nor via env var (ambiguous reverse-mapping for
+            # this hyphenated channel name). Optional location: if the file is absent Quarkus
+            # warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -113,6 +121,9 @@ spec:
             - name: kafka-truststore
               mountPath: /mnt/kafka-truststore
               readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
+              readOnly: true
           resources:
             requests:
               cpu: 200m
@@ -129,6 +140,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: audit-service-msg-override
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Part of the fleet sweep tracked in #686. `openbank-audit-service`'s `application.yaml`
set `group.id: audit-service` and `auto.offset.reset: earliest` as plain YAML keys
under the `audit-events-in` channel (`mp.messaging.incoming.audit-events-in`). Quarkus's
YAML config source unconditionally quotes any leaf map key containing a literal dot when
registering it as a MicroProfile Config property — so these registered only as
`mp.messaging.incoming.audit-events-in."group.id"` (literal quotes in the property name),
never as the plain key `KafkaConnectorIncomingConfiguration.getGroupId()` /
`getAutoOffsetReset()` actually read.

Effects:
- `group.id` silently fell back to Quarkus's default (`quarkus.application.name` =
  `openbank-audit-service`). The Strimzi `KafkaUser` ACL
  (`openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml`) only grants `Read` on
  consumer group `audit-service` — not `openbank-audit-service` — so every consumer poll
  got a silent `org.apache.kafka.common.errors.GroupAuthorizationException`.
- `auto.offset.reset` silently fell back to Kafka's client default (`latest`) instead of
  the intended `earliest`, so a consumer would silently skip backlogged messages on first
  boot / after any group reset.

## Fix

- `openbank-audit-service/src/main/resources/application.yaml`: removed the dotted
  `group.id` / `auto.offset.reset` keys from the `audit-events-in` channel block, with a
  comment explaining why and pointing at the gitops override.
- `openbank-infra/gitops/components/audit/audit-service-msg-override.yaml` (new): a
  `ConfigMap` in the `audit` namespace holding a properties-file override
  (`mp.messaging.incoming.audit-events-in.group.id=audit-service`,
  `...auto.offset.reset=earliest`, `config_ordinal=500`).
- `openbank-infra/gitops/components/audit/audit-service.yaml`: mounts that ConfigMap at
  `/mnt/msg-config` and points `QUARKUS_CONFIG_LOCATIONS` at
  `/mnt/msg-config/override.properties`.

**Why a properties file and not env vars:** `audit-events-in` is a hyphenated channel
name. The env-var form (`MP_MESSAGING_INCOMING_AUDIT_EVENTS_IN_GROUP_ID`) was tried for
transaction-service's hyphenated `payment-scheme-accepted` channel and reverted
(#2649 → #2659) because SmallRye's channel discovery reverse-maps env var names to
property names ambiguously and the pod failed to start. A properties file's flat
`key=value` lines carry the exact hyphenated/dotted property name unambiguously. This
mirrors the currently-live fix for transaction-service
(`openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml`).

**No ACL change needed:** the KafkaUser ACL already grants Read on consumer group
`audit-service` (verified in `kafka-audit-mtls.yaml`) — the YAML's original intent
(`group.id: audit-service`) already matched the ACL; only the config plumbing was
broken. The ConfigMap's value is set to `audit-service` to match exactly.

Refs #686.

## Test plan

This is a config-only change — no service code was compiled or touched, so no Gradle
build was run.

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` validated on all three touched/added
      YAML files.
- [ ] After deploy: confirm the audit-service pod passes `q/health` (readiness/liveness)
      and does NOT crash-loop.
- [ ] `kafka-consumer-groups.sh --bootstrap-server <broker> --describe --group
      audit-service` shows the audit-service pod as an active member (no
      `GroupAuthorizationException` in pod logs).
- [ ] Confirm `mp.messaging.incoming.audit-events-in.group.id` resolves to `audit-service`
      at runtime (e.g. via `/q/health` or a debug log of `ConfigProvider.getConfig()`).