### PR TITLE
fix(infra): disable Kyverno image-verify cache on the SBOM attestation policy

### DIFF
--- a/openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
+++ b/openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
@@ -56,6 +56,19 @@ spec:
           mutateDigest: false
           verifyDigest: false
           required: true
+          # useCache: false — mirrors the same-day fix in verify-images-policy.yaml.
+          # This rule and the signature rule race on the same ECR credential temp file
+          # inside the admission-controller pod; whichever loses the race gets its
+          # transient failure cached as if it were a real verification result, poisoning
+          # every later admission for that tag until the cache entry expires or the pod
+          # restarts. The signature policy got useCache: false today (2026-07-09) for the
+          # admin-ui hit of this bug, but this policy was left on the default (cached) —
+          # confirmed live in-cluster still denying openbank-billing-service:sandbox-16d25569
+          # on repeat ArgoCD retries although `cosign verify`/`verify-attestation` both pass
+          # against the same tag with the same key. Audit mode never blocks the pod either
+          # way, but a poisoned PolicyReport entry defeats the whole point of step 1
+          # (surfacing real violations) and would silently pass step 2's redeploy check.
+          useCache: false
           attestations:
             - predicateType: https://cyclonedx.org/bom
               attestors:


### PR DESCRIPTION
## Summary
- `verify-openbank-image-signatures` already has `useCache: false` (added today, 2026-07-09, after admin-ui hit a cache-poisoning bug).
- `verify-openbank-image-sbom-attestation` was left on the cached default and hits the identical bug: this rule and the signature rule race on the same ECR credential temp file inside the Kyverno admission-controller pod, and whichever loses the race gets its transient failure cached as a real verification result — poisoning every later admission for that tag until the cache entry expires or the pod restarts.
- Confirmed live in-cluster while deploying billing-service `v0.5.2` (#601/#616/#690): ArgoCD kept retrying and Kyverno kept denying `openbank-billing-service:sandbox-16d25569` as "unverified" for both policies, even though `cosign verify` and `cosign verify-attestation` both pass locally against the exact same tag and KMS key.
- Audit mode never blocks the pod either way, but a poisoned `PolicyReport` entry defeats the whole point of the policy's step 1 (surfacing real SBOM-attestation violations) and would silently satisfy step 2's "redeploy the fleet, verify 0 fails" criterion with false negatives.

## Test plan
- [x] Confirmed via `kubectl get clusterpolicy verify-openbank-image-sbom-attestation -o jsonpath='{.spec.rules[0].verifyImages[0].useCache}'` that the live cluster object was `true` before this change.
- [ ] After merge + ArgoCD sync, verify `kubectl get clusterpolicy verify-openbank-image-sbom-attestation -o jsonpath='...useCache'` reports `false`.
- [ ] Verify a fresh admission (e.g. the pending billing-service rollout) no longer gets a stale-cached "unverified" result for an image that `cosign verify-attestation` independently confirms is valid.

Refs #601