### PR TITLE
fix(kyc-service): fix silent Kafka group.id/auto.offset.reset config bug

### DIFF
--- a/openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml
@@ -1,0 +1,41 @@
+# Image-independent convergence of the party-events-in consumer settings (#686).
+#
+# application.yaml's mp.messaging.incoming.party-events-in block used plain YAML keys
+# (group.id / auto.offset.reset / client.id) containing a literal dot. Quarkus's YAML
+# config source unconditionally quotes any such leaf key when registering it as a
+# MicroProfile Config property, so it registers only as the quoted
+# mp.messaging.incoming.party-events-in."group.id" — never the plain
+# mp.messaging.incoming.party-events-in.group.id that KafkaConnectorIncomingConfiguration
+# actually reads. group.id silently fell back to quarkus.application.name
+# (openbank-kyc-service), which the kyc-service KafkaUser ACL (kafka-kyc-mtls.yaml) never
+# granted Read on group kyc-service-party — every consumer poll got a silent
+# GroupAuthorizationException.
+#
+# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
+# scanning config property NAMES, and the env-var form
+# (MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_*) reverse-maps ambiguously for a hyphenated
+# channel name → a broken channel → startup crash (this exact approach was tried for
+# transaction-service's payment-scheme-accepted channel and reverted, #2649→#2659). A
+# properties file carries the EXACT hyphenated/dotted keys, so discovery is unambiguous.
+#
+# client.id is intentionally omitted here (and removed from application.yaml) rather than
+# reproduced: it only affects broker-side client identification in logs/JMX, not
+# authorization, and it isn't certain the ${quarkus.uuid} expression still expands from an
+# externally-loaded properties config source the same way it does from the baked
+# application.yaml. Dropping it is cosmetic-only; re-add once verified.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
+# Loaded via QUARKUS_CONFIG_LOCATIONS on the Rollout.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyc-service-msg-override
+  namespace: kyc
+  labels:
+    app.kubernetes.io/name: kyc-service
+    app.kubernetes.io/part-of: kyc
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.party-events-in.group.id=kyc-service-party
+    mp.messaging.incoming.party-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/kyc/kyc-service.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service.yaml
@@ -120,6 +120,12 @@ spec:
             # PARTY_CREATED so onboarding activates without an operator. MUST be false in prod.
             - name: OPENBANK_KYC_AUTO_APPROVE
               value: "true"
+            # #686: load the party-events-in group.id / auto.offset.reset override (see
+            # kyc-service-msg-override ConfigMap, mounted below) as an external Quarkus config
+            # source so the dotted YAML keys' true values reach MicroProfile Config unambiguously.
+            # Optional location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
           startupProbe:
             tcpSocket:
               port: management
@@ -152,6 +158,9 @@ spec:
             - name: kafka-truststore
               mountPath: /mnt/kafka-truststore
               readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
+              readOnly: true
           resources:
             requests:
               cpu: 100m
@@ -168,6 +177,9 @@ spec:
         - name: kafka-truststore
           secret:
             secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: kyc-service-msg-override
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-kyc-service/src/main/resources/application.yaml
+++ b/openbank-kyc-service/src/main/resources/application.yaml
@@ -104,13 +104,22 @@ mp:
       # PARTY_CREATED → auto-open a KYC case (ADR-0068). earliest so a case is opened even
       # for parties created before this consumer first joined the group; openCaseForParty is
       # idempotent so replaying the topic does not create duplicate cases.
+      #
+      # client.id / group.id / auto.offset.reset are deliberately NOT set here: Quarkus's YAML
+      # config source unconditionally quotes any leaf key containing a literal dot (e.g.
+      # `group.id`) when registering it as a MicroProfile Config property, so it silently
+      # registers as `mp.messaging.incoming.party-events-in."group.id"` — never the plain
+      # `mp.messaging.incoming.party-events-in.group.id` that KafkaConnectorIncomingConfiguration
+      # actually reads. group.id then silently fell back to quarkus.application.name
+      # (openbank-kyc-service), which the KafkaUser ACL (kafka-kyc-mtls.yaml) never granted Read
+      # on group kyc-service-party — a silent GroupAuthorizationException on every poll (#686).
+      # These are instead set via the kyc-service-msg-override ConfigMap (QUARKUS_CONFIG_LOCATIONS
+      # properties file, see openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml),
+      # whose flat key=value lines carry the exact dotted property name unambiguously.
       party-events-in:
         connector: smallrye-kafka
-        client.id: kyc-service-party-${quarkus.uuid}
-        group.id: kyc-service-party
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
     outgoing:
       kyc-events-out:
         connector: smallrye-kafka


### PR DESCRIPTION
## Summary

- Part of the fleet sweep in #686. `openbank-kyc-service`'s `application.yaml` set `mp.messaging.incoming.party-events-in`'s `client.id`, `group.id`, and `auto.offset.reset` as plain dotted YAML leaf keys. Quarkus's YAML config source unconditionally quotes any such leaf key when registering it as a MicroProfile Config property, so these registered only as e.g. `mp.messaging.incoming.party-events-in."group.id"` — never the plain key `KafkaConnectorIncomingConfiguration.getGroupId()` actually reads.
- `group.id` silently fell back to Quarkus's default (`quarkus.application.name` = `openbank-kyc-service`). The `kyc-service` `KafkaUser` ACL (`openbank-infra/gitops/components/kyc/kafka-kyc-mtls.yaml`) grants `Read` only on consumer group `kyc-service-party` — so every consumer poll on `party-events-in` silently hit `GroupAuthorizationException`. `auto.offset.reset` had the quieter failure mode of silently falling back to Kafka's `latest` default instead of `earliest`, silently skipping backlog on first boot/after a group reset.
- Fix: removed the dotted keys from `application.yaml` and set them via a properties-file external config source instead (new `kyc-service-msg-override` ConfigMap + `QUARKUS_CONFIG_LOCATIONS` on the Rollout) — the proven pattern already live for `transaction-service`'s `payment-scheme-accepted` channel (`transaction-service-msg-override.yaml`). Per this sweep's guidance, env vars (`MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_*`) were deliberately **not** used: that exact approach was tried for `transaction-service`'s hyphenated `payment-scheme-accepted` channel and reverted (#2649→#2659) because SmallRye's channel discovery reverse-maps env var names to property names ambiguously and the pod fails to start. `party-events-in` is also hyphenated, so it carries the same risk — a properties file's flat `key=value` lines carry the exact hyphenated/dotted property name unambiguously.
- `client.id` is dropped rather than reproduced in the override ConfigMap: it only affects broker-side client identification in logs/JMX (not authorization), and I'm not confident `${quarkus.uuid}` expression expansion still works the same way from an externally-loaded properties config source as it does from the baked `application.yaml`. Per the task guidance, leaving it removed/broken (cosmetic-only impact) was chosen over risking an unverified expression-expansion path. It's fine to re-add once verified against a real cluster.

## Changed files

- `openbank-kyc-service/src/main/resources/application.yaml` — removed the three dotted keys from `party-events-in`, added an explanatory comment referencing #686.
- `openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml` (new) — ConfigMap in namespace `kyc`, `override.properties` with `config_ordinal=500` + the two properties (`group.id`, `auto.offset.reset`), modeled on `transaction-service-msg-override.yaml`.
- `openbank-infra/gitops/components/kyc/kyc-service.yaml` — added `QUARKUS_CONFIG_LOCATIONS=/mnt/msg-config/override.properties` env var, `msg-override` volumeMount (`/mnt/msg-config`, readOnly), and `msg-override` volume (configMap `kyc-service-msg-override`) to the `kyc-service` container, matching the shape used for `transaction-service` in `payments-services.yaml`.

This is a config-only change — no application code touched, no API surface change, no `openapi.yaml` bump needed. Not a money-path service (`openbank-kyc-service` is not in `rules.yaml: money_path_services`).

## Test plan

- [x] Validated all three touched/added YAML files parse (`python3 -c "import yaml; yaml.safe_load_all(...)"`) — no syntax errors.
- [x] Confirmed the `kyc-service` `KafkaUser` ACL (`kafka-kyc-mtls.yaml`) grants `Read` on group `kyc-service-party` — matches the `group.id` value now set via the override ConfigMap.
- [ ] Post-deploy (human/CI): confirm the `kyc-service` pod actually joins consumer group `kyc-service-party` (not the `openbank-kyc-service` fallback) — e.g. via `kafka-consumer-groups.sh --describe --group kyc-service-party` or Loki logs, and confirm no `GroupAuthorizationException` appears.
- [ ] Post-deploy (human/CI): confirm `auto.offset.reset` behaves as `earliest` on first boot / after a group reset (no unexpected skipped backlog).
- [ ] Post-deploy (human/CI): if `client.id` matters for broker-side JMX/log correlation, verify whether `${quarkus.uuid}` expansion actually works from the properties-file config source before re-adding it to the ConfigMap.
- Did not run `./gradlew` per task instructions (YAML-only change, avoids corrupting a shared Gradle cache from concurrent agents).

Refs #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)