### PR TITLE
fix(agent-service): wire Kafka mTLS + fix oversight-events group.id YAML bug

### DIFF
--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -272,10 +272,37 @@ agent:
 
 mp:
   messaging:
+    connector:
+      smallrye-kafka:
+        security.protocol: ${KAFKA_SECURITY_PROTOCOL:PLAINTEXT}
+        ssl.keystore.location: ${KAFKA_SSL_KEYSTORE_LOCATION:}
+        ssl.keystore.type: ${KAFKA_SSL_KEYSTORE_TYPE:PKCS12}
+        ssl.keystore.password: ${KAFKA_SSL_KEYSTORE_PASSWORD:}
+        ssl.truststore.location: ${KAFKA_SSL_TRUSTSTORE_LOCATION:}
+        ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
+        ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
     incoming:
       oversight-events:
         connector: smallrye-kafka
         topic: ${AGENT_OVERSIGHT_KAFKA_TOPIC:openbank.oversight-triggers}
-        group.id: agent-oversight-consumer
-        auto.offset.reset: latest
         enabled: ${AGENT_OVERSIGHT_KAFKA_ENABLED:false}
+        # group.id / auto.offset.reset are deliberately NOT set as YAML keys here — see
+        # openbank-infra/gitops/components/agent/agent-service-msg-override.yaml (mounted via
+        # QUARKUS_CONFIG_LOCATIONS) for where they're set instead. Summary: SmallRye Config's
+        # YAML source unconditionally quotes any leaf map key containing a literal dot
+        # (`group.id` becomes the registered property name `"group.id"`, quotes included — true
+        # whether or not the YAML key itself is quoted), so KafkaConnectorIncomingConfiguration's
+        # plain config.getOptionalValue("group.id", ...) never finds it. group.id then silently
+        # falls back to Quarkus's default (quarkus.application.name = openbank-agent-service),
+        # which the agent-service KafkaUser ACL never granted — every poll would hit
+        # GroupAuthorizationException. auto.offset.reset silently falls back to Kafka's client
+        # default (latest) instead of the intended latest-is-fine-here value, but the same bug
+        # class applies regardless (issue #686).
+        #
+        # A properties-file override (not MP_MESSAGING_INCOMING_*_GROUP_ID env vars) is used
+        # because `oversight-events` is a hyphenated channel name: SmallRye's channel discovery
+        # cannot reliably reverse-map hyphenated MP_MESSAGING_INCOMING_OVERSIGHT_EVENTS_* env
+        # names back to the channel, and can register a broken channel that fails startup
+        # (confirmed on transaction-service's payment-scheme-accepted channel, #2649 -> reverted
+        # in #2659). A properties file carries the exact hyphenated property key, so discovery
+        # is unambiguous.

--- a/openbank-infra/gitops/components/agent/agent-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service-msg-override.yaml
@@ -1,0 +1,33 @@
+# Image-independent convergence of the oversight-events consumer settings
+# (issue #686, same pattern as components/payments/transaction-service-msg-override.yaml).
+#
+# The values below are set correctly in agent-service's application.yaml as of this
+# change (as plain, non-dotted property keys), but the deployed image may still lag a
+# few commits behind main until the next auto-deploy rebuild picks this fix up. Rather
+# than wait on that, mount them as a Quarkus external config source so the running
+# (possibly older) image also gets the correct group.id / auto.offset.reset.
+#
+# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
+# scanning config property NAMES, and the env-var form
+# (MP_MESSAGING_INCOMING_OVERSIGHT_EVENTS_*) reverse-maps ambiguously for a hyphenated
+# channel name → a broken channel → startup crash (this is exactly what happened for
+# transaction-service's payment-scheme-accepted channel: #2649, reverted in #2659). A
+# properties file carries the EXACT hyphenated keys, so discovery is unambiguous.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
+# Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment. Once the image is rebuilt from
+# main with the application.yaml fix baked in, these equal the baked values and this
+# ConfigMap can be dropped.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-service-msg-override
+  namespace: platform
+  labels:
+    app.kubernetes.io/name: agent-service
+    app.kubernetes.io/part-of: platform
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.oversight-events.group.id=agent-oversight-consumer
+    mp.messaging.incoming.oversight-events.auto.offset.reset=latest

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -142,10 +142,47 @@ spec:
             # ADR-0031 D9 P2 (Refs #703): Kafka event trigger for compliance-officer sweep.
             # Wakes the oversight sweep immediately when AML/sanctions events arrive, in addition
             # to the 30-minute scheduler cadence. Topic managed by Strimzi topic operator.
+            #
+            # ADR-0137 (issue #686): mTLS listener :9093, not the plaintext :9092 listener.
+            # Since the ADR-0137 fleet sweep (#2665) completed, the broker authorizer runs with
+            # allow.everyone.if.no.acl.found=false cluster-wide, so User:ANONYMOUS on :9092 is
+            # denied on every topic — the consumer would never authenticate on :9092 at all.
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: "openbank-cluster-kafka-bootstrap.messaging.svc:9092"
+              value: "openbank-cluster-kafka-bootstrap.messaging.svc:9093"
             - name: AGENT_OVERSIGHT_KAFKA_ENABLED
               value: "true"
+            # mTLS client identity (KafkaUser `agent-service`, kafka-agent-mtls.yaml) — same
+            # pattern as kyc-service / fraud-service. Keystore + cluster-CA truststore are
+            # Strimzi-minted in `messaging` and projected into `platform` by the ExternalSecrets
+            # in kafka-agent-mtls.yaml (this namespace's first ESO Kafka-cert projection).
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka-keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: agent-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka-truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
+            # Issue #686: image-independent convergence of the oversight-events consumer's
+            # group.id / auto.offset.reset (agent-service-msg-override ConfigMap, mounted
+            # below) as an external Quarkus config source, so a lagging deployed image also
+            # picks up the fix without waiting for a rebuild. Optional in spirit (see
+            # transaction-service-msg-override.yaml precedent) — if the file were absent,
+            # Quarkus just warns and continues on the baked application.yaml values.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
             # ADR-0031 D3b: pki-agent CA cert (base64-encoded PEM) — used by AgentSvidVerifier
             # to validate per-run OpenBao-issued certs. Public root; safe in the manifest.
             # Rotate by re-running the openbao-agent-identity-sync CronJob and updating here.
@@ -182,6 +219,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka-keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka-truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
+              readOnly: true
           resources:
             requests:
               cpu: 250m
@@ -262,6 +308,15 @@ spec:
         - name: opa-bundle
           configMap:
             name: agent-opa-bundle
+        - name: kafka-keystore
+          secret:
+            secretName: agent-service-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: agent-service-msg-override
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml
+++ b/openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml
@@ -1,0 +1,109 @@
+# Kafka mTLS identity + ACLs for openbank-agent-service (ADR-0137 fleet gate,
+# issue #686).
+#
+# agent-service consumes compliance-officer oversight-sweep triggers from
+# openbank.oversight-triggers (group: agent-oversight-consumer, ADR-0031 D9
+# P2) to wake the scheduled oversight sweep immediately instead of waiting for
+# the 30-minute cadence. It has no other Kafka traffic (no producer side).
+#
+# Until this change, agent-service had NO KafkaUser at all and pointed its
+# consumer at the plaintext plain:9092 listener. Since the ADR-0137 fleet
+# sweep (#2665) completed, the broker authorizer runs with
+# allow.everyone.if.no.acl.found=false cluster-wide (see components/kafka/
+# kafka.yaml) — every principal, ACL'd or not, is denied on plain:9092
+# (User:ANONYMOUS). So the consumer was fully non-functional, independently
+# of the group.id YAML-quoting bug fixed alongside this file (issue #686).
+#
+# Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one
+# principal for all of this service's Kafka traffic. These resources live in
+# `messaging` (where the Strimzi User Operator watches); the User Operator
+# mints a per-user Secret of the same name there (user.crt/key/p12 +
+# user.password + ca.crt). Those secrets are projected into the `platform`
+# namespace (where agent-service runs) by External Secrets below — the SAME
+# cross-namespace pattern used for `payments` (kafka-scheme-accepted-acl.yaml)
+# and every other onboarded namespace, extended here to `platform` for the
+# first time. `platform` had no prior Kafka mTLS / ESO cert-projection wiring
+# of any kind before this change.
+---
+# ── KafkaUser: agent-service ────────────────────────────────────────────────
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # ADR-0137: certs (KafkaUsers→Strimzi secrets→ESO projection) must land
+    # before the platform Deployment rolls pods onto mTLS; lower waves sync
+    # first and ArgoCD blocks on ExternalSecrets reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: agent-service
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: openbank.oversight-triggers
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: agent-oversight-consumer
+          patternType: literal
+        operations: [Read]
+        host: "*"
+---
+# ── ExternalSecret: agent-service keystore ──────────────────────────────────
+# Projects the Strimzi-minted agent-service Secret from `messaging` into
+# `platform`. `dataFrom.extract` copies every key verbatim, preserving the
+# binary PKCS#12 payload byte-for-byte. deletionPolicy: Retain so a transient
+# store/RBAC blip never deletes a live keystore out from under a running pod.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: agent-service-kafka-keystore
+  namespace: platform
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: agent-service-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: agent-service
+---
+# ── ExternalSecret: cluster CA truststore ───────────────────────────────────
+# Shared cluster-CA truststore projected into `platform` — identical pattern
+# to every other namespace (kyc, fraud, payments, etc.). If `platform` grows a
+# second service needing this same truststore, this ExternalSecret should be
+# shared rather than duplicated (none exists yet — agent-service is the first
+# Kafka mTLS client in this namespace).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-cluster-ca-truststore
+  namespace: platform
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-cluster-ca-truststore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: openbank-cluster-cluster-ca-cert

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -270,6 +270,7 @@ rules:
       - audit-service
       - kyc-service
       - anacredit-service               # issue #638: LoanStageEventConsumer (ADR-0037 follow-up)
+      - agent-service                   # issue #686: oversight-triggers consumer, ns platform (first ESO client there)
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary

Fixes agent-service's `oversight-events` Kafka consumer, which was fully non-functional for
two compounding reasons (per issue #686's audit):

1. **Silent YAML dotted-key bug** — `group.id` / `auto.offset.reset` were plain dotted YAML
   keys under `mp.messaging.incoming.oversight-events`. Quarkus's YAML config source
   unconditionally quotes any leaf key containing a literal dot, registering it as
   `"group.id"` (quotes included) — never the plain `group.id` that
   `KafkaConnectorIncomingConfiguration` reads. `group.id` silently fell back to
   `quarkus.application.name` (`openbank-agent-service`).
2. **No Kafka identity existed for this service at all**, and the consumer pointed at
   `plain:9092`. Since the ADR-0137 fleet sweep (#2665) completed, the broker authorizer runs
   with `allow.everyone.if.no.acl.found=false` **cluster-wide** — `User:ANONYMOUS` is denied
   on **every** topic on `:9092`, not just this one. So the consumer was completely
   non-functional regardless of bug (1).

This is the more involved fix in the #686 sweep: it stands up Kafka mTLS infrastructure for
agent-service (namespace `platform`) from scratch, extending the ADR-0137 cross-namespace ESO
cert-projection pattern to a namespace that has never used it before.

## What changed

- **`openbank-infra/gitops/components/agent/kafka-agent-mtls.yaml` (new)** — Strimzi
  `KafkaUser` `agent-service` (ns `messaging`, `authentication: tls`) granting Read+Describe on
  topic `openbank.oversight-triggers` and Read on consumer group `agent-oversight-consumer`,
  plus two `ExternalSecret`s projecting the keystore and the shared cluster-CA truststore from
  `messaging` into `platform`. Modelled directly on
  `openbank-infra/gitops/components/kyc/kafka-kyc-mtls.yaml` and
  `openbank-infra/gitops/components/fraud-service/kafka-fraud-mtls.yaml` (fraud-service is the
  closest analog: also a plain `Deployment`, not a canary `Rollout`).
- **`openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml`** — added
  `agent-service` to the shared `eso-kafka-cert-reader` Role's `resourceNames` allowlist in
  `messaging` (one line, same pattern as the existing `anacredit-service` entry / PR #662).
  This Role is what lets ESO's kubernetes-provider `ClusterSecretStore` (`kafka-messaging-certs`,
  already cluster-scoped, no change needed there) read the new Secret on behalf of `platform`'s
  ExternalSecrets.
- **`openbank-infra/gitops/components/agent/agent-service.yaml`** — `KAFKA_BOOTSTRAP_SERVERS`
  changed from `:9092` to `:9093` (tls listener, same hostname); added
  `KAFKA_SECURITY_PROTOCOL=SSL` + keystore/truststore env vars + `volumeMounts`/`volumes` for
  the two new Secrets (same shape as `kyc-service`/`fraud-service`); added
  `QUARKUS_CONFIG_LOCATIONS` pointing at a new override ConfigMap (see below).
- **`openbank-infra/gitops/components/agent/agent-service-msg-override.yaml` (new)** — a
  properties-file `ConfigMap` (`config_ordinal=500`) setting
  `mp.messaging.incoming.oversight-events.group.id=agent-oversight-consumer` and
  `...auto.offset.reset=latest` as plain (non-YAML) property names, mounted via
  `QUARKUS_CONFIG_LOCATIONS`. Modelled on
  `openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml`. **Why a
  properties file and not env vars** (`MP_MESSAGING_INCOMING_OVERSIGHT_EVENTS_*`): `oversight-events`
  is a hyphenated channel name, and SmallRye's channel discovery cannot reliably reverse-map a
  hyphenated `MP_MESSAGING_INCOMING_*` env var back to the channel — this crashed
  transaction-service's `payment-scheme-accepted` channel on startup (#2649, reverted in #2659).
  A properties file carries the exact hyphenated key, so discovery is unambiguous.
- **`openbank-agent-service/src/main/resources/application.yaml`** — removed the dotted
  `group.id`/`auto.offset.reset` keys (with a comment pointing at the ConfigMap above, same
  wording style as fraud-service's fix); added the
  `mp.messaging.connector.smallrye-kafka` SSL block (defaults to `PLAINTEXT` for local
  dev/test, overridden by the gitops env vars) — this block didn't exist yet since
  agent-service never had any Kafka SSL wiring.

## What I investigated and confirmed (not assumed)

- **No existing ESO/Kafka-mTLS wiring in `platform`** before this change — grepped every
  `ExternalSecret`/`ClusterSecretStore` reference under `namespace: platform` across
  `openbank-infra/gitops/components/`; the only hits were unrelated Vault-backed secrets
  (`es-agent-service.yaml` for `GROQ_API_KEY`/`OIDC_CLIENT_SECRET`, `es-copilot-service.yaml`,
  `nvidia-externalsecret.yaml`). This is genuinely the first Kafka cert projection into
  `platform`.
- **`ClusterSecretStore kafka-messaging-certs` is already cluster-scoped** — no per-namespace
  change needed there, only the RBAC `Role.resourceNames` in `messaging` (which I did update).
- **No NetworkPolicy change needed.** All fleet NetworkPolicies are generated by
  `gen-network-policies.py` and are **ingress-only** (`policyTypes: ["Ingress"]`, confirmed by
  grep — no `Egress` policyType exists anywhere in `openbank-infra/gitops/components/` except
  two unrelated observability files). Neither `platform` nor `messaging` has any default-deny
  or egress-restricting NetworkPolicy today. So agent-service reaching
  `messaging:9093` requires no NetworkPolicy addition.
- **Confirmed live in `openbank-infra/gitops/components/kafka/kafka.yaml`** that
  `allow.everyone.if.no.acl.found` is currently `"false"` (the ADR-0137 fleet sweep, #2665, is
  marked complete in that file's comments) — this is what makes the *current* plaintext
  wiring fully broken, not just the group-id bug.

## What I could not verify (provisional / needs human check before and after apply)

Per the task's request to be conservative and honest — this cannot be verified against a live
cluster from here:

- **Exact Strimzi-minted secret key names** (`user.p12`, `user.password`, `ca.p12`,
  `ca.password`) — copied verbatim from the `kyc-service`/`fraud-service` pattern, not
  independently verified against a live `KafkaUser` secret.
- **Whether `eso-kafka-cert-reader`'s RoleBinding subject (`external-secrets/external-secrets`
  SA) still matches the live ESO controller.** Runbook 0008's pre-flight check #1 covers this;
  I did not have a cluster to check against.
- **Apply ordering.** Like every other service in this pattern, the `KafkaUser` + `ExternalSecret`s
  must land and reach `SecretSynced`/`Ready` *before* the `agent-service` Deployment rolls onto
  the new env — otherwise the pod tries to mount a Secret that doesn't exist yet and CrashLoops
  on `volumeMounts`. Sync-wave annotations (`-2` for the KafkaUser/RBAC, `-1` for the
  ExternalSecrets) mirror the existing convention but I could not confirm ArgoCD actually
  gates on them the same way runbook 0008 describes for `payments`.
- **Whether `agent-service`'s `oversight-events` channel is single-hyphen-safe for env vars**
  in principle — I did not test this; I followed the task's explicit instruction to use the
  properties-file pattern regardless, consistent with `transaction-service-msg-override.yaml`.
- I did **not** run `./gradlew` (per instructions — YAML-only change, other agents may be
  running Gradle concurrently in this environment). All touched/new YAML files were checked
  with `python3 -c "yaml.safe_load_all(...)"` and the existing
  `.github/scripts/check-duplicate-yaml-keys.sh` guard (passes, 0 duplicate keys).

## Suggested staged-apply order (runbook 0008 spirit)

1. Apply `kafka-agent-mtls.yaml`'s `KafkaUser` + the `eso-kafka-cert-reader` Role update in
   `messaging` first; confirm `kubectl -n messaging get kafkauser agent-service` is `Ready`.
2. Confirm the two `ExternalSecret`s in `platform` reach `SecretSynced=True`
   (`kubectl -n platform get externalsecret agent-service-kafka-keystore kafka-cluster-ca-truststore`).
3. Only then roll `agent-service.yaml`'s Deployment change — otherwise the new `volumeMounts`
   reference Secrets that don't exist yet.
4. Verify: no `SSL handshake` / `GroupAuthorizationException` in agent-service logs, and the
   oversight sweep still fires (`AGENT_OVERSIGHT_KAFKA_ENABLED=true`).

## Linked issues

Refs #686 (fleet sweep — this is the `openbank-agent-service` item; not `Closes`, other
services in the sweep have their own PRs).

## Money-path / approvals

`agent-service` is not in `rules.yaml: money_path_services` — 1 approval, no threat model
required.
