### PR TITLE
feat(account): validate account opening against product-catalog (ADR-0158, issue #668)

### DIFF
--- a/docs/adr/0158-account-opening-validates-against-product-catalog.md
+++ b/docs/adr/0158-account-opening-validates-against-product-catalog.md
@@ -1,0 +1,110 @@
+# ADR-0158 — Account opening validates against product-catalog
+
+Date: 2026-07-09
+Decision-Status: Accepted
+Delivery-Status: Complete
+Author(s): jiri.raska
+
+**Delivery note (2026-07-09):**
+- ✅ Shipped: `AccountService.openAccount` now consults product-catalog via a new
+  `ProductCatalogPort` before persisting a new account — rejects a product that
+  product-catalog confirms does not exist, or that exists but is not `ACTIVE`.
+  Fails open (proceeds, logged) when product-catalog cannot be reached.
+- ⬜ **Deliberately not done in this increment** (see Alternatives): currency-match
+  against the product's declared currency / `multiCurrencyConfig`, `minBalance`/
+  `maxBalance` limits, and `eligibilitySegments` (requires the customer's segment,
+  not available in `OpenAccountCommand` today). Tracked as a follow-up under issue #668.
+
+## Context
+
+ADR-0105 (unified product identity) made an account's `productId` a canonical
+product-catalog UUID and closed the *lookup* gap — `GET product-catalog/products/{id}`
+now resolves for every account. It deliberately did not address a second gap issue #668
+(product configurability) surfaced: **account opening never validates the product at
+all**. `AccountService.openAccount` stores `command.productId` as-is — an operator (or a
+buggy caller) can open an account against a UUID that product-catalog has never heard of,
+or one that was deliberately deactivated (`ProductStatus.INACTIVE`/`DRAFT`), and nothing
+in account-service notices.
+
+This is exactly the "consumers resolve products, not constants" principle from issue
+#668, applied to the one check cheap and unambiguous enough to ship in one increment:
+**does this product exist, and is it open for business.**
+
+## Decision
+
+### D1 — `ProductCatalogPort`, fail-open
+
+A new outbound port, mirroring the shape already used in `openbank-interest-service`
+(ADR-0157) and `openbank-billing-service`'s existing `ProductCatalogPort`:
+
+```kotlin
+sealed interface ProductLookupResult {
+    data class Found(val product: CatalogProduct) : ProductLookupResult
+    data object NotFound : ProductLookupResult
+    data object Unavailable : ProductLookupResult
+}
+interface ProductCatalogPort {
+    suspend fun findById(productId: UUID): ProductLookupResult
+}
+```
+
+`openAccount` calls it right after the sanctions gate (ADR-0032 §C), before IBAN
+generation:
+- `NotFound` → reject (`ProductNotEligibleException`, mapped to 422 via the
+  libs-runtime `IllegalStateExceptionMapper` — deliberately NOT a bare `RuntimeException`
+  like the pre-existing `AccountOpeningBlockedByScreeningException`, which has no
+  dedicated mapper and falls through to the generic 500 handler; not repeating that gap
+  here, though it remains a latent issue in that sibling exception, untouched by this PR).
+- `Found` with `status != "ACTIVE"` → reject, same exception.
+- `Found` with `status == "ACTIVE"` → proceeds.
+- `Unavailable` (timeout/5xx/connection refused) → **proceeds anyway, logged**.
+  product-catalog is reference data, not money-path (`rules.yaml: money_path_services`
+  does not list it) — an outage there must never block account opening. This is a
+  **deliberately different posture** from the sanctions gate three lines above it, which
+  fails closed: an unreachable compliance screen is a regulatory risk, an unreachable
+  product catalogue is not. The adjacent code makes both postures visible side by side,
+  so a future reader sees the distinction is intentional, not an inconsistency.
+
+### D2 — Scope: existence + status only, not yet currency/limits/eligibility
+
+Three richer checks were considered and deferred (not because they're wrong, but
+because each needs data this increment doesn't have cleanly):
+- **Currency match** — `Product.currency` vs. `command.currency` — complicated by
+  `MultiCurrencyConfig`: a multi-currency product may legitimately accept an account
+  opened in any of several currencies, and getting that logic right needs its own
+  design pass, not a bolt-on here.
+- **`minBalance`/`maxBalance`** — these gate an opening *deposit*, and
+  `OpenAccountCommand` carries no deposit amount today (balance init is event-driven,
+  ADR-0073, decoupled from `openAccount` entirely).
+- **`eligibilitySegments`** — requires the customer's segment, which
+  `OpenAccountCommand` doesn't carry; resolving it would mean a new dependency on
+  party-service, a bigger increment than "does the product exist."
+
+Shipping existence+status now, honestly scoping the rest as follow-up, is preferred over
+either blocking on the full set or silently skipping the whole check.
+
+## Alternatives considered
+
+- **Fail closed on product-catalog unavailability**, matching the sanctions gate's
+  posture. Rejected: product-catalog carries no regulatory obligation like sanctions
+  screening does: a reference-data outage is an availability incident, not a compliance
+  gap, and should not turn into an account-opening outage for every product.
+- **A shared library module for "resolve + validate a product"** across interest-service,
+  billing-service and account-service. Rejected for now: each consumer's failure posture
+  and validated fields differ enough (interest-service checks day-count, billing-service
+  reads the fee list, account-service checks existence+status) that a shared abstraction
+  would need to be either too generic to add value or too configurable to stay simple.
+  Revisit if a fourth consumer needs the same shape.
+
+## Consequences
+
+**Positive:** an account can no longer be opened against a nonexistent or deactivated
+product — closing a real data-integrity gap issue #668 identified, with the exact same
+proven fail-open/fail-closed split already established in ADR-0157.
+
+**Negative:** a new cross-service REST dependency (account-service → product-catalog) on
+the account-opening path; mitigated by the fail-open posture (never blocks on an outage).
+
+**Neutral:** no DB migration (validation only, no new persisted field); no change to the
+existing sanctions/IBAN checks; money-path controls (2 approvals, threat model) apply to
+this PR since `openbank-account-service` is in `rules.yaml: money_path_services`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -160,10 +160,11 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0154](0154-agent-pr-approval-policy.md) | Independent agent PR approval for non-sensitive changes | Accepted | Shipped | — |
 | [0155](0155-four-eyes-enforcement-for-money-path-actions.md) | Four-eyes enforcement for money-path actions | Proposed | Partial — pilot only (openbank-sepa-payment) | — |
 | [0156](0156-agent-charters-as-markdown-alongside-agents-yaml.md) | Agent charters as Markdown alongside agents.yaml | Accepted | Shipped | — |
+| [0158](0158-account-opening-validates-against-product-catalog.md) | Account opening validates against product-catalog | Accepted | Complete | — |
 
 ---
 
-**Numbering gaps:** 0015 0127 0128 0129 0130 0131 do not correspond to a file in this repo's history —
+**Numbering gaps:** 0015 0127 0128 0129 0130 0131 0157 do not correspond to a file in this repo's history —
 confirmed by `git log --diff-filter=A` across all branches, not just an absent
 current file. ADR-0132 was one of these gaps until it was cited in code/config
 comments before the file existed and has since been written down properly

--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -22,13 +22,15 @@ that is balance-service).
                                                                 +--> [(account_outbox)] --outbox--> [Kafka account events]
                                                                 |
                                                                 +--> [sanctions-service] (OIDC M2M, sync, ADR-0032)
+                                                                |
+                                                                +--> [product-catalog] (unauthenticated read, sync, fail-open, ADR-0158)
 [Kafka party events] --in--> [account-service PartyEventConsumer] --activate--> [account-service]
                                                                 |
                                                                 +--M2M client_credentials (ROLE_OPERATOR)--> [transaction-service POST /api/v1/transactions]   (welcome bonus, sandbox-only)
 ```
 
 - **External entities:** operators/admins (human, OIDC via Keycloak), downstream consumers of account events, party-service (event source).
-- **Trust boundaries:** UI↔service (mTLS + OIDC + OPA authz, ADR-0034); service↔Postgres; service↔Kafka (outbox + party-events-in); **service↔transaction-service (outbound M2M, new — welcome-bonus grant)**; **account-service↔sanctions-service** (new, OIDC M2M, ADR-0032 §C).
+- **Trust boundaries:** UI↔service (mTLS + OIDC + OPA authz, ADR-0034); service↔Postgres; service↔Kafka (outbox + party-events-in); **service↔transaction-service (outbound M2M, new — welcome-bonus grant)**; **account-service↔sanctions-service** (new, OIDC M2M, ADR-0032 §C); **account-service↔product-catalog** (new, unauthenticated read, ADR-0158 — fail-**open**, a deliberately different posture from the sanctions gate: an unreachable product catalogue is reference-data unavailability, not a compliance risk, and must never block account opening).
 - **Assets:** account identity, IBAN, freeze/closure state, ownership linkage, **the oidc-client M2M secret** (grants ROLE_OPERATOR on the money path).
 
 ## 3. Authn/Authz
@@ -84,6 +86,15 @@ not change any existing request's outcome until explicitly flipped.
 
 ## 6. Change log
 
+- **2026-07-09** — Account opening validates against product-catalog (ADR-0158, issue #668).
+  New outbound trust boundary: `account-service → product-catalog` (`GET /api/v1/products/{id}`,
+  unauthenticated, sync). `openAccount` now rejects a `productId` product-catalog confirms does
+  not exist, or that exists but is not `ACTIVE`. **Deliberately fail-open** on product-catalog
+  unavailability (timeout/5xx) — a different posture from the adjacent sanctions gate, which
+  fails closed: product-catalog is reference data (`rules.yaml: money_path_services` does not
+  list it), not a regulatory control, so an outage there must never block account opening.
+  New `ProductNotEligibleException` maps to 422 via the existing libs-runtime
+  `IllegalStateExceptionMapper`. No DB schema change; rollback = revert the commit.
 - **2026-06-09** — Customer-mediated ownership guard on the read endpoints (`getAccount`,
   `getAccountByIban`, `getBalance`): when `X-Customer-Party-Id` is present the account must belong to
   that party (else 404). Defense-in-depth for the edge IDOR fix (security finding A1). No data-flow or

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/ProductCatalogPort.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/ProductCatalogPort.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.application.port.out
+
+import java.util.UUID
+
+/** The minimal projection of a product-catalog `Product` needed to validate account opening (issue #668). */
+data class CatalogProduct(val id: UUID, val code: String, val status: String)
+
+/**
+ * The outcome of resolving a product by its canonical id from `openbank-product-catalog`
+ * (ADR-0105 unified product identity; issue #668). [Unavailable] is distinct from a confirmed
+ * miss: [findByCode] returns `null` for a genuine 404 (the product does not exist), while an
+ * implementation resolves to [Unavailable] on a fault/timeout — the caller's fail-open policy
+ * only applies to the latter.
+ */
+sealed interface ProductLookupResult {
+    data class Found(val product: CatalogProduct) : ProductLookupResult
+    data object NotFound : ProductLookupResult
+    data object Unavailable : ProductLookupResult
+}
+
+/**
+ * Outbound port resolving a product's canonical definition from product-catalog, so account
+ * opening can validate against it rather than accepting an arbitrary UUID with no check
+ * (issue #668). product-catalog is read-only reference data, not money-path
+ * (`rules.yaml: money_path_services` does not list it) — implementations MUST fail safe,
+ * resolving to [ProductLookupResult.Unavailable] rather than propagating a failure that would
+ * block account opening on a reference-data outage. This is a DIFFERENT posture from the
+ * sanctions gate (ADR-0032 §C fails closed): an unreachable compliance screen is a regulatory
+ * risk, an unreachable product catalogue is not.
+ */
+interface ProductCatalogPort {
+    suspend fun findById(productId: UUID): ProductLookupResult
+}

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -26,6 +26,8 @@ import com.openbank.account.application.port.out.AccountSanctionsScreeningPort
 import com.openbank.account.application.port.out.BalanceQueryPort
 import com.openbank.account.application.port.out.BalanceView
 import com.openbank.account.application.port.out.CurrencyPocketRepository
+import com.openbank.account.application.port.out.ProductCatalogPort
+import com.openbank.account.application.port.out.ProductLookupResult
 import com.openbank.account.domain.event.AccountClosedEvent
 import com.openbank.account.domain.event.AccountCreatedEvent
 import com.openbank.account.domain.event.AccountStatusChangedEvent
@@ -50,6 +52,7 @@ import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
+@Suppress("LongParameterList")
 class AccountService(
     private val accountRepository: AccountRepository,
     private val balancePort: BalanceQueryPort,
@@ -57,10 +60,12 @@ class AccountService(
     private val ibanGenerator: IbanGenerator,
     private val pocketRepository: CurrencyPocketRepository,
     private val sanctionsScreening: AccountSanctionsScreeningPort,
+    private val productCatalog: ProductCatalogPort,
     private val metrics: DomainMetrics,
     private val clock: Clock,
 ) : AccountUseCase {
 
+    @Suppress("LongMethod") // issue #668: the product-catalog validation block added a few lines past threshold
     override suspend fun openAccount(command: OpenAccountCommand): Account {
         // Idempotent replay (#465): a repeated key returns the original account and never opens
         // a second one. The Redis record in the REST layer is only a response cache — this DB
@@ -83,6 +88,22 @@ class AccountService(
         )
         if (screening.status == "HIT" || screening.status == "REVIEW") {
             throw AccountOpeningBlockedByScreeningException(command.partyId, screening.matchedName)
+        }
+
+        // Issue #668: an account can no longer be opened against a product that doesn't exist or
+        // has been deactivated. Fails OPEN (proceeds, logged) when product-catalog is unreachable —
+        // reference data, not money-path; a DIFFERENT posture from the sanctions gate above.
+        when (val lookup = productCatalog.findById(command.productId)) {
+            is ProductLookupResult.NotFound ->
+                throw ProductNotEligibleException(command.productId, "product does not exist")
+            is ProductLookupResult.Found ->
+                if (lookup.product.status != "ACTIVE") {
+                    throw ProductNotEligibleException(
+                        command.productId,
+                        "product status is ${lookup.product.status}, not ACTIVE",
+                    )
+                }
+            ProductLookupResult.Unavailable -> Unit
         }
 
         val iban = ibanGenerator.generate(command.currency)
@@ -448,3 +469,14 @@ class AccountUpdateConflictException(message: String, cause: Throwable? = null) 
 
 class AccountOpeningBlockedByScreeningException(partyId: UUID, matchedName: String?) :
     RuntimeException("Account opening blocked by sanctions screening for party $partyId (matched: $matchedName)")
+
+/**
+ * Issue #668: account opening refused because product-catalog confirmed the product doesn't
+ * exist, or exists but isn't ACTIVE. Never thrown when product-catalog is merely unreachable —
+ * that fails open (see [ProductCatalogPort]). Extends [IllegalStateException] deliberately (not
+ * a bare [RuntimeException] like [AccountOpeningBlockedByScreeningException]) so it resolves to
+ * the libs-runtime `IllegalStateExceptionMapper` (422 BUSINESS_RULE_VIOLATION) instead of falling
+ * through to the generic 500 mapper.
+ */
+class ProductNotEligibleException(productId: UUID, reason: String) :
+    IllegalStateException("Cannot open account against product $productId: $reason")

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogAdapter.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogAdapter.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.infrastructure.client
+
+import com.openbank.account.application.port.out.CatalogProduct
+import com.openbank.account.application.port.out.ProductCatalogPort
+import com.openbank.account.application.port.out.ProductLookupResult
+import io.quarkus.logging.Log
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import jakarta.ws.rs.WebApplicationException
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.util.UUID
+
+/**
+ * **Fail-open** adapter over [ProductCatalogClient] (issue #668). Unlike [SanctionsScreeningAdapter]
+ * (fails closed — a missing compliance screen is a regulatory risk), an unreachable product
+ * catalogue must never block account opening: product-catalog is reference data, not money-path.
+ * A confirmed 404 is NOT treated the same way as an outage: it maps to [ProductLookupResult.NotFound],
+ * which the caller's validation DOES act on (an operator cannot open an account against a product
+ * that does not exist).
+ */
+@ApplicationScoped
+class ProductCatalogAdapter : ProductCatalogPort {
+
+    @Inject
+    @RestClient
+    lateinit var client: ProductCatalogClient
+
+    // TooGenericExceptionCaught: deliberately fail-open on ANY fault (network error, timeout,
+    // unexpected 5xx) — see the class doc. Narrowing this would leave a class of faults
+    // unhandled and blocking account opening, exactly what this adapter exists to prevent.
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun findById(productId: UUID): ProductLookupResult = try {
+        val response = client.getById(productId.toString()).awaitSuspending()
+        ProductLookupResult.Found(CatalogProduct(UUID.fromString(response.id), response.code, response.status))
+    } catch (e: WebApplicationException) {
+        val status = e.response?.status ?: 0
+        if (status == Response.Status.NOT_FOUND.statusCode) {
+            ProductLookupResult.NotFound
+        } else {
+            Log.warnf("product-catalog returned HTTP %d for product %s; validation skipped", status, productId)
+            ProductLookupResult.Unavailable
+        }
+    } catch (e: Exception) {
+        Log.warnf("product-catalog unavailable for %s; validation skipped: %s", productId, e.message)
+        ProductLookupResult.Unavailable
+    }
+}

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogClient.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogClient.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+// product-catalog's product-read endpoints are unauthenticated (public reference data), so no
+// OidcClientRequestReactiveFilter provider here, unlike SanctionsServiceClient.
+@RegisterRestClient(configKey = "product-catalog-api")
+@Path("/api/v1/products")
+@Produces(MediaType.APPLICATION_JSON)
+interface ProductCatalogClient {
+    @GET
+    @Path("/{id}")
+    fun getById(@PathParam("id") id: String): Uni<ProductCatalogResponse>
+}
+
+/** The subset of product-catalog's `Product` this service actually consumes (issue #668). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ProductCatalogResponse(val id: String, val code: String, val status: String)

--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -84,6 +84,11 @@ quarkus:
       url: ${SANCTIONS_SERVICE_URL:http://openbank-sanctions-service:8110}
       connect-timeout: 3000
       read-timeout: 5000
+    # Issue #668: unauthenticated read of product-catalog reference data at account-open time.
+    "product-catalog-api":
+      url: ${PRODUCT_CATALOG_SERVICE_URL:http://openbank-product-catalog:8080}
+      connect-timeout: 3000
+      read-timeout: 5000
 
   shutdown:
     timeout: 30S

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceLifecycleTest.kt
@@ -21,6 +21,7 @@ import com.openbank.account.application.port.out.AccountSanctionsScreeningPort
 import com.openbank.account.application.port.out.BalanceQueryPort
 import com.openbank.account.application.port.out.BalanceView
 import com.openbank.account.application.port.out.CurrencyPocketRepository
+import com.openbank.account.application.port.out.ProductCatalogPort
 import com.openbank.account.domain.event.AccountClosedEvent
 import com.openbank.account.domain.event.AccountStatusChangedEvent
 import com.openbank.account.domain.model.Account
@@ -62,6 +63,7 @@ class AccountServiceLifecycleTest {
     private lateinit var ibanGenerator: IbanGenerator
     private lateinit var pocketRepository: CurrencyPocketRepository
     private lateinit var sanctionsScreening: AccountSanctionsScreeningPort
+    private lateinit var productCatalog: ProductCatalogPort
     private lateinit var metrics: DomainMetrics
     private lateinit var service: AccountService
 
@@ -73,6 +75,7 @@ class AccountServiceLifecycleTest {
         ibanGenerator = mockk()
         pocketRepository = mockk()
         sanctionsScreening = mockk()
+        productCatalog = mockk()
         metrics = mockk(relaxed = true)
         service =
             AccountService(
@@ -82,6 +85,7 @@ class AccountServiceLifecycleTest {
                 ibanGenerator,
                 pocketRepository,
                 sanctionsScreening,
+                productCatalog,
                 metrics,
                 Clock.fixed(fixedInstant, ZoneOffset.UTC),
             )

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
@@ -11,7 +11,10 @@ import com.openbank.account.application.port.out.AccountRepository
 import com.openbank.account.application.port.out.AccountSanctionsScreeningPort
 import com.openbank.account.application.port.out.AccountScreeningUnavailableException
 import com.openbank.account.application.port.out.BalanceQueryPort
+import com.openbank.account.application.port.out.CatalogProduct
 import com.openbank.account.application.port.out.CurrencyPocketRepository
+import com.openbank.account.application.port.out.ProductCatalogPort
+import com.openbank.account.application.port.out.ProductLookupResult
 import com.openbank.account.application.port.out.SanctionsScreenResult
 import com.openbank.account.domain.event.AccountCreatedEvent
 import com.openbank.account.domain.model.Account
@@ -45,6 +48,7 @@ class AccountServiceTest {
     private lateinit var ibanGenerator: IbanGenerator
     private lateinit var pocketRepository: CurrencyPocketRepository
     private lateinit var sanctionsScreening: AccountSanctionsScreeningPort
+    private lateinit var productCatalog: ProductCatalogPort
     private lateinit var metrics: DomainMetrics
     private lateinit var service: AccountService
 
@@ -56,7 +60,11 @@ class AccountServiceTest {
         ibanGenerator = mockk()
         pocketRepository = mockk()
         sanctionsScreening = mockk()
+        productCatalog = mockk()
         metrics = mockk(relaxed = true)
+        // Default: product-catalog unreachable — the fail-open path, so every pre-existing test
+        // that doesn't care about product validation keeps passing unchanged.
+        coEvery { productCatalog.findById(any()) } returns ProductLookupResult.Unavailable
         service =
             AccountService(
                 accountRepository,
@@ -65,6 +73,7 @@ class AccountServiceTest {
                 ibanGenerator,
                 pocketRepository,
                 sanctionsScreening,
+                productCatalog,
                 metrics,
                 Clock.fixed(Instant.parse("2024-01-15T12:00:00Z"), ZoneOffset.UTC),
             )
@@ -311,6 +320,72 @@ class AccountServiceTest {
 
         assertThat(savedSlot.captured.sanctionsStatus).isEqualTo("CLEAR")
         assertThat(savedSlot.captured.sanctionsScreenedAt).isNotNull()
+    }
+
+    // --- Product validation at account-open (issue #668) --------------------------------------
+
+    @Test
+    fun `openAccount refuses a product that product-catalog confirms does not exist`() {
+        val command = openAccountCommand()
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+        coEvery { productCatalog.findById(command.productId) } returns ProductLookupResult.NotFound
+
+        assertThatThrownBy { runBlocking { service.openAccount(command) } }
+            .isInstanceOf(ProductNotEligibleException::class.java)
+            .hasMessageContaining("does not exist")
+
+        coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
+    }
+
+    @Test
+    fun `openAccount refuses a product that is not ACTIVE`() {
+        val command = openAccountCommand()
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+        coEvery { productCatalog.findById(command.productId) } returns
+            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "DRAFT"))
+
+        assertThatThrownBy { runBlocking { service.openAccount(command) } }
+            .isInstanceOf(ProductNotEligibleException::class.java)
+            .hasMessageContaining("DRAFT")
+
+        coVerify(exactly = 0) { accountRepository.saveNewAccount(any(), any(), any()) }
+    }
+
+    @Test
+    fun `openAccount proceeds when product-catalog confirms an ACTIVE product`(): Unit = runBlocking {
+        val iban = Iban.of("CZ6508000000192000145399")
+        val command = openAccountCommand()
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+        coEvery { productCatalog.findById(command.productId) } returns
+            ProductLookupResult.Found(CatalogProduct(command.productId, "SAVINGS_STANDARD", "ACTIVE"))
+        every { ibanGenerator.generate(command.currency) } returns iban
+        coEvery { accountRepository.existsByIban(iban) } returns false
+        coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
+        coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
+
+        val result = service.openAccount(command)
+
+        assertThat(result.status).isEqualTo(AccountStatus.ACTIVE)
+    }
+
+    @Test
+    fun `openAccount proceeds without validation when product-catalog is unavailable`(): Unit = runBlocking {
+        val iban = Iban.of("CZ6508000000192000145399")
+        val command = openAccountCommand()
+        coEvery { accountRepository.findByIdempotencyKey(any()) } returns null
+        coEvery { sanctionsScreening.screen(any(), any()) } returns SanctionsScreenResult("CLEAR", 0.0, null)
+        coEvery { productCatalog.findById(command.productId) } returns ProductLookupResult.Unavailable
+        every { ibanGenerator.generate(command.currency) } returns iban
+        coEvery { accountRepository.existsByIban(iban) } returns false
+        coEvery { accountRepository.saveNewAccount(any(), any(), any()) } answers { firstArg() }
+        coEvery { eventPublisher.publish(any(), any(), any()) } returns Unit
+
+        val result = service.openAccount(command)
+
+        assertThat(result.status).isEqualTo(AccountStatus.ACTIVE)
     }
 
     @Test


### PR DESCRIPTION
## Summary

The last remaining genuine gap from issue #668's product-configurability scope (billing-service already reads its fee schedule from product-catalog; ADR-0105 already unified product identity but didn't add validation). `AccountService.openAccount` stored `command.productId` as-is with zero check — an account could be opened against a UUID product-catalog has never heard of, or one deliberately deactivated.

### The fix (ADR-0158)

New `ProductCatalogPort`, consulted right after the sanctions gate (ADR-0032 §C), before IBAN generation:
- **Unknown product** → reject (`ProductNotEligibleException`, 422 via the existing libs-runtime `IllegalStateExceptionMapper` — deliberately not a bare `RuntimeException` like the pre-existing `AccountOpeningBlockedByScreeningException`, which has no dedicated mapper and falls through to a generic 500; not repeating that gap here).
- **Product found but not `ACTIVE`** → reject, same exception.
- **product-catalog unreachable** → proceeds anyway, logged. Deliberately a **different posture** from the adjacent sanctions gate: product-catalog is reference data, not money-path (`rules.yaml: money_path_services` doesn't list it), so an outage there must never block account opening the way an unreachable compliance screen would. The code makes both postures visible side by side so this reads as intentional, not inconsistent.

### Deliberately out of scope (documented in ADR-0158 as follow-ups)

- Currency-match against the product's declared currency — complicated by `multiCurrencyConfig`, needs its own design pass.
- `minBalance`/`maxBalance` — these gate an opening deposit, and `OpenAccountCommand` carries no deposit amount today (balance init is event-driven, ADR-0073).
- `eligibilitySegments` — needs the customer's segment, not available without a new party-service dependency.

Shipping existence+status now, honestly scoping the rest as follow-up, beats either blocking on the full set or skipping the check entirely.

## Test plan

- [x] `./gradlew :openbank-account-service:ktlintCheck :openbank-account-service:detekt :openbank-account-service:test` — green, 22 + 30 tests, 0 failures.
- [x] New tests: unknown product rejected; non-ACTIVE product rejected; ACTIVE product proceeds; product-catalog unavailable proceeds (fail-open) — plus every pre-existing sanctions/IBAN test still passes unchanged (default mock: product-catalog unavailable).

## Money-path

`openbank-account-service` is a money-path service (`rules.yaml: money_path_services`) — this PR needs 2 approvals + the updated threat model (`docs/threat-models/openbank-account-service.md`) per ADR-0030.

Refs #667, #668