### PR TITLE
fix(card-issuance-service): provision Kafka mTLS identity + fix dotted group.id keys

### DIFF
--- a/openbank-card-issuance-service/src/main/resources/application.yaml
+++ b/openbank-card-issuance-service/src/main/resources/application.yaml
@@ -90,11 +90,25 @@ mp:
     incoming:
       party-events-in:
         connector: smallrye-kafka
-        client.id: cardissuance-party-${quarkus.uuid}
-        group.id: cardissuance-party
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
+        # client.id / group.id / auto.offset.reset are deliberately NOT set as YAML keys here.
+        # SmallRye Config's YAML source unconditionally quotes any leaf map key containing a
+        # literal dot (`group.id` registers only as the literal property name `"group.id"`,
+        # quotes included), so KafkaConnectorIncomingConfiguration's plain
+        # config.getOptionalValue("group.id", ...) never finds it — group.id then silently falls
+        # back to Quarkus's default (quarkus.application.name = openbank-card-issuance-service),
+        # which this service's KafkaUser ACL does not grant Read/Describe on
+        # (openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml, group
+        # cardissuance-party), so every consumer poll would hit a silent
+        # GroupAuthorizationException. auto.offset.reset would likewise silently fall back to
+        # Kafka's `latest` default instead of `earliest`. Set instead via the
+        # card-issuance-service-msg-override ConfigMap (QUARKUS_CONFIG_LOCATIONS,
+        # config_ordinal=500) — a properties FILE, not env vars, because the hyphenated channel
+        # name `party-events-in` breaks SmallRye's channel discovery when config is supplied as
+        # MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_* env vars (tried fleet-wide for
+        # transaction-service and reverted, #2649 -> #2659; see
+        # openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml).
     outgoing:
       # ADR-0050 transactional-outbox egress. The dispatcher sets the Kafka key (= aggregate id, N2)
       # and ce-id/idempotency-key/ce-type headers (N3) via OutgoingKafkaRecordMetadata, so both a key

--- a/openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml
@@ -1,0 +1,39 @@
+# Image-independent Kafka consumer config for card-issuance-service's
+# `party-events-in` channel (issue #686 sweep).
+#
+# openbank-card-issuance-service/src/main/resources/application.yaml
+# deliberately does NOT set client.id / group.id / auto.offset.reset as YAML keys
+# under mp.messaging.incoming.party-events-in — SmallRye Config's YAML source
+# unconditionally quotes any leaf map key containing a literal dot, so those keys
+# silently never resolve (see the comment there). This ConfigMap supplies them
+# instead as a Quarkus external config source.
+#
+# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
+# scanning config property NAMES, and the env-var form
+# (MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_*) reverse-maps ambiguously for a
+# hyphenated channel name ("party-events-in") -> a broken channel -> startup
+# crash (this is exactly #2649, reverted, documented in ADR-0137 / runbook 0008
+# and in transaction-service-msg-override.yaml). A properties file carries the
+# EXACT hyphenated keys, so channel discovery is unambiguous.
+#
+# group.id MUST match the Read grant on consumer group `cardissuance-party` in
+# this service's KafkaUser ACL (kafka-scheme-accepted-acl.yaml), or every
+# consumer poll gets Kafka's GroupAuthorizationException.
+#
+# config_ordinal=500 forces this source to outrank the baked application.yaml
+# (~254). Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment
+# (payments-services.yaml).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: card-issuance-service-msg-override
+  namespace: payments
+  labels:
+    app.kubernetes.io/name: card-issuance-service
+    app.kubernetes.io/part-of: payments
+data:
+  override.properties: |
+    config_ordinal=500
+    mp.messaging.incoming.party-events-in.client.id=cardissuance-party-${quarkus.uuid}
+    mp.messaging.incoming.party-events-in.group.id=cardissuance-party
+    mp.messaging.incoming.party-events-in.auto.offset.reset=earliest

--- a/openbank-infra/gitops/components/payments/kafka-mtls-externalsecrets.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-mtls-externalsecrets.yaml
@@ -148,6 +148,27 @@ spec:
     - extract:
         key: clearing-service
 ---
+# card-issuance-service keystore (issue #686 — first mTLS wiring for this service).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: card-issuance-service-kafka-keystore
+  namespace: payments
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: card-issuance-service-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: card-issuance-service
+---
 # Shared cluster-CA truststore — same for every client; one projection, mounted
 # read-only by all Rollouts in payments.
 apiVersion: external-secrets.io/v1beta1

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -196,6 +196,47 @@ spec:
         operations: [Write, Describe]
         host: "*"
 ---
+# ── card-issuance-service (issue #686 sweep) ────────────────────────────────
+# First mTLS wiring for this service — it has never had a KafkaUser before now
+# (unlike the other five #686 services, which already had one with a wrong
+# ACL/group mismatch). Consumes openbank.party.events (group: cardissuance-party,
+# GDPR Art.17 erasure -> PartyEventConsumer anonymises cardholder PII) and
+# produces its own domain events to openbank.cards.events, which is unlocked
+# (no ACL needed, same identity model as every other service here). Required
+# because the cluster's allow.everyone.if.no.acl.found is "false" (kafka.yaml) —
+# without mTLS + this ACL the consumer cannot connect on tls:9093 at all, and
+# plain:9092 denies User:ANONYMOUS on every topic fleet-wide.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # ADR-0137: certs (KafkaUsers→Strimzi secrets→ESO projection) must land
+    # before the payments Deployment rolls the pod onto mTLS; lower waves sync
+    # first and ArgoCD blocks on the ExternalSecrets reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: card-issuance-service
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: openbank.party.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: cardissuance-party
+          patternType: literal
+        operations: [Read]
+        host: "*"
+---
 # ── External Secrets reader (ADR-0137) ──────────────────────────────────────
 # The Strimzi User Operator writes the KafkaUser keystores (and the cluster CA
 # truststore) as Secrets in THIS namespace (messaging), but the services run in

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1745,6 +1745,11 @@ spec:
 # Customer-facing via customer-edge (/customer/v1/cards). Kafka + CNPG.
 # Image pinned to the fleet tag for bootstrap; auto-deploy rewrites it once this
 # manifest exists.
+# mTLS to Strimzi (ADR-0137, issue #686): first Kafka wiring for this service —
+# authenticates as the KafkaUser 'card-issuance-service'
+# (kafka-scheme-accepted-acl.yaml); keystore/truststore PKCS#12 are projected
+# from `messaging` by External Secrets (kafka-mtls-externalsecrets.yaml) and
+# mounted below, same pattern as transaction-service.
 # ─────────────────────────────────────────────────────────────────────────────
 apiVersion: apps/v1
 kind: Deployment
@@ -1792,9 +1797,38 @@ spec:
                   name: card-issuance-db-app
                   key: password
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
             - name: QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            # mTLS to Strimzi (ADR-0137, issue #686). See application.yaml's
+            # mp.messaging.connector.smallrye-kafka.* for how these map to the
+            # SmallRye Kafka connector's SSL config.
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka/keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: card-issuance-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka/truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
+            # issue #686: group.id/auto.offset.reset/client.id for party-events-in
+            # (card-issuance-service-msg-override ConfigMap, mounted below) — see
+            # application.yaml for why these can't be plain YAML keys. Optional
+            # location: if the file is absent Quarkus warns and continues.
+            - name: QUARKUS_CONFIG_LOCATIONS
+              value: /mnt/msg-config/override.properties
             - name: QUARKUS_REDIS_HOSTS
               value: redis://redis.payments.svc:6379
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
@@ -1834,6 +1868,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka/keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka/truststore
+              readOnly: true
+            - name: msg-override
+              mountPath: /mnt/msg-config
+              readOnly: true
           resources:
             requests:
               cpu: 250m
@@ -1844,6 +1887,15 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        - name: kafka-keystore
+          secret:
+            secretName: card-issuance-service-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
+        - name: msg-override
+          configMap:
+            name: card-issuance-service-msg-override
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

card-issuance-service's `party-events-in` consumer has two compounding gaps from issue #686:
(1) the same silent YAML dotted-key bug as the other five services in the sweep, and (2) — unlike
those five — no Kafka mTLS identity at all, so even a fixed `group.id` could not connect once the
cluster's `allow.everyone.if.no.acl.found` gate was flipped to `false`. This PR fixes both: it
provisions the missing Strimzi `KafkaUser` + ESO cert projection + mTLS wiring, and moves
`client.id`/`group.id`/`auto.offset.reset` out of the broken YAML shape into a properties-file
`ConfigMap` override, following the transaction-service template from ADR-0137/runbook 0008.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #686

## Changes

- `openbank-card-issuance-service/src/main/resources/application.yaml`: removed the dotted
  `client.id`/`group.id`/`auto.offset.reset` keys from `mp.messaging.incoming.party-events-in`
  (SmallRye Config's YAML source quotes any leaf key with a literal dot, so these silently never
  resolved — `group.id` fell back to `quarkus.application.name`, which the (previously
  nonexistent) KafkaUser ACL didn't grant; `auto.offset.reset` fell back to Kafka's `latest`
  instead of `earliest`). Added an in-file comment explaining why and pointing at the ConfigMap.
- **New** `openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml`:
  ConfigMap supplying `client.id`/`group.id`/`auto.offset.reset` for `party-events-in` as a
  properties file (`QUARKUS_CONFIG_LOCATIONS`, `config_ordinal=500`) — a **properties file, not
  env vars**, because the hyphenated channel name `party-events-in` breaks SmallRye's channel
  discovery when supplied via `MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_*` env vars (this is exactly
  the documented `#2649 → #2659` regression in ADR-0137/runbook 0008 — tried fleet-wide for
  transaction-service, reverted). Modeled directly on
  `transaction-service-msg-override.yaml`.
- `openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml`: added a new Strimzi
  `KafkaUser` `card-issuance-service` (namespace `messaging`, `authentication: tls`) granting
  Read+Describe on topic `openbank.party.events` and Read on consumer group `cardissuance-party`.
  This service had **no KafkaUser at all** before this PR — first mTLS identity ever provisioned
  for it. The `eso-kafka-cert-reader` Role's `resourceNames` already listed `card-issuance-service`
  (fleet pre-registration, per the comment in `kafka.yaml`: "Non-deployed services (card-issuance,
  sdd, standing-order, tpp-registry) are RBAC pre-registered"), so **no RBAC change was needed**
  there — verified by grep before assuming.
- `openbank-infra/gitops/components/payments/kafka-mtls-externalsecrets.yaml`: added an
  `ExternalSecret` `card-issuance-service-kafka-keystore` (namespace `payments`) projecting the
  new KafkaUser's Strimzi-minted keystore Secret. Reused the **already-shared**
  `kafka-cluster-ca-truststore` ExternalSecret in the same file rather than duplicating it (it's
  namespace-shared, already projected for every other payments service).
- `openbank-infra/gitops/components/payments/payments-services.yaml`: card-issuance-service's
  container spec — switched `KAFKA_BOOTSTRAP_SERVERS` /
  `QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA_BOOTSTRAP_SERVERS` from `plain:9092` (no security
  config at all, previously) to `tls:9093`; added the `KAFKA_SECURITY_PROTOCOL` /
  `KAFKA_SSL_KEYSTORE_*` / `KAFKA_SSL_TRUSTSTORE_*` env vars, `QUARKUS_CONFIG_LOCATIONS` for the
  new override ConfigMap, and the matching `volumeMounts`/`volumes` (`kafka-keystore`,
  `kafka-truststore`, `msg-override`) — all copied 1:1 from transaction-service's existing,
  working block in the same file. Diffed carefully to confirm no other service's block in this
  large shared file was touched.

## What I copied from transaction-service, and why

Everything in the mTLS wiring (KafkaUser shape, ExternalSecret shape, container SSL env vars,
volume names/mount paths, the properties-file-not-env-vars ConfigMap pattern) is modeled 1:1 on
transaction-service's already-live, e2e-verified ADR-0137 wiring in this same set of files. I did
not invent any new convention. The only card-issuance-specific choices are: the KafkaUser's ACL
list (Read+Describe on `openbank.party.events` + Read on group `cardissuance-party`, vs.
transaction-service's Read+Describe+Write-DLQ on `payment.scheme-accepted`), and putting the new
KafkaUser in the existing `kafka-scheme-accepted-acl.yaml` file (alongside every other
`payments`-namespace KafkaUser) rather than a new dedicated file — `payments` already keeps all
its per-service KafkaUsers in one file, unlike e.g. `kyc`'s single-service `kafka-kyc-mtls.yaml`,
so I followed the file's own established local convention rather than the `kyc` example.

## Assumptions I could not verify against a live cluster

- **Strimzi Secret naming**: assumed the Strimzi User Operator names the keystore Secret exactly
  after the `KafkaUser` name (`card-issuance-service`), matching every existing
  `ExternalSecret.spec.dataFrom.extract.key` in this repo (`transaction-service`, `sepa-payment`,
  `kyc-service`, `account-service`, etc. all follow this 1:1 naming). I did not find a
  counter-example anywhere in the repo, but this is a Strimzi behavior I can't confirm without a
  live `KafkaUser` reconcile.
- **`eso-kafka-cert-reader` Role already covers this Secret name** — verified by reading the
  `resourceNames` list directly (line ~266 of `kafka-scheme-accepted-acl.yaml`, pre-existing
  `card-issuance-service` entry), not by testing an actual `kubectl get secret` + RBAC check.
- **Cross-namespace egress (`payments` → `messaging:9093`) is unrestricted**: I found **no**
  `NetworkPolicy` of `policyTypes: [Egress]` anywhere in `openbank-infra/gitops/components/payments/`
  or `.../kafka/` — every generated policy in `payments/network-policies.yaml` is `Ingress`-only.
  By Kubernetes semantics, a pod with no `Egress`-type policy selecting it has unrestricted egress,
  and transaction-service already reaches `messaging:9093` under the exact same (absence of)
  policy. I could not verify this against the live cluster, only against the checked-in manifests.
- **`gen-network-policies.py`'s derived `kafka-broker-ingress-allow-list`** (ingress side, in
  `messaging`, derived from every client's `KAFKA_BOOTSTRAP_SERVERS`): I found no committed
  `network-policies.yaml` under `openbank-infra/gitops/components/kafka/` in this repo snapshot at
  all (the generator's `messaging`-namespace output isn't checked in yet), so there's nothing to
  regenerate for *this* change — but if that file exists on `main`/live and I'm missing it, it
  should be regenerated (`python3 openbank-infra/scripts/gen-network-policies.py`) after this
  merges so the broker's ingress allow-list picks up card-issuance-service as a `9093` client.
- **`${quarkus.uuid}` expression resolution from an external `QUARKUS_CONFIG_LOCATIONS` properties
  file**: verified via research (not a live boot test) that SmallRye Config's expression
  interceptor resolves `${...}` after all config sources are merged, independent of which source
  contributed the literal — so `client.id=cardissuance-party-${quarkus.uuid}` in the new ConfigMap
  should resolve the same way it did as a YAML key. Not verified with an actual pod boot.

## What a human should double-check before/after this is applied to the real cluster

Per runbook 0008's staged-apply spirit — **do not apply this all at once**:

1. **Stage 1**: sync the new `KafkaUser` (`kafka-scheme-accepted-acl.yaml`) first and confirm
   Strimzi mints `Secret/card-issuance-service` in `messaging` (`kubectl -n messaging get
   kafkauser card-issuance-service` → `Ready=True`; `kubectl -n messaging get secret
   card-issuance-service`).
2. **Stage 2**: sync the new `ExternalSecret` (`kafka-mtls-externalsecrets.yaml`) and confirm it
   reaches `SecretSynced=True` in `payments` (`kubectl -n payments get externalsecret
   card-issuance-service-kafka-keystore`) **before** the Deployment picks up the new
   volume/volumeMount — otherwise the pod will fail to mount a keystore Secret that doesn't exist
   yet and crash-loop on a money-adjacent (not money-path, but customer-facing) service.
3. **Stage 3**: only then roll `payments-services.yaml`'s card-issuance-service Deployment change.
   Since this is a plain `Deployment` (not an Argo `Rollout` like transaction-service), there's no
   canary — a bad rollout replaces the single replica directly. Watch
   `kubectl -n payments logs deploy/card-issuance-service | grep -iE "SSL|9093|GroupAuthorization"`
   for handshake/auth errors after rollout.
4. **Verify the consumer actually joins `cardissuance-party`** (not a fallback group) —
   `kafka-consumer-groups.sh --describe --group cardissuance-party` should show the consumer, and
   `--group openbank-card-issuance-service` (the old broken fallback) should show nothing new.
5. **Not addressed here, pre-existing, worth a separate look**: `card-issuance-http-scaledobject.yaml`
   scales the Deployment to zero on HTTP idle (KEDA HTTP add-on, T1). Its own comment already flags
   that a `PARTY_ERASED` GDPR-erasure event arriving while scaled to zero queues until the next
   HTTP-triggered wake — this PR doesn't change that behavior, just fixes the consumer's identity
   and group once the pod *is* running.
6. This is **not** a money-path service (`rules.yaml: money_path_services` does not list it), so
   this PR needs 1 approval, no threat model.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — no Kotlin code changed.
- [ ] Unit tests added/updated — not applicable; this is a gitops/config-only fix, no behavior
      change to test at the unit level (the previous behavior was "consumer can't connect at all",
      which isn't unit-testable).
- [ ] Integration tests added/updated — not added; a Testcontainers boot IT would need a live
      Kafka+mTLS setup this PR can't verify from here (unlike the fraud-service #685 fix, which had
      an existing plaintext-Kafka Testcontainers harness to extend).
- [ ] Contract tests updated — N/A, no API change.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, no Kotlin changed; per task
      instructions Gradle was deliberately not run (other agents may be running it concurrently).
- [x] No new lint warnings — YAML validated with `yamllint` (`key-duplicates` check) and
      `python3 -c "yaml.safe_load_all(...)"` on every touched file.
- [ ] OpenAPI spec regenerated — N/A, no REST API change.
- [ ] Flyway migration — N/A, no DB change.
- [ ] Avro schema versioned — N/A, no event schema change (existing `openbank.party.events`
      consumer, no new event shape).
- [ ] Docs updated — no ADR needed (this follows ADR-0137's already-accepted template, not a new
      decision); the per-service recipe already lives in issue #686.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs — all secret material
      (`user.password`, `ca.password`, keystore/truststore bytes) stays in Strimzi-minted /
      ESO-projected `Secret` objects, referenced only by name.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress` — no Kotlin changed.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — this adds Kafka client-cert auth wiring
      (infra/config, not application code); flagging for reviewer awareness even though it's not
      an app-level auth/crypto code change.
- [ ] PII path changed? — no; the consumer's PII-handling logic (GDPR Art. 17 erasure in
      `PartyEventConsumer`) is unchanged, only its ability to actually receive the event.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [ ] GDPR — indirect: this fixes the *transport* so `PartyEventConsumer`'s existing Art. 17
  erasure handling actually receives `PARTY_ERASED` events reliably (previously it may have
  silently never joined the right consumer group even before the ACL gap existed). No change to
  the erasure logic itself.
- [x] None (net new compliance impact) — this closes an operational gap, not a new compliance
  surface.

## Rollout / Rollback

- Deployment strategy: rolling (plain `apps/v1 Deployment`, not a canary `Rollout`) — staged
  gitops apply per runbook 0008's spirit (KafkaUser + ESO secret before the Deployment env/mount
  change), see "What a human should double-check" above.
- Rollback plan: revert this PR's commit. Fast path if only the pod needs to unblock: revert the
  Deployment's `KAFKA_BOOTSTRAP_SERVERS` back to `:9092` PLAINTEXT and drop the SSL env/mounts —
  but per runbook 0008 this only works cleanly if the topic/group carry no ACL; since this PR
  *adds* the ACL, a partial rollback would need to also delete the `card-issuance-service`
  `KafkaUser` (removing the ACL) to actually restore anonymous-plaintext access. Full revert
  (delete the KafkaUser + revert the Deployment/ConfigMap/ExternalSecret) is the clean rollback.
- Data migration reversible: N/A, no data migration.

## Reviewer notes

This is the most involved of the six #686 sweep fixes — the other five only needed a group.id/ACL
alignment; this one needed net-new Kafka mTLS infrastructure since card-issuance-service never had
any. Please double check the Strimzi Secret-naming assumption and the egress-NetworkPolicy
assumption called out above — I could not verify either against a live cluster from this
environment. Not a money-path service, so 1 approval should suffice per `rules.yaml`.
