### PR TITLE
docs(adr): mark ADR-0156 delivered — charters, drill-down and agentId filter all shipped

### DIFF
--- a/docs/adr/0156-agent-charters-as-markdown-alongside-agents-yaml.md
+++ b/docs/adr/0156-agent-charters-as-markdown-alongside-agents-yaml.md
@@ -2,8 +2,16 @@
 
 Date: 2026-07-08
 Decision-Status: Accepted
-Delivery-Status: Partial
+Delivery-Status: Shipped
 Author(s): jiri.raska
+
+**Delivery note (2026-07-10):** all four decision points are merged and live —
+`docs/agents/<id>.md` charters + the id-parity CI gate (PR #598), the admin-ui
+bundling, BFF route and `/iaops/agents/<id>` drill-down page (PR #599, deployed via
+`admin-ui-deploy.yml` on 2026-07-09), and the `ProposalResource` `agentId` filter with
+the `openapi.yaml` documentation of `/api/v1/proposals*` (PR #600, released as
+agent-service 1.14.0). The finops cost bridge mentioned in
+`docs/agents/finops-agent.md` remains a separate, out-of-scope follow-up.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -159,7 +159,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0153](0153-savings-goal-metadata.md) | Savings goal metadata on account-service | Accepted | Shipped | — |
 | [0154](0154-agent-pr-approval-policy.md) | Independent agent PR approval for non-sensitive changes | Accepted | Shipped | — |
 | [0155](0155-four-eyes-enforcement-for-money-path-actions.md) | Four-eyes enforcement for money-path actions | Proposed | Partial — pilot only (openbank-sepa-payment) | — |
-| [0156](0156-agent-charters-as-markdown-alongside-agents-yaml.md) | Agent charters as Markdown alongside agents.yaml | Accepted | Partial | — |
+| [0156](0156-agent-charters-as-markdown-alongside-agents-yaml.md) | Agent charters as Markdown alongside agents.yaml | Accepted | Shipped | — |
 
 ---
 


### PR DESCRIPTION
## Summary

Flip ADR-0156 `Delivery-Status: Partial → Shipped` with a delivery note, and regenerate the ADR index. All four decision points of the ADR are merged and live; the status was set to Partial while PRs #599/#600 were still open and is now stale.

## Type of change

- [x] docs

## Linked issues

N/A — status-only ADR delivery flip; the delivery work itself landed via #598/#599/#600.

## Changes

- `docs/adr/0156-*.md`: `Delivery-Status: Partial → Shipped` + delivery note citing the three delivery PRs (#598 charters + CI parity gate, #599 admin-ui drill-down — deployed 2026-07-09, #600 agent-service `agentId` filter — released as agent-service 1.14.0). The finops cost bridge referenced in `docs/agents/finops-agent.md` is explicitly noted as an out-of-scope follow-up.
- `docs/adr/README.md`: regenerated via `docs/adr/gen-index.sh` (derived data, not hand-edited).

## Definition of Done

- [x] Docs updated (README, ADR if architectural).
- `check-adr-registry.sh` passes locally: 150 ADRs, unique numbers, headings match filenames, index fresh.
- No code, config, API, DB, or event change — remaining checklist items N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- No new dependencies, no auth/crypto/payment/PII/cardholder path touched.
