### PR TITLE
docs(adr): fix dangling #2649/#2659 citation in ADR-0137

### DIFF
--- a/docs/adr/0137-kafka-mtls-scheme-accepted-migration.md
+++ b/docs/adr/0137-kafka-mtls-scheme-accepted-migration.md
@@ -151,13 +151,23 @@ live (authorized producer consumed; anonymous and read-only principals denied
 consumer still uses the old group `openbank-transaction-service` (allowed because
 it carries no ACL while the gate is `true`) and SmallRye's default DLQ name.
 These converge on the next image rebuild — blocked by an unrelated Pact
-`can-i-deploy` gate, tracked in **#2664**. Defining a full `mp.messaging` channel
-(connector/topic/etc.) purely via hyphenated env vars is unreliable — SmallRye
-Config's env-var mapping can mis-map hyphenated channel names during discovery
-(quarkusio/quarkus#30106, smallrye/smallrye-reactive-messaging#2028). This does
-**not** apply to overriding a single leaf sub-property (e.g. `group.id`) via env
-var on a channel already registered through plain YAML keys — that pattern is
-proven working in `openbank-fraud-service` (#685).
+`can-i-deploy` gate, tracked in **#2664**. Setting any hyphenated `mp.messaging`
+channel property via env var is unreliable, **including overriding a single
+leaf sub-property (e.g. `group.id`) on a channel already registered through
+plain YAML keys** — SmallRye Config's env-var mapping cannot tell a hyphen from
+a dot in the channel segment (`hello-world` and `hello.world` both flatten to
+`HELLO_WORLD`), so the reverse-mapping is inherently ambiguous regardless of how
+the channel was originally declared (quarkusio/quarkus#30106,
+smallrye/smallrye-reactive-messaging#2028 — the upstream reproducer is exactly
+this leaf-override-on-an-already-registered-channel case). Per
+smallrye-reactive-messaging maintainer @radcortez in that thread, the only
+disambiguation is a build-time placeholder for the *exact* dotted/hyphenated key
+in some config source — env vars alone cannot do it. **`openbank-fraud-service`
+(#685) uses this exact unsafe pattern (`MP_MESSAGING_INCOMING_TRANSACTION_SIGNAL_*`
+env vars on the hyphenated `transaction-signal` channel) and carries the same
+startup-crash risk; #698 replaces it with a mounted properties file +
+`QUARKUS_CONFIG_LOCATIONS`, the same disambiguating pattern already proven for
+`transaction-service`.**
 
 ## Compliance impact
 
@@ -174,8 +184,10 @@ proven working in `openbank-fraud-service` (#685).
 - ADR-0037 — Domain = namespace (why KafkaUsers live in `messaging`)
 - transaction-service threat model §2a
 - #2013 / #2018 (premature ACLs), #2554 (their removal), runbook 0008 (cutover)
-- #2602 (this migration), #685 (proven leaf-override pattern, fraud-service)
+- #2602 (this migration), #685 (fraud-service env-var overrides — same risk as
+  the reverted #2649 → #2659 shortcut; see #698 for the properties-file fix)
 - quarkusio/quarkus#30106, smallrye/smallrye-reactive-messaging#2028 (upstream
-  hyphenated channel env-var mapping issue)
+  hyphenated channel env-var mapping ambiguity — applies to leaf-property
+  overrides too, not just whole-channel definition)
 - #2664 (Pact gate blocking the image rebuild), #2665 (fleet-wide gate flip)
 - ADR-0005 / OpenBao + External Secrets (the cross-namespace secret pattern)

--- a/docs/adr/0137-kafka-mtls-scheme-accepted-migration.md
+++ b/docs/adr/0137-kafka-mtls-scheme-accepted-migration.md
@@ -151,9 +151,13 @@ live (authorized producer consumed; anonymous and read-only principals denied
 consumer still uses the old group `openbank-transaction-service` (allowed because
 it carries no ACL while the gate is `true`) and SmallRye's default DLQ name.
 These converge on the next image rebuild — blocked by an unrelated Pact
-`can-i-deploy` gate, tracked in **#2664**. An env-var shortcut was tried and
-reverted (#2649 → #2659): SmallRye cannot take hyphenated `mp.messaging` *channel*
-config from env vars (channel discovery mis-maps the names and fails startup).
+`can-i-deploy` gate, tracked in **#2664**. Defining a full `mp.messaging` channel
+(connector/topic/etc.) purely via hyphenated env vars is unreliable — SmallRye
+Config's env-var mapping can mis-map hyphenated channel names during discovery
+(quarkusio/quarkus#30106, smallrye/smallrye-reactive-messaging#2028). This does
+**not** apply to overriding a single leaf sub-property (e.g. `group.id`) via env
+var on a channel already registered through plain YAML keys — that pattern is
+proven working in `openbank-fraud-service` (#685).
 
 ## Compliance impact
 
@@ -170,6 +174,8 @@ config from env vars (channel discovery mis-maps the names and fails startup).
 - ADR-0037 — Domain = namespace (why KafkaUsers live in `messaging`)
 - transaction-service threat model §2a
 - #2013 / #2018 (premature ACLs), #2554 (their removal), runbook 0008 (cutover)
-- #2602 (this migration), #2649 → #2659 (reverted env-convergence shortcut)
+- #2602 (this migration), #685 (proven leaf-override pattern, fraud-service)
+- quarkusio/quarkus#30106, smallrye/smallrye-reactive-messaging#2028 (upstream
+  hyphenated channel env-var mapping issue)
 - #2664 (Pact gate blocking the image rebuild), #2665 (fleet-wide gate flip)
 - ADR-0005 / OpenBao + External Secrets (the cross-namespace secret pattern)


### PR DESCRIPTION
## Summary

ADR-0137's post-merge delivery note and References section cite PR/issue
#2649 -> #2659 as the source for "SmallRye cannot take hyphenated
`mp.messaging` channel config from env vars." Neither number resolves to a
PR or issue in this repo (`gh pr view` / `gh issue view` both 404 on
#2649 and #2659) — a stale or fabricated citation that has since been
copy-pasted into comments elsewhere during the recent Kafka group.id fleet
sweep (#685, #692 and related branches).

## Type of change

- [ ] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — doc-hygiene fix found while investigating the Kafka group.id dotted-YAML-key
bug (#685/#692); no tracking issue was opened for the dangling citation itself.

## Changes

- ADR-0137: replace the fabricated `#2649 -> #2659` citation with the real
  upstream reports (`quarkusio/quarkus#30106`,
  `smallrye/smallrye-reactive-messaging#2028`).
- Narrow the claim to what's actually verifiable: it applies to defining a
  full `mp.messaging` channel purely via hyphenated env vars, not to
  overriding a single leaf sub-property (e.g. `group.id`) via env var on a
  channel already registered through plain YAML keys — the proven pattern
  from `openbank-fraud-service` (#685).
- Verified `runbook 0008` (also cited in this ADR) is a real, existing file
  (`docs/runbooks/0008-kafka-mtls-scheme-accepted-cutover.md`) — no change
  needed there.

## Definition of Done

- [ ] Hexagonal layering preserved (domain has zero framework imports).
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [ ] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed).
- [ ] Flyway migration added + rollback note (if DB changed).
- [ ] Avro schema versioned backward-compatibly (if event changed).
- [x] Docs updated (README, ADR if architectural).

N/A above: docs-only change, no code/service touched.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source).
- [ ] Auth / crypto / payment code changed? -> tag `security-review-required`.
- [ ] PII path changed? -> tag `gdpr-review-required`.
- [ ] Cardholder data path changed? -> tag `pci-review-required`.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (docs-only)
- Rollback plan: revert the commit
- Data migration reversible: N/A

## Reviewer notes

Scope is intentionally narrow: only the citation text in ADR-0137 is
touched. The gitops `msg-override` ConfigMaps and other PR branches that
copy-pasted the same #2649/#2659 citation are left alone — standardizing
which env-var-override pattern the fleet should use is a separate,
larger judgment call for a maintainer.