### PR TITLE
fix(gitops): exclude datastore wire ports from admin-ui NetworkPolicy rule

### DIFF
--- a/openbank-infra/gitops/components/accounts/network-policies.yaml
+++ b/openbank-infra/gitops/components/accounts/network-policies.yaml
@@ -158,10 +158,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/agent/network-policies.yaml
+++ b/openbank-infra/gitops/components/agent/network-policies.yaml
@@ -85,8 +85,6 @@ spec:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP
-          port: 6379
-        - protocol: TCP
           port: 9121
     - from:
         - namespaceSelector:

--- a/openbank-infra/gitops/components/aml/network-policies.yaml
+++ b/openbank-infra/gitops/components/aml/network-policies.yaml
@@ -86,10 +86,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/billing/network-policies.yaml
+++ b/openbank-infra/gitops/components/billing/network-policies.yaml
@@ -76,10 +76,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/consent/network-policies.yaml
+++ b/openbank-infra/gitops/components/consent/network-policies.yaml
@@ -79,10 +79,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/customer-edge/network-policies.yaml
+++ b/openbank-infra/gitops/components/customer-edge/network-policies.yaml
@@ -86,10 +86,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/dispute-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/dispute-service/network-policies.yaml
@@ -83,10 +83,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/fraud-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/fraud-service/network-policies.yaml
@@ -76,10 +76,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/fx-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/fx-service/network-policies.yaml
@@ -88,10 +88,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/interest-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/interest-service/network-policies.yaml
@@ -83,10 +83,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -229,8 +229,6 @@ spec:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP
-          port: 6379
-        - protocol: TCP
           port: 9121
     - from:
         - namespaceSelector:

--- a/openbank-infra/gitops/components/psd2-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/psd2-service/network-policies.yaml
@@ -77,10 +77,3 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379

--- a/openbank-infra/gitops/components/sanctions-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/network-policies.yaml
@@ -35,13 +35,6 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/openbank-infra/gitops/components/sca/network-policies.yaml
+++ b/openbank-infra/gitops/components/sca/network-policies.yaml
@@ -35,13 +35,6 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/openbank-infra/gitops/components/tpp-registry/network-policies.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/network-policies.yaml
@@ -35,13 +35,6 @@ spec:
   ingress:
     - from:
         - podSelector: {}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: admin-ui
-      ports:
-        - protocol: TCP
-          port: 6379
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/openbank-infra/scripts/gen-network-policies.py
+++ b/openbank-infra/scripts/gen-network-policies.py
@@ -20,6 +20,9 @@ openbank-infra/gitops/components/, extracts those edges and emits one
     monitor is reachable by Prometheus the moment its monitor is declared,
   - admin-ui allowed on every service HTTP port (the BFF discovers services
     dynamically via the k8s API, ADR-0051/0056 — its edges are not in env),
+    EXCEPT ports named for a datastore wire protocol (INTERNAL_ONLY_PORT_NAMES,
+    e.g. "redis") — those are same-namespace-only, since admin-ui never speaks
+    the raw wire protocol directly,
   - ingress-nginx allowed where an Ingress backend declares it,
   - the keda namespace (KEDA HTTP add-on interceptor) allowed on the HTTP port
     of any workload fronted by an HTTPScaledObject (T1 scale-to-zero) — the
@@ -68,6 +71,19 @@ ADMIN_UI_NS = "admin-ui"
 INGRESS_NS = "ingress-nginx"
 MESSAGING_NS = "messaging"
 KEDA_NS = "keda"
+
+# Container ports that speak a datastore wire protocol, not HTTP — keyed by the
+# `ports[].name` every gitops manifest already uses by convention (e.g. the
+# fleet's `redis.yaml` Deployments all name their port "redis"). A port whose
+# name lands here is never bucketed into http_ports, so it does NOT get the
+# admin-ui BFF-discovery rule, an ingress-nginx rule, or a KEDA HTTP add-on
+# rule — those all assume "reachable HTTP API", which a Redis/Postgres wire
+# port is not. It still gets the same-namespace rule (unconditional), and
+# still gets the management/security-scanner rules if it separately exposes a
+# port literally named "management". This is the gap behind the fraud-service
+# online-feature-store Redis fix (PR #706): any non-"management" port was
+# unconditionally treated as an admin-ui-reachable HTTP port.
+INTERNAL_ONLY_PORT_NAMES = {"redis", "postgres", "postgresql"}
 
 HEADER = """\
 # SPDX-License-Identifier: Apache-2.0
@@ -268,8 +284,12 @@ def main():
         mgmt_port = wl["ports"].get("management")
         if mgmt_port is None and MGMT_PORT in wl["ports"].values():
             mgmt_port = MGMT_PORT
+        internal_only_ports = {
+            p for n, p in wl["ports"].items() if n in INTERNAL_ONLY_PORT_NAMES
+        }
         http_ports = sorted(
-            p for n, p in wl["ports"].items() if p != mgmt_port
+            p for n, p in wl["ports"].items()
+            if p != mgmt_port and p not in internal_only_ports
         )
         callers = sorted(edges.get((ns, wl_name), set()) - {ns})
         ing_ports = {

--- a/openbank-infra/scripts/gen_network_policies_test.py
+++ b/openbank-infra/scripts/gen_network_policies_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Unit tests for gen-network-policies.py's internal-only port exclusion.
+
+Focused on the bug where any container port not literally named "management" was
+unconditionally bucketed into http_ports and granted an admin-ui BFF-discovery
+ingress rule — correct for a service's actual REST API, wrong for a datastore
+wire-protocol port (e.g. a Redis sidecar's port 6379), which admin-ui never calls
+directly. Regression coverage for the fraud-service online-feature-store Redis fix
+(PR #706), which surfaced the gap.
+
+The module under test has a hyphenated filename (not import-able as a normal
+module), so it is loaded via importlib — same technique as
+authz_coverage_report_test.py.
+
+Run:  python3 -m unittest openbank-infra/scripts/gen_network_policies_test.py -v
+  or: python3 openbank-infra/scripts/gen_network_policies_test.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+_SCRIPT_PATH = Path(__file__).parent / "gen-network-policies.py"
+_spec = importlib.util.spec_from_file_location("gen_network_policies", _SCRIPT_PATH)
+gen = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(gen)
+
+
+_FIXTURE_MANIFEST = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: svc-a
+  namespace: svc-a
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: svc-a
+    spec:
+      containers:
+        - name: svc-a
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: management
+              containerPort: 8085
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: svc-a
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      containers:
+        - name: redis
+          ports:
+            - name: redis
+              containerPort: 6379
+"""
+
+
+class InternalOnlyPortExclusionTest(unittest.TestCase):
+    """End-to-end: run main() against a fixture gitops tree, inspect the output."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        root = Path(self._tmpdir.name)
+        ns_dir = root / "svc-a"
+        ns_dir.mkdir()
+        (ns_dir / "workloads.yaml").write_text(_FIXTURE_MANIFEST, encoding="utf-8")
+
+        self._orig_components = gen.COMPONENTS
+        gen.COMPONENTS = str(root)
+        self.addCleanup(setattr, gen, "COMPONENTS", self._orig_components)
+
+        gen.main()
+        self._policies = list(
+            yaml.safe_load_all((ns_dir / "network-policies.yaml").read_text(encoding="utf-8"))
+        )
+
+    def _policy(self, name: str) -> dict:
+        for pol in self._policies:
+            if pol and pol["metadata"]["name"] == name:
+                return pol
+        raise AssertionError(f"no policy named {name} in {self._policies}")
+
+    def test_http_workload_still_gets_admin_ui_rule(self) -> None:
+        """Regression guard: the fix must not blanket-exclude real HTTP ports."""
+        pol = self._policy("svc-a-ingress-allow-list")
+        admin_ui_rules = [
+            r for r in pol["spec"]["ingress"]
+            if any(
+                f.get("namespaceSelector", {}).get("matchLabels", {}).get(
+                    "kubernetes.io/metadata.name"
+                ) == "admin-ui"
+                for f in r.get("from", [])
+            )
+        ]
+        self.assertEqual(len(admin_ui_rules), 1)
+        self.assertEqual(admin_ui_rules[0]["ports"], [{"protocol": "TCP", "port": 8080}])
+
+    def test_redis_port_gets_no_admin_ui_rule(self) -> None:
+        """The bug: redis's wire-protocol port must not be BFF-discoverable."""
+        pol = self._policy("redis-ingress-allow-list")
+        for rule in pol["spec"]["ingress"]:
+            for f in rule.get("from", []):
+                ns = f.get("namespaceSelector", {}).get("matchLabels", {}).get(
+                    "kubernetes.io/metadata.name"
+                )
+                self.assertNotEqual(
+                    ns, "admin-ui",
+                    f"redis policy must not admit admin-ui, got rule: {rule}",
+                )
+
+    def test_redis_policy_is_same_namespace_only(self) -> None:
+        """No management port + no declared callers -> exactly the same-ns rule."""
+        pol = self._policy("redis-ingress-allow-list")
+        self.assertEqual(pol["spec"]["ingress"], [{"from": [{"podSelector": {}}]}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`gen-network-policies.py` bucketed any container port not literally named
`management` into `http_ports` and unconditionally granted it an admin-ui
BFF-discovery ingress rule. That's correct for a service's real REST API but
wrong for a datastore wire-protocol port (e.g. Redis 6379) — the gap flagged
inline in [PR #706](https://github.com/JiRaska/open-bank-oss/pull/706)'s
fraud-service Redis fix.

## Type of change

- [x] fix (bug fix)
- [ ] feat (new functionality)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — direct follow-up to the gap flagged inline in PR #706's commit message; no tracking issue was filed for it.

## Changes

- `gen-network-policies.py`: add `INTERNAL_ONLY_PORT_NAMES` (`redis`, `postgres`, `postgresql`); ports with these names are excluded from `http_ports`, so they fall back to the same-namespace-only rule the header comment already claimed they got.
- Regenerated `network-policies.yaml` fleet-wide (`python3 openbank-infra/scripts/gen-network-policies.py`). The gap was fleet-wide, not specific to fraud-service — 12 services with a plain Redis sidecar lost the spurious admin-ui rule on 6379; `agent` and `payments` correctly keep their admin-ui rule on 9121 (the `redis_exporter` sidecar's real HTTP metrics port).
- Added `gen_network_policies_test.py` (end-to-end against a fixture gitops tree): a real HTTP port still gets the admin-ui rule; a redis-named port does not; a redis workload with no management port ends up same-namespace-only.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — N/A, infra script.
- [x] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved) — N/A.
- [ ] Contract tests updated (if public API changed) — N/A, no API change.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes — N/A, Python script, not a Gradle module.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed) — N/A.
- [ ] Flyway migration added + rollback note (if DB changed) — N/A.
- [ ] Avro schema versioned backward-compatibly (if event changed) — N/A.
- [x] Docs updated (README, ADR if architectural) — updated the generator's own module docstring + header template.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification — N/A, Python.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — No.
- [ ] PII path changed? — No.
- [ ] Cardholder data path changed? — No.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: applies on next GitOps sync (declarative NetworkPolicy, no pod restart needed).
- Rollback plan: revert this PR and re-run the generator, or hand-restore the removed admin-ui/6379 rule; no data involved.
- Data migration reversible: N/A.

## Reviewer notes

This *tightens* network access (removes an over-broad allow rule) — it does not grant anything new. Nothing in `openbank-admin-ui` calls a service's Redis directly, so no traffic should actually be affected; this closes an unused hole in the enforced (VPC CNI standard mode) NetworkPolicy baseline.