### PR TITLE
chore(gitops): auto-deploy services @ 771528c5f36ab45ed9914afbd39df4092b082146

### DIFF
--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -33,7 +33,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: fraud-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-357b9db6
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-771528c5
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8133}


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 771528c5f36ab45ed9914afbd39df4092b082146.

**Changed services:** ["openbank-fraud-service"]

Each image tag was updated to `sandbox-771528c5f36ab45ed9914afbd39df4092b082146` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.