### PR TITLE
feat(billing): discover the billing-cycle account batch from account-service (ADR-0143)

### DIFF
--- a/docs/adr/0143-runtime-product-fee-posting-via-a-dedicated-billing-service.md
+++ b/docs/adr/0143-runtime-product-fee-posting-via-a-dedicated-billing-service.md
@@ -2,13 +2,13 @@
 
 Date: 2026-06-29
 Decision-Status: Accepted   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
-Delivery-Status: Partial    <!-- Planned | Partial | Shipped | N/A — decision-only; phases 1a/1b/2a/2b/2c/2c-ii/2d/2e implemented pending money-path review (PR TBD); real-environment e2e verification + four-eyes enforcement flip still required before production -->
+Delivery-Status: Partial    <!-- Planned | Partial | Shipped | N/A — decision-only; phases 1a/1b/2a/2b/2c/2c-ii/2d merged via PR #549, 2e via PR #672 (superseding #637), gitops DB/Redis via #683/#684; real-environment e2e verification + four-eyes enforcement flip still required before production -->
 Author(s): Jiri Raska
 
-**Delivery note (updated 2026-07-07):**
+**Delivery note (updated 2026-07-10):**
 - **Service skeleton and logic** — ✅ Shipped: `openbank-billing-service` Dockerfile + GitOps added (PR #2813); phases 1a/1b/2a/2b/2c-i merged; four-eyes `post` verb, `@RestClient` ledger posting, idempotency, balance/account context reads designed.
-- **Phase 2c (persistence + outbox + ledger posting + scheduled trigger)** — ✅ Implemented, pending
-  the required 2-approval + threat-model money-path review (ADR-0030) before merge: Flyway
+- **Phase 2c (persistence + outbox + ledger posting + scheduled trigger)** — ✅ Merged (PR #549,
+  money-path review per ADR-0030): Flyway
   migrations (`billing_cycle_assessment`, `assessed_fee`, `billing_outbox`), a `@RestClient` ledger
   posting adapter (`LedgerPostingAdapter`/`BillingJournalFactory`, mirrors
   `openbank-settlement-service`/`openbank-lending-service`), the transactional outbox
@@ -48,9 +48,14 @@ Author(s): Jiri Raska
   `reversal_reason`, `reversed_at`) via `V4__add_fee_reversal.sql`. Idempotent (re-reversing an
   already-REVERSAL_PENDING/REVERSED fee is a no-op replay) and fails cleanly — 404 for a fee never
   assessed, 409 for a fee never POSTED (waived/zero/still PENDING/FAILED) — never a generic 500.
-- **Known gaps, honestly scoped (not blockers for this PR, but block production go-live):**
-  there is no fleet-wide "list every billable account" read port, so `BillingCycleScheduler`'s
-  account batch is operator-configured rather than autonomously discovered (disabled by default);
+- **Account discovery (issue #548 follow-up)** — ✅ Implemented: account-service exposes the
+  fleet-wide `GET /api/v1/accounts/active` read (cursor-paginated, ACTIVE rows only, page cap
+  200); `BillingCycleScheduler` consumes it via `BillableAccountDiscoveryPort` when the
+  operator CSV is empty **and** `openbank.billing.scheduler.discovery-enabled=true` (its own
+  opt-in on top of `enabled`, since a discovered sweep charges every active account in the
+  fleet). An operator-configured CSV still wins as a deliberate manual override; default
+  config remains a safe no-op.
+- **Known gaps, honestly scoped (block production go-live):**
   `authz.four-eyes.enforce` needs a deliberate flip once the maker/checker runbook is reviewed;
   none of this has been deployed to or verified in a real environment (sandbox) yet.
 - **Money-path go-live** — ⬜ Still deploy-gated pending: real-environment (sandbox) e2e

--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -123,11 +123,17 @@ Trust boundaries: every inbound/outbound hop is service↔service over mTLS with
   lag is a correctness assumption to be reconciled.
 - Fee reversal/refund is **not** in the initial charge path (milestone 2e) and is required before
   any production go-live.
-- **No fleet-wide "list every billable account" read port exists yet.** `BillingCycleScheduler`'s
-  account batch is therefore operator-configured (`openbank.billing.scheduler.account-ids`), not
-  autonomously discovered — disabled by default (`openbank.billing.scheduler.enabled=false`) so it
-  cannot charge anyone by accident before that follow-up lands. Mirrors the same honestly-scoped
-  gap in `InterestService.accrueAll`/`capitalizeAll`.
+- **Account discovery (2026-07-10):** `BillingCycleScheduler`'s batch can now be autonomously
+  discovered from account-service's fleet-wide `GET /api/v1/accounts/active`
+  (`BillableAccountDiscoveryPort` → the existing billing→account-service trust boundary and OIDC
+  M2M client — no new boundary, a second read on an established one). Because a discovered sweep
+  charges EVERY active account, it is double-gated: `openbank.billing.scheduler.enabled` AND
+  `openbank.billing.scheduler.discovery-enabled` (both default `false`); a configured
+  `account-ids` CSV always wins as a deliberate manual override. A failed page read aborts the
+  sweep (fail-closed, logged) — never a silently partial batch; the monthly re-run is idempotent
+  per (cycleId, accountId, currency). Residual: a compromised account-service response could
+  inflate the batch — bounded by assessment idempotency and by every charge still resolving its
+  own account/product context fail-closed before any posting.
 - `authz.four-eyes.enforce=false` by default (see §3): until an operator flips it on for this
   service, `billing.post` is authorized (single principal) but not yet dual-controlled in
   practice — OPA computing `four_eyes_required` correctly is necessary but not sufficient without
@@ -158,3 +164,8 @@ Trust boundaries: every inbound/outbound hop is service↔service over mTLS with
   404/409 failure modes. Phase 2d's DST invariant wired to a new seeded `FeeBillingScenario`
   (previously vacuous — confirmed and fixed, see §5). Updated the residual-risks list; removed the
   now-resolved DST-scenario gap and the phase-2e-not-built gap.
+- 2026-07-10 — account discovery landed (issue #548 follow-up): the cycle sweep can page
+  account-service's fleet-wide `GET /api/v1/accounts/active` via `BillableAccountDiscoveryPort`.
+  No new trust boundary (same billing→account-service OIDC M2M client as the existing account
+  read). Double-gated opt-in (`discovery-enabled` on top of `enabled`, both default off); CSV
+  override wins; fail-closed page reads. Rewrote the §5 "no discovery port" residual accordingly.

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/application/port/out/BillingPorts.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/application/port/out/BillingPorts.kt
@@ -96,3 +96,18 @@ interface LedgerPostingPort {
      */
     suspend fun postReversal(command: FeeReversalCommand): UUID
 }
+
+/** One page of the fleet-wide ACTIVE-account sweep (ADR-0143 billing discovery, issue #548). */
+data class BillableAccountsPage(val accountIds: List<String>, val nextCursor: String?)
+
+/**
+ * Discovers the accounts a billing cycle sweeps — account-service's fleet-wide
+ * `GET /api/v1/accounts/active` read (ADR-0143 / issue #548 follow-up: replaces the
+ * operator-configured account CSV as the batch source). Cursor-paginated; a `null`
+ * [BillableAccountsPage.nextCursor] means the sweep is complete. Backed by a reactive
+ * REST client; errors propagate so a failed page read aborts (and logs) the sweep
+ * rather than silently billing a partial batch.
+ */
+interface BillableAccountDiscoveryPort {
+    suspend fun activeAccounts(limit: Int, afterCursor: String?): BillableAccountsPage
+}

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/adapter/RealBillingAdapters.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/adapter/RealBillingAdapters.kt
@@ -6,6 +6,8 @@ package com.openbank.billing.infrastructure.adapter
 
 import com.openbank.billing.application.port.out.AccountBilling
 import com.openbank.billing.application.port.out.AccountContextPort
+import com.openbank.billing.application.port.out.BillableAccountDiscoveryPort
+import com.openbank.billing.application.port.out.BillableAccountsPage
 import com.openbank.billing.application.port.out.ProductCatalogPort
 import com.openbank.billing.domain.BillableFee
 import com.openbank.billing.infrastructure.client.AccountRestClient
@@ -43,6 +45,26 @@ class RestAccountContextPort(
             currency = currency,
         )
         return AccountBilling(productId = account.productId, context = context)
+    }
+}
+
+/**
+ * Discovers the billing sweep's account batch from account-service's fleet-wide
+ * `GET /api/v1/accounts/active` (ADR-0143 / issue #548 follow-up). Deliberately NOT
+ * fail-open: an error propagates so the scheduler aborts (and logs) the sweep instead of
+ * silently billing a partial batch — the monthly re-run is idempotent per
+ * (cycleId, accountId, currency), so an aborted sweep is safely retried.
+ */
+@ApplicationScoped
+class RestBillableAccountDiscoveryPort(@RestClient private val accounts: AccountRestClient) :
+    BillableAccountDiscoveryPort {
+
+    override suspend fun activeAccounts(limit: Int, afterCursor: String?): BillableAccountsPage {
+        val page = accounts.listActiveAccounts(limit, afterCursor).awaitSuspending()
+        return BillableAccountsPage(
+            accountIds = page.data.map { it.id },
+            nextCursor = if (page.pagination.hasNextPage) page.pagination.nextCursor else null,
+        )
     }
 }
 

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/client/BillingRestClients.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/client/BillingRestClients.kt
@@ -13,6 +13,7 @@ import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
@@ -38,6 +39,17 @@ data class AccountDto(val id: String, val productId: String, val currencyCode: S
 /** The subset of balance-service `GET /api/v1/balances/{accountId}/{currency}` we need. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class BalanceDto(val accountId: String, val currency: String, val currentBalance: BigDecimal)
+
+/** The subset of account-service's cursor-page envelope the discovery sweep needs. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountPageInfoDto(val hasNextPage: Boolean = false, val nextCursor: String? = null)
+
+/** One page of account-service `GET /api/v1/accounts/active` (ADR-0143 billing discovery). */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountPageDto(
+    val data: List<AccountDto> = emptyList(),
+    val pagination: AccountPageInfoDto = AccountPageInfoDto(),
+)
 
 /**
  * Product-catalog fee definitions (the catalog is the fee source-of-truth). product-catalog now
@@ -65,6 +77,11 @@ interface AccountRestClient {
     @GET
     @Path("/accounts/{id}")
     fun getAccount(@PathParam("id") accountId: String): Uni<AccountDto>
+
+    /** Fleet-wide ACTIVE-account sweep, cursor-paginated (ADR-0143 billing discovery). */
+    @GET
+    @Path("/accounts/active")
+    fun listActiveAccounts(@QueryParam("limit") limit: Int, @QueryParam("cursor") cursor: String?): Uni<AccountPageDto>
 }
 
 /** Balance read — balance is PII, so the call propagates an OIDC service token. */

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/scheduler/BillingCycleScheduler.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/scheduler/BillingCycleScheduler.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.billing.infrastructure.scheduler
 
+import com.openbank.billing.application.port.out.BillableAccountDiscoveryPort
 import com.openbank.billing.application.usecase.BillingCycleService
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
@@ -22,15 +23,19 @@ import java.util.Optional
  * directly (ADR-0100 DST rule, CI-enforced) — and delegates to [BillingCycleService.runCycle] for
  * every configured account.
  *
- * **Known limitation, honestly scoped**: there is no fleet-wide "list every billable account"
- * read port yet (account-service's `listAccounts` is scoped to a single `partyId`, and a
- * monthly-turnover-style aggregate read port does not exist either — ADR-0143's own "Negative"
- * consequences section flags this). Until that port lands, the account batch this scheduler
- * assesses is **operator-configured** (`openbank.billing.scheduler.account-ids`, a comma-separated
- * list) rather than autonomously discovered — the same honesty this codebase already applies to
- * `InterestService.accrueAll`/`capitalizeAll` (both are documented stubs pending "fetch all active
- * accounts"). An empty list is a safe no-op default so this scheduler cannot charge anyone by
- * accident before an operator wires real account discovery (a follow-up, tracked in the PR).
+ * **Batch source** (ADR-0143 / issue #548 follow-up): the fleet-wide "list every billable
+ * account" read port now exists — account-service's `GET /api/v1/accounts/active`, consumed via
+ * [BillableAccountDiscoveryPort]. Because a discovered sweep charges every ACTIVE account in the
+ * fleet, it is guarded by its own opt-in flag on top of `enabled`:
+ *
+ *  1. `openbank.billing.scheduler.account-ids` set → that operator-configured CSV is the batch
+ *     (deliberate manual override; discovery is NOT consulted).
+ *  2. CSV empty + `openbank.billing.scheduler.discovery-enabled=true` → the batch is discovered
+ *     by paging `activeAccounts` (page size `discovery-page-size`), one `runCycle` per page so a
+ *     large book never materializes in memory. A page-read failure aborts the sweep (logged
+ *     error); the monthly re-run is idempotent per (cycleId, accountId, currency).
+ *  3. Neither → safe no-op, same as before this port existed — the scheduler still cannot
+ *     charge anyone by accident on default config.
  */
 @ApplicationScoped
 class BillingCycleScheduler {
@@ -54,6 +59,16 @@ class BillingCycleScheduler {
     @ConfigProperty(name = "openbank.billing.scheduler.currency", defaultValue = "CZK")
     lateinit var currency: String
 
+    /** Opt-in for the fleet-wide discovered sweep (see class KDoc rule 2) — default OFF. */
+    @ConfigProperty(name = "openbank.billing.scheduler.discovery-enabled", defaultValue = "false")
+    var discoveryEnabled: Boolean = false
+
+    @ConfigProperty(name = "openbank.billing.scheduler.discovery-page-size", defaultValue = "100")
+    var discoveryPageSize: Int = DEFAULT_DISCOVERY_PAGE_SIZE
+
+    @Inject
+    lateinit var accountDiscovery: BillableAccountDiscoveryPort
+
     private val log = Logger.getLogger(BillingCycleScheduler::class.java)
 
     @Scheduled(
@@ -68,22 +83,68 @@ class BillingCycleScheduler {
             log.debug("[billing-cycle-scheduler] Disabled — skipping sweep")
             return
         }
+        val cycleId = cycleIdFor(LocalDate.now(clock))
         val accountIds = accountIdsCsv.orElse("").split(",").map { it.trim() }.filter { it.isNotEmpty() }
-        if (accountIds.isEmpty()) {
-            log.debug("[billing-cycle-scheduler] No accounts configured — skipping sweep")
+        when {
+            // Rule 1 (class KDoc): an operator-configured CSV is a deliberate manual override.
+            accountIds.isNotEmpty() -> {
+                log.infof(
+                    "[billing-cycle-scheduler] Starting billing cycle %s for %d configured account(s)",
+                    cycleId,
+                    accountIds.size,
+                )
+                val processed = billingCycleService.runCycle(cycleId, accountIds, currency)
+                log.infof(
+                    "[billing-cycle-scheduler] Billing cycle %s done: %d account(s) processed",
+                    cycleId,
+                    processed,
+                )
+            }
+            discoveryEnabled -> runDiscoveredSweep(cycleId)
+            else -> log.debug("[billing-cycle-scheduler] No accounts configured, discovery off — skipping sweep")
+        }
+    }
+
+    /** Rule 2 (class KDoc): page through account-service's ACTIVE-account sweep, one cycle per page. */
+    @Suppress("TooGenericExceptionCaught") // a failed sweep must abort with ONE clear log line, whatever threw
+    private suspend fun runDiscoveredSweep(cycleId: String) {
+        log.infof("[billing-cycle-scheduler] Starting billing cycle %s via account discovery", cycleId)
+        var cursor: String? = null
+        var pages = 0
+        var processed = 0
+        try {
+            do {
+                val page = accountDiscovery.activeAccounts(discoveryPageSize, cursor)
+                if (page.accountIds.isNotEmpty()) {
+                    processed += billingCycleService.runCycle(cycleId, page.accountIds, currency)
+                    pages++
+                }
+                cursor = page.nextCursor
+            } while (cursor != null)
+        } catch (e: Exception) {
+            // Abort, don't swallow-and-continue: the monthly re-run is idempotent per
+            // (cycleId, accountId, currency), so the safe move is to stop and retry whole.
+            log.errorf(
+                e,
+                "[billing-cycle-scheduler] Billing cycle %s aborted after %d page(s), %d account(s) processed",
+                cycleId,
+                pages,
+                processed,
+            )
             return
         }
-        val cycleId = cycleIdFor(LocalDate.now(clock))
         log.infof(
-            "[billing-cycle-scheduler] Starting billing cycle %s for %d configured account(s)",
+            "[billing-cycle-scheduler] Billing cycle %s done: %d account(s) processed across %d page(s)",
             cycleId,
-            accountIds.size,
+            processed,
+            pages,
         )
-        val processed = billingCycleService.runCycle(cycleId, accountIds, currency)
-        log.infof("[billing-cycle-scheduler] Billing cycle %s done: %d account(s) processed", cycleId, processed)
     }
 
     companion object {
+        /** Matches account-service's own default page size for the /accounts/active sweep. */
+        const val DEFAULT_DISCOVERY_PAGE_SIZE = 100
+
         private val CYCLE_ID_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM")
 
         /** The billing cycle id for a date: the calendar month, e.g. `2026-07`. */

--- a/openbank-billing-service/src/main/resources/application.yaml
+++ b/openbank-billing-service/src/main/resources/application.yaml
@@ -129,13 +129,18 @@ openbank:
     initial-delay: 5s
   billing:
     scheduler:
-      # Disabled by default: the account batch is operator-configured (no fleet-wide account
-      # discovery port exists yet — see BillingCycleScheduler's KDoc). Flip on and set
-      # account-ids only after that follow-up lands or for a deliberately scoped manual run.
+      # Disabled by default — the scheduler cannot charge anyone on default config.
+      # Batch source (BillingCycleScheduler KDoc, ADR-0143 / issue #548): account-ids CSV set
+      # -> deliberate manual override; CSV empty + discovery-enabled=true -> the batch is
+      # discovered from account-service's fleet-wide GET /api/v1/accounts/active; neither -> no-op.
       enabled: "${BILLING_SCHEDULER_ENABLED:false}"
       cron: "${BILLING_SCHEDULER_CRON:0 0 3 1 * ?}"
       account-ids: "${BILLING_SCHEDULER_ACCOUNT_IDS:}"
       currency: "${BILLING_SCHEDULER_CURRENCY:CZK}"
+      # Fleet-wide discovered sweep charges EVERY active account — its own opt-in on top of
+      # `enabled`, so flipping the scheduler on for a scoped manual run can never fan out.
+      discovery-enabled: "${BILLING_SCHEDULER_DISCOVERY_ENABLED:false}"
+      discovery-page-size: "${BILLING_SCHEDULER_DISCOVERY_PAGE_SIZE:100}"
 
 "%dev":
   quarkus:

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingCycleSchedulerTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingCycleSchedulerTest.kt
@@ -4,6 +4,8 @@
 
 package com.openbank.billing
 
+import com.openbank.billing.application.port.out.BillableAccountDiscoveryPort
+import com.openbank.billing.application.port.out.BillableAccountsPage
 import com.openbank.billing.application.usecase.BillingCycleService
 import com.openbank.billing.infrastructure.scheduler.BillingCycleScheduler
 import io.mockk.coEvery
@@ -78,6 +80,80 @@ class BillingCycleSchedulerTest {
 
         scheduler.runSweep()
 
+        coVerify(exactly = 1) { cycleService.runCycle("2026-07", listOf("acc-1", "acc-2"), "CZK") }
+    }
+
+    // ── Discovered sweep (ADR-0143 / issue #548 follow-up) ────────────────────────────────
+
+    private fun discoveryScheduler(
+        cycleService: BillingCycleService,
+        discovery: BillableAccountDiscoveryPort,
+        csv: Optional<String> = Optional.empty(),
+        discoveryOn: Boolean = true,
+    ) = BillingCycleScheduler().apply {
+        billingCycleService = cycleService
+        clock = Clock.fixed(Instant.parse("2026-07-15T03:00:00Z"), ZoneOffset.UTC)
+        enabled = true
+        accountIdsCsv = csv
+        currency = "CZK"
+        discoveryEnabled = discoveryOn
+        discoveryPageSize = 2
+        accountDiscovery = discovery
+    }
+
+    @Test
+    fun `discovered sweep pages through active accounts, one cycle per page`(): Unit = runBlocking {
+        val cycleService = mockk<BillingCycleService>()
+        val discovery = mockk<BillableAccountDiscoveryPort>()
+        coEvery { discovery.activeAccounts(2, null) } returns
+            BillableAccountsPage(listOf("acc-1", "acc-2"), nextCursor = "c1")
+        coEvery { discovery.activeAccounts(2, "c1") } returns
+            BillableAccountsPage(listOf("acc-3"), nextCursor = null)
+        coEvery { cycleService.runCycle("2026-07", listOf("acc-1", "acc-2"), "CZK") } returns 2
+        coEvery { cycleService.runCycle("2026-07", listOf("acc-3"), "CZK") } returns 1
+
+        discoveryScheduler(cycleService, discovery).runSweep()
+
+        coVerify(exactly = 1) { cycleService.runCycle("2026-07", listOf("acc-1", "acc-2"), "CZK") }
+        coVerify(exactly = 1) { cycleService.runCycle("2026-07", listOf("acc-3"), "CZK") }
+    }
+
+    @Test
+    fun `operator-configured CSV wins over discovery`(): Unit = runBlocking {
+        val cycleService = mockk<BillingCycleService>()
+        val discovery = mockk<BillableAccountDiscoveryPort>()
+        coEvery { cycleService.runCycle("2026-07", listOf("acc-9"), "CZK") } returns 1
+
+        discoveryScheduler(cycleService, discovery, csv = Optional.of("acc-9")).runSweep()
+
+        coVerify(exactly = 1) { cycleService.runCycle("2026-07", listOf("acc-9"), "CZK") }
+        coVerify(exactly = 0) { discovery.activeAccounts(any(), any()) }
+    }
+
+    @Test
+    fun `discovery off and no CSV stays a safe no-op`(): Unit = runBlocking {
+        val cycleService = mockk<BillingCycleService>()
+        val discovery = mockk<BillableAccountDiscoveryPort>()
+
+        discoveryScheduler(cycleService, discovery, discoveryOn = false).runSweep()
+
+        coVerify(exactly = 0) { cycleService.runCycle(any(), any(), any()) }
+        coVerify(exactly = 0) { discovery.activeAccounts(any(), any()) }
+    }
+
+    @Test
+    fun `a failed page read aborts the sweep without throwing`(): Unit = runBlocking {
+        val cycleService = mockk<BillingCycleService>()
+        val discovery = mockk<BillableAccountDiscoveryPort>()
+        coEvery { discovery.activeAccounts(2, null) } returns
+            BillableAccountsPage(listOf("acc-1", "acc-2"), nextCursor = "c1")
+        coEvery { discovery.activeAccounts(2, "c1") } throws IllegalStateException("account-service unreachable")
+        coEvery { cycleService.runCycle("2026-07", listOf("acc-1", "acc-2"), "CZK") } returns 2
+
+        discoveryScheduler(cycleService, discovery).runSweep()
+
+        // The first page was processed; the failure stopped the sweep (idempotent monthly retry)
+        // and did not propagate out of the @Scheduled entrypoint.
         coVerify(exactly = 1) { cycleService.runCycle("2026-07", listOf("acc-1", "acc-2"), "CZK") }
     }
 }

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/RestBillingAdaptersTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/RestBillingAdaptersTest.kt
@@ -5,8 +5,11 @@
 package com.openbank.billing
 
 import com.openbank.billing.infrastructure.adapter.RestAccountContextPort
+import com.openbank.billing.infrastructure.adapter.RestBillableAccountDiscoveryPort
 import com.openbank.billing.infrastructure.adapter.RestProductCatalogPort
 import com.openbank.billing.infrastructure.client.AccountDto
+import com.openbank.billing.infrastructure.client.AccountPageDto
+import com.openbank.billing.infrastructure.client.AccountPageInfoDto
 import com.openbank.billing.infrastructure.client.AccountRestClient
 import com.openbank.billing.infrastructure.client.BalanceDto
 import com.openbank.billing.infrastructure.client.BalanceRestClient
@@ -65,6 +68,44 @@ class RestBillingAdaptersTest {
 
         assertThat(r).isNotNull
         assertThat(r!!.context.balance).isNull()
+    }
+
+    @Test
+    fun `activeAccounts maps ids and forwards the cursor only while more pages exist`(): Unit = runBlocking {
+        val accounts = mockk<AccountRestClient>()
+        every { accounts.listActiveAccounts(100, null) } returns Uni.createFrom().item(
+            AccountPageDto(
+                data = listOf(AccountDto("acc-1", "prod-1", "CZK"), AccountDto("acc-2", "prod-1", "CZK")),
+                pagination = AccountPageInfoDto(hasNextPage = true, nextCursor = "c1"),
+            ),
+        )
+        every { accounts.listActiveAccounts(100, "c1") } returns Uni.createFrom().item(
+            AccountPageDto(
+                data = listOf(AccountDto("acc-3", "prod-2", "CZK")),
+                pagination = AccountPageInfoDto(hasNextPage = false, nextCursor = null),
+            ),
+        )
+        val port = RestBillableAccountDiscoveryPort(accounts)
+
+        val first = port.activeAccounts(100, null)
+        assertThat(first.accountIds).containsExactly("acc-1", "acc-2")
+        assertThat(first.nextCursor).isEqualTo("c1")
+
+        val last = port.activeAccounts(100, "c1")
+        assertThat(last.accountIds).containsExactly("acc-3")
+        assertThat(last.nextCursor).isNull()
+    }
+
+    @Test
+    fun `activeAccounts propagates a failed page read instead of failing open`(): Unit = runBlocking {
+        val accounts = mockk<AccountRestClient>()
+        every { accounts.listActiveAccounts(any(), any()) } returns
+            Uni.createFrom().failure(RuntimeException("account-service down"))
+        val port = RestBillableAccountDiscoveryPort(accounts)
+
+        val thrown = runCatching { port.activeAccounts(100, null) }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(RuntimeException::class.java)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes the last implementable follow-up of #548: `BillingCycleScheduler` can now discover its account batch autonomously from account-service's fleet-wide `GET /api/v1/accounts/active` (added in #735), instead of relying solely on the operator-configured CSV. Also refreshes ADR-0143's stale delivery note and the billing threat model.

**Depends on #735** (the account-service endpoint) — merge that first; until it is deployed, a discovery-enabled sweep aborts fail-closed on the 404 and logs.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #548

## Changes

- `BillableAccountDiscoveryPort` + `RestBillableAccountDiscoveryPort` (pages `GET /api/v1/accounts/active` via the existing billing→account-service OIDC M2M client — no new trust boundary).
- `BillingCycleScheduler`: batch-source precedence — (1) operator CSV wins as a deliberate manual override, (2) else discovery when `openbank.billing.scheduler.discovery-enabled=true` (**its own opt-in on top of `enabled`, both default `false`** — a discovered sweep charges every ACTIVE account, so flipping the scheduler on for a scoped manual run can never fan out), (3) else safe no-op, as before. One `runCycle` per page (`discovery-page-size`, default 100) so a large book never materializes in memory; a failed page read aborts the sweep fail-closed with one error log — never a silently partial batch (monthly re-run is idempotent per cycle/account/currency).
- ADR-0143: delivery note was stale ("pending money-path review, PR TBD") — refreshed to reflect 2c merged in #549, 2e in #672 (superseding #637), gitops provisioning in #683/#684, and this discovery follow-up. Remaining go-live gates unchanged: four-eyes enforce flip + sandbox e2e.
- Threat model: §5 residual rewritten (discovery now exists, double-gated), §6 changelog entry added.
- Tests: scheduler paging / CSV-override / double-gate no-op / abort-on-failure; adapter mapping + fail-closed propagation.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] `test detekt ktlintCheck koverVerify quarkusBuild` pass locally for the module.
- [x] No new lint warnings.
- OpenAPI/Flyway/Avro: N/A — no inbound API, DB, or event change (outbound REST client only).
- [x] Docs updated (ADR delivery note + threat model).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- **New `@Suppress("TooGenericExceptionCaught")`** on `runDiscoveredSweep` (justification: whatever a page read throws — REST client `ProcessingException`, timeout, mapping error — the correct behaviour is identical: abort the sweep with one clear error log and let the idempotent monthly re-run retry; catching narrowly would let an unclassified failure escape the abort logging. Same pattern as `LoanStageEventConsumer`/`ModelGateway`).
- [x] No new third-party dependency.
- Money-path service — 2 human approvals + threat-model review required (ADR-0030); threat-model updated in this PR. **Not auto-mergeable by design.**
