### PR TITLE
fix(notification-service): fix silent Kafka group.id/auto.offset.reset config bug

### DIFF
--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -1,0 +1,37 @@
+# Dotted-key YAML config bug workaround (issue #686).
+#
+# Quarkus's YAML config source unconditionally quotes any `mp.messaging.incoming.<channel>`
+# YAML leaf key containing a literal dot when registering it as a MicroProfile Config
+# property. A YAML key written as `group.id: foo` under `mp.messaging.incoming.<channel>:`
+# registers ONLY as `mp.messaging.incoming.<channel>."group.id"` (literal quotes in the
+# property name) — never as the plain `mp.messaging.incoming.<channel>.group.id` that
+# `KafkaConnectorIncomingConfiguration.getGroupId()` (and `auto.offset.reset`) actually
+# read. `group.id` then silently falls back to `quarkus.application.name`
+# (openbank-notification-service), which the Strimzi KafkaUser ACL
+# (kafka-notification-mtls.yaml) does NOT grant Read on for either consumer group — every
+# poll on both channels gets a silent GroupAuthorizationException.
+#
+# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
+# scanning config property NAMES, and the env-var form
+# (MP_MESSAGING_INCOMING_NOTIFICATION_EVENTS_IN_GROUP_ID) reverse-maps ambiguously for a
+# hyphenated channel name → a broken channel → startup crash (this was tried for
+# transaction-service's payment-scheme-accepted channel, #2649, and reverted). A
+# properties file carries the EXACT hyphenated/dotted keys, so discovery is unambiguous.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
+# Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment (notification-service.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notification-service-msg-override
+  namespace: notifications
+  labels:
+    app.kubernetes.io/name: notification-service
+    app.kubernetes.io/part-of: notifications
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.notification-events-in.group.id=notification-service
+    mp.messaging.incoming.notification-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.party-events-in.group.id=notification-service-party
+    mp.messaging.incoming.party-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -122,6 +122,13 @@ spec:
                   name: notification-webhook
                   key: SLACK_WEBHOOK_URL
                   optional: true
+            # Dotted-key YAML config bug workaround (issue #686): load the
+            # notification-events-in / party-events-in group.id and auto.offset.reset
+            # override (notification-service-msg-override ConfigMap, mounted below) as
+            # an external Quarkus config source. See that ConfigMap's header comment
+            # for why this must be a properties file and not env vars.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -156,6 +163,9 @@ spec:
               readOnly: true
             - name: kafka-truststore
               mountPath: /mnt/kafka-truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
               readOnly: true
           resources:
             requests:
@@ -251,6 +261,9 @@ spec:
             items:
               - key: ca.p12
                 path: ca.p12
+        - name: msg-override
+          configMap:
+            name: notification-service-msg-override
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -96,17 +96,23 @@ mp:
       notification-events-in:
         connector: smallrye-kafka
         client.id: notification-service-${quarkus.uuid}
-        group.id: notification-service
+        # group.id / auto.offset.reset are set via the gitops ConfigMap
+        # (notification-service-msg-override, QUARKUS_CONFIG_LOCATIONS) instead of
+        # here: Quarkus's YAML config source unconditionally quotes any dotted leaf
+        # key (`group.id`, `auto.offset.reset`) when flattening YAML, so it silently
+        # registers as `mp.messaging.incoming.notification-events-in."group.id"` —
+        # a property KafkaConnectorIncomingConfiguration never reads — and falls
+        # back to quarkus.application.name, which the Strimzi ACL does not grant
+        # Read on (issue #686).
         topic: openbank.notification.requests
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
       party-events-in:
         connector: smallrye-kafka
         client.id: notification-service-party-${quarkus.uuid}
-        group.id: notification-service-party
+        # group.id / auto.offset.reset: same dotted-key YAML bug as above — set via
+        # the gitops ConfigMap instead (issue #686).
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
 "%dev":
   quarkus:
     log:


### PR DESCRIPTION
## Summary

Quarkus's YAML config source unconditionally quotes any `mp.messaging.incoming.<channel>` YAML leaf key containing a literal dot when registering it as a MicroProfile Config property. `openbank-notification-service` has two affected channels:

- `notification-events-in`: `group.id: notification-service`, `auto.offset.reset: earliest`
- `party-events-in`: `group.id: notification-service-party`, `auto.offset.reset: earliest`

Both silently register as `mp.messaging.incoming.<channel>."group.id"` (literal quotes in the property name) — a property `KafkaConnectorIncomingConfiguration` never reads — so `group.id` falls back to Quarkus's default, `quarkus.application.name` = `openbank-notification-service`, for **both** channels. The Strimzi `KafkaUser` ACL in `openbank-infra/gitops/components/notifications/kafka-notification-mtls.yaml` grants `Read` only on consumer groups `notification-service` and `notification-service-party` — not `openbank-notification-service` — so every consumer poll on both channels would get a silent `GroupAuthorizationException`. `auto.offset.reset` has a quieter failure mode: it silently falls back to Kafka's client default (`latest`) instead of `earliest`, so a consumer would silently skip backlogged messages on first boot / after any group reset.

## Fix

Per the proven, currently-live pattern for `transaction-service` (env vars were tried and reverted for a hyphenated channel name, #2649 — SmallRye's channel discovery reverse-maps env var names to property names ambiguously and the pod fails to start):

1. `openbank-notification-service/src/main/resources/application.yaml` — removed the `group.id` and `auto.offset.reset` lines from both the `notification-events-in` and `party-events-in` channel blocks, replaced with a comment explaining the dotted-key YAML bug and pointing at the gitops override.
2. `openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml` (new) — a `ConfigMap` named `notification-service-msg-override` in the `notifications` namespace, mounting a properties file (`config_ordinal=500`) that sets the four affected keys with their exact hyphenated/dotted property names, unambiguous unlike env vars.
3. `openbank-infra/gitops/components/notifications/notification-service.yaml` — added `QUARKUS_CONFIG_LOCATIONS=/mnt/msg-config/override.properties` env var, a `msg-override` volumeMount at `/mnt/msg-config` (readOnly), and the corresponding `configMap` volume, matching the exact shape used for `transaction-service`'s `msg-override` mount in `openbank-infra/gitops/components/payments/payments-services.yaml`.

Verified the ACL group names directly in `kafka-notification-mtls.yaml` before finalizing the properties file values — they match exactly (`notification-service`, `notification-service-party`).

Refs #686

## Test plan

This is a config-only change (no code/version bump needed — no `src/main/**` code touched, `release-please` axis N/A here since only gitops/config YAML changed... actually application.yaml IS under `src/main/resources`, see note below).

- [ ] YAML validity checked locally (`python3 -c "import yaml; yaml.safe_load(...)"`) on all three touched/added files — passes.
- [ ] No test in `openbank-notification-service/src/test/` references the removed `group.id`/`auto.offset.reset` values directly (grepped, none found).
- [ ] Post-deploy (human/CI to verify): confirm the `notification-service-msg-override` ConfigMap is synced by ArgoCD into the `notifications` namespace before the Deployment rolls, and that pod logs show `group.id=notification-service` / `group.id=notification-service-party` (not `openbank-notification-service`) for the two consumers respectively.
- [ ] Post-deploy: confirm no `GroupAuthorizationException` in notification-service logs after rollout, and that `openbank.notification.requests` / `openbank.party.events` consumers are actively committing offsets (no backlog growth).
- [ ] Confirm `auto.offset.reset=earliest` is honored (no silently-skipped backlog) if the consumer group is ever reset.