### PR TITLE
fix(notification-service): fix silent Kafka client.id dotted-key bug

### DIFF
--- a/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-msg-override.yaml
@@ -18,6 +18,12 @@
 # transaction-service's payment-scheme-accepted channel, #2649, and reverted). A
 # properties file carries the EXACT hyphenated/dotted keys, so discovery is unambiguous.
 #
+# client.id is included below too (cosmetic-only — broker-side log/JMX label, not
+# authorization) rather than left as a broken YAML key: SmallRye's expression-expansion
+# interceptor (which resolves ${quarkus.uuid}) runs after config sources merge, so it
+# applies identically regardless of which source supplied the raw string — a properties
+# file is no different from application.yaml here.
+#
 # config_ordinal=500 forces this source to outrank the baked application.yaml (~254).
 # Loaded via QUARKUS_CONFIG_LOCATIONS on the Deployment (notification-service.yaml).
 apiVersion: v1
@@ -31,7 +37,9 @@ metadata:
 data:
   override.properties: |
     config_ordinal=500
+    mp.messaging.incoming.notification-events-in.client.id=notification-service-${quarkus.uuid}
     mp.messaging.incoming.notification-events-in.group.id=notification-service
     mp.messaging.incoming.notification-events-in.auto.offset.reset=earliest
+    mp.messaging.incoming.party-events-in.client.id=notification-service-party-${quarkus.uuid}
     mp.messaging.incoming.party-events-in.group.id=notification-service-party
     mp.messaging.incoming.party-events-in.auto.offset.reset=earliest

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -95,22 +95,21 @@ mp:
     incoming:
       notification-events-in:
         connector: smallrye-kafka
-        client.id: notification-service-${quarkus.uuid}
-        # group.id / auto.offset.reset are set via the gitops ConfigMap
+        # client.id / group.id / auto.offset.reset are set via the gitops ConfigMap
         # (notification-service-msg-override, QUARKUS_CONFIG_LOCATIONS) instead of
         # here: Quarkus's YAML config source unconditionally quotes any dotted leaf
-        # key (`group.id`, `auto.offset.reset`) when flattening YAML, so it silently
-        # registers as `mp.messaging.incoming.notification-events-in."group.id"` —
-        # a property KafkaConnectorIncomingConfiguration never reads — and falls
-        # back to quarkus.application.name, which the Strimzi ACL does not grant
-        # Read on (issue #686).
+        # key (`client.id`, `group.id`, `auto.offset.reset`) when flattening YAML, so
+        # it silently registers as `mp.messaging.incoming.notification-events-in."group.id"`
+        # etc. — properties KafkaConnectorIncomingConfiguration never reads. group.id
+        # falls back to quarkus.application.name, which the Strimzi ACL does not grant
+        # Read on (issue #686); client.id is cosmetic (broker-side log/JMX label only)
+        # but left broken the same way if not moved out too.
         topic: openbank.notification.requests
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
       party-events-in:
         connector: smallrye-kafka
-        client.id: notification-service-party-${quarkus.uuid}
-        # group.id / auto.offset.reset: same dotted-key YAML bug as above — set via
-        # the gitops ConfigMap instead (issue #686).
+        # client.id / group.id / auto.offset.reset: same dotted-key YAML bug as above —
+        # set via the gitops ConfigMap instead (issue #686).
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":


### PR DESCRIPTION
## Summary
Follow-up to #693. That PR correctly fixed the `group.id`/`auto.offset.reset` silent-fallback bug for both `notification-events-in` and `party-events-in`, but left `client.id` (also a literal-dot leaf key, same root cause) as a plain YAML key in `application.yaml` — where it's still silently dropped by Quarkus's YAML config flattener the same way `group.id` was. Unlike its sibling fixes (kyc-service, onboarding-service), this one wasn't moved into the properties-file override.

- Cosmetic-only impact (broker-side consumer client identification in logs/JMX, not authorization) — not a functional regression, just an inconsistent cleanup.
- Moves `client.id` into the `notification-service-msg-override` ConfigMap alongside `group.id`/`auto.offset.reset`, matching the pattern used everywhere else in the #686 sweep.
- Confirmed `${quarkus.uuid}` expression expansion is source-agnostic (SmallRye's expression interceptor runs after all config sources merge), so moving it to an externally-loaded properties file doesn't change its resolved value.

## Test plan
- [x] Validated YAML syntax on both touched files.
- [x] Ran `check-dotted-mp-messaging-keys.sh` (the #688 CI guard) against `openbank-notification-service` — the `client.id`/`group.id`/`auto.offset.reset` findings are gone; only the already-known-safe `value.deserializer` key remains (resolves via a separate Quarkus connector default, unaffected by this bug in practice).
- [ ] Post-merge: confirm notification-service pods still show the intended client id in Kafka broker logs/JMX (cosmetic verification only).

Refs #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)