### PR TITLE
fix(onboarding-service): fix silent Kafka group.id/auto.offset.reset config bug

### DIFF
--- a/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
@@ -1,0 +1,42 @@
+# Fix for the dotted-key YAML config bug (issue #686, fleet sweep).
+#
+# Quarkus's YAML config source (quarkus-config-yaml / SmallRye YamlConfigSource#flattenYaml)
+# unconditionally quotes any mp.messaging.incoming.<channel> YAML leaf key containing a
+# literal dot when registering it as a MicroProfile Config property. A YAML key written as
+# `group.id: foo` under `mp.messaging.incoming.<channel>:` in application.yaml registers ONLY
+# as `mp.messaging.incoming.<channel>."group.id"` (literal quotes in the property name) —
+# never as the plain `mp.messaging.incoming.<channel>.group.id` that
+# KafkaConnectorIncomingConfiguration.getGroupId() (and the auto.offset.reset equivalent)
+# actually reads. group.id then silently falls back to Quarkus's default
+# (quarkus.application.name = openbank-onboarding-service), which the Strimzi KafkaUser ACL
+# (kafka-onboarding-mtls.yaml) does NOT grant Read on for any of the three groups below —
+# so every consumer poll on all three channels gets a silent GroupAuthorizationException.
+#
+# Why a properties FILE and not env vars: SmallRye discovers messaging channels by scanning
+# config property NAMES, and the env-var form (MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_GROUP_ID
+# etc.) reverse-maps ambiguously for hyphenated channel names -> a broken channel -> startup
+# crash (this was tried for transaction-service's payment-scheme-accepted channel, #2649,
+# and reverted in #2659; see ADR-0137). A properties file carries the EXACT dotted/hyphenated
+# property names unambiguously, so channel discovery is unambiguous.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
+# Loaded via QUARKUS_CONFIG_LOCATIONS on the Rollout (onboarding-service.yaml). Same pattern
+# as transaction-service's msg-override ConfigMap
+# (openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: onboarding-service-msg-override
+  namespace: onboarding
+  labels:
+    app.kubernetes.io/name: onboarding-service
+    app.kubernetes.io/part-of: onboarding
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.party-events-in.group.id=onboarding-service-party
+    mp.messaging.incoming.party-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.kyc-events-in.group.id=onboarding-service-kyc
+    mp.messaging.incoming.kyc-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.sca-events-in.group.id=onboarding-service-sca
+    mp.messaging.incoming.sca-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
@@ -114,6 +114,12 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # issue #686: group.id / auto.offset.reset override (onboarding-service-msg-override
+            # ConfigMap, mounted below) as an external Quarkus config source, since the dotted
+            # YAML keys in application.yaml silently never register as the plain MicroProfile
+            # Config property Quarkus reads (ADR-0137 pattern, see transaction-service).
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -146,6 +152,9 @@ spec:
             - name: kafka-truststore
               mountPath: /mnt/kafka/truststore
               readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -162,6 +171,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: onboarding-service-msg-override
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-onboarding-service/src/main/resources/application.yaml
+++ b/openbank-onboarding-service/src/main/resources/application.yaml
@@ -87,28 +87,33 @@ mp:
         ssl.truststore.location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
         ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
         ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
+    # NOTE (issue #686): group.id / auto.offset.reset (and client.id) are intentionally
+    # NOT set here for party-events-in / kyc-events-in / sca-events-in. Quarkus's YAML
+    # config source unconditionally quotes any mp.messaging.incoming.<channel> leaf key
+    # containing a literal dot when registering it as a MicroProfile Config property, so
+    # a YAML `group.id: foo` here would register as the literal property
+    # `mp.messaging.incoming.<channel>."group.id"` — never the plain
+    # `mp.messaging.incoming.<channel>.group.id` that KafkaConnectorIncomingConfiguration
+    # actually reads. group.id then silently falls back to quarkus.application.name,
+    # which the Strimzi KafkaUser ACL (kafka-onboarding-mtls.yaml) does NOT grant Read on
+    # for any of these three groups -> silent GroupAuthorizationException on every poll.
+    # These keys are instead supplied via a properties-file override
+    # (onboarding-service-msg-override ConfigMap, QUARKUS_CONFIG_LOCATIONS,
+    # config_ordinal=500) whose flat key=value lines carry the exact dotted property
+    # name unambiguously. Same pattern as transaction-service's msg-override (ADR-0137).
     incoming:
       party-events-in:
         connector: smallrye-kafka
-        client.id: onboarding-service-party-${quarkus.uuid}
-        group.id: onboarding-service-party
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
       kyc-events-in:
         connector: smallrye-kafka
-        client.id: onboarding-service-kyc-${quarkus.uuid}
-        group.id: onboarding-service-kyc
         topic: openbank.kyc.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
       sca-events-in:
         connector: smallrye-kafka
-        client.id: onboarding-service-sca-${quarkus.uuid}
-        group.id: onboarding-service-sca
         topic: openbank.sca.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
 
 openbank:
   rate-limit:


### PR DESCRIPTION
## Summary

Quarkus's YAML config source (`quarkus-config-yaml` / SmallRye `YamlConfigSource#flattenYaml`) unconditionally quotes any `mp.messaging.incoming.<channel>` YAML leaf key containing a literal dot when registering it as a MicroProfile Config property. In `openbank-onboarding-service`'s `application.yaml`, this affected all three consumer channels:

- `party-events-in`: `client.id`, `group.id: onboarding-service-party`, `auto.offset.reset: earliest`
- `kyc-events-in`: `client.id`, `group.id: onboarding-service-kyc`, `auto.offset.reset: earliest`
- `sca-events-in`: `client.id`, `group.id: onboarding-service-sca`, `auto.offset.reset: earliest`

Each `group.id`/`auto.offset.reset` line registered only as the literal quoted property (e.g. `mp.messaging.incoming.party-events-in."group.id"`), never as the plain property `KafkaConnectorIncomingConfiguration.getGroupId()` actually reads. As a result:

- `group.id` silently fell back to `quarkus.application.name` (`openbank-onboarding-service`) for **all three** channels.
- The Strimzi `KafkaUser` ACL in `openbank-infra/gitops/components/onboarding/kafka-onboarding-mtls.yaml` grants `Read` only on the three specific groups `onboarding-service-party`, `onboarding-service-kyc`, `onboarding-service-sca` — **not** `openbank-onboarding-service`.
- Every consumer poll on all three channels would hit a silent `GroupAuthorizationException`.
- `auto.offset.reset` also silently fell back to Kafka's `latest` default instead of `earliest`, risking silently skipped backlog on first boot / after a group reset.

## Fix

Per the proven, currently-live pattern used for `transaction-service` (ADR-0137), rather than env vars (an env-var approach for a hyphenated channel name was tried and reverted — #2649 → #2659 — because SmallRye's channel discovery reverse-maps hyphenated env var names ambiguously and the pod fails to start):

1. **`openbank-onboarding-service/src/main/resources/application.yaml`**: removed the dotted `client.id` / `group.id` / `auto.offset.reset` keys from all three `mp.messaging.incoming.*` channel blocks, with a comment explaining why (dotted-key YAML bug, issue #686) and where the values now come from. `client.id` was dropped entirely rather than routed through the override file — it's cosmetic-only (unlike `group.id`, it carries no authorization risk), so the simplest fix was to just not set it.
2. **`openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml`** (new): a `ConfigMap` named `onboarding-service-msg-override` in the `onboarding` namespace, `config_ordinal=500`, with a flat `override.properties` carrying the exact dotted property names for `group.id` and `auto.offset.reset` for all three channels — matching the ACL group names exactly.
3. **`openbank-infra/gitops/components/onboarding/onboarding-service.yaml`**: added `QUARKUS_CONFIG_LOCATIONS=/mnt/msg-config/override.properties` env var, a `msg-override` volumeMount at `/mnt/msg-config` (readOnly), and the corresponding `msg-override` ConfigMap volume — mirroring `transaction-service`'s existing `msg-override` wiring in `openbank-infra/gitops/components/payments/payments-services.yaml`.

Verified the three ACL group names directly against `kafka-onboarding-mtls.yaml` (`onboarding-service-party`, `onboarding-service-kyc`, `onboarding-service-sca`) before finalizing the properties file.

This is config-only — no application code changed, no `version.txt` bump needed until this lands via a service code change (release-please handles versioning automatically; hand-editing `version.txt` is forbidden per this repo's `CLAUDE.md`).

Refs #686

## Test plan

This is a config-only change (application.yaml + gitops manifests). No local build was run (`./gradlew` intentionally skipped — no code changed, and to avoid corrupting the shared Gradle cache with other concurrent agents). Verification should happen post-deploy:

- [ ] YAML validity confirmed locally (`python3 -c "import yaml; yaml.safe_load(...)"` on all three touched/added files) — done in this PR.
- [ ] After ArgoCD syncs, confirm the `onboarding-service-msg-override` ConfigMap is mounted at `/mnt/msg-config` in the running pod and `QUARKUS_CONFIG_LOCATIONS` is set.
- [ ] Confirm via `ConfigProvider.getConfig().getOptionalValue("mp.messaging.incoming.party-events-in.group.id", String.class)` (or equivalent debug endpoint/log) that each channel's `group.id` now resolves to `onboarding-service-{party,kyc,sca}`, not `openbank-onboarding-service`.
- [ ] Confirm no `GroupAuthorizationException` in onboarding-service logs after rollout, and that consumer lag on all three topics (`openbank.party.events`, `openbank.kyc.events`, `openbank.sca.events`) decreases as expected.
- [ ] Confirm `auto.offset.reset=earliest` takes effect (no unexpected backlog skip on a fresh consumer group / pod restart).