### PR TITLE
fix(analytics-sink): move group.id off dotted YAML keys

### DIFF
--- a/openbank-analytics-sink/build.gradle.kts
+++ b/openbank-analytics-sink/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
     // unaffected; run them explicitly with `-PwithDocker` (see tasks.test below).
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
+    // Boot IT proving the Kafka consumer joins the intended group.id (issue #686) — see
+    // AnalyticsEventsConsumerGroupIdBootIT.kt.
+    testImplementation(libs.testcontainers.redpanda)
 }
 kotlin {
     jvmToolchain(25)

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -96,10 +96,19 @@ mp:
         #
         # This service has NO gitops manifest yet (never deployed — no version.txt, not a
         # released component). Whoever wires up its first deployment manifest MUST set these
-        # as env vars there, matching the intended values previously in this YAML block:
-        #   MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_GROUP_ID=analytics-sink
-        #   MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_AUTO_OFFSET_RESET=earliest
-        # Do not re-add them as dotted YAML keys — that reintroduces this exact bug.
+        # via a properties-file ConfigMap loaded with QUARKUS_CONFIG_LOCATIONS
+        # (config_ordinal=500), matching the intended values previously in this YAML block:
+        #   mp.messaging.incoming.analytics-events-in.group.id=analytics-sink
+        #   mp.messaging.incoming.analytics-events-in.auto.offset.reset=earliest
+        # Mirror the ConfigMap/mount/env-var structure already used by onboarding-service
+        # (openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml)
+        # and other services in the #686 sweep. Do NOT set these via
+        # MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_* env vars — SmallRye's env-var
+        # reverse-mapping is ambiguous for hyphenated channel names like
+        # analytics-events-in and can crash at boot (quarkusio/quarkus#30106,
+        # smallrye/smallrye-reactive-messaging#2028; this was tried and reverted for
+        # fraud-service, PR #685 -> #698). Do not re-add them as dotted YAML keys either —
+        # that reintroduces this exact bug.
 
 "%dev":
   quarkus:

--- a/openbank-analytics-sink/src/main/resources/application.yaml
+++ b/openbank-analytics-sink/src/main/resources/application.yaml
@@ -1,6 +1,14 @@
 quarkus:
   application:
     name: openbank-analytics-sink
+    # PRE-EXISTING ISSUE, out of scope for this fix (Refs #686): this repo's convention is to
+    # NEVER set quarkus.application.version explicitly — it should derive from version.txt at
+    # build time via the Quarkus Gradle plugin (enforced fleet-wide for released components by
+    # check-app-version-override.sh). This service has no version.txt yet (not a released
+    # component — see build.gradle.kts `version = "0.1.0-SNAPSHOT"`), so there is nothing to
+    # derive from; deleting this line now would leave the value undefined rather than fix
+    # anything. Resolve this when the service is registered as a released component
+    # (release-please-config.json + .release-please-manifest.json) by deleting this key.
     version: 0.1.0
   http:
     port: 8134
@@ -69,13 +77,29 @@ mp:
       analytics-events-in:
         connector: smallrye-kafka
         client.id: analytics-sink-${quarkus.uuid}
-        group.id: analytics-sink
         # Same domain-event topics the audit service ingests. The analytics layer is fed
         # from the existing outbox stream (ADR-0003) — it is NOT a second extraction path
         # (no Debezium/WAL CDC), so it adds no read load on the operational databases.
         topics: openbank.account.events,openbank.transaction.events,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
-        auto.offset.reset: earliest
+        # group.id / auto.offset.reset are deliberately NOT set as YAML keys here — see
+        # openbank-fraud-service's application.yaml / openbank-anacredit-service's
+        # application.yaml for the reference wording (Refs #686). Summary: SmallRye Config's
+        # YAML source unconditionally quotes any leaf map key containing a literal dot
+        # (`group.id` becomes the registered property name `"group.id"`, quotes included —
+        # true whether or not the YAML key itself is quoted), so
+        # KafkaConnectorIncomingConfiguration's plain config.getOptionalValue("group.id", ...)
+        # never finds it. group.id then silently falls back to Quarkus's default
+        # (quarkus.application.name), and auto.offset.reset silently falls back to Kafka's
+        # client default (latest) instead of earliest — a consumer would silently skip
+        # backlogged messages on first boot.
+        #
+        # This service has NO gitops manifest yet (never deployed — no version.txt, not a
+        # released component). Whoever wires up its first deployment manifest MUST set these
+        # as env vars there, matching the intended values previously in this YAML block:
+        #   MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_GROUP_ID=analytics-sink
+        #   MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_AUTO_OFFSET_RESET=earliest
+        # Do not re-add them as dotted YAML keys — that reintroduces this exact bug.
 
 "%dev":
   quarkus:

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/integration/AnalyticsEventsConsumerGroupIdBootIT.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/integration/AnalyticsEventsConsumerGroupIdBootIT.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.integration
+
+import com.openbank.analytics.it.RedpandaTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.ListConsumerGroupsOptions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.util.Properties
+
+/**
+ * Guards the `mp.messaging.incoming.analytics-events-in` dotted-key YAML flattening bug (issue
+ * #686): SmallRye Config's YAML source unconditionally quotes any leaf map key containing a literal
+ * dot, so `group.id: analytics-sink` written as a YAML key never actually resolves — it registers
+ * only as the quoted property name `"group.id"`, which `KafkaConnectorIncomingConfiguration`'s plain
+ * lookup never finds. `group.id` then silently falls back to Quarkus's default
+ * (`quarkus.application.name` = "openbank-analytics-sink") instead of the intended
+ * "analytics-sink" — a real KafkaUser ACL grant, once this service is actually deployed, would very
+ * plausibly not match that fallback (same defect class caught live for openbank-fraud-service and
+ * openbank-anacredit-service).
+ *
+ * `application.yaml` no longer sets `group.id`/`auto.offset.reset` as YAML keys at all (fixed here);
+ * this service has no gitops manifest yet (never deployed), so whoever deploys it first must set the
+ * equivalent `MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_*` env vars (see the comment in
+ * `application.yaml`). This test can't exercise env vars directly, so [RedpandaTestResource] sets the
+ * equivalent property via its returned Map (a real runtime property source, not YAML) — the point of
+ * this test is to assert the consumer actually joins the intended group, not the buggy fallback,
+ * proving [com.openbank.analytics.application.AnalyticsConsumer]'s `@Incoming("analytics-events-in")`
+ * wiring reads whatever `group.id` is configured correctly.
+ *
+ * Tagged `integration` per this module's convention (see `build.gradle.kts`): excluded from the
+ * default offline `test` task, run explicitly with `-PwithDocker`. [RedpandaTestResource] self-skips
+ * (aborts) when Docker is unavailable, mirroring the other `*IT.kt` classes in this module.
+ */
+@Tag("integration")
+@QuarkusTest
+@QuarkusTestResource(RedpandaTestResource::class)
+class AnalyticsEventsConsumerGroupIdBootIT {
+
+    @Test
+    fun `consumer joins the configured analytics-sink group id, not the buggy default fallback`() {
+        val bootstrap = RedpandaTestResource.lastBootstrapServers
+            ?: error("RedpandaTestResource did not record its bootstrap servers")
+
+        AdminClient.create(
+            Properties().apply { put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap) },
+        ).use { admin ->
+            val deadline = System.currentTimeMillis() + DEADLINE_MS
+            var groupIds: Set<String> = emptySet()
+            while (System.currentTimeMillis() < deadline) {
+                groupIds = admin.listConsumerGroups(ListConsumerGroupsOptions())
+                    .all().get().map { it.groupId() }.toSet()
+                if (groupIds.isNotEmpty()) break
+                Thread.sleep(POLL_INTERVAL_MS)
+            }
+            // The regression: without the fix this set contains "openbank-analytics-sink" (the
+            // Quarkus default-name fallback) instead of the intended "analytics-sink" — reproducing
+            // exactly what a real Kafka broker ACL, once one exists, would reject.
+            assertThat(groupIds).contains(EXPECTED_GROUP_ID)
+            assertThat(groupIds).doesNotContain(BUGGY_FALLBACK_GROUP_ID)
+        }
+    }
+
+    private companion object {
+        const val DEADLINE_MS = 20_000L
+        const val POLL_INTERVAL_MS = 1_000L
+        const val EXPECTED_GROUP_ID = "analytics-sink"
+        const val BUGGY_FALLBACK_GROUP_ID = "openbank-analytics-sink"
+    }
+}

--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/it/RedpandaTestResource.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/it/RedpandaTestResource.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.analytics.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.redpanda.RedpandaContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Isolated Redpanda (Kafka API) broker per test JVM via Testcontainers, for booting the real
+ * `@Incoming("analytics-events-in")` consumer (issue #686). This service owns no OLTP database
+ * (ADR-0022 — see `application.yaml`'s "NOTE: no datasource" comment) and the default
+ * `LoggingAnalyticsSink` / `LoggingDeadLetterSink` bindings need no external system, so a broker is
+ * the only piece of infra a real boot needs here.
+ */
+class RedpandaTestResource : QuarkusTestResourceLifecycleManager {
+
+    private var redpanda: RedpandaContainer? = null
+
+    override fun start(): Map<String, String> {
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val rp = RedpandaContainer(
+            DockerImageName.parse("redpandadata/redpanda:v24.1.2")
+                .asCompatibleSubstituteFor("docker.redpanda.com/redpandadata/redpanda"),
+        )
+        rp.start()
+        redpanda = rp
+        lastBootstrapServers = rp.bootstrapServers
+
+        return mapOf(
+            "kafka.bootstrap.servers" to rp.bootstrapServers,
+            "mp.messaging.connector.smallrye-kafka.bootstrap.servers" to rp.bootstrapServers,
+            // Set here — a genuine runtime property source, not YAML — for the same reason
+            // production sets it via env vars (issue #686): SmallRye Config's YAML source
+            // unconditionally quotes any leaf map key containing a literal dot, so a `group.id`
+            // written as a YAML key in application.yaml never resolves. A
+            // QuarkusTestResourceLifecycleManager's returned Map does not go through that
+            // flattener, so this is the one place in the test tree that can genuinely exercise the
+            // fixed group id end-to-end.
+            "mp.messaging.incoming.analytics-events-in.group.id" to "analytics-sink",
+            "mp.messaging.incoming.analytics-events-in.auto.offset.reset" to "earliest",
+            "quarkus.devservices.enabled" to "false",
+            // Unrelated pre-existing defect surfaced by this being the service's first-ever real
+            // @QuarkusTest boot (issue #686 is scoped to the Kafka group.id bug only, so this is
+            // worked around here rather than fixed): openbank.analytics.schema.known resolves via
+            // ${ANALYTICS_SCHEMA_KNOWN:} to a literal empty string when unset, and
+            // ConfigSchemaCatalogSource declares it as plain `String` (not `Optional<String>`).
+            // SmallRye's ConfigRecorder.validateConfigProperties treats an empty-string resolution
+            // as "no value" for the built-in String converter and throws SRCFG00040 eagerly at
+            // startup — the exact class of bug CLAUDE.md's "@ConfigProperty optional field must be
+            // Optional<String>" pitfall describes. Give it a non-empty value here so this IT can
+            // actually boot; see the flagged follow-up in the PR description.
+            "openbank.analytics.schema.known" to "unused.placeholder:1",
+        )
+    }
+
+    override fun stop() {
+        redpanda?.stop()
+    }
+
+    companion object {
+        /**
+         * Set by [start] and read by test classes that need to talk to the broker directly (e.g.
+         * [com.openbank.analytics.integration.AnalyticsEventsConsumerGroupIdBootIT]'s `AdminClient`).
+         * A static holder is simplest here since [QuarkusTestResourceLifecycleManager] instances
+         * aren't injectable.
+         */
+        @Volatile
+        var lastBootstrapServers: String? = null
+            private set
+    }
+}


### PR DESCRIPTION
## Summary

`openbank-analytics-sink`'s `mp.messaging.incoming.analytics-events-in` block set `group.id` and
`auto.offset.reset` as dotted YAML keys, which SmallRye Config's YAML flattener silently mis-registers
(same defect class as PR #685 / #701, issue #686). This service is not yet deployed anywhere (no
`version.txt`, no gitops manifest), so this fix is narrower than the rest of the sweep: it corrects the
`application.yaml` and adds a boot IT, but doesn't touch gitops or bump a version.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #686

## Changes

- Removed the dotted `group.id` / `auto.offset.reset` YAML keys from
  `mp.messaging.incoming.analytics-events-in` in
  `openbank-analytics-sink/src/main/resources/application.yaml`; added a comment explaining the
  SmallRye YAML-flattening bug and instructing whoever deploys this service first to set
  `MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_GROUP_ID=analytics-sink` and
  `MP_MESSAGING_INCOMING_ANALYTICS_EVENTS_IN_AUTO_OFFSET_RESET=earliest` as env vars in that manifest.
- Added `AnalyticsEventsConsumerGroupIdBootIT` (Testcontainers Redpanda only, no Postgres — this
  service owns no OLTP database) proving the consumer joins group `analytics-sink`, not the buggy
  `openbank-analytics-sink` default-name fallback. Tagged `integration` per this module's existing
  convention (excluded from the default `test` task, run with `-PwithDocker`).
- Added `libs.testcontainers.redpanda` to `build.gradle.kts` (dependency already existed in the shared
  version catalog; other services' `*IT.kt` in this module use `testcontainers-postgresql`/`vault`, this
  is the first to need Kafka).

## Flagged, out of scope

- **`quarkus.application.version: 0.1.0`** is explicitly set in `application.yaml`. This repo's
  convention is to never set this key (it should derive from `version.txt`), but this service has no
  `version.txt` yet — nothing to derive from — so I left it with an explanatory comment instead of
  deleting it. Resolve when the service becomes a released component.
- Writing the boot IT (this service's first-ever real `@QuarkusTest` boot) surfaced an **unrelated**
  latent defect: `ConfigSchemaCatalogSource.knownSpec` is declared `String` with
  `@ConfigProperty(defaultValue = "")`, and `openbank.analytics.schema.known` resolves to a literal
  empty string when unset — SmallRye's eager config validation throws `SRCFG00040` and the app never
  boots. Same defect class as CLAUDE.md's "`@ConfigProperty` optional field must be `Optional<String>`"
  pitfall. Worked around in the test resource (non-empty placeholder value) to keep this PR scoped to
  the Kafka bug; a follow-up fix (and a scan of ~5 sibling `@ConfigProperty(defaultValue = "")` fields
  in this service with the same pattern) has been spun off separately.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Integration tests added (Testcontainers boot IT).
- [ ] Unit tests — n/a, no behavior change to unit-testable logic.
- [ ] Contract tests — n/a, no public API change.
- [x] `./gradlew :openbank-analytics-sink:ktlintCheck :openbank-analytics-sink:detekt :openbank-analytics-sink:quarkusBuild :openbank-analytics-sink:test` passes; boot IT verified separately with `-PwithDocker`.
- [ ] OpenAPI spec — n/a.
- [ ] Flyway migration — n/a, no DB.
- [ ] Avro/event schema — n/a, no schema change.
- [ ] Docs — n/a.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress(...)`.
- [x] No new third-party dependency (testcontainers-redpanda already in the shared version catalog,
      used by sibling services).
- [ ] Auth / crypto / payment code — n/a.
- [ ] PII path — n/a.
- [ ] Cardholder data path — n/a.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: n/a — this service is not deployed anywhere yet.
- Rollback plan: n/a.
- Data migration reversible: n/a.

## Reviewer notes

This service has no `version.txt` and no gitops manifest, so this PR intentionally does not bump a
version or touch `openbank-infra/gitops/`. Per the sweep issue #686 recipe, per-service PRs normally
also update the gitops manifest with env vars — that step is deferred here until the service is
actually registered as a released/deployed component.
