### PR TITLE
feat(observability): declare per-money-path-service SLOs (issue #669)

### DIFF
--- a/.github/scripts/check-slo-registry.py
+++ b/.github/scripts/check-slo-registry.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""SLO registry consistency gate (issue #669 scope item 3, rules.yaml: slo).
+
+Enforces the invariant: every entry in `rules.yaml: money_path_services` has an
+availability + latency Pyrra `ServiceLevelObjective` in
+`openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml`, and
+each object's `target`/`window` matches the governed values declared in
+`rules.yaml: slo` — so a target can only change by editing the governed source,
+never by hand-editing the reconciled Pyrra CR (rule #7, "derived data is never
+hand-edited").
+
+Mirrors check-release-registration.py: PyYAML-based (already installed earlier
+in the same CI job by the gen-network-policies step), single violations list.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+RULES = REPO / "openbank-libs" / "governance" / "rules.yaml"
+SLO_MANIFEST = REPO / "openbank-infra" / "gitops" / "components" / "observability" / "pyrra-slo-money-path.yaml"
+
+
+def short_name(service: str) -> str:
+    """openbank-ledger-service -> ledger (mirrors rest.rego's normalisation, rules.yaml money_path prefix-override comment)."""
+    s = service.removeprefix("openbank-")
+    return s.removesuffix("-service")
+
+
+def main() -> int:
+    rules = yaml.safe_load(RULES.read_text(encoding="utf-8"))
+    money_path_services: list[str] = rules["money_path_services"]
+    slo = rules["slo"]
+
+    if not SLO_MANIFEST.exists():
+        print(f"::error::{SLO_MANIFEST} does not exist — every money-path service needs an SLO object there.")
+        return 1
+
+    objects = [d for d in yaml.safe_load_all(SLO_MANIFEST.read_text(encoding="utf-8")) if d]
+    by_name = {o["metadata"]["name"]: o for o in objects}
+
+    violations: list[str] = []
+
+    for service in money_path_services:
+        s = short_name(service)
+        for kind, target, window in (
+            ("availability", slo["availability_target"], slo["availability_window"]),
+            ("latency", slo["latency_target_percent"], slo["latency_window"]),
+        ):
+            name = f"openbank-{s}-{kind}"
+            obj = by_name.get(name)
+            if obj is None:
+                violations.append(
+                    f"{service}: missing ServiceLevelObjective '{name}' in {SLO_MANIFEST.name} "
+                    f"(rules.yaml: money_path_services has this service, slo defines a {kind} target)."
+                )
+                continue
+            spec = obj.get("spec", {})
+            if str(spec.get("target")) != str(target):
+                violations.append(
+                    f"{name}: spec.target={spec.get('target')!r} does not match rules.yaml: "
+                    f"slo {kind} target {target!r} — edit rules.yaml, then regenerate the Pyrra object."
+                )
+            if str(spec.get("window")) != str(window):
+                violations.append(
+                    f"{name}: spec.window={spec.get('window')!r} does not match rules.yaml: "
+                    f"slo {kind} window {window!r} — edit rules.yaml, then regenerate the Pyrra object."
+                )
+            label_service = obj.get("metadata", {}).get("labels", {}).get("openbank.io/money-path-service")
+            if label_service != service:
+                violations.append(
+                    f"{name}: metadata.labels['openbank.io/money-path-service']={label_service!r} "
+                    f"does not match the owning service {service!r}."
+                )
+
+    # An SLO object naming a service that isn't (or no longer is) money-path is orphaned data.
+    money_path_shorts = {short_name(s) for s in money_path_services}
+    for name, obj in by_name.items():
+        label_service = obj.get("metadata", {}).get("labels", {}).get("openbank.io/money-path-service")
+        if label_service and short_name(label_service) not in money_path_shorts:
+            violations.append(
+                f"{name}: labelled for {label_service!r}, which is not in rules.yaml: "
+                f"money_path_services — remove the orphaned SLO object or restore the service to the list."
+            )
+
+    print("SLO registry consistency gate (issue #669, rules.yaml: slo)")
+    print(f"  money-path services: {len(money_path_services)}")
+    print(f"  SLO objects found:   {len(objects)}  (expected {len(money_path_services) * 2})")
+    if violations:
+        print("  VIOLATIONS:")
+        for v in violations:
+            print(f"    - {v}")
+        return 1
+    print("  OK: every money-path service has a matching, governed availability + latency SLO.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,12 @@ jobs:
       - name: governance-script unit tests
         run: python3 -m unittest discover -s openbank-infra/scripts -p '*_test.py' -v
 
+      # issue #669 scope item 3 / rules.yaml: slo. Every money_path_services entry needs a
+      # matching availability + latency Pyrra ServiceLevelObjective whose target/window match
+      # the governed values in rules.yaml — pyyaml is already installed by the step above.
+      - name: SLO registry consistency (issue #669, rules.yaml: slo)
+        run: python3 .github/scripts/check-slo-registry.py
+
       # ADR-0030 D2: every money-path service must ship a structured STRIDE/DFD
       # threat model. stdlib-only gate, ratchets coverage (a new money-path
       # service or a deleted/stubbed model fails here). Part of the always-run,

--- a/docs/adr/0088-observability-extension-oncall-slo-retention-mobile-rum.md
+++ b/docs/adr/0088-observability-extension-oncall-slo-retention-mobile-rum.md
@@ -14,6 +14,16 @@
 >   route points at GoAlert generic-API webhook; ntfy is the contact method for paging.
 > - **D2 — Pyrra** live: `gitops/components/observability/pyrra.yaml` + `pyrra-crd.yaml`. SLO
 >   operator reconciles `ServiceLevelObjective` CRs into multi-window burn-rate `PrometheusRules`.
+> - **D2 rollout (2026-07-10, issue #669 scope item 3)** — the sample fleet-wide SLO is now
+>   joined by a per-money-path-service pair (availability + latency) for all 17 services in
+>   `rules.yaml: money_path_services`: `gitops/components/observability/pyrra-slo-money-path.yaml`,
+>   targets governed by `rules.yaml: slo` (99.9% availability / 30d, 99% of requests <1s / 30d;
+>   REFERENCE defaults, not calibrated against real traffic — see the file header). CI
+>   (`check-slo-registry.py`) fails on drift between the two. `tempo.yaml`'s span-metrics
+>   processor gained an explicit `histogram_buckets` list so the latency indicator's `le="1"`
+>   selector reads a real bucket (Tempo's default buckets have no exact 1s boundary). This
+>   satisfies the go-live gate's "Pyrra SLOs declared ... 30-day error-budget baseline
+>   established" item below for the money-path fleet, not just the payment rails.
 > - **D3 — Loki + Tempo on S3**: both apps reference `ADR-0088 D3` in their gitops YAML; Loki
 >   `object_store: s3` and Tempo `backend: s3` are active in the sandbox (IRSA, `openbank-observability-s3`).
 > - **D4a — `opentelemetry-android`** skeleton merged (openbank-app #55); iOS no-op stub in place.
@@ -200,6 +210,10 @@ Three non-negotiables for a bank (these, not the SDK, are why this is an ADR):
 - [ ] On-call schedule + escalation policy defined; GoAlert Postgres backed up.
 - [ ] Loki/Tempo on S3 with retention policy ≥ audit window; restore from object store rehearsed.
 - [ ] Pyrra SLOs declared for each payment rail; 30-day error-budget baseline established.
+      **Declared** (2026-07-10): all 17 money-path services, availability + latency, governed
+      by `rules.yaml: slo` — see the D2 rollout note above. **Baseline still open**: the
+      sandbox has no real production traffic, so there is no 30-day burn-rate history to
+      report yet (issue #669's load-benchmark scope, deferred).
 - [ ] Mobile OTLP ingest gateway threat-modelled; PII redaction + auth + rate-limit verified; consent wired.
 
 ---

--- a/openbank-infra/gitops/apps/tempo.yaml
+++ b/openbank-infra/gitops/apps/tempo.yaml
@@ -72,6 +72,15 @@ spec:
               local_blocks:
                 flush_to_storage: true
                 filter_server_spans: false
+              # Explicit latency buckets (issue #669 SLO definitions): Tempo's default
+              # span-metrics buckets (2ms..4.1s exponential) do NOT include a clean 1s
+              # boundary, so a Pyrra `latency` indicator selecting `le="1"` would silently
+              # match zero series — the exact "wrong label, empty result" class of bug this
+              # repo has been burned by before (see podmonitor-openbank-services.yaml).
+              # These boundaries give every money-path SLO's 1s p99 threshold (rules.yaml:
+              # slo.latency_threshold_seconds) a real bucket to read.
+              span_metrics:
+                histogram_buckets: [0.1, 0.25, 0.5, 1, 2, 5]
           # Enable the processors for ALL tenants (span-metrics = RED,
           # service-graphs = dependency edges). The chart templates the main
           # config's `overrides:` block from `.Values.tempo.overrides`

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "6ee9534b9ef6e8d5"
+    openbank.tech/policy-checksum: "f23d7e86bc3ae564"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -872,7 +872,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1170,6 +1170,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6ee9534b9ef6e8d5"
+        openbank.tech/policy-checksum: "f23d7e86bc3ae564"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "363ecd4754d6d9bc"
+    openbank.tech/policy-checksum: "001169d06e2744a0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -916,7 +916,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1214,6 +1214,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "363ecd4754d6d9bc"
+        openbank.tech/policy-checksum: "001169d06e2744a0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "e3e44ea329747d9d"
+    openbank.tech/policy-checksum: "784fb21b0d5e46e3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -821,7 +821,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1119,6 +1119,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e3e44ea329747d9d"
+        openbank.tech/policy-checksum: "784fb21b0d5e46e3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "3128b4236d286a51"
+    openbank.tech/policy-checksum: "36fe51fc9e4cbe0f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -839,7 +839,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1137,6 +1137,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3128b4236d286a51"
+        openbank.tech/policy-checksum: "36fe51fc9e4cbe0f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "7e535ab651bf2bc5"
+    openbank.tech/policy-checksum: "f5294f71b7da7eec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -904,7 +904,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1202,6 +1202,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7e535ab651bf2bc5"
+        openbank.tech/policy-checksum: "f5294f71b7da7eec"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "deb6c71645a3f6d0"
+    openbank.tech/policy-checksum: "a4e2c6d0018918bb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -465,7 +465,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -763,6 +763,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "deb6c71645a3f6d0"
+        openbank.tech/policy-checksum: "a4e2c6d0018918bb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "03d237310a4c83f3"
+    openbank.tech/policy-checksum: "f26ee191275191e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -832,7 +832,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1130,6 +1130,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "03d237310a4c83f3"
+        openbank.tech/policy-checksum: "f26ee191275191e9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "0b978f9fcd38b38e"
+    openbank.tech/policy-checksum: "30447d2d3c213fac"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -869,7 +869,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1167,6 +1167,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0b978f9fcd38b38e"
+        openbank.tech/policy-checksum: "30447d2d3c213fac"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "fd03e5c79bd5d8b7"
+    openbank.tech/policy-checksum: "6075207ce346047b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -928,7 +928,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1226,6 +1226,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fd03e5c79bd5d8b7"
+        openbank.tech/policy-checksum: "6075207ce346047b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "d3508b335201f102"
+    openbank.tech/policy-checksum: "f09136eaa0f32e68"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -885,7 +885,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1183,6 +1183,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d3508b335201f102"
+        openbank.tech/policy-checksum: "f09136eaa0f32e68"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "deb6c71645a3f6d0"
+    openbank.tech/policy-checksum: "a4e2c6d0018918bb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -465,7 +465,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -763,6 +763,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "deb6c71645a3f6d0"
+        openbank.tech/policy-checksum: "a4e2c6d0018918bb"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
+++ b/openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml
@@ -1,0 +1,763 @@
+# Per-money-path-service SLOs (issue #669 scope item 3, rules.yaml: slo). One availability
+# + one latency ServiceLevelObjective per rules.yaml: money_path_services entry, generated
+# from the governed targets there (availability_target/window, latency_target_percent/
+# threshold/window) — check-slo-registry.sh (CI) fails if this file and rules.yaml drift, or
+# if a money-path service is missing either object. Pyrra (ADR-0088 D2) reconciles each into
+# multi-window burn-rate PrometheusRules; error budgets are visible in the pyrra-api UI.
+#
+# Availability uses the same traces_spanmetrics_calls_total{service=...} indicator as the
+# fleet dashboards (dashboard-openbank-ledger-integrity.yaml et al.) — Tempo span-metrics,
+# zero app instrumentation (ADR-0082). Latency uses the traces_spanmetrics_latency_bucket
+# histogram at the le="1" boundary explicitly configured in tempo.yaml's span_metrics
+# processor (Tempo's default buckets don't include a clean 1s boundary).
+#
+# Targets are REFERENCE defaults (rules.yaml: slo comment) — not calibrated against real
+# production traffic. Revisit once the load-benchmark / DR-drill scope of issue #669 lands.
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-ledger-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-ledger-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-ledger-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-ledger-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-ledger-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-ledger-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-ledger-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-ledger-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-ledger-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-ledger-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-transaction-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-transaction-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-transaction-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-transaction-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-transaction-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-transaction-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-transaction-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-transaction-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-transaction-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-transaction-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-account-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-account-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-account-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-account-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-account-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-account-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-account-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-account-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-account-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-account-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-balance-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-balance-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-balance-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-balance-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-balance-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-balance-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-balance-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-balance-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-balance-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-balance-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sepa-payment-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sepa-payment
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-sepa-payment availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-sepa-payment",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sepa-payment"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sepa-payment-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sepa-payment
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-sepa-payment latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-sepa-payment",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sepa-payment"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sepa-instant-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sepa-instant
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-sepa-instant availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-sepa-instant",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sepa-instant"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sepa-instant-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sepa-instant
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-sepa-instant latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-sepa-instant",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sepa-instant"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-domestic-payment-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-domestic-payment
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-domestic-payment availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-domestic-payment",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-domestic-payment"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-domestic-payment-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-domestic-payment
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-domestic-payment latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-domestic-payment",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-domestic-payment"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-clearing-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-clearing-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-clearing-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-clearing-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-clearing-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-clearing-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-clearing-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-clearing-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-clearing-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-clearing-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-swift-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-swift-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-swift-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-swift-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-swift-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-swift-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-swift-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-swift-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-swift-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-swift-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-fx-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-fx-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-fx-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-fx-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-fx-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-fx-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-fx-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-fx-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-fx-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-fx-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-lending-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-lending-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-lending-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-lending-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-lending-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-lending-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-lending-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-lending-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-lending-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-lending-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sca-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sca-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-sca-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-sca-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sca-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sca-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sca-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-sca-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-sca-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sca-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-consent-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-consent-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-consent-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-consent-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-consent-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-consent-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-consent-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-consent-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-consent-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-consent-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-fraud-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-fraud-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-fraud-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-fraud-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-fraud-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-fraud-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-fraud-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-fraud-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-fraud-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-fraud-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-billing-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-billing-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-billing-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-billing-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-billing-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-billing-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-billing-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-billing-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-billing-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-billing-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-settlement-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-settlement-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-settlement-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-settlement-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-settlement-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-settlement-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-settlement-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-settlement-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-settlement-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-settlement-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sanctions-availability
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sanctions-service
+spec:
+  target: "99.9"
+  window: 30d
+  description: "openbank-sanctions-service availability — non-error span ratio (issue #669, rules.yaml: slo.availability_target)."
+  indicator:
+    ratio:
+      errors:
+        metric: traces_spanmetrics_calls_total{service="openbank-sanctions-service",status_code="STATUS_CODE_ERROR"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sanctions-service"}
+---
+apiVersion: pyrra.dev/v1alpha1
+kind: ServiceLevelObjective
+metadata:
+  name: openbank-sanctions-latency
+  namespace: observability
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    app.kubernetes.io/part-of: observability
+    pyrra.dev/team: platform
+    openbank.io/money-path-service: openbank-sanctions-service
+spec:
+  target: "99"
+  window: 30d
+  description: "openbank-sanctions-service latency — share of requests faster than 1s (issue #669, rules.yaml: slo.latency_threshold_seconds)."
+  indicator:
+    latency:
+      success:
+        metric: traces_spanmetrics_latency_bucket{service="openbank-sanctions-service",le="1"}
+      total:
+        metric: traces_spanmetrics_calls_total{service="openbank-sanctions-service"}

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "79404aab0e40d0a3"
+    openbank.tech/policy-checksum: "caaacf5b02b50aae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -875,7 +875,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1173,6 +1173,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bbe3e7e5c719a07e"
+    openbank.tech/policy-checksum: "72c02de1f8e33e89"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -860,7 +860,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1158,6 +1158,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f0b0d714ab5fe016" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "f88fd5107d94241d" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c5d55b969d23c34f"
+        openbank.tech/policy-checksum: "8b0bea30249bb414"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "bbe3e7e5c719a07e" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "72c02de1f8e33e89" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c45f495d5812b599"
+        openbank.tech/policy-checksum: "8e2e42f5b990936a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "79404aab0e40d0a3" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "caaacf5b02b50aae" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1943,7 +1943,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "53a11364f418dd19" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "c899f3a01905dac9" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2333,7 +2333,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2307277d44ae0f83"
+        openbank.tech/policy-checksum: "d181a833e54577b1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c45f495d5812b599"
+    openbank.tech/policy-checksum: "8e2e42f5b990936a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -833,7 +833,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1131,6 +1131,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c5d55b969d23c34f"
+    openbank.tech/policy-checksum: "8b0bea30249bb414"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -854,7 +854,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1152,6 +1152,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "53a11364f418dd19"
+    openbank.tech/policy-checksum: "c899f3a01905dac9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -834,7 +834,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1132,6 +1132,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2307277d44ae0f83"
+    openbank.tech/policy-checksum: "d181a833e54577b1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -837,7 +837,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1135,6 +1135,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f0b0d714ab5fe016"
+    openbank.tech/policy-checksum: "f88fd5107d94241d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -890,7 +890,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1188,6 +1188,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "4dd4409364137618"
+    openbank.tech/policy-checksum: "40df2f409e24943b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -843,7 +843,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1141,6 +1141,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4dd4409364137618"
+        openbank.tech/policy-checksum: "40df2f409e24943b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "140d33d3995ca014"
+    openbank.tech/policy-checksum: "266f1233bb8be714"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -857,7 +857,7 @@ data:
 
     schema_version: 1
     source_of_truth: true
-    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+    related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
     # ---------------------------------------------------------------------------------------
     # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -1155,6 +1155,31 @@ data:
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+    # ---------------------------------------------------------------------------------------
+    # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+    # availability + latency target applied uniformly across every money_path_services entry
+    # above (no separate service list here — money_path_services is the one list, to avoid the
+    # two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+    # multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+    # (availability + latency) per service in
+    # openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+    # check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+    # object, or if an existing object's target/window drifts from the values below — so
+    # dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+    #
+    # Targets are REFERENCE defaults, not calibrated against real production incident or
+    # traffic history — this is a reference implementation with no live customer traffic (same
+    # honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+    # load-benchmark / DR-drill scope of issue #669 produces real numbers.
+    slo:
+      availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+      availability_window: 30d
+      latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+      # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+      # the SLO burn-rate should page before the blunter absolute-latency alert does.
+      latency_threshold_seconds: 1
+      latency_window: 30d
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "140d33d3995ca014"
+        openbank.tech/policy-checksum: "266f1233bb8be714"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -15,7 +15,7 @@
 
 schema_version: 1
 source_of_truth: true
-related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082]
+related_adrs: [ADR-0005, ADR-0014, ADR-0020, ADR-0029, ADR-0030, ADR-0031, ADR-0040, ADR-0043, ADR-0052, ADR-0053, ADR-0054, ADR-0060, ADR-0082, ADR-0088]
 
 # ---------------------------------------------------------------------------------------
 # Conventional Commits — the vocabulary (mirrors CONTRIBUTING.md, authoritative here).
@@ -313,6 +313,31 @@ money_path_services:
   - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
   - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
   - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+
+# ---------------------------------------------------------------------------------------
+# SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
+# availability + latency target applied uniformly across every money_path_services entry
+# above (no separate service list here — money_path_services is the one list, to avoid the
+# two-lists-drift class of bug rule #7 exists to prevent). Reconciled into Prometheus
+# multi-window burn-rate rules by Pyrra (ADR-0088 D2), one ServiceLevelObjective pair
+# (availability + latency) per service in
+# openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml.
+# check-slo-registry.sh (CI, required) fails if a money-path service is missing either SLO
+# object, or if an existing object's target/window drifts from the values below — so
+# dashboards/alerts derive from this governed data, never a hand-edited PrometheusRule.
+#
+# Targets are REFERENCE defaults, not calibrated against real production incident or
+# traffic history — this is a reference implementation with no live customer traffic (same
+# honesty disclosure as the openbank-lending-service PD/LGD placeholders). Revisit once the
+# load-benchmark / DR-drill scope of issue #669 produces real numbers.
+slo:
+  availability_target: "99.9"           # percent of non-error requests, uniform fleet-wide
+  availability_window: 30d
+  latency_target_percent: "99"          # percent of requests faster than latency_threshold_seconds
+  # tighter than the fleet HighLatencyP99 alert (2s, prometheus-rules-tier1.yaml) by design:
+  # the SLO burn-rate should page before the blunter absolute-latency alert does.
+  latency_threshold_seconds: 1
+  latency_window: 30d
 review:
   default_approvals: 1
   money_path_approvals: 2               # CONTRIBUTING.md + branch protection


### PR DESCRIPTION
## Summary

Adds governed, per-money-path-service SLO definitions (availability + latency) — the "SLO definitions" scope item of issue #669's operational-evidence ask. Only that item; the load-benchmark and DR-drill scope items remain deferred pending a separate scope decision.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #669

## Changes

- `openbank-libs/governance/rules.yaml`: new `slo` section — a single availability (99.9%/30d) + latency (99% of requests <1s, 30d) target applied uniformly to every `money_path_services` entry (17 services). No separate per-service list — reuses `money_path_services` to avoid a second list drifting out of sync.
- `openbank-infra/gitops/components/observability/pyrra-slo-money-path.yaml` (new): one availability + one latency Pyrra `ServiceLevelObjective` per money-path service (34 objects), generated from the `rules.yaml: slo` targets. Reconciled by the existing Pyrra operator (ADR-0088 D2) into multi-window burn-rate `PrometheusRule`s — visible in the `pyrra-api` error-budget UI.
- `openbank-infra/gitops/apps/tempo.yaml`: explicit `histogram_buckets` on the span-metrics processor. Tempo's default buckets (2ms..4.1s exponential) have no exact 1s boundary, so the latency SLO's `le="1"` selector would have silently matched zero series without this — the same "wrong label → empty result" defect class this repo has been burned by before (`podmonitor-openbank-services.yaml`).
- `.github/scripts/check-slo-registry.py` (new) + `.github/workflows/ci.yml`: required CI gate. Fails if a money-path service is missing either SLO object, or if an object's `target`/`window` drifts from the governed `rules.yaml` values — so the Pyrra manifest can only be changed by editing the governed source (rule #7: derived data is never hand-edited).
- `docs/adr/0088-observability-extension-oncall-slo-retention-mobile-rum.md`: delivery-note update documenting the D2 rollout, and an honest split on the go-live checklist item ("SLOs declared" done; "30-day error-budget baseline" still open — no real production traffic to baseline against yet).

Targets are explicitly disclosed as reference defaults, not calibrated against real traffic (same honesty convention as the lending-service PD/LGD placeholders) — this is a reference implementation with no live customer traffic yet.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — N/A, no service code touched.
- [ ] Unit tests added/updated.
- [ ] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed).
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no Gradle module touched.
- [x] No new lint warnings. — verified locally: `check-slo-registry.py` passes (and correctly fails on an injected drift), yamllint passes on all changed/new YAML with CI's exact config, `rules.yaml`/`pyrra-slo-money-path.yaml` parse cleanly, `docs/adr/gen-index.sh` produces no diff.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A.
- [ ] Flyway migration added + rollback note (if DB changed). — N/A.
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A.
- [x] Docs updated (README, ADR if architectural). — ADR-0088 delivery note.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. — none added.
- [x] No new third-party dependency, OR: dependency review attached (license, CVE, source). — none added (PyYAML already used elsewhere in this exact CI job).
- [ ] Auth / crypto / payment code changed? → tag `security-review-required`. — N/A, observability config only.
- [ ] PII path changed? → tag `gdpr-review-required`. — N/A.
- [ ] Cardholder data path changed? → tag `pci-review-required`. — N/A.

## Compliance impact

- [ ] PCI DSS
- [ ] DORA
- [ ] GDPR
- [ ] PSD2 / SCA / RTS
- [ ] AML / 5AMLD
- [ ] CNB reporting
- [x] None

## Rollout / Rollback

- Deployment strategy: GitOps (ArgoCD auto-sync on merge to main); `pyrra-slo-money-path.yaml` is picked up automatically by the existing `observability-components` Application (directory recurse). No live-cluster action taken by this PR itself.
- Rollback plan: revert the PR — ArgoCD prunes the removed `ServiceLevelObjective` objects and Pyrra's generated `PrometheusRule`s along with them. The `tempo.yaml` bucket change is additive (new `le` boundaries alongside existing ones); reverting it just stops emitting the new boundaries, no data loss.
- Data migration reversible: N/A.

## Reviewer notes

This does not touch the two harder scope items of #669 (load benchmark, chaos/DR drill) — those need a live sandbox EKS decision (destructive DR actions, benchmark placement) the user explicitly deferred. `le="1"` in the latency indicator depends on the new `tempo.yaml` `histogram_buckets` actually reconciling on the live cluster; I could not verify this against a running Prometheus from this session (no destructive/live-infra actions taken), so please confirm the bucket shows up in `traces_spanmetrics_latency_bucket` after this syncs before treating the latency SLO as trustworthy.