### PR TITLE
fix(gitops): repair Flyway checksum mismatch on onboarding-service V1

### DIFF
--- a/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
+++ b/openbank-infra/gitops/components/onboarding/onboarding-service.yaml
@@ -72,6 +72,16 @@ spec:
                 secretKeyRef:
                   name: onboarding-db-app
                   key: password
+            # Flyway checksum mismatch on V1 (2026-07-10): the 2026-06-27 repo-wide MPL->Apache-2.0
+            # relicense (60e0263f, #2276) flipped the SPDX header on every migration file including
+            # this one, changing V1's checksum. onboarding-service hadn't been redeployed since, so
+            # the mismatch was latent until this Kafka group.id fix's rollout hit it. Repair-at-start
+            # re-baselines the recorded checksum to the current (relicensed) file — safe because the
+            # relicense was a comment-only change, no SQL executed differently. Remove this once the
+            # live schema_history row is repaired (one successful boot is enough; safe to leave
+            # briefly if unsure, repair is a no-op once checksums already match).
+            - name: QUARKUS_FLYWAY_REPAIR_AT_START
+              value: "true"
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
             - name: QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA_BOOTSTRAP_SERVERS


### PR DESCRIPTION
## Summary
onboarding-service's new pod (carrying the Kafka group.id fix, #692) crash-looped with `FlywayValidateException: checksum mismatch` on migration V1. Root cause: the 2026-06-27 repo-wide MPL→Apache-2.0 relicense (60e0263f, #2276) flipped the SPDX header on every migration file, including `V1__create_onboarding_records.sql`, changing its checksum. onboarding-service hadn't been redeployed since that relicense commit, so the mismatch was latent until this rollout.

Fix: `QUARKUS_FLYWAY_REPAIR_AT_START=true`, re-baselining the recorded checksum to the current (relicensed) file. Safe — the relicense was comment-only, no SQL executed differently.

Applied live to unblock immediately (verified: new pod `1/1 Running`, 0 restarts); this PR makes it durable in git.

**Likely affects other services** not redeployed since 2026-06-27 with Flyway migrations predating the relicense — flagging as a fleet-wide follow-up, out of scope here.

## Test plan
- [x] Live-verified: patched the Rollout, new pod reached `1/1 Running` with no crash-loop
- [ ] Remove `QUARKUS_FLYWAY_REPAIR_AT_START` in a follow-up once confirmed the schema_history checksum is durably repaired (safe to leave briefly — repair is a no-op once checksums match)

Linked issues: Refs #686