### PR TITLE
docs: fix fabricated citations and over-corrected claim in Kafka msg-override comments

### DIFF
--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -299,10 +299,16 @@ mp:
         # default (latest) instead of the intended latest-is-fine-here value, but the same bug
         # class applies regardless (issue #686).
         #
-        # A properties-file override (not MP_MESSAGING_INCOMING_*_GROUP_ID env vars) is used
-        # because `oversight-events` is a hyphenated channel name: SmallRye's channel discovery
-        # cannot reliably reverse-map hyphenated MP_MESSAGING_INCOMING_OVERSIGHT_EVENTS_* env
-        # names back to the channel, and can register a broken channel that fails startup
-        # (confirmed on transaction-service's payment-scheme-accepted channel, #2649 -> reverted
-        # in #2659). A properties file carries the exact hyphenated property key, so discovery
-        # is unambiguous.
+        # A properties-file override (not MP_MESSAGING_INCOMING_*_GROUP_ID env vars) is used,
+        # matching the pattern already established for transaction-service's
+        # payment-scheme-accepted channel. A properties file carries the exact hyphenated
+        # property key unambiguously, avoiding any reliance on MicroProfile Config's env-var-name
+        # reverse-mapping for channel discovery.
+        #
+        # Correction: an earlier version of this comment claimed the env-var form was "confirmed"
+        # to break transaction-service's channel, citing issues #2649/#2659 as proof — those issue
+        # numbers do not exist in this repository (a fabricated citation that propagated from
+        # docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain env-var approach is
+        # independently verified to work once a channel is already registered via YAML
+        # connector/topic keys (PR #685, PR #701) — this properties-file mechanism is kept as a
+        # valid alternative, not because env vars are broken.

--- a/openbank-agent-service/src/main/resources/application.yaml
+++ b/openbank-agent-service/src/main/resources/application.yaml
@@ -305,10 +305,15 @@ mp:
         # property key unambiguously, avoiding any reliance on MicroProfile Config's env-var-name
         # reverse-mapping for channel discovery.
         #
-        # Correction: an earlier version of this comment claimed the env-var form was "confirmed"
-        # to break transaction-service's channel, citing issues #2649/#2659 as proof — those issue
-        # numbers do not exist in this repository (a fabricated citation that propagated from
-        # docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain env-var approach is
-        # independently verified to work once a channel is already registered via YAML
-        # connector/topic keys (PR #685, PR #701) — this properties-file mechanism is kept as a
-        # valid alternative, not because env vars are broken.
+        # Correction (round 2): an earlier version of this comment first cited nonexistent issues
+        # #2649/#2659, then over-corrected to claim env vars are "independently verified to work"
+        # here — that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+        # smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where
+        # an env-var override of a single leaf property (e.g. `retries`, here `group.id`/
+        # `auto.offset.reset`) on a HYPHENATED channel name crashes Quarkus at startup
+        # (`SRMSG00071`, "connector attribute must be set for channel <wrong split>") — regardless
+        # of whether the channel is already registered via YAML/annotations. Boot tests added
+        # during this sweep inject the override via a QuarkusTestResourceLifecycleManager config
+        # map, not a real OS env var, so they don't exercise this failure mode. This properties-file
+        # mechanism is the CORRECT choice for a hyphenated channel like `oversight-events`, not
+        # merely a stylistic alternative.

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -101,13 +101,18 @@ mp:
       # unambiguously, avoiding any reliance on MicroProfile Config's env-var-name reverse-mapping
       # for channel discovery. See issue #686.
       #
-      # Correction: an earlier version of this comment claimed env vars were "previously broken"
-      # for transaction-service's channel, citing issues #2649/#2659 as proof — those issue
-      # numbers do not exist in this repository (a fabricated citation that propagated from
-      # docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain env-var approach is
-      # independently verified to work once a channel is already registered via YAML
-      # connector/topic keys (PR #685, PR #701) — this properties-file mechanism is kept as a
-      # valid alternative, not because env vars are broken.
+      # Correction (round 2): an earlier version of this comment first cited nonexistent issues
+      # #2649/#2659, then over-corrected to claim env vars are "independently verified to work"
+      # here — that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+      # smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where
+      # an env-var override of a single leaf property (e.g. `retries`, here `group.id`/
+      # `auto.offset.reset`) on a HYPHENATED channel name crashes Quarkus at startup
+      # (`SRMSG00071`, "connector attribute must be set for channel <wrong split>") — regardless
+      # of whether the channel is already registered via YAML/annotations. Boot tests added
+      # during this sweep inject the override via a QuarkusTestResourceLifecycleManager config
+      # map, not a real OS env var, so they don't exercise this failure mode. This properties-file
+      # mechanism is the CORRECT choice for a hyphenated channel like `audit-events-in`, not
+      # merely a stylistic alternative.
       audit-events-in:
         connector: smallrye-kafka
         client.id: audit-service-${quarkus.uuid}

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -96,10 +96,18 @@ mp:
       # the audit-service KafkaUser ACL (kafka-audit-mtls.yaml) does NOT grant Read on (only
       # "audit-service" is granted) — every consumer poll got a silent
       # org.apache.kafka.common.errors.GroupAuthorizationException. A properties file (not an env
-      # var) is used because this channel name is hyphenated (audit-events-in): SmallRye's env-var
-      # reverse-mapping for hyphenated/dotted channel names is ambiguous and previously broke
-      # transaction-service's payment-scheme-accepted channel this way (reverted, #2649→#2659); a
-      # properties file carries the exact property name unambiguously. See issue #686.
+      # var) is used here, matching the pattern already established for transaction-service's
+      # payment-scheme-accepted channel; it carries the exact hyphenated/dotted property name
+      # unambiguously, avoiding any reliance on MicroProfile Config's env-var-name reverse-mapping
+      # for channel discovery. See issue #686.
+      #
+      # Correction: an earlier version of this comment claimed env vars were "previously broken"
+      # for transaction-service's channel, citing issues #2649/#2659 as proof — those issue
+      # numbers do not exist in this repository (a fabricated citation that propagated from
+      # docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain env-var approach is
+      # independently verified to work once a channel is already registered via YAML
+      # connector/topic keys (PR #685, PR #701) — this properties-file mechanism is kept as a
+      # valid alternative, not because env vars are broken.
       audit-events-in:
         connector: smallrye-kafka
         client.id: audit-service-${quarkus.uuid}

--- a/openbank-card-issuance-service/src/main/resources/application.yaml
+++ b/openbank-card-issuance-service/src/main/resources/application.yaml
@@ -104,11 +104,19 @@ mp:
         # GroupAuthorizationException. auto.offset.reset would likewise silently fall back to
         # Kafka's `latest` default instead of `earliest`. Set instead via the
         # card-issuance-service-msg-override ConfigMap (QUARKUS_CONFIG_LOCATIONS,
-        # config_ordinal=500) — a properties FILE, not env vars, because the hyphenated channel
-        # name `party-events-in` breaks SmallRye's channel discovery when config is supplied as
-        # MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_* env vars (tried fleet-wide for
-        # transaction-service and reverted, #2649 -> #2659; see
-        # openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml).
+        # config_ordinal=500) — a properties FILE, matching the pattern already established for
+        # transaction-service's payment-scheme-accepted channel (see
+        # openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml); it
+        # carries the exact hyphenated property key unambiguously, avoiding any reliance on
+        # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+        #
+        # Correction: an earlier version of this comment claimed the env-var form was tried
+        # fleet-wide and reverted for transaction-service's channel, citing issues #2649/#2659 as
+        # proof — those issue numbers do not exist in this repository (a fabricated citation that
+        # propagated from docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain
+        # env-var approach is independently verified to work once a channel is already registered
+        # via YAML connector/topic keys (PR #685, PR #701) — this properties-file mechanism is
+        # kept as a valid alternative, not because env vars are broken.
     outgoing:
       # ADR-0050 transactional-outbox egress. The dispatcher sets the Kafka key (= aggregate id, N2)
       # and ce-id/idempotency-key/ce-type headers (N3) via OutgoingKafkaRecordMetadata, so both a key

--- a/openbank-card-issuance-service/src/main/resources/application.yaml
+++ b/openbank-card-issuance-service/src/main/resources/application.yaml
@@ -110,13 +110,18 @@ mp:
         # carries the exact hyphenated property key unambiguously, avoiding any reliance on
         # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
         #
-        # Correction: an earlier version of this comment claimed the env-var form was tried
-        # fleet-wide and reverted for transaction-service's channel, citing issues #2649/#2659 as
-        # proof — those issue numbers do not exist in this repository (a fabricated citation that
-        # propagated from docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain
-        # env-var approach is independently verified to work once a channel is already registered
-        # via YAML connector/topic keys (PR #685, PR #701) — this properties-file mechanism is
-        # kept as a valid alternative, not because env vars are broken.
+        # Correction (round 2): an earlier version of this comment first cited nonexistent issues
+        # #2649/#2659, then over-corrected to claim env vars are "independently verified to work"
+        # here — that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+        # smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where
+        # an env-var override of a single leaf property (e.g. `retries`, here `group.id`/
+        # `auto.offset.reset`) on a HYPHENATED channel name crashes Quarkus at startup
+        # (`SRMSG00071`, "connector attribute must be set for channel <wrong split>") — regardless
+        # of whether the channel is already registered via YAML/annotations. Boot tests added
+        # during this sweep inject the override via a QuarkusTestResourceLifecycleManager config
+        # map, not a real OS env var, so they don't exercise this failure mode. This properties-file
+        # mechanism is the CORRECT choice for a hyphenated channel like `party-events-in`, not
+        # merely a stylistic alternative.
     outgoing:
       # ADR-0050 transactional-outbox egress. The dispatcher sets the Kafka key (= aggregate id, N2)
       # and ce-id/idempotency-key/ce-type headers (N3) via OutgoingKafkaRecordMetadata, so both a key

--- a/openbank-fraud-service/src/main/resources/application.yaml
+++ b/openbank-fraud-service/src/main/resources/application.yaml
@@ -93,14 +93,19 @@ mp:
         # (loaded via QUARKUS_CONFIG_LOCATIONS) for why and where they're set instead, matching the
         # pattern already established for transaction-service's payment-scheme-accepted channel.
         #
-        # Correction: an earlier version of this comment claimed the env-var form (PR #685's
-        # original fix) was "unsafe for a hyphenated channel name" per ADR-0137's "known follow-up"
-        # section, citing issues #2649/#2659 as proof — those issue numbers do not exist in this
-        # repository (a fabricated citation that propagated from
-        # docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain env-var approach is
-        # independently verified to work once a channel is already registered via YAML
-        # connector/topic keys (this is exactly PR #685's original, working fix; see also PR #701)
-        # — the properties-file mechanism here is a valid alternative, not a required correction.
+        # Correction (round 2): an earlier version of this comment first cited nonexistent issues
+        # #2649/#2659, then over-corrected to claim PR #685's original env-var fix was
+        # "independently verified to work" — that overstated it too. The genuine concern is real:
+        # quarkusio/quarkus#30106 and smallrye/smallrye-reactive-messaging#2028 document a live,
+        # unresolved upstream bug where an env-var override of a single leaf property (e.g.
+        # `retries`, here `group.id`/`auto.offset.reset`/`dead-letter-queue.topic`) on a HYPHENATED
+        # channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must be set
+        # for channel <wrong split>") — regardless of whether the channel is already registered
+        # via YAML/annotations. #685's own regression test didn't catch this because it injects
+        # the override via a QuarkusTestResourceLifecycleManager config map, not a real OS env var,
+        # so it doesn't exercise this failure mode. This properties-file mechanism is the CORRECT
+        # choice for the hyphenated `transaction-signal` channel, not merely a stylistic
+        # alternative or a required-but-optional correction.
         # Summary: SmallRye Config's YAML source unconditionally quotes any leaf map key
         # containing a literal dot (`group.id` becomes the registered property name `"group.id"`,
         # quotes included — true whether or not the YAML key itself is quoted), so

--- a/openbank-fraud-service/src/main/resources/application.yaml
+++ b/openbank-fraud-service/src/main/resources/application.yaml
@@ -90,9 +90,18 @@ mp:
         failure-strategy: dead-letter-queue
         # group.id / auto.offset.reset / dead-letter-queue.topic are deliberately NOT set as YAML
         # keys here — see openbank-infra/gitops/components/fraud-service/fraud-service-msg-override.yaml
-        # (loaded via QUARKUS_CONFIG_LOCATIONS) for why and where they're set instead. NOT env vars:
-        # that was tried (#685) and is unsafe for a hyphenated channel name like this one — see
-        # ADR-0137's "known follow-up" section (#2649 -> #2659, reverted). Summary: SmallRye Config's YAML source unconditionally quotes any leaf map key
+        # (loaded via QUARKUS_CONFIG_LOCATIONS) for why and where they're set instead, matching the
+        # pattern already established for transaction-service's payment-scheme-accepted channel.
+        #
+        # Correction: an earlier version of this comment claimed the env-var form (PR #685's
+        # original fix) was "unsafe for a hyphenated channel name" per ADR-0137's "known follow-up"
+        # section, citing issues #2649/#2659 as proof — those issue numbers do not exist in this
+        # repository (a fabricated citation that propagated from
+        # docs/adr/0137-kafka-mtls-scheme-accepted-migration.md). The plain env-var approach is
+        # independently verified to work once a channel is already registered via YAML
+        # connector/topic keys (this is exactly PR #685's original, working fix; see also PR #701)
+        # — the properties-file mechanism here is a valid alternative, not a required correction.
+        # Summary: SmallRye Config's YAML source unconditionally quotes any leaf map key
         # containing a literal dot (`group.id` becomes the registered property name `"group.id"`,
         # quotes included — true whether or not the YAML key itself is quoted), so
         # KafkaConnectorIncomingConfiguration's plain config.getOptionalValue("group.id", ...) never

--- a/openbank-infra/gitops/components/agent/agent-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service-msg-override.yaml
@@ -13,15 +13,17 @@
 # file carries the exact hyphenated keys unambiguously, avoiding any reliance on MicroProfile
 # Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
-# env-var form was tried and reverted for transaction-service due to a startup crash on
-# hyphenated channel names. Those issue numbers do not exist in this repository — the claim was
-# a fabricated citation that had propagated from a stale reference in
-# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
-# independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism is kept here as a valid, working alternative — not because env vars are broken.
+# Correction (round 2): an earlier version of this comment first cited nonexistent issues
+# #2649/#2659, then over-corrected to claim env vars are "independently verified to work" here —
+# that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property (e.g. `retries`, here `group.id`/`auto.offset.reset`)
+# on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must
+# be set for channel <wrong split>") — regardless of whether the channel is already registered
+# via YAML/annotations. Boot tests added during this sweep inject the override via a
+# QuarkusTestResourceLifecycleManager config map, not a real OS env var, so they don't exercise
+# this failure mode. This properties-file mechanism is the CORRECT choice for a hyphenated
+# channel like `oversight-events`, not merely a stylistic alternative.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment. Once the image is rebuilt from

--- a/openbank-infra/gitops/components/agent/agent-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service-msg-override.yaml
@@ -7,12 +7,21 @@
 # than wait on that, mount them as a Quarkus external config source so the running
 # (possibly older) image also gets the correct group.id / auto.offset.reset.
 #
-# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
-# scanning config property NAMES, and the env-var form
-# (MP_MESSAGING_INCOMING_OVERSIGHT_EVENTS_*) reverse-maps ambiguously for a hyphenated
-# channel name → a broken channel → startup crash (this is exactly what happened for
-# transaction-service's payment-scheme-accepted channel: #2649, reverted in #2659). A
-# properties file carries the EXACT hyphenated keys, so discovery is unambiguous.
+# Why a properties FILE and not env vars: this mirrors the pre-existing pattern already used
+# for transaction-service's payment-scheme-accepted channel
+# (openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml). A properties
+# file carries the exact hyphenated keys unambiguously, avoiding any reliance on MicroProfile
+# Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
+# env-var form was tried and reverted for transaction-service due to a startup crash on
+# hyphenated channel names. Those issue numbers do not exist in this repository — the claim was
+# a fabricated citation that had propagated from a stale reference in
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
+# independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism is kept here as a valid, working alternative — not because env vars are broken.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment. Once the image is rebuilt from

--- a/openbank-infra/gitops/components/audit/audit-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service-msg-override.yaml
@@ -18,15 +18,17 @@
 # file carries the exact hyphenated/dotted property name unambiguously, avoiding any reliance on
 # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
-# env-var form was tried and reverted for transaction-service due to a startup crash on
-# hyphenated channel names. Those issue numbers do not exist in this repository — the claim was
-# a fabricated citation that had propagated from a stale reference in
-# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
-# independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism is kept here as a valid, working alternative — not because env vars are broken.
+# Correction (round 2): an earlier version of this comment first cited nonexistent issues
+# #2649/#2659, then over-corrected to claim env vars are "independently verified to work" here —
+# that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property (e.g. `retries`, here `group.id`/`auto.offset.reset`)
+# on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must
+# be set for channel <wrong split>") — regardless of whether the channel is already registered
+# via YAML/annotations. Boot tests added during this sweep inject the override via a
+# QuarkusTestResourceLifecycleManager config map, not a real OS env var, so they don't exercise
+# this failure mode. This properties-file mechanism is the CORRECT choice for a hyphenated
+# channel like `audit-events-in`, not merely a stylistic alternative.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254). Loaded via
 # QUARKUS_CONFIG_LOCATIONS on the Deployment (audit-service.yaml).

--- a/openbank-infra/gitops/components/audit/audit-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service-msg-override.yaml
@@ -12,12 +12,21 @@
 # "audit-service" is granted) — every consumer poll gets a silent
 # org.apache.kafka.common.errors.GroupAuthorizationException.
 #
-# Why a properties FILE and not env vars: SmallRye discovers messaging channels by scanning
-# config property NAMES, and the env-var form (MP_MESSAGING_INCOMING_AUDIT_EVENTS_IN_*)
-# reverse-maps ambiguously for a hyphenated channel name like audit-events-in → a broken channel
-# → startup crash (this exact approach was tried for transaction-service's hyphenated
-# payment-scheme-accepted channel and reverted, #2649→#2659). A properties file carries the EXACT
-# hyphenated/dotted property name unambiguously, so discovery is unambiguous.
+# Why a properties FILE and not env vars: this mirrors the pre-existing pattern already used
+# for transaction-service's payment-scheme-accepted channel
+# (openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml). A properties
+# file carries the exact hyphenated/dotted property name unambiguously, avoiding any reliance on
+# MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
+# env-var form was tried and reverted for transaction-service due to a startup crash on
+# hyphenated channel names. Those issue numbers do not exist in this repository — the claim was
+# a fabricated citation that had propagated from a stale reference in
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
+# independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism is kept here as a valid, working alternative — not because env vars are broken.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254). Loaded via
 # QUARKUS_CONFIG_LOCATIONS on the Deployment (audit-service.yaml).

--- a/openbank-infra/gitops/components/fraud-service/fraud-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service-msg-override.yaml
@@ -10,14 +10,21 @@
 # granted Read/Describe on — every poll got a silent GroupAuthorizationException until it landed
 # inside Quarkus's synchronous startup window and became a fatal crash-loop.
 #
-# Why NOT env vars either (this superseded #685's original fix): ADR-0137's "known follow-up"
-# section documents that MP_MESSAGING_INCOMING_<CHANNEL>_* env vars were tried for a HYPHENATED
-# mp.messaging channel name (payment-scheme-accepted) and reverted (#2649 → #2659) — SmallRye's
-# channel discovery reverse-maps the env var name to a property name ambiguously and the pod fails
-# to start. `transaction-signal` is hyphenated too, and #685's own regression test
-# (TransactionSignalConsumerBootIT) injected the property directly via a
-# QuarkusTestResourceLifecycleManager config map — a different, always-safe mechanism — so it never
-# actually exercised the env var path and could not have caught this.
+# This mirrors the pre-existing pattern already used for transaction-service's
+# payment-scheme-accepted channel (transaction-service-msg-override.yaml). A properties file
+# carries the exact hyphenated/dotted property name unambiguously, avoiding any reliance on
+# MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment claimed this "superseded #685's original fix"
+# because ADR-0137's "known follow-up" section documented MP_MESSAGING_INCOMING_<CHANNEL>_* env
+# vars being tried and reverted for a hyphenated channel name, citing issues #2649/#2659 as proof.
+# Those issue numbers do not exist in this repository — a fabricated citation that propagated
+# from a stale reference in docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. #685's original
+# env-var fix is independently verified to work correctly once a channel is already registered
+# via YAML connector/topic keys (which is true for `transaction-signal`) — confirmed by a
+# standalone SmallRye Config test and by PR #701 (openbank-anacredit-service)'s passing boot test
+# using the same env-var mechanism. This properties-file mechanism remains a valid, working
+# alternative — not a required correction to #685.
 #
 # A properties FILE carries the exact hyphenated/dotted property name unambiguously (no YAML
 # flattening, no env-var reverse-mapping) — the same proven pattern already live for

--- a/openbank-infra/gitops/components/fraud-service/fraud-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service-msg-override.yaml
@@ -15,16 +15,17 @@
 # carries the exact hyphenated/dotted property name unambiguously, avoiding any reliance on
 # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment claimed this "superseded #685's original fix"
-# because ADR-0137's "known follow-up" section documented MP_MESSAGING_INCOMING_<CHANNEL>_* env
-# vars being tried and reverted for a hyphenated channel name, citing issues #2649/#2659 as proof.
-# Those issue numbers do not exist in this repository — a fabricated citation that propagated
-# from a stale reference in docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. #685's original
-# env-var fix is independently verified to work correctly once a channel is already registered
-# via YAML connector/topic keys (which is true for `transaction-signal`) — confirmed by a
-# standalone SmallRye Config test and by PR #701 (openbank-anacredit-service)'s passing boot test
-# using the same env-var mechanism. This properties-file mechanism remains a valid, working
-# alternative — not a required correction to #685.
+# Correction (round 2): an earlier version of this comment first cited nonexistent issues
+# #2649/#2659, then over-corrected to claim #685's original env-var fix was "independently
+# verified to work" — that overstated it too. The genuine concern is real:
+# quarkusio/quarkus#30106 and smallrye/smallrye-reactive-messaging#2028 document a live,
+# unresolved upstream bug where an env-var override of a single leaf property on a HYPHENATED
+# channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must be set for
+# channel <wrong split>") — regardless of whether the channel is already registered via
+# YAML/annotations. #685's own regression test didn't catch this because it injects the override
+# via a QuarkusTestResourceLifecycleManager config map, not a real OS env var, so it doesn't
+# exercise this failure mode. This properties-file mechanism is the CORRECT choice for the
+# hyphenated `transaction-signal` channel, not merely a stylistic alternative.
 #
 # A properties FILE carries the exact hyphenated/dotted property name unambiguously (no YAML
 # flattening, no env-var reverse-mapping) — the same proven pattern already live for

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -68,17 +68,18 @@ spec:
             # see fraud-service-msg-override.yaml — matching the pattern already established for
             # transaction-service (transaction-service-msg-override.yaml).
             #
-            # Correction: an earlier version of this comment claimed this change was required
-            # because ADR-0137's "known follow-up" section documented the env-var form being tried
-            # and reverted for a hyphenated channel name, citing issues #2649/#2659 as proof. Those
-            # issue numbers do not exist in this repository — a fabricated citation that propagated
-            # from a stale reference in docs/adr/0137-kafka-mtls-scheme-accepted-migration.md.
-            # #685's original env-var fix is independently verified to work correctly once a
-            # channel is already registered via YAML connector/topic keys (true for
-            # `transaction-signal`) — confirmed by a standalone SmallRye Config test and by PR #701
-            # (openbank-anacredit-service)'s passing boot test using the same env-var mechanism.
-            # This properties-file mechanism remains a valid, working alternative — not a required
-            # correction to #685.
+            # Correction (round 2): an earlier version of this comment first cited nonexistent
+            # issues #2649/#2659, then over-corrected to claim #685's original env-var fix was
+            # "independently verified to work" — that overstated it too. The genuine concern is
+            # real: quarkusio/quarkus#30106 and smallrye/smallrye-reactive-messaging#2028 document
+            # a live, unresolved upstream bug where an env-var override of a single leaf property
+            # on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector
+            # attribute must be set for channel <wrong split>") — regardless of whether the channel
+            # is already registered via YAML/annotations. #685's own regression test didn't catch
+            # this because it injects the override via a QuarkusTestResourceLifecycleManager config
+            # map, not a real OS env var, so it doesn't exercise this failure mode. This
+            # properties-file mechanism is the CORRECT choice for the hyphenated
+            # `transaction-signal` channel, not merely a stylistic alternative.
             - name: QUARKUS_CONFIG_LOCATIONS
               value: /mnt/msg-config/override.properties
             - name: KAFKA_SECURITY_PROTOCOL

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -64,19 +64,21 @@ spec:
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
             # #685 originally set these as MP_MESSAGING_INCOMING_TRANSACTION_SIGNAL_* env vars.
-            # Reverted here (open-bank-oss#686 follow-up): ADR-0137's "known follow-up" section
-            # documents that this exact approach — an env var for a HYPHENATED mp.messaging
-            # channel name — was tried for `payment-scheme-accepted` and reverted (#2649→#2659):
-            # SmallRye's channel discovery reverse-maps the env var name to a property name
-            # ambiguously and the pod fails to start. `transaction-signal` is hyphenated too, and
-            # #685's own regression test (TransactionSignalConsumerBootIT) never actually exercised
-            # this env var — it injects the property directly via a
-            # QuarkusTestResourceLifecycleManager config map (a different, always-safe mechanism),
-            # so it could not have caught this. Loading a properties FILE via
-            # QUARKUS_CONFIG_LOCATIONS instead — see fraud-service-msg-override.yaml — carries the
-            # exact hyphenated/dotted property name unambiguously (no YAML flattening, no env-var
-            # reverse-mapping), matching the proven pattern already live for transaction-service
-            # (transaction-service-msg-override.yaml).
+            # Switched here to loading a properties FILE via QUARKUS_CONFIG_LOCATIONS instead —
+            # see fraud-service-msg-override.yaml — matching the pattern already established for
+            # transaction-service (transaction-service-msg-override.yaml).
+            #
+            # Correction: an earlier version of this comment claimed this change was required
+            # because ADR-0137's "known follow-up" section documented the env-var form being tried
+            # and reverted for a hyphenated channel name, citing issues #2649/#2659 as proof. Those
+            # issue numbers do not exist in this repository — a fabricated citation that propagated
+            # from a stale reference in docs/adr/0137-kafka-mtls-scheme-accepted-migration.md.
+            # #685's original env-var fix is independently verified to work correctly once a
+            # channel is already registered via YAML connector/topic keys (true for
+            # `transaction-signal`) — confirmed by a standalone SmallRye Config test and by PR #701
+            # (openbank-anacredit-service)'s passing boot test using the same env-var mechanism.
+            # This properties-file mechanism remains a valid, working alternative — not a required
+            # correction to #685.
             - name: QUARKUS_CONFIG_LOCATIONS
               value: /mnt/msg-config/override.properties
             - name: KAFKA_SECURITY_PROTOCOL

--- a/openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml
@@ -11,12 +11,21 @@
 # granted Read on group kyc-service-party — every consumer poll got a silent
 # GroupAuthorizationException.
 #
-# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
-# scanning config property NAMES, and the env-var form
-# (MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_*) reverse-maps ambiguously for a hyphenated
-# channel name → a broken channel → startup crash (this exact approach was tried for
-# transaction-service's payment-scheme-accepted channel and reverted, #2649→#2659). A
-# properties file carries the EXACT hyphenated/dotted keys, so discovery is unambiguous.
+# Why a properties FILE and not env vars: this mirrors the pre-existing pattern already used
+# for transaction-service's payment-scheme-accepted channel
+# (openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml). A properties
+# file carries the exact hyphenated/dotted keys unambiguously, avoiding any reliance on
+# MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
+# env-var form was tried and reverted for transaction-service due to a startup crash on
+# hyphenated channel names. Those issue numbers do not exist in this repository — the claim was
+# a fabricated citation that had propagated from a stale reference in
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
+# independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism is kept here as a valid, working alternative — not because env vars are broken.
 #
 # client.id is intentionally omitted here (and removed from application.yaml) rather than
 # reproduced: it only affects broker-side client identification in logs/JMX, not

--- a/openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/kyc/kyc-service-msg-override.yaml
@@ -17,15 +17,17 @@
 # file carries the exact hyphenated/dotted keys unambiguously, avoiding any reliance on
 # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
-# env-var form was tried and reverted for transaction-service due to a startup crash on
-# hyphenated channel names. Those issue numbers do not exist in this repository — the claim was
-# a fabricated citation that had propagated from a stale reference in
-# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
-# independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism is kept here as a valid, working alternative — not because env vars are broken.
+# Correction (round 2): an earlier version of this comment first cited nonexistent issues
+# #2649/#2659, then over-corrected to claim env vars are "independently verified to work" here —
+# that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property (e.g. `retries`, here `group.id`/`auto.offset.reset`)
+# on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must
+# be set for channel <wrong split>") — regardless of whether the channel is already registered
+# via YAML/annotations. Boot tests added during this sweep inject the override via a
+# QuarkusTestResourceLifecycleManager config map, not a real OS env var, so they don't exercise
+# this failure mode. This properties-file mechanism is the CORRECT choice for a hyphenated
+# channel like `party-events-in`, not merely a stylistic alternative.
 #
 # client.id is intentionally omitted here (and removed from application.yaml) rather than
 # reproduced: it only affects broker-side client identification in logs/JMX, not

--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -11,12 +11,21 @@
 # (kafka-notification-mtls.yaml) does NOT grant Read on for either consumer group — every
 # poll on both channels gets a silent GroupAuthorizationException.
 #
-# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
-# scanning config property NAMES, and the env-var form
-# (MP_MESSAGING_INCOMING_NOTIFICATION_EVENTS_IN_GROUP_ID) reverse-maps ambiguously for a
-# hyphenated channel name → a broken channel → startup crash (this was tried for
-# transaction-service's payment-scheme-accepted channel, #2649, and reverted). A
-# properties file carries the EXACT hyphenated/dotted keys, so discovery is unambiguous.
+# Why a properties FILE and not env vars: this mirrors the pre-existing pattern already used
+# for transaction-service's payment-scheme-accepted channel
+# (openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml). A properties
+# file carries the exact hyphenated/dotted keys unambiguously, avoiding any reliance on
+# MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment cited issue #2649 as proof that the env-var
+# form was tried and reverted for transaction-service due to a startup crash on hyphenated
+# channel names. That issue number does not exist in this repository — the claim was a
+# fabricated citation that had propagated from a stale reference in
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
+# independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism is kept here as a valid, working alternative — not because env vars are broken.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment (notification-service.yaml).

--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -17,15 +17,17 @@
 # file carries the exact hyphenated/dotted keys unambiguously, avoiding any reliance on
 # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment cited issue #2649 as proof that the env-var
-# form was tried and reverted for transaction-service due to a startup crash on hyphenated
-# channel names. That issue number does not exist in this repository — the claim was a
-# fabricated citation that had propagated from a stale reference in
-# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
-# independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism is kept here as a valid, working alternative — not because env vars are broken.
+# Correction (round 2): an earlier version of this comment first cited a nonexistent issue
+# #2649, then over-corrected to claim env vars are "independently verified to work" here — that
+# overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property (e.g. `retries`, here `group.id`/`auto.offset.reset`)
+# on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must
+# be set for channel <wrong split>") — regardless of whether the channel is already registered
+# via YAML/annotations. Boot tests added during this sweep inject the override via a
+# QuarkusTestResourceLifecycleManager config map, not a real OS env var, so they don't exercise
+# this failure mode. This properties-file mechanism is the CORRECT choice for hyphenated channels
+# like `notification-events-in`/`party-events-in`, not merely a stylistic alternative.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment (notification-service.yaml).

--- a/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
@@ -18,16 +18,17 @@
 # file carries the exact dotted/hyphenated property names unambiguously, avoiding any reliance on
 # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
-# env-var form was tried and reverted for transaction-service due to a startup crash on hyphenated
-# channel names. Those issue numbers do not exist in this repository — the claim was a fabricated
-# citation that had propagated from a stale reference in
-# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
-# independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism is kept here as a valid, working alternative that matches transaction-service's
-# existing precedent — not because the env-var approach is broken.
+# Correction (round 2): an earlier version of this comment first cited nonexistent issues
+# #2649/#2659, then over-corrected to claim env vars are "independently verified to work" here —
+# that overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property (e.g. `retries`, here `group.id`/`auto.offset.reset`)
+# on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must
+# be set for channel <wrong split>") — regardless of whether the channel is already registered
+# via YAML/annotations. Boot tests added during this sweep inject the override via a
+# QuarkusTestResourceLifecycleManager config map, not a real OS env var, so they don't exercise
+# this failure mode. This properties-file mechanism is the CORRECT choice for the hyphenated
+# `party-events-in`/`kyc-events-in`/`sca-events-in` channels, not merely a stylistic alternative.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Rollout (onboarding-service.yaml). Same pattern

--- a/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml
@@ -12,12 +12,22 @@
 # (kafka-onboarding-mtls.yaml) does NOT grant Read on for any of the three groups below —
 # so every consumer poll on all three channels gets a silent GroupAuthorizationException.
 #
-# Why a properties FILE and not env vars: SmallRye discovers messaging channels by scanning
-# config property NAMES, and the env-var form (MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_GROUP_ID
-# etc.) reverse-maps ambiguously for hyphenated channel names -> a broken channel -> startup
-# crash (this was tried for transaction-service's payment-scheme-accepted channel, #2649,
-# and reverted in #2659; see ADR-0137). A properties file carries the EXACT dotted/hyphenated
-# property names unambiguously, so channel discovery is unambiguous.
+# Why a properties FILE and not env vars: this mirrors the pre-existing pattern already used for
+# transaction-service's payment-scheme-accepted channel
+# (openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml). A properties
+# file carries the exact dotted/hyphenated property names unambiguously, avoiding any reliance on
+# MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment cited issues #2649/#2659 as proof that the
+# env-var form was tried and reverted for transaction-service due to a startup crash on hyphenated
+# channel names. Those issue numbers do not exist in this repository — the claim was a fabricated
+# citation that had propagated from a stale reference in
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
+# independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism is kept here as a valid, working alternative that matches transaction-service's
+# existing precedent — not because the env-var approach is broken.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Rollout (onboarding-service.yaml). Same pattern

--- a/openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml
@@ -8,13 +8,20 @@
 # silently never resolve (see the comment there). This ConfigMap supplies them
 # instead as a Quarkus external config source.
 #
-# Why a properties FILE and not env vars: SmallRye discovers messaging channels by
-# scanning config property NAMES, and the env-var form
-# (MP_MESSAGING_INCOMING_PARTY_EVENTS_IN_*) reverse-maps ambiguously for a
-# hyphenated channel name ("party-events-in") -> a broken channel -> startup
-# crash (this is exactly #2649, reverted, documented in ADR-0137 / runbook 0008
-# and in transaction-service-msg-override.yaml). A properties file carries the
-# EXACT hyphenated keys, so channel discovery is unambiguous.
+# Why a properties FILE and not env vars: this mirrors the pre-existing pattern already used
+# for transaction-service's payment-scheme-accepted channel (transaction-service-msg-override.yaml).
+# A properties file carries the exact hyphenated keys unambiguously, avoiding any reliance on
+# MicroProfile Config's env-var-name reverse-mapping for channel discovery.
+#
+# Correction: an earlier version of this comment cited issue #2649 as proof that the env-var
+# form was tried and reverted for transaction-service due to a startup crash on hyphenated
+# channel names (also referenced in ADR-0137 / runbook 0008). That issue number does not exist
+# in this repository — the claim was a fabricated citation that had propagated from a stale
+# reference in docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach
+# is independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism is kept here as a valid, working alternative — not because env vars are broken.
 #
 # group.id MUST match the Read grant on consumer group `cardissuance-party` in
 # this service's KafkaUser ACL (kafka-scheme-accepted-acl.yaml), or every

--- a/openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-service-msg-override.yaml
@@ -13,15 +13,17 @@
 # A properties file carries the exact hyphenated keys unambiguously, avoiding any reliance on
 # MicroProfile Config's env-var-name reverse-mapping for channel discovery.
 #
-# Correction: an earlier version of this comment cited issue #2649 as proof that the env-var
-# form was tried and reverted for transaction-service due to a startup crash on hyphenated
-# channel names (also referenced in ADR-0137 / runbook 0008). That issue number does not exist
-# in this repository — the claim was a fabricated citation that had propagated from a stale
-# reference in docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach
-# is independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys (which is the case here): see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism is kept here as a valid, working alternative — not because env vars are broken.
+# Correction (round 2): an earlier version of this comment first cited a nonexistent issue
+# #2649, then over-corrected to claim env vars are "independently verified to work" here — that
+# overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property (e.g. `retries`, here `group.id`/`auto.offset.reset`)
+# on a HYPHENATED channel name crashes Quarkus at startup (`SRMSG00071`, "connector attribute must
+# be set for channel <wrong split>") — regardless of whether the channel is already registered
+# via YAML/annotations. Boot tests added during this sweep inject the override via a
+# QuarkusTestResourceLifecycleManager config map, not a real OS env var, so they don't exercise
+# this failure mode. This properties-file mechanism is the CORRECT choice for the hyphenated
+# `party-events-in` channel, not merely a stylistic alternative.
 #
 # group.id MUST match the Read grant on consumer group `cardissuance-party` in
 # this service's KafkaUser ACL (kafka-scheme-accepted-acl.yaml), or every

--- a/openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml
@@ -6,10 +6,21 @@
 # external config source so the running (old) image picks them up.
 #
 # Why a properties FILE and not env vars: SmallRye discovers messaging channels by
-# scanning config property NAMES, and the env-var form
-# (MP_MESSAGING_INCOMING_PAYMENT_SCHEME_ACCEPTED_*) reverse-maps ambiguously →
-# a broken channel → startup crash (that was #2649, reverted). A properties file
-# carries the EXACT hyphenated keys, so discovery is unambiguous.
+# scanning config property NAMES; a properties file carries the exact hyphenated keys
+# unambiguously, avoiding any reliance on MicroProfile Config's env-var-name reverse-mapping
+# for channel discovery.
+#
+# Correction: an earlier version of this comment claimed the env-var form was "tried" and
+# "reverted" for this channel, citing issue #2649 as proof. That issue number does not exist in
+# this repository, and no record of an actual env-var attempt/revert for this channel could be
+# found — this appears to be the origin of a fabricated citation that was subsequently copied
+# (and elaborated on) into several other services' equivalent override files, and into
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
+# independently verified to work correctly once a channel is already registered via YAML
+# connector/topic keys: see PR #685 (openbank-fraud-service) and PR #701
+# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
+# mechanism remains a valid, working choice for this channel — kept as-is (it is genuinely live
+# in production and working) — not because env vars are broken.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml
 # (~254). Loaded via QUARKUS_CONFIG_LOCATIONS on the Rollout. Once the image is

--- a/openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-service-msg-override.yaml
@@ -10,17 +10,20 @@
 # unambiguously, avoiding any reliance on MicroProfile Config's env-var-name reverse-mapping
 # for channel discovery.
 #
-# Correction: an earlier version of this comment claimed the env-var form was "tried" and
-# "reverted" for this channel, citing issue #2649 as proof. That issue number does not exist in
-# this repository, and no record of an actual env-var attempt/revert for this channel could be
+# Correction (round 2): an earlier version of this comment claimed the env-var form was "tried"
+# and "reverted" for this channel, citing issue #2649 as proof. That issue number does not exist
+# in this repository, and no record of an actual env-var attempt/revert for this channel could be
 # found — this appears to be the origin of a fabricated citation that was subsequently copied
 # (and elaborated on) into several other services' equivalent override files, and into
-# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. The plain env-var approach is
-# independently verified to work correctly once a channel is already registered via YAML
-# connector/topic keys: see PR #685 (openbank-fraud-service) and PR #701
-# (openbank-anacredit-service), both merged with passing boot tests. This properties-file
-# mechanism remains a valid, working choice for this channel — kept as-is (it is genuinely live
-# in production and working) — not because env vars are broken.
+# docs/adr/0137-kafka-mtls-scheme-accepted-migration.md. A follow-up correction then over-corrected
+# the other direction, claiming the env-var approach is "independently verified to work" — that
+# overstated it too. The genuine concern is real: quarkusio/quarkus#30106 and
+# smallrye/smallrye-reactive-messaging#2028 document a live, unresolved upstream bug where an
+# env-var override of a single leaf property on a HYPHENATED channel name crashes Quarkus at
+# startup (`SRMSG00071`, "connector attribute must be set for channel <wrong split>") — regardless
+# of whether the channel is already registered via YAML/annotations. This properties-file
+# mechanism is the CORRECT choice for the hyphenated `payment-scheme-accepted` channel — it is
+# genuinely live in production and working — not merely a stylistic alternative.
 #
 # config_ordinal=500 forces this source to outrank the baked application.yaml
 # (~254). Loaded via QUARKUS_CONFIG_LOCATIONS on the Rollout. Once the image is


### PR DESCRIPTION
## Summary (revised — see update below)

**Update:** this PR went through two rounds. The first commit fixed a fabricated citation but overstated the correction. The second commit fixes that overstatement. Read on for the full, current picture.

### Round 1 — the fabricated citation

Several `application.yaml` and gitops `msg-override.yaml` comments (agent-service, audit-service, card-issuance-service, fraud-service, kyc-service, notification-service, onboarding-service, plus the original `transaction-service-msg-override.yaml`) cited issues **#2649 → #2659** as proof that `MP_MESSAGING_INCOMING_*_GROUP_ID` env vars break for hyphenated Kafka channel names. Neither issue exists in this repository (confirmed via `gh issue view`, both 404) — this part of the finding stands.

### Round 2 — my own over-correction

My first commit replaced the fake citation with a claim that the plain env-var approach is "independently verified to work... once a channel is already registered via YAML connector/topic keys," citing PR #685 and PR #701 as proof. **That claim is wrong.**

I fetched the real upstream reports directly (`quarkusio/quarkus#30106`, `smallrye/smallrye-reactive-messaging#2028`) — the same ones already correctly cited in `docs/adr/0137-kafka-mtls-scheme-accepted-migration.md` via PR #700. Both describe a live, unresolved bug: an env-var override of a single leaf property (e.g. `retries`) on an already-registered, hyphenated channel name (defined via `@Incoming`, equivalent to YAML `connector`/`topic` keys) crashes Quarkus at startup with `SRMSG00071` ("connector attribute must be set for channel `<wrong split>`") — the channel-name/property-name split from the flat env-var form is structurally ambiguous, regardless of prior registration.

The boot tests added during this sweep (including for PR #685 and PR #701) inject the override via a `QuarkusTestResourceLifecycleManager` config map, **not a real OS environment variable** — a mechanism that bypasses the exact ambiguity in question, so a passing test doesn't demonstrate the env-var path is safe. Concretely: PR #701 (anacredit-service) and PR #703 (customer-edge) were each switched from the env-var mechanism to the properties-file mechanism *before* merging — the correct call, made independently of this PR.

## Net result

- The `#2649`/`#2659` citation numbers are fabricated — fixed, stands.
- The properties-file/ConfigMap mechanism is the **correct choice** for hyphenated channel names, not merely a stylistic alternative sitting next to a "proven-safe" env-var approach.
- Every comment touched by this PR now cites the real upstream issues (`quarkusio/quarkus#30106`, `smallrye/smallrye-reactive-messaging#2028`) instead of the fake ones, and states the technical conclusion accurately.

**Comment-only change — zero functional/behavioral difference** in both commits. No `version.txt` bumps, no gitops Rollout/Deployment/ConfigMap data values touched, no config keys added/removed/reordered.

## Test plan

- [x] `grep` confirms no uncorrected fabricated citation remains (only the correction text itself, which explicitly names and retracts the old claim).
- [x] Every edited YAML file re-validated with `yaml.safe_load`/`safe_load_all` — all parse cleanly.
- [x] No config values, env var names, or ConfigMap data changed in either commit — diff is comments only.

Refs #686, #700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)