### PR TITLE
chore(governance): refresh stale skeleton annotations for fraud/billing (issue #667)

### DIFF
--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "3c155edb91dc7a1f"
+    openbank.tech/policy-checksum: "78e69b979075036f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1159,8 +1159,8 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3c155edb91dc7a1f"
+        openbank.tech/policy-checksum: "78e69b979075036f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "cba7562026b4d6c9"
+    openbank.tech/policy-checksum: "5d3318c2352d152d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -724,8 +724,8 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cba7562026b4d6c9"
+        openbank.tech/policy-checksum: "5d3318c2352d152d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "cba7562026b4d6c9"
+    openbank.tech/policy-checksum: "5d3318c2352d152d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -724,8 +724,8 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "cba7562026b4d6c9"
+        openbank.tech/policy-checksum: "5d3318c2352d152d"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "36759213ddc520a1"
+    openbank.tech/policy-checksum: "e0c94d0cdac6084f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1098,8 +1098,8 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "36759213ddc520a1"
+        openbank.tech/policy-checksum: "e0c94d0cdac6084f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -309,8 +309,8 @@ money_path_services:
   - openbank-lending-service
   - openbank-sca-service
   - openbank-consent-service
-  - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-  - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+  - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+  - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
   - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
   - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
 review:


### PR DESCRIPTION
## Summary

- `rules.yaml`'s `money_path_services` list still commented `openbank-fraud-service` as "first executable landed (Phase 1 skeleton)" and `openbank-billing-service` as "fee posting to the ledger (Phase 2b skeleton)" — both stale since #670/#672/#675 merged.
- Updated the inline comments only:
  - `openbank-fraud-service` — v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration).
  - `openbank-billing-service` — fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live.
- No rule/policy change — comment text only, closes part of #667's acceptance criteria ("rules.yaml no longer annotates fraud-service/billing-service as skeletons").

Refs #667