### PR TITLE
feat(account): list ACTIVE accounts fleet-wide for billing discovery (ADR-0143)

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -204,3 +204,18 @@ not change any existing request's outcome until explicitly flipped.
   enforce` stays `false`** — no behavior change to any existing request; this PR only wires the
   mechanism. Rollback: revert the commit (no DB/schema change; `ApprovalStore` records live in
   Redis with a TTL).
+- **2026-07-10** — Added `GET /api/v1/accounts/active` (fleet-wide ACTIVE-account sweep,
+  cursor-paginated; ADR-0143: the "list every billable account" read billing-service's cycle
+  scheduler discovers its batch from, issue #548). Touches the **I — information disclosure**
+  row: like `/search`, this is an account-enumeration surface — and a deliberately *broader* one
+  (no fragment required). Bounded the same way: `@RolesAllowed(SERVICE, VIEWER, OPERATOR,
+  ADMIN)` — never `@PermitAll`, asserted end-to-end by `ActiveAccountsApiIT` (401/403/200);
+  page size capped at 200 (`MAX_ACTIVE_LIST_LIMIT`) so one request cannot dump the whole book;
+  keyset cursor (stable under concurrent open/close); returns only ACTIVE rows, so a billing
+  sweep can never pick up a CLOSED/FROZEN account. No query input beyond limit/cursor — no
+  injection surface (status is a server-side constant, cursor decodes to a UUID or 500s before
+  any query). **Risk class = confidentiality** (fleet-wide enumeration by an over-privileged or
+  compromised staff/service token). Residual: any caller with an allowed role sees the whole
+  active book — acceptable because the roles are staff/M2M only and the same information is
+  already reachable via repeated `/search` paging; gateway rate limits apply. No DB change, no
+  new index (status + PK keyset uses the existing primary key). Rollback: revert the commit.

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/in/AccountPorts.kt
@@ -45,6 +45,12 @@ data class GetAccountByIbanQuery(val iban: String)
 data class ListAccountsQuery(val partyId: UUID, val limit: Int = 20, val afterCursor: String? = null)
 data class SearchAccountsQuery(val query: String, val limit: Int = 20, val afterCursor: String? = null)
 
+/**
+ * Fleet-wide sweep over ACTIVE accounts, cursor-paginated (ADR-0143: the "list every billable
+ * account" read port billing-service's cycle scheduler discovers its batch from).
+ */
+data class ListActiveAccountsQuery(val limit: Int = 100, val afterCursor: String? = null)
+
 data class AddPocketCommand(val accountId: UUID, val currency: CurrencyCode, val requestedBy: UUID)
 data class ClosePocketCommand(val accountId: UUID, val currency: CurrencyCode, val requestedBy: UUID)
 data class ListPocketsQuery(val accountId: UUID)
@@ -76,6 +82,9 @@ interface AccountUseCase {
     suspend fun getAccountByIban(query: GetAccountByIbanQuery): Account
     suspend fun listAccounts(query: ListAccountsQuery): CursorPage<Account>
     suspend fun searchAccounts(query: SearchAccountsQuery): CursorPage<Account>
+
+    /** All ACTIVE accounts, fleet-wide, keyset-paginated by id (ADR-0143 billing discovery). */
+    suspend fun listActiveAccounts(query: ListActiveAccountsQuery): CursorPage<Account>
     suspend fun getBalance(accountId: UUID): BalanceView
     suspend fun addPocket(command: AddPocketCommand): CurrencyPocket
     suspend fun closePocket(command: ClosePocketCommand): CurrencyPocket

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/AccountPorts.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/port/out/AccountPorts.kt
@@ -13,6 +13,9 @@ import java.time.Instant
 import java.util.UUID
 
 /** Outbound persistence port for the account aggregate (single IBAN, N currency pockets). */
+// TooManyFunctions: cohesive query/persist surface of ONE aggregate — splitting would
+// scatter it across artificial sub-ports (same rationale as KycRepositoryPort).
+@Suppress("TooManyFunctions")
 interface AccountRepository {
 
     suspend fun findById(id: UUID): Account?
@@ -28,6 +31,12 @@ interface AccountRepository {
      * cursor, identically to [findByPartyId].
      */
     suspend fun searchByIban(normalizedFragment: String, limit: Int, afterId: UUID?): List<Account>
+
+    /**
+     * Every ACTIVE account, fleet-wide, keyset-paginated by id for a stable cursor, identically
+     * to [findByPartyId] (ADR-0143: billing-service's cycle-sweep discovery read).
+     */
+    suspend fun findActive(limit: Int, afterId: UUID?): List<Account>
 
     suspend fun save(account: Account): Account
 

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/application/usecase/AccountService.kt
@@ -4,7 +4,22 @@
 
 package com.openbank.account.application.usecase
 
-import com.openbank.account.application.port.`in`.*
+import com.openbank.account.application.port.`in`.AccountUseCase
+import com.openbank.account.application.port.`in`.AddPocketCommand
+import com.openbank.account.application.port.`in`.ClearSavingsGoalCommand
+import com.openbank.account.application.port.`in`.CloseAccountCommand
+import com.openbank.account.application.port.`in`.ClosePocketCommand
+import com.openbank.account.application.port.`in`.FreezeAccountCommand
+import com.openbank.account.application.port.`in`.GetAccountByIbanQuery
+import com.openbank.account.application.port.`in`.GetAccountQuery
+import com.openbank.account.application.port.`in`.ListAccountsQuery
+import com.openbank.account.application.port.`in`.ListActiveAccountsQuery
+import com.openbank.account.application.port.`in`.ListPocketsQuery
+import com.openbank.account.application.port.`in`.OpenAccountCommand
+import com.openbank.account.application.port.`in`.ResolvePocketQuery
+import com.openbank.account.application.port.`in`.SearchAccountsQuery
+import com.openbank.account.application.port.`in`.UnfreezeAccountCommand
+import com.openbank.account.application.port.`in`.UpdateSavingsGoalCommand
 import com.openbank.account.application.port.out.AccountEventPublisher
 import com.openbank.account.application.port.out.AccountRepository
 import com.openbank.account.application.port.out.AccountSanctionsScreeningPort
@@ -259,6 +274,22 @@ class AccountService(
         )
     }
 
+    override suspend fun listActiveAccounts(query: ListActiveAccountsQuery): CursorPage<Account> {
+        // A fleet-wide sweep read (ADR-0143 billing discovery) — larger pages than the
+        // customer-facing list are practical here, but the size is still capped so a single
+        // request cannot dump the whole book.
+        val limit = query.limit.coerceIn(1, MAX_ACTIVE_LIST_LIMIT)
+        val afterId = query.afterCursor?.let { UUID.fromString(CursorEncoder.decode(it)) }
+        val accounts = accountRepository.findActive(limit + 1, afterId)
+        val hasNext = accounts.size > limit
+        val page = if (hasNext) accounts.dropLast(1) else accounts
+        val nextCursor = if (hasNext) CursorEncoder.encode(page.last().id.toString()) else null
+        return CursorPage(
+            data = page,
+            pagination = PageInfo(limit = limit, hasNextPage = hasNext, nextCursor = nextCursor),
+        )
+    }
+
     override suspend fun getBalance(accountId: UUID): BalanceView {
         val account = requireAccount(accountId)
         return balancePort.getByAccountAndCurrency(accountId, account.currency.code)
@@ -395,6 +426,13 @@ class AccountService(
 
         /** Upper bound on the search page size, to cap the account-enumeration surface. */
         const val MAX_SEARCH_LIMIT = 50
+
+        /**
+         * Upper bound on the active-account sweep page size (ADR-0143 billing discovery).
+         * Larger than [MAX_SEARCH_LIMIT] because the caller is a paging batch job, not an
+         * interactive search — but still bounded so one request cannot dump the whole book.
+         */
+        const val MAX_ACTIVE_LIST_LIMIT = 200
     }
 }
 

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountRepositoryImpl.kt
@@ -38,6 +38,7 @@ class AccountIdempotencyRepository(private val clock: Clock) :
 }
 
 @ApplicationScoped
+@Suppress("TooManyFunctions") // 1:1 impl of AccountRepository — see the port's own suppression rationale
 class AccountRepositoryImpl(
     // internal, not private: the file-scope versionMatchedUpdate extension below (#465,
     // outside the class body) stamps updatedAt from this clock — Kotlin's `private` on a
@@ -88,6 +89,18 @@ class AccountRepositoryImpl(
             }
             query.page(0, limit).list()
         }.awaitSuspending().map { it.toDomain() }
+
+    override suspend fun findActive(limit: Int, afterId: UUID?): List<Account> = Panache.withSession {
+        // Keyset pagination on the primary key, same stability contract as findByPartyId /
+        // searchByIban — a sweep that pages while accounts open/close never skips or repeats
+        // a row it has already passed (ADR-0143 billing discovery).
+        val query = if (afterId != null) {
+            find("status = ?1 AND id > ?2 ORDER BY id", AccountStatus.ACTIVE.name, afterId)
+        } else {
+            find("status = ?1 ORDER BY id", AccountStatus.ACTIVE.name)
+        }
+        query.page(0, limit).list()
+    }.awaitSuspending().map { it.toDomain() }
 
     override suspend fun save(account: Account): Account {
         val entity = account.toEntity()

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/rest/AccountResource.kt
@@ -14,6 +14,7 @@ import com.openbank.account.application.port.`in`.FreezeAccountCommand
 import com.openbank.account.application.port.`in`.GetAccountByIbanQuery
 import com.openbank.account.application.port.`in`.GetAccountQuery
 import com.openbank.account.application.port.`in`.ListAccountsQuery
+import com.openbank.account.application.port.`in`.ListActiveAccountsQuery
 import com.openbank.account.application.port.`in`.ListPocketsQuery
 import com.openbank.account.application.port.`in`.OpenAccountCommand
 import com.openbank.account.application.port.`in`.ResolvePocketQuery
@@ -208,6 +209,23 @@ class AccountResource(
             return Response.status(400).entity(mapOf("error" to "q is required")).build()
         }
         val page = accountUseCase.searchAccounts(SearchAccountsQuery(q, limit, cursor))
+        return Response.ok(page.toResponse()).build()
+    }
+
+    // ADR-0143: the fleet-wide "list every billable account" read billing-service's cycle
+    // scheduler discovers its batch from. Deliberately NOT customer-facing: no partyId scoping
+    // header, staff/service roles only, page size capped in the use-case. The literal /active
+    // segment wins over the /{accountId} template per JAX-RS matching, so no route ambiguity.
+    @GET
+    @Path("/active")
+    @RolesAllowed(Roles.SERVICE, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "account.list")
+    @Operation(summary = "List all ACTIVE accounts fleet-wide, cursor-paginated (billing discovery)")
+    suspend fun listActiveAccounts(
+        @QueryParam("limit") @DefaultValue("100") limit: Int,
+        @QueryParam("cursor") cursor: String?,
+    ): Response {
+        val page = accountUseCase.listActiveAccounts(ListActiveAccountsQuery(limit, cursor))
         return Response.ok(page.toResponse()).build()
     }
 

--- a/openbank-account-service/src/main/resources/openapi.yaml
+++ b/openbank-account-service/src/main/resources/openapi.yaml
@@ -3,9 +3,9 @@
 openapi: 3.1.0
 info:
   title: Account Service API
-  # Kept in lockstep with version.txt / quarkus.application.version
-  # (ADR-0029 D2 single-source invariant).
-  version: 1.3.1
+  # API-contract axis (ADR-0048) — bumps are classified from the OpenAPI diff,
+  # independently of the release version in version.txt.
+  version: 1.4.0
   description: BIAN-aligned account lifecycle management — open, query, freeze, close accounts.
   contact:
     name: OpenBank Platform
@@ -130,6 +130,36 @@ paths:
                 $ref: '#/components/schemas/AccountPage'
         '400':
           description: q query parameter is required
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/accounts/active:
+    get:
+      tags: [Accounts]
+      summary: List all ACTIVE accounts fleet-wide, cursor-paginated
+      description: >
+        Fleet-wide sweep over ACTIVE accounts (ADR-0143: the "list every billable account"
+        read billing-service's cycle scheduler discovers its batch from). Staff/service roles
+        only — not customer-facing. Page size is capped at 200.
+      operationId: listActiveAccounts
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+            maximum: 200
+        - name: cursor
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Paginated list of ACTIVE accounts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPage'
         '403':
           $ref: '#/components/responses/Forbidden'
 

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/application/usecase/AccountServiceTest.kt
@@ -3,6 +3,7 @@ package com.openbank.account.application.usecase
 
 import com.openbank.account.application.port.`in`.CloseAccountCommand
 import com.openbank.account.application.port.`in`.ListAccountsQuery
+import com.openbank.account.application.port.`in`.ListActiveAccountsQuery
 import com.openbank.account.application.port.`in`.OpenAccountCommand
 import com.openbank.account.application.port.`in`.SearchAccountsQuery
 import com.openbank.account.application.port.out.AccountEventPublisher
@@ -199,6 +200,34 @@ class AccountServiceTest {
         assertThat(page.data).containsExactly(accounts[0], accounts[1])
         assertThat(page.pagination.hasNextPage).isTrue()
         assertThat(CursorEncoder.decode(page.pagination.nextCursor!!)).isEqualTo(accounts[1].id.toString())
+    }
+
+    @Test
+    fun `list active accounts decodes incoming cursor and emits next cursor from last item`(): Unit = runBlocking {
+        val afterId = UUID.randomUUID()
+        val accounts = listOf(
+            account(id = UUID.randomUUID(), partyId = UUID.randomUUID()),
+            account(id = UUID.randomUUID(), partyId = UUID.randomUUID()),
+            account(id = UUID.randomUUID(), partyId = UUID.randomUUID()),
+        )
+        coEvery { accountRepository.findActive(3, afterId) } returns accounts
+
+        val page = service.listActiveAccounts(
+            ListActiveAccountsQuery(limit = 2, afterCursor = CursorEncoder.encode(afterId.toString())),
+        )
+
+        assertThat(page.data).containsExactly(accounts[0], accounts[1])
+        assertThat(page.pagination.hasNextPage).isTrue()
+        assertThat(CursorEncoder.decode(page.pagination.nextCursor!!)).isEqualTo(accounts[1].id.toString())
+    }
+
+    @Test
+    fun `list active accounts caps the page size at the sweep maximum`(): Unit = runBlocking {
+        coEvery { accountRepository.findActive(any(), null) } returns emptyList()
+
+        service.listActiveAccounts(ListActiveAccountsQuery(limit = 9999))
+
+        coVerify { accountRepository.findActive(AccountService.MAX_ACTIVE_LIST_LIMIT + 1, null) }
     }
 
     // ── Sanctions gate tests (ADR-0032 §C) ────────────────────────────────────

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/AccountSecurityContractTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/rest/AccountSecurityContractTest.kt
@@ -56,6 +56,7 @@ class AccountSecurityContractTest {
             "getAccount",
             "getAccountByIban",
             "listAccounts",
+            "listActiveAccounts",
             "searchAccounts",
             "getBalance",
             "listPockets",

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/ActiveAccountsApiIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/ActiveAccountsApiIT.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.account.integration
+
+import com.openbank.libs.security.Roles
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.hamcrest.Matchers.everyItem
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Security + behaviour contract for the fleet-wide active-account listing (ADR-0143: the
+ * "list every billable account" read billing-service's cycle scheduler discovers its batch
+ * from). Like `/search`, `/api/v1/accounts/active` is an account-enumeration surface, so the
+ * access contract is asserted end-to-end against the real Quarkus stack:
+ *
+ *  - **401** — an unauthenticated caller is rejected before any query runs.
+ *  - **403** — an authenticated caller whose role is outside `{SERVICE, VIEWER, OPERATOR, ADMIN}`
+ *    is rejected (here `ROLE_COMPLIANCE`), proving `@RolesAllowed` actually gates the route.
+ *  - **200** — an allowed role can sweep; a freshly-opened (ACTIVE) account appears, and every
+ *    returned row is ACTIVE — the sweep never leaks CLOSED/FROZEN accounts to a billing run.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.account.it.PostgresRedpandaRedisTestResource::class)
+class ActiveAccountsApiIT {
+
+    private val partyId = UUID.fromString("00000000-1111-0000-0000-000000000002")
+    private val productId = UUID.fromString("00000000-2222-0000-0000-000000000001")
+
+    @Test
+    fun `GET active without authentication returns 401`() {
+        When {
+            get("/api/v1/accounts/active")
+        } Then {
+            statusCode(401)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = [Roles.COMPLIANCE])
+    fun `GET active with a role outside the allowed set returns 403`() {
+        When {
+            get("/api/v1/accounts/active")
+        } Then {
+            statusCode(403)
+        }
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = [Roles.OPERATOR])
+    fun `GET active returns the freshly opened account and only ACTIVE rows`() {
+        // Seed an account so there is a real ACTIVE row to find (same fixtures as AccountApiIT).
+        val seeded = Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(
+                """
+                {
+                  "partyId": "$partyId",
+                  "productId": "$productId",
+                  "accountType": "CURRENT",
+                  "currencyCode": "CZK",
+                  "legalName": "Billing Sweep Customer"
+                }
+                """.trimIndent(),
+            )
+        } When {
+            post("/api/v1/accounts")
+        } Then {
+            statusCode(201)
+        }
+        val accountId: String = seeded.extract().body().jsonPath().getString("id")
+
+        Given {
+            queryParam("limit", 200)
+        } When {
+            get("/api/v1/accounts/active")
+        } Then {
+            statusCode(200)
+            body("data.id", hasItem(accountId))
+            body("data.status", everyItem(`is`("ACTIVE")))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/accounts/active` — a cursor-paginated, keyset-stable sweep over ACTIVE accounts. This is the fleet-wide "list every billable account" read port ADR-0143 flags as missing: `BillingCycleScheduler` in billing-service is currently operator-configured (`openbank.billing.scheduler.account-ids` CSV) because no such read existed. The billing-side consumer lands in a follow-up PR.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #548 (deferred follow-up: "a fleet-wide 'list every billable account' read port")

## Changes

- `AccountUseCase.listActiveAccounts` + `ListActiveAccountsQuery`, `AccountRepository.findActive` — keyset pagination by id (stable under concurrent open/close), page capped at `MAX_ACTIVE_LIST_LIMIT = 200`.
- `GET /api/v1/accounts/active` on `AccountResource` — `@RolesAllowed(SERVICE, VIEWER, OPERATOR, ADMIN)` (same read set as `/search`), `@Authorize(action = "account.list")` (existing action, no new OPA vocabulary). Literal `/active` segment wins over the `/{accountId}` template per JAX-RS matching.
- `openapi.yaml`: new path documented; **info.version 1.3.1 → 1.4.0** (new endpoint = minor on the API-contract axis, ADR-0048). Also fixed the stale "lockstep with version.txt" comment on `info.version` — the axes are independent (version.txt is 0.13.0).
- Threat model: new **I — information disclosure** changelog entry (fleet-wide enumeration surface, mitigations, residual risk).
- Tests: `ActiveAccountsApiIT` (401 unauthenticated / 403 disallowed role / 200 + only-ACTIVE-rows, end-to-end against the real stack), `AccountServiceTest` cursor + cap unit tests, `AccountSecurityContractTest` registers the new read.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [x] `detekt ktlintCheck koverVerify quarkusBuild` pass locally for the module.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (if REST API changed).
- Flyway/Avro: N/A — no DB or event change.
- [x] Docs updated (threat model).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- **New `@Suppress("TooManyFunctions")`** on `AccountRepository` + its impl (justification: the port is the cohesive query/persist surface of one aggregate; the added `findActive` tips it to detekt's threshold of 11 and splitting a single method out would scatter the aggregate's persistence surface — same rationale as the existing `KycRepositoryPort` suppression).
- [x] No new third-party dependency.
- Money-path service — 2 human approvals + threat-model review required (ADR-0030); threat-model entry included in this PR. **Not auto-mergeable by design.**
