### PR TITLE
feat(perf): money-path write benchmark + docker-compose local-dev fixes (issue #669)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,5 +336,6 @@ openbank-admin-ui/patch-*.js
 # artifact left in the repo root.
 sbom-downloads/
 reports/
+!perf/reports/
 *-sbom.cdx.json
 [0-9]* test-reports-*

--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -81,7 +81,12 @@ quarkus:
     transaction-service:
       url: ${TRANSACTION_SERVICE_URL:http://localhost:8102}
     "sanctions-service":
-      url: ${SANCTIONS_SERVICE_URL:http://openbank-sanctions-service:8110}
+      # Was :8110 — that's sca-service's port, not sanctions-service's (QUARKUS_HTTP_PORT
+      # 8123 in docker-compose.yml). Never caught because no local docker-compose run had
+      # ever exercised account-service + sanctions-service together (issue #669 load-benchmark
+      # setup() was the first) — sanctions screening fails closed, so every local account
+      # creation was silently blocked, not just slow.
+      url: ${SANCTIONS_SERVICE_URL:http://openbank-sanctions-service:8123}
       connect-timeout: 3000
       read-timeout: 5000
     # Issue #668: unauthenticated read of product-catalog reference data at account-open time.

--- a/openbank-infra/docker-compose.yml
+++ b/openbank-infra/docker-compose.yml
@@ -380,6 +380,33 @@ services:
       - openbank-net
 
   # ─────────────────────────────────────────────
+  # Temporal (payment orchestration, ADR-0120 Phase 5) — dev-mode single binary, in-memory,
+  # no separate Postgres/Cassandra. This is LOCAL DEV ONLY; the sandbox EKS cluster runs the
+  # real Temporal Helm release (openbank-infra/gitops/components/temporal/temporal-helmrelease.yaml)
+  # with CNPG-backed persistence. Was previously absent from docker-compose entirely — transaction-
+  # service's PaymentWorkerRegistrar would register a worker that never dispatched (issue #669
+  # load-benchmark: `POST /api/v1/transactions` blocks until its PaymentWorkflow completes, so
+  # without this every local write hangs).
+  # --namespace pre-registers `openbank-payments` in addition to the always-created `default`
+  # namespace, matching transaction-service's TemporalConfig default (TEMPORAL_NAMESPACE).
+  temporal:
+    image: temporalio/temporal:1.7.3
+    container_name: openbank-temporal
+    restart: unless-stopped
+    command: server start-dev --ip 0.0.0.0 --namespace openbank-payments
+    ports:
+      - "7233:7233"
+      - "8233:8233"
+    healthcheck:
+      test: ["CMD", "temporal", "operator", "cluster", "health", "--address", "127.0.0.1:7233"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    networks:
+      - openbank-net
+
+  # ─────────────────────────────────────────────
   # Application Services
   # ─────────────────────────────────────────────
   account-service:
@@ -412,15 +439,20 @@ services:
       QUARKUS_HTTP_PORT: "8100"
       QUARKUS_FLYWAY_MIGRATE_AT_START: "true"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      # sanctions-service listens on 8123 (its own QUARKUS_HTTP_PORT below), not the stale
+      # :8110 fallback in account-service's application.yaml default (fixed alongside this).
+      SANCTIONS_SERVICE_URL: http://sanctions-service:8123
     ports:
       - "8100:8100"
     depends_on:
       postgres:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      sanctions-service:
         condition: service_healthy
     networks:
       - openbank-net
@@ -445,7 +477,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_aml
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_aml
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -471,7 +503,7 @@ services:
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OIDC_ENABLED: "false"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8117:8117"
@@ -503,7 +535,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_audit
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_audit
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -628,7 +660,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_balances
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_balances
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -687,7 +719,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_cards
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_cards
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -712,7 +744,7 @@ services:
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8118:8118"
@@ -743,7 +775,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_clearing
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_clearing
       QUARKUS_DATASOURCE_USERNAME: openbank
       QUARKUS_DEV_UI_ENABLED: "false"
@@ -764,7 +796,7 @@ services:
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
     ports:
       - "8124:8124"
     depends_on:
@@ -795,7 +827,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_consents
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_consents
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -819,7 +851,7 @@ services:
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8106:8106"
@@ -848,7 +880,7 @@ services:
     restart: unless-stopped
     environment:
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_dispute
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_dispute
       QUARKUS_DATASOURCE_USERNAME: openbank
       QUARKUS_DEV_UI_ENABLED: "false"
@@ -869,7 +901,7 @@ services:
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
     ports:
       - "8135:8135"
     depends_on:
@@ -902,7 +934,7 @@ services:
 
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_domestic_payments
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_domestic_payments
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -927,7 +959,7 @@ services:
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8116:8116"
@@ -956,7 +988,7 @@ services:
     restart: unless-stopped
     environment:
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_interest
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_interest
       QUARKUS_DATASOURCE_USERNAME: openbank
       QUARKUS_DEV_UI_ENABLED: "false"
@@ -977,7 +1009,7 @@ services:
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
     ports:
@@ -1010,7 +1042,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_kyc
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_kyc
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1070,7 +1102,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_ledger
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_ledger
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1129,7 +1161,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_notifications
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_notifications
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1185,7 +1217,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_parties
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_parties
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1240,7 +1272,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_pid
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_pid
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1293,7 +1325,7 @@ services:
     environment:
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_sca
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_sca
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1319,7 +1351,7 @@ services:
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8110:8110"
@@ -1351,7 +1383,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       OPENBANK_SCT_INST_EXECUTION_TIMEOUT_SECONDS: 10
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_sepa_instant
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_sepa_instant
       QUARKUS_DATASOURCE_USERNAME: openbank
       QUARKUS_DEV_UI_ENABLED: "false"
@@ -1372,7 +1404,7 @@ services:
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
     ports:
       - "8127:8127"
     depends_on:
@@ -1405,7 +1437,7 @@ services:
 
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_sepa_payments
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_sepa_payments
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1430,7 +1462,7 @@ services:
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8115:8115"
@@ -1466,7 +1498,7 @@ services:
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_sanctions
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_sanctions
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1487,11 +1519,20 @@ services:
       QUARKUS_LOG_CONSOLE_JSON: "false"
       QUARKUS_MANAGEMENT_ENABLED: "true"
       QUARKUS_MANAGEMENT_PORT: 8085
+      # Matches the real gitops deployment (sanctions-service.yaml AUTHZ_ENFORCE=false):
+      # OPA rest.rego has no allowed_reasons rule that authorizes a resourceless
+      # `sanctions.create` M2M call (issue #669 load-benchmark discovered this — an
+      # account-service->sanctions-service screening call is unconditionally OPA-denied
+      # once AUTHZ_ENFORCE=true; every allowed_reasons rule needs either input.resource
+      # or a specific caller identity this M2M client doesn't match). Local dev was never
+      # overriding this default (code default is `true`, diverging from prod's `false`)
+      # because nobody had run account-service + sanctions-service together locally before.
+      AUTHZ_ENFORCE: "false"
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8123:8123"
@@ -1521,7 +1562,7 @@ services:
     environment:
       QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_tpp_registry
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_DATASOURCE_REACTIVE_MAX_SIZE: 5
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_tpp_registry
       QUARKUS_DATASOURCE_USERNAME: openbank
@@ -1551,7 +1592,7 @@ services:
       QUARKUS_OIDC_CLIENT_ID: openbank-services
       QUARKUS_OIDC_CREDENTIALS_SECRET: changeme_local_oidc_client_dev_only
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
     ports:
       - "8108:8108"
@@ -1698,9 +1739,10 @@ services:
       QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_HTTP_PORT: "8102"
       LEDGER_SERVICE_URL: http://ledger-service:8101
+      TEMPORAL_SERVER_URL: temporal:7233
       QUARKUS_FLYWAY_MIGRATE_AT_START: "true"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_HTTP_HEADER__X_CONTENT_TYPE_OPTIONS__VALUE: nosniff
@@ -1716,6 +1758,8 @@ services:
       postgres:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      temporal:
         condition: service_healthy
     networks:
       - openbank-net
@@ -1747,7 +1791,7 @@ services:
       QUARKUS_HTTP_PORT: "8119"
       QUARKUS_FLYWAY_MIGRATE_AT_START: "true"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       QUARKUS_HTTP_HEADER__X_CONTENT_TYPE_OPTIONS__VALUE: nosniff
@@ -1788,14 +1832,14 @@ services:
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_standing_orders
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_standing_orders
       QUARKUS_DATASOURCE_USERNAME: openbank
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_HTTP_PORT: 8121
       QUARKUS_MANAGEMENT_ENABLED: "true"
       QUARKUS_MANAGEMENT_PORT: 8085
       QUARKUS_DEV_UI_ENABLED: "false"
       QUARKUS_FLYWAY_MIGRATE_AT_START: "true"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
       QUARKUS_HTTP_HEADER__X_CONTENT_TYPE_OPTIONS__VALUE: nosniff
       QUARKUS_HTTP_HEADER__X_FRAME_OPTIONS__VALUE: DENY
@@ -1835,7 +1879,7 @@ services:
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_swift
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_swift
       QUARKUS_DATASOURCE_USERNAME: openbank
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_HTTP_PORT: 8122
       QUARKUS_MANAGEMENT_ENABLED: "true"
@@ -1843,7 +1887,7 @@ services:
       QUARKUS_DEV_UI_ENABLED: "false"
       QUARKUS_FLYWAY_MIGRATE_AT_START: "true"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
       QUARKUS_HTTP_HEADER__X_CONTENT_TYPE_OPTIONS__VALUE: nosniff
       QUARKUS_HTTP_HEADER__X_FRAME_OPTIONS__VALUE: DENY
@@ -1883,14 +1927,14 @@ services:
       QUARKUS_DATASOURCE_REACTIVE_URL: postgresql://postgres:5432/openbank_security
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/openbank_security
       QUARKUS_DATASOURCE_USERNAME: openbank
-      QUARKUS_DATASOURCE_PASSWORD: openbank_secret
+      QUARKUS_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
       QUARKUS_HTTP_PORT: 8120
       QUARKUS_MANAGEMENT_ENABLED: "true"
       QUARKUS_MANAGEMENT_PORT: 8085
       QUARKUS_DEV_UI_ENABLED: "false"
       QUARKUS_FLYWAY_MIGRATE_AT_START: "true"
       QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
-      QUARKUS_REDIS_HOSTS: redis://:openbank_cache_secret@valkey:6379
+      QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       QUARKUS_SHUTDOWN_TIMEOUT: 30S
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/realms/openbank
       QUARKUS_OIDC_CLIENT_ID: openbank-services

--- a/perf/k6/money-path-write-benchmark.js
+++ b/perf/k6/money-path-write-benchmark.js
@@ -201,11 +201,19 @@ export const options = {
   },
 };
 
+// CodeQL's js/insecure-randomness taint tracking merges this pool index with the
+// Idempotency-Key header built in the same postTransaction() call (same pattern as
+// uuidv4() above) — crypto.getRandomValues() over Math.random() closes that flow too,
+// not just satisfies the query literally.
+function randomPoolIndex(length) {
+  return crypto.getRandomValues(new Uint32Array(1))[0] % length;
+}
+
 function randomDistinctPair(pool) {
-  const a = pool[Math.floor(Math.random() * pool.length)];
-  let b = pool[Math.floor(Math.random() * pool.length)];
+  const a = pool[randomPoolIndex(pool.length)];
+  let b = pool[randomPoolIndex(pool.length)];
   while (b === a && pool.length > 1) {
-    b = pool[Math.floor(Math.random() * pool.length)];
+    b = pool[randomPoolIndex(pool.length)];
   }
   return [a, b];
 }

--- a/perf/k6/money-path-write-benchmark.js
+++ b/perf/k6/money-path-write-benchmark.js
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// k6 money-path WRITE benchmark (issue #669 scope item 1 — "money-path load benchmark").
+//
+// money-path-smoke.js is deliberately read-only ("Authenticated write baselines are a
+// separate, carefully-scoped follow-up"). This is that follow-up: it drives real concurrent
+// postings through account-service -> transaction-service -> [Temporal PaymentWorkflow] ->
+// balance-service (hold) + ledger-service (journal), and records TPS + latency percentiles.
+//
+// LOCAL ONLY BY DESIGN. This mutates money-path state (creates accounts, posts real ledger
+// journals) — it must never run against a shared cluster where other work depends on that
+// data. Target the docker-compose stack (openbank-infra/docker-compose.yml), never the
+// sandbox EKS PERF_LEDGER_URL/PERF_TXN_URL used by money-path-smoke.js's perf-baseline.yml.
+//
+// Prerequisites (see perf/reports/ for the exact command + versions used for the committed
+// baseline numbers, and the real gaps this run surfaced):
+//   cd openbank-infra && cp .env.example .env && docker compose up -d \
+//     postgres kafka schema-registry keycloak opa temporal sanctions-service \
+//     account-service balance-service ledger-service transaction-service
+//   docker compose run --rm kafka-init   # topics must exist BEFORE any account is created —
+//                                         # balance-service learns an account exists only via
+//                                         # its account.opened Kafka consumer; an account
+//                                         # created before kafka-init 404s on its first hold.
+//   (temporal must be present — POST /api/v1/transactions blocks on a PaymentWorkflow that
+//   never runs without it; sanctions-service must be present — account-service's screening
+//   adapter fails CLOSED, unlike product-catalog's fail-open lookup, so account creation is
+//   blocked without it. sanctions-service additionally needs AUTHZ_ENFORCE=false — matching
+//   its real gitops deployment today — because OPA's rest.rego has no allow rule for a
+//   resourceless M2M `sanctions.create` call yet, see the linked follow-up issue.)
+//
+// Run:
+//   ACCOUNT_URL=http://localhost:8100 TXN_URL=http://localhost:8102 \
+//   KEYCLOAK_URL=http://localhost:8080 \
+//   k6 run perf/k6/money-path-write-benchmark.js
+//
+// Thresholds are ADVISORY, same convention as money-path-smoke.js (issue #334) — a breach is
+// the tripwire to investigate, not a build failure; run with --no-thresholds-fail in CI.
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Counter } from "k6/metrics";
+
+const ACCOUNT_URL = __ENV.ACCOUNT_URL || "http://localhost:8100";
+const TXN_URL = __ENV.TXN_URL || "http://localhost:8102";
+const KEYCLOAK_URL = __ENV.KEYCLOAK_URL || "http://localhost:8080";
+// Dev-only confidential client, service-account role ROLE_OPERATOR (openbank-realm.json).
+// NEVER a real credential — same value as openbank-infra/docker/keycloak/realm/openbank-realm.json.
+const CLIENT_ID = __ENV.CLIENT_ID || "openbank-services";
+const CLIENT_SECRET = __ENV.CLIENT_SECRET || "CHANGE_ME_LOCAL_DEV_ONLY";
+
+// Independent-pairs pool: each VU picks two distinct accounts at random — models steady,
+// uncontended traffic. Contention pool: deliberately tiny, so many concurrent VUs fight over
+// the SAME few accounts' optimistic-lock version — models the exact class of bug the 2026-07
+// test-stack audit found (lost updates, double-open, no-@Version races; issue #465/#527).
+const INDEPENDENT_POOL_SIZE = Number(__ENV.INDEPENDENT_POOL_SIZE || 20);
+const CONTENTION_POOL_SIZE = Number(__ENV.CONTENTION_POOL_SIZE || 3);
+const FUNDING_AMOUNT = "1000000.00";
+const TRANSFER_AMOUNT = "10.00";
+
+const postLatency = new Trend("txn_post_ms", true);
+const postSuccess = new Counter("txn_post_success");
+const postFailure = new Counter("txn_post_failure");
+
+// k6 v0.53+ exposes the WebCrypto API as a global (no import) — no remote jslib dependency,
+// no hand-rolled Math.random() UUID (CodeQL correctly flags Math.random() feeding anything
+// named like a UUID/token as js/insecure-randomness; crypto.randomUUID() is the real fix, not
+// a suppression — idempotency keys benefit from genuine uniqueness under concurrent VUs too).
+function uuidv4() {
+  return crypto.randomUUID();
+}
+
+function getToken() {
+  const res = http.post(
+    `${KEYCLOAK_URL}/realms/openbank/protocol/openid-connect/token`,
+    { grant_type: "client_credentials", client_id: CLIENT_ID, client_secret: CLIENT_SECRET },
+    { headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+  );
+  if (res.status !== 200) {
+    throw new Error(`token request failed: ${res.status} ${res.body}`);
+  }
+  return res.json("access_token");
+}
+
+function openAccount(token) {
+  const res = http.post(
+    `${ACCOUNT_URL}/api/v1/accounts`,
+    JSON.stringify({
+      partyId: uuidv4(),
+      // product-catalog is not part of this local subset — account-service's ProductCatalogPort
+      // is fail-OPEN (issue #668/PR #727) so an unreachable lookup still allows account
+      // creation; an arbitrary UUID here is intentional, not a shortcut around a real check.
+      productId: uuidv4(),
+      accountType: "CURRENT",
+      // CZK, not EUR: PaymentJournalFactory's cash-clearing leg for a one-sided (non-
+      // internal-transfer) payment is hardcoded to a CZK-only GL account regardless of the
+      // transaction's actual currency — a real bug found while building this benchmark
+      // (flagged separately, see perf/reports/ for the exact symptom). A non-CZK funding
+      // CREDIT gets a 422 from ledger-service and the transaction ends FAILED. CZK is the
+      // only currency the seeded GL chart of accounts actually supports end-to-end today.
+      currencyCode: "CZK",
+      legalName: "K6 Benchmark Account",
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        "Idempotency-Key": uuidv4(),
+      },
+    },
+  );
+  if (res.status !== 201) {
+    throw new Error(`account creation failed: ${res.status} ${res.body}`);
+  }
+  return res.json("id");
+}
+
+function postTransaction(token, type, sourceAccountId, targetAccountId, amount) {
+  const start = Date.now();
+  const res = http.post(
+    `${TXN_URL}/api/v1/transactions`,
+    JSON.stringify({
+      idempotencyKey: uuidv4(),
+      type,
+      sourceAccountId,
+      targetAccountId,
+      amount,
+      currencyCode: "CZK",
+      valueDate: new Date().toISOString().slice(0, 10),
+      description: "k6 money-path write benchmark",
+    }),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      tags: { name: `txn_${type.toLowerCase()}` },
+      timeout: "30s", // PaymentWorkflow round-trip, not a plain HTTP call — generous budget.
+    },
+  );
+  postLatency.add(Date.now() - start);
+  const ok = res.status === 201;
+  ok ? postSuccess.add(1) : postFailure.add(1);
+  check(res, { "transaction 201": () => ok });
+  return ok;
+}
+
+export function setup() {
+  const token = getToken();
+  const fund = (id) => postTransaction(token, "CREDIT", null, id, FUNDING_AMOUNT);
+
+  const independentAccounts = [];
+  for (let i = 0; i < INDEPENDENT_POOL_SIZE; i++) {
+    const id = openAccount(token);
+    fund(id);
+    independentAccounts.push(id);
+  }
+
+  const contentionAccounts = [];
+  for (let i = 0; i < CONTENTION_POOL_SIZE; i++) {
+    const id = openAccount(token);
+    fund(id);
+    contentionAccounts.push(id);
+  }
+
+  return { token, independentAccounts, contentionAccounts };
+}
+
+export const options = {
+  scenarios: {
+    // Uncontended baseline: each iteration picks a random distinct pair from a pool large
+    // enough that two VUs rarely touch the same account at once.
+    steady_writes: {
+      executor: "ramping-vus",
+      exec: "steadyWrites",
+      startVUs: 1,
+      stages: [
+        { duration: "20s", target: 10 },
+        { duration: "40s", target: 10 },
+        { duration: "10s", target: 0 },
+      ],
+      gracefulStop: "15s",
+    },
+    // Deliberate contention: many VUs transferring between the SAME 3 accounts — every
+    // posting races another for the same account's optimistic-lock version. Starts after
+    // steady_writes finishes so the two don't confound each other's latency numbers.
+    contention_writes: {
+      executor: "ramping-vus",
+      exec: "contentionWrites",
+      startVUs: 1,
+      startTime: "75s",
+      stages: [
+        { duration: "10s", target: 15 },
+        { duration: "30s", target: 15 },
+        { duration: "10s", target: 0 },
+      ],
+      gracefulStop: "15s",
+    },
+  },
+  thresholds: {
+    // Advisory tripwires — run with --no-thresholds-fail (money-path-smoke.js convention).
+    "txn_post_ms": ["p(95)<3000"],
+    "txn_post_failure": ["count<1"],
+  },
+};
+
+function randomDistinctPair(pool) {
+  const a = pool[Math.floor(Math.random() * pool.length)];
+  let b = pool[Math.floor(Math.random() * pool.length)];
+  while (b === a && pool.length > 1) {
+    b = pool[Math.floor(Math.random() * pool.length)];
+  }
+  return [a, b];
+}
+
+export function steadyWrites(data) {
+  const [from, to] = randomDistinctPair(data.independentAccounts);
+  postTransaction(data.token, "TRANSFER", from, to, TRANSFER_AMOUNT);
+  sleep(0.2);
+}
+
+export function contentionWrites(data) {
+  const [from, to] = randomDistinctPair(data.contentionAccounts);
+  postTransaction(data.token, "TRANSFER", from, to, TRANSFER_AMOUNT);
+}

--- a/perf/k6/money-path-write-benchmark.js
+++ b/perf/k6/money-path-write-benchmark.js
@@ -206,7 +206,15 @@ export const options = {
 // uuidv4() above) — crypto.getRandomValues() over Math.random() closes that flow too,
 // not just satisfies the query literally.
 function randomPoolIndex(length) {
-  return crypto.getRandomValues(new Uint32Array(1))[0] % length;
+  // Plain `% length` on a uint32 is biased toward low indices whenever length doesn't evenly
+  // divide 2^32 (CodeQL js/biased-cryptographic-random). Rejection sampling over the largest
+  // multiple of length below 2^32 keeps the distribution uniform.
+  const range = Math.floor(0x100000000 / length) * length;
+  let x;
+  do {
+    x = crypto.getRandomValues(new Uint32Array(1))[0];
+  } while (x >= range);
+  return x % length;
 }
 
 function randomDistinctPair(pool) {

--- a/perf/reports/2026-07-10-money-path-write-benchmark.md
+++ b/perf/reports/2026-07-10-money-path-write-benchmark.md
@@ -1,0 +1,164 @@
+# Money-path write benchmark — 2026-07-10
+
+Issue #669 scope item 1 ("money-path load benchmark"). First **write** baseline — the existing
+`perf/k6/money-path-smoke.js` is deliberately read-only. This run drives real concurrent postings
+through `account-service -> transaction-service -> [Temporal PaymentWorkflow] -> balance-service
+(hold) + ledger-service (journal)` and reports throughput/latency plus what broke along the way.
+
+**Local only, by design.** This mutates money-path state (creates accounts, posts real ledger
+journals). It ran against a local `docker-compose` stack, never the shared sandbox EKS cluster —
+out of scope for this pass (deferred, per the explicit scope decision on issue #669).
+
+## TL;DR
+
+- **0 transaction failures** across two runs (2,197 + 469 = 2,666 postings), including a dedicated
+  contention scenario that deliberately hammers 3 accounts with 15 concurrent VUs. Correctness held.
+- Getting a *single* write to complete locally required fixing **five** previously-latent defects —
+  nobody had run this write path end-to-end on a clean local checkout before. Those are the more
+  important finding of this exercise; see "What broke" below.
+- Throughput/latency numbers are **not stable across repeated runs on this machine** — see
+  "Numbers" and the honesty note below. Treat them as an order-of-magnitude baseline, not a
+  precise SLA figure, and treat the *investigation* they triggered as the actual deliverable.
+
+## Environment (exact, for reproducibility)
+
+| | |
+|---|---|
+| Host | Apple M2 Max, 12 cores, 32 GiB RAM, macOS 26.4.1 |
+| Container runtime | OrbStack, Docker server 29.4.0 |
+| JDK | Temurin 25.0.3+9 (host-run services — see "How this was actually run") |
+| k6 | v2.1.0 (darwin/arm64) |
+| Repo commit | `5431d9829b63f2b13b4dea2ebc0052136221592d` (branch `perf/money-path-write-benchmark`, based on `origin/main`) |
+| Service versions | account-service 0.13.0, balance-service 1.8.3, ledger-service 1.10.4, transaction-service 1.13.1, sanctions-service 0.6.5 |
+| Temporal | `temporalio/temporal:1.7.3`, dev-mode single binary, in-memory (new — see "What broke") |
+
+This is a single shared development laptop, not isolated benchmark hardware — other processes
+(IDE, browser, this very Claude Code session) were running concurrently. Numbers have correspondingly
+wide error bars; a real capacity baseline needs dedicated hardware or the sandbox EKS cluster
+(explicitly out of scope for this pass).
+
+## How this was actually run
+
+`docker-compose.yml`'s own `standalone-service.Dockerfile` builds each service **inside Docker**
+via `./gradlew quarkusBuild` from a cold cache. That path OOM'd the container runtime after ~40
+minutes across 4 parallel builds (`rpc error: code = Unavailable desc = error reading from server:
+EOF` — a BuildKit connectivity loss, matching this repo's own documented "Parallel Docker/Gradle
+builds OOM" pitfall, just never hit from a **cold** Gradle cache before). Fell back to building the
+uber-jars host-side with a warm `~/.gradle` cache (45s for 4 services) and running them as plain
+`java -jar` processes against the same dockerized infra (Postgres/Kafka/Keycloak/OPA/Temporal/Valkey).
+This is *not* how CI or production builds these images — it was the pragmatic path to get a working
+local write-path stack without burning another 40 minutes per retry. `build-push-service.sh`
+(host-side build, then `docker build` with a plain `COPY`) is still the right pattern for anything
+that needs an actual container image.
+
+## What broke (the real finding)
+
+Every one of these was a genuine, previously-undiscovered defect — not a benchmark-script bug —
+found only because this was, as far as I can tell, the first time anyone ran the full write path
+against a clean local checkout:
+
+1. **Temporal was entirely absent from `docker-compose.yml`.** `POST /api/v1/transactions` blocks
+   on a `PaymentWorkflow` that never runs without it — every local write silently hung. Added a
+   dev-mode `temporalio/temporal:1.7.3` container (`temporal server start-dev`, in-memory, zero
+   extra Postgres/Cassandra) and wired `transaction-service`'s `TEMPORAL_SERVER_URL`.
+2. **`account-service`'s sanctions-service client pointed at the wrong port** (`:8110`, actually
+   sca-service's port; sanctions-service listens on `:8123`). Sanctions screening fails **closed**
+   (unlike product-catalog's fail-open lookup), so every local account creation was silently
+   blocked, not just slow. Fixed the wrong fallback default and added an explicit compose override.
+3. **22 of 27 service blocks in `docker-compose.yml` hardcode a stale literal Postgres password**
+   instead of `${POSTGRES_PASSWORD}` (from `.env`, correctly used by only 5 services). Confirmed by
+   testing real peer-to-peer auth over the Docker network, not the
+   trust-auth-by-default `docker exec` shortcut. This meant a fresh `docker compose up` following
+   the documented `.env.example` recipe could never have booted most of the local stack. Same
+   pattern, same fix, for 18 hardcoded Valkey passwords. Bulk sed-fixed across the whole file.
+4. **OPA's `rest.rego` has no rule authorizing the M2M `sanctions.create` call at all.** A
+   service-account token is classified `HUMAN` (documented quirk, see the file's own comment on
+   `edge-service-notification`), and the only rule that would grant a HUMAN+`ROLE_OPERATOR` caller
+   requires a resource-scoped action — `sanctions.create` has none. Confirmed by direct testing:
+   `403 {"code":"FORBIDDEN","message":"policy denied"}`. Not a live incident — the real gitops
+   deployment already runs sanctions-service with `AUTHZ_ENFORCE=false` (advisory-only), which
+   masks it — but it's a **blocking pre-condition** for that gate ever graduating to enforced.
+   Local dev was simply never told about that `false`; added the matching override. Deeper policy
+   fix flagged as a separate follow-up (not safe to rush a same-day OPA authz change).
+5. **`PaymentJournalFactory`'s cash-clearing leg is hardcoded to a CZK-only GL account** regardless
+   of the transaction's actual currency. A same-currency, one-sided (non-internal-transfer) payment
+   in any other currency — confirmed with EUR — gets `422` from `ledger-service` and the whole
+   transaction ends `FAILED` after the `LedgerCallGuard` circuit breaker trips. Every account/amount
+   in this benchmark uses CZK to avoid it. Flagged as a separate follow-up (real accounting-chart
+   design work, money-path domain logic, needs the 2-approval + threat-model process).
+6. **Kafka topics must exist *before* the first account is created.** `KAFKA_AUTO_CREATE_TOPICS_ENABLE:
+   false` + `kafka-init` never having been run meant `balance-service` never learned an account
+   existed (no `account.opened` consumption) — its first `placeHold` call 404'd. Not a code bug,
+   just an easy-to-miss local setup step; documented explicitly in the k6 script's header now.
+
+None of these are exotic — every one is the "nobody ever actually ran this locally" class of bug
+this repo's own CLAUDE.md has hit repeatedly (stale ktlint wildcards, wrong podmonitor namespace
+list, etc.). That pattern held here too, just for the write path as a whole rather than one file.
+
+## Numbers
+
+**Run 1** (clean, no per-request trace export — the summary-only path):
+
+| Metric | Value |
+|---|---|
+| Total postings | 2,197 (0 failed) |
+| Achieved throughput | ~16.7 req/s (`steady_writes`: 10 VUs uncontended; `contention_writes`: 15 VUs on 3 shared accounts) |
+| Latency (all postings) | avg 435ms · p50 251ms · p90 345ms · p95 2.25s · max 6.35s |
+
+**Run 2** (identical script, run immediately after run 1, with full per-request JSON trace export
+enabled via `k6 run --out json=...`):
+
+| Metric | Value |
+|---|---|
+| Total postings | 469 (0 failed) — k6 issued far fewer requests in the same wall-clock budget |
+| Latency (`steady_writes`, uncontended) | p50 250ms · p90 **6.15s** · p95 **6.17s** — a step function, not gradual drift |
+| Latency (`contention_writes`, 15 VUs / 3 accounts) | median already at **6.10s**, i.e. saturated from the start |
+
+**Honesty note on the run-to-run gap.** Run 2 is dramatically worse and I have not root-caused why
+with confidence. Working hypotheses, in rough order of likelihood, none confirmed:
+- Several services run with `QUARKUS_DATASOURCE_JDBC_MAX_SIZE: 5` (a deliberately small local-dev
+  pool) — 5 connections shared across 10–15 concurrent VUs plausibly queues under load.
+- Temporal's dev-mode server is single-node and in-memory; by run 2 it had accumulated workflow
+  history from ~2,200 prior executions with no restart in between.
+- k6's own `--out json` write path adds overhead that competes with the JVM services for host
+  CPU on a single shared laptop with ~9 concurrent JVM processes already running.
+
+I'm reporting both runs rather than picking the flattering one. The **repeatable, load-sensitive
+degradation itself** is the more useful signal than either individual number — it's exactly the
+"contention behaviour worth measuring, not just peak TPS" issue #669 asked for, and it surfaced on
+the very first attempt to measure it. A real capacity conclusion needs: isolated hardware, JDBC
+pool tuning experiments, and Temporal server metrics — none of which are in scope for this pass.
+
+## Re-running this
+
+```bash
+cd openbank-infra
+cp .env.example .env
+docker compose up -d postgres kafka schema-registry keycloak opa temporal sanctions-service \
+  account-service balance-service ledger-service transaction-service
+docker compose run --rm kafka-init   # MUST run before the first account is created
+
+ACCOUNT_URL=http://localhost:8100 TXN_URL=http://localhost:8102 KEYCLOAK_URL=http://localhost:8080 \
+  k6 run perf/k6/money-path-write-benchmark.js
+```
+
+If `docker compose up --build` OOMs on a cold Gradle cache (see "How this was actually run" above),
+build host-side first: `./gradlew :openbank-account-service:quarkusBuild
+:openbank-balance-service:quarkusBuild :openbank-ledger-service:quarkusBuild
+:openbank-transaction-service:quarkusBuild :openbank-sanctions-service:quarkusBuild
+-Dquarkus.package.jar.type=uber-jar`, then run the resulting jars with `java -jar`, pointing every
+`QUARKUS_DATASOURCE_*_URL` / `KAFKA_BOOTSTRAP_SERVERS` / `QUARKUS_OIDC_AUTH_SERVER_URL` /
+`QUARKUS_REDIS_HOSTS` at `localhost` instead of the compose service DNS names, plus
+`SANCTIONS_SERVICE_URL=http://localhost:8123` for account-service and
+`TEMPORAL_SERVER_URL=localhost:7233` for transaction-service.
+
+## Deferred (explicit scope decision on issue #669)
+
+- Running this (or a heavier variant) against the shared sandbox EKS cluster, with a documented
+  node shape.
+- The chaos/DR drill (kill a money-path pod mid-flow, force a Postgres failover).
+
+## Linked follow-ups filed from this run
+
+- OPA `rest.rego` M2M `sanctions.create` authorization gap (item 4 above).
+- `PaymentJournalFactory` non-CZK cash-clearing leg (item 5 above).


### PR DESCRIPTION
## Summary

Delivers the "money-path load benchmark" scope item of issue #669: a reproducible k6 write benchmark driving real concurrent postings through `account-service -> transaction-service -> Temporal PaymentWorkflow -> balance-service + ledger-service`, run locally against `docker-compose` (never the shared sandbox EKS cluster — out of scope per the explicit prior scope decision on this issue).

Getting a single write to complete locally required fixing several previously-latent defects that had apparently never been exercised before — that's arguably the more valuable output of this PR. Split into two commits: infra fixes, then the benchmark itself.

## Type of change

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

Refs #669

## Changes

**Commit 1 — infra fixes** (`openbank-infra/docker-compose.yml`, `openbank-account-service/src/main/resources/application.yaml`):
- 22 of 27 service blocks hardcoded the wrong Postgres password (`openbank_secret`) instead of `${POSTGRES_PASSWORD}` — confirmed by testing real peer-to-peer auth over the Docker network (not the trust-auth-by-default `docker exec` shortcut). A fresh `docker compose up` following the documented `.env.example` recipe could never have booted most of the local stack. Same bug, same fix, for 18 hardcoded Valkey passwords.
- account-service's sanctions-service REST client pointed at `:8110` (actually sca-service's port); sanctions-service listens on `:8123`. Sanctions screening fails **closed**, so every local account creation was silently blocked, not just slow.
- Temporal was entirely absent from `docker-compose.yml`. `POST /api/v1/transactions` blocks on a `PaymentWorkflow` that never runs without it. Added a dev-mode `temporalio/temporal:1.7.3` container (in-memory, zero extra Postgres/Cassandra) and wired `TEMPORAL_SERVER_URL`.
- sanctions-service additionally needs `AUTHZ_ENFORCE=false` locally to match its real gitops deployment — OPA's `rest.rego` has no allow rule for the resourceless M2M `sanctions.create` call yet (flagged as a separate follow-up, not safe to rush a same-day authz policy change).

**Commit 2 — the benchmark** (`perf/k6/money-path-write-benchmark.js`, `perf/reports/2026-07-10-money-path-write-benchmark.md`, `.gitignore`):
- New k6 script: `setup()` creates + funds accounts via account-service, then two scenarios — `steady_writes` (uncontended random pairs) and `contention_writes` (many VUs on a tiny shared account pool, since the 2026-07 test-stack audit's race-condition findings make contention behaviour worth measuring, not just peak TPS).
- Committed, versioned report with exact environment, exact re-run command, and honest numbers from two runs: **0 transaction failures across 2,666 postings**, but throughput/latency were **not stable run-to-run** on this shared laptop — reported both runs rather than the flattering one, with working hypotheses (small JDBC pools, single-node in-memory Temporal, host contention) rather than a false-confidence root cause.
- `.gitignore`'s bare `reports/` pattern (meant for Gradle test HTML output) was silently swallowing `perf/reports/`; added a `!perf/reports/` negation.

Two additional defects were found but **not** fixed here (flagged as separate follow-up tasks, both needing careful, non-rushed review):
- OPA `rest.rego` has no rule authorizing the M2M `sanctions.create` call at all — masked today by `AUTHZ_ENFORCE=false` in the real deployment, but a blocking pre-condition for that gate ever graduating to enforced.
- `PaymentJournalFactory`'s cash-clearing leg is hardcoded to a CZK-only GL account regardless of the transaction's actual currency — confirmed live (EUR fails with 422, CZK succeeds). Every account/amount in the benchmark uses CZK to route around it.

## Definition of Done

- [x] Hexagonal layering preserved — N/A, only infra config + one REST-client URL default touched, no domain logic.
- [ ] Unit tests added/updated. — N/A, no application code behavior changed.
- [ ] Integration tests added/updated. — N/A.
- [ ] Contract tests updated. — N/A, no API changed.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` passes. — N/A, no Gradle module touched (one `application.yaml` string fix).
- [x] No new lint warnings. — verified locally: `docker compose config` validates, yamllint passes on the changed YAML with CI's exact config.
- [ ] OpenAPI spec regenerated. — N/A.
- [ ] Flyway migration added. — N/A.
- [ ] Avro schema versioned. — N/A.
- [x] Docs updated. — the versioned benchmark report + inline comments explaining every fix.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. — all local-dev-only placeholder values, already the repo's existing convention (`.env.example`).
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification. — none added.
- [x] No new third-party dependency. — `temporalio/temporal` is a pinned Docker image for local dev only, not a build dependency.
- [ ] Auth / crypto / payment code changed? — the `SANCTIONS_SERVICE_URL` default fix touches a REST client base URI, not auth/crypto logic itself; flagging for visibility since it's sanctions-adjacent.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A — local-dev tooling only (`docker-compose.yml`, a perf script, a REST-client default). No gitops/cluster change.
- Rollback plan: revert the PR.
- Data migration reversible: N/A.

## Reviewer notes

The password/URL fixes in commit 1 are worth double-checking against your own `.env` if you've been relying on a long-lived local `postgres_data` volume — mine had drifted from an unrelated prior session and I had to wipe it to get a real signal on which password actually worked. The benchmark report is intentionally not flattering about run-to-run stability; I'd rather that be visible than polished away.