### PR TITLE
feat(anacredit): add Dockerfile and register with auto-deploy fleet

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -90,7 +90,16 @@ jobs:
           # and released cleanly but never deployed — "Detect changed services" always
           # printed "No deployable services changed" because the service was simply
           # never a candidate, regardless of what changed. Re-added here.
-          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service'
+          # anacredit-service had the same gap PLUS no Dockerfile ever committed — the
+          # running sandbox pod traces back to an image built from a Dockerfile that only
+          # ever existed on someone's laptop. Neither build-push-service.sh nor this
+          # workflow's own Docker-push step read a per-service Dockerfile for the build
+          # itself (both generate their own from a canonical template); the per-service
+          # Dockerfile is only grepped for its EXPOSE line to set the container port
+          # (falls back to 8080 if absent). Added openbank-anacredit-service/Dockerfile
+          # (EXPOSE 8137, matching the gitops manifest) alongside this entry so the port
+          # extraction is correct, not just defaulted.
+          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service'
 
           # Manual dispatch: rebuild the requested module(s), or the full deployable
           # fleet when no input is given. Only services that actually carry a gitops

--- a/openbank-anacredit-service/Dockerfile
+++ b/openbank-anacredit-service/Dockerfile
@@ -1,0 +1,34 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+# Build from the FULL repo root context, NOT a selective per-module COPY. The root
+# settings.gradle.kts unconditionally `include`s all 30+ modules with an explicit
+# projectDir each, so Gradle configuration fails ("Configuring project ':openbank-
+# ledger-service' without an existing directory") unless every module dir is present.
+# Building from inside the module with its own gradlew instead trips a
+# quarkusGenerateCode -> jar -> classes circular dependency. Mirrors the canonical
+# openbank-infra/docker/services/standalone-service.Dockerfile. .dockerignore strips
+# build/, .gradle/, node_modules/ so the context stays lean.
+COPY . /build
+
+# Kotlin 2.3 + Quarkus 3.33 compile is heap-hungry; size the JVM up front.
+ENV GRADLE_OPTS="-Xmx2g -Xms256m -XX:MaxMetaspaceSize=512m"
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-anacredit-service:quarkusBuild \
+      -Dorg.gradle.java.installations.auto-detect=false \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-anacredit-service/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-anacredit-service/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-anacredit-service/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-anacredit-service/build/quarkus-app/quarkus/ /app/quarkus/
+
+EXPOSE 8137
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]


### PR DESCRIPTION
## Summary
- `openbank-anacredit-service` is running in the sandbox cluster (pod healthy) from image `sandbox-be701531`, but no `Dockerfile` for it was ever committed — the image was built and pushed manually from a Dockerfile that only ever existed locally. Any future change to this service could not be rebuilt through any documented or automated path.
- Added `openbank-anacredit-service/Dockerfile`, mirroring the `openbank-product-catalog` template (same multi-stage build shape, no DB-specific steps needed for the Docker layer). `EXPOSE 8137` matches the gitops manifest's `containerPort` (see the service's own `CLAUDE.md`: "port 8137").
- The service also had the same gap billing-service had (#616): missing from `auto-deploy.yml`'s `ALL_SERVICES`, despite having a gitops manifest and a `release-please` registration — zero auto-deploy coverage. Added.

## Context
Neither `build-push-service.sh` nor `auto-deploy.yml`'s own Docker-push step actually *require* a per-service `Dockerfile` to build the image — both generate their own from a canonical template (`openbank-infra/docker/services/standalone-service.Dockerfile` / `.github/workflows/Dockerfile.deploy`). The per-service `Dockerfile` is only grepped for its `EXPOSE` line to set the container port (falls back to `8080` if absent). So the missing Dockerfile wasn't actually blocking a rebuild via CI — but it meant the currently-running image is unreproducible, and a manual rebuild via `build-push-service.sh` would silently default to the wrong port. This PR fixes both: the service is now in the auto-deploy fleet, and rebuilding will use the correct port.

## Test plan
- [ ] After merge, manually trigger `workflow_dispatch` for `openbank-anacredit-service` to confirm the build succeeds and the image port/manifest stay consistent.
- [x] Confirmed `openbank-anacredit-service` has a gitops manifest (`openbank-infra/gitops/components/anacredit/anacredit-service.yaml`, `containerPort: 8137`) and is registered in `release-please-config.json`.

Refs #601