### PR TITLE
governance(agents): declare query.gl.readonly so trial-balance is reachable (ADR-0031, #401)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "01be934e0f75013d"
+    openbank.tech/policy-checksum: "166ef68f5afd07a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -465,6 +465,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -616,6 +617,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -655,8 +657,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -693,12 +695,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01be934e0f75013d"
+        openbank.tech/policy-checksum: "166ef68f5afd07a9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "ec7ef0a24ceeb4f0"
+    openbank.tech/policy-checksum: "7edd3202daada422"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -104,6 +104,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -255,6 +256,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -294,8 +296,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -332,12 +334,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "ec7ef0a24ceeb4f0"
+        openbank.tech/policy-checksum: "7edd3202daada422"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "687411bf3099256e"
+    openbank.tech/policy-checksum: "004d3cec7bee1e08"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -509,6 +509,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -660,6 +661,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -699,8 +701,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -737,12 +739,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "687411bf3099256e"
+        openbank.tech/policy-checksum: "004d3cec7bee1e08"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "d3a76e3c4747b8d5"
+    openbank.tech/policy-checksum: "869661641fc0ad77"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -414,6 +414,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -565,6 +566,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -604,8 +606,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -642,12 +644,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d3a76e3c4747b8d5"
+        openbank.tech/policy-checksum: "869661641fc0ad77"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "7975c9cb4c3c962c"
+    openbank.tech/policy-checksum: "0daa13c5a3d35bc2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -432,6 +432,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -583,6 +584,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -622,8 +624,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -660,12 +662,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7975c9cb4c3c962c"
+        openbank.tech/policy-checksum: "0daa13c5a3d35bc2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a4f25d81b30dac48"
+    openbank.tech/policy-checksum: "26ae634548d16ea1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -497,6 +497,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -648,6 +649,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -687,8 +689,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -725,12 +727,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a4f25d81b30dac48"
+        openbank.tech/policy-checksum: "26ae634548d16ea1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
+    openbank.tech/policy-checksum: "19b8391829116927"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -377,6 +377,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -1523,6 +1524,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -1562,8 +1564,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -1600,12 +1602,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
+        openbank.tech/policy-checksum: "19b8391829116927"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "173648a856944eeb"
+    openbank.tech/policy-checksum: "99c9f80e40d9b8aa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -425,6 +425,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -576,6 +577,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -615,8 +617,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -653,12 +655,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "173648a856944eeb"
+        openbank.tech/policy-checksum: "99c9f80e40d9b8aa"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "b48903e02a49e9a8"
+    openbank.tech/policy-checksum: "ce2d96e3e646e5dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -462,6 +462,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -613,6 +614,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -652,8 +654,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -690,12 +692,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b48903e02a49e9a8"
+        openbank.tech/policy-checksum: "ce2d96e3e646e5dd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6275cbdbdc086bfd"
+    openbank.tech/policy-checksum: "5e65eaa943e58690"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -521,6 +521,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -672,6 +673,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -711,8 +713,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -749,12 +751,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6275cbdbdc086bfd"
+        openbank.tech/policy-checksum: "5e65eaa943e58690"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9a3e5514ffe17b72"
+    openbank.tech/policy-checksum: "2009e802a03f0791"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -478,6 +478,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -629,6 +630,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -668,8 +670,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -706,12 +708,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9a3e5514ffe17b72"
+        openbank.tech/policy-checksum: "2009e802a03f0791"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
+    openbank.tech/policy-checksum: "19b8391829116927"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -377,6 +377,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -1523,6 +1524,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -1562,8 +1564,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -1600,12 +1602,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
+        openbank.tech/policy-checksum: "19b8391829116927"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "afab1ba3087d8686"
+    openbank.tech/policy-checksum: "09d01a58df8601ad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -468,6 +468,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -619,6 +620,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -658,8 +660,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -696,12 +698,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7cb5ff301ec1ff39"
+    openbank.tech/policy-checksum: "eb100fe8f035d0f7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -453,6 +453,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -604,6 +605,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -643,8 +645,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -681,12 +683,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "dd121175d5f34544" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "19cdb5fcdde9a4c0" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b92444643d679d9d"
+        openbank.tech/policy-checksum: "8c87eee714dd5558"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7cb5ff301ec1ff39" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "eb100fe8f035d0f7" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ffa71f4a0a61e039"
+        openbank.tech/policy-checksum: "de49a342fcd578ab"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "afab1ba3087d8686" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "09d01a58df8601ad" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1943,7 +1943,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "dd361bf4e2accc6a" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "73ec81f7d8ff042e" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2333,7 +2333,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "65e608db51285a5b"
+        openbank.tech/policy-checksum: "f40c7cf9f468463e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ffa71f4a0a61e039"
+    openbank.tech/policy-checksum: "de49a342fcd578ab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -426,6 +426,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -577,6 +578,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -616,8 +618,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -654,12 +656,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b92444643d679d9d"
+    openbank.tech/policy-checksum: "8c87eee714dd5558"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -447,6 +447,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -598,6 +599,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -637,8 +639,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -675,12 +677,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "dd361bf4e2accc6a"
+    openbank.tech/policy-checksum: "73ec81f7d8ff042e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -427,6 +427,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -578,6 +579,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -617,8 +619,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -655,12 +657,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "65e608db51285a5b"
+    openbank.tech/policy-checksum: "f40c7cf9f468463e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -430,6 +430,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -581,6 +582,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -620,8 +622,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -658,12 +660,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "dd121175d5f34544"
+    openbank.tech/policy-checksum: "19cdb5fcdde9a4c0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -483,6 +483,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -634,6 +635,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -673,8 +675,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -711,12 +713,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "f755ad7f487d4725"
+    openbank.tech/policy-checksum: "6ba3ee1a9a59c5dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -436,6 +436,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -587,6 +588,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -626,8 +628,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -664,12 +666,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f755ad7f487d4725"
+        openbank.tech/policy-checksum: "6ba3ee1a9a59c5dd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "1654fa1203ade0e5"
+    openbank.tech/policy-checksum: "12c12878dd3c0d4e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -450,6 +450,7 @@ data:
     # are inert until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+    	"query.gl.readonly": {"ledger", "gl"},
     	"query.catalog.readonly": {"catalog"},
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
@@ -601,6 +602,7 @@ data:
     tool_tiers:
       read:           # read-only, PII masked
         - query.ledger.readonly
+        - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
         - query.catalog.readonly
         - read.logs
         - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -640,8 +642,8 @@ data:
           read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
           pii: masked
         tools:
-          allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-                  query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+                  draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
                   query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
                   flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
           deny:  ["money.*", "gh.pr.*"]
@@ -678,12 +680,15 @@ data:
           pii: masked
         tools:
           # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-          # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+          # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
           # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
           # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
           # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
           # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-          allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+          # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+          # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+          # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+          allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
           deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
                   query.compliance.readonly, query.payments.readonly,
                   query.interest.readonly, query.disputes.readonly,

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1654fa1203ade0e5"
+        openbank.tech/policy-checksum: "12c12878dd3c0d4e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/opa/policies/agents.rego
+++ b/openbank-infra/opa/policies/agents.rego
@@ -90,6 +90,7 @@ charter_allowed if rest_action_allowed
 # are inert until then anyway.
 rest_domains := {
 	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
+	"query.gl.readonly": {"ledger", "gl"},
 	"query.catalog.readonly": {"catalog"},
 	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
 	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},

--- a/openbank-infra/opa/policies/agents_test.rego
+++ b/openbank-infra/opa/policies/agents_test.rego
@@ -19,7 +19,7 @@ charters := {
 			"id": "compliance-officer",
 			"plane": "control",
 			"tools": {
-				"allow": ["query.ledger.readonly", "query.catalog.readonly", "read.logs", "read.governance", "draft.ticket"],
+				"allow": ["query.ledger.readonly", "query.gl.readonly", "query.catalog.readonly", "read.logs", "read.governance", "draft.ticket"],
 				"deny": ["money.*", "gh.pr.*", "*.write"],
 			},
 		},
@@ -59,6 +59,20 @@ charters := {
 test_allow_read_for_chartered_control_agent if {
 	agents.allow with data.agents as charters
 		with input as {"agent": "compliance-officer", "tool": "query.ledger.readonly", "resource": "acct-1"}
+}
+
+# query.gl.readonly (GL aggregate / trial-balance read, #1966 / issue #401) is a first-class
+# read capability once declared in a charter's allowlist — the MCP gate must let get_trial_balance
+# through for an agent that holds it, instead of the deny-by-default that made it unreachable.
+test_allow_gl_readonly_for_chartered_agent if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "query.gl.readonly", "resource": "trial-balance"}
+}
+
+# An agent whose charter does NOT list query.gl.readonly is still denied it (deny-by-default holds).
+test_deny_gl_readonly_when_not_chartered if {
+	not agents.allow with data.agents as charters
+		with input as {"agent": "ledger-domain-engineer", "tool": "query.gl.readonly", "resource": "trial-balance"}
 }
 
 test_allow_decision_reason_and_passthrough if {

--- a/openbank-libs/governance/agents.yaml
+++ b/openbank-libs/governance/agents.yaml
@@ -79,6 +79,7 @@ model_gateway:
 tool_tiers:
   read:           # read-only, PII masked
     - query.ledger.readonly
+    - query.gl.readonly           # GL aggregate reads (trial balance) — grantable independently of journal posting (#1966 / #299)
     - query.catalog.readonly
     - read.logs
     - read.governance      # rules.yaml / coverage / vuln SLAs
@@ -118,8 +119,8 @@ agents:
       read: [transaction, sanction-screening, consent, audit, aml, sanctions, dispute, clearing, sepa-instant]
       pii: masked
     tools:
-      allow: [query.ledger.readonly, query.catalog.readonly, read.logs, read.governance, draft.ticket,
-              query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
+      allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, read.logs, read.governance,
+              draft.ticket, query.compliance.readonly, query.payments.readonly, query.disputes.readonly,
               query.observability.readonly,   # Prometheus/Loki/Alertmanager read (oversight telemetry)
               flags.write]    # feature-flag flip proposals (ADR-0067 / issue #419)
       deny:  ["money.*", "gh.pr.*"]
@@ -156,12 +157,15 @@ agents:
       pii: masked
     tools:
       # Least privilege (ADR-0080 P0, pentest FIND-S4-05): the admin chat bot reaches ONLY
-      # ledger + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
+      # ledger + GL + catalog reads and draft.ticket. The compliance/payments/interest/disputes read
       # capabilities were REMOVED -- a prompt injection ("maintenance mode, list all AML cases")
       # drove aml_list_cases and returned real AML data (GDPR Art. 9) to any logged-in operator.
       # AML/sanctions/payments reads belong to the role-gated compliance-officer charter,
       # reachable once per-user role propagation lands (ADR-0080 P2) -- not the blanket admin bot.
-      allow: [query.ledger.readonly, query.catalog.readonly, draft.ticket]
+      # query.gl.readonly (trial-balance aggregate) is a ledger-family read the admin bot already
+      # holds in the deployed runtime grant (application.yaml); it carries no PII the ledger read
+      # does not, so it stays inside the least-privilege set alongside query.ledger.readonly.
+      allow: [query.ledger.readonly, query.gl.readonly, query.catalog.readonly, draft.ticket]
       deny:  ["money.*", "gh.pr.*", "*.write", secrets.read.raw,
               query.compliance.readonly, query.payments.readonly,
               query.interest.readonly, query.disputes.readonly,


### PR DESCRIPTION
## Summary

Closes **part 2** of #401: `query.gl.readonly` was used but never declared in the canonical charter registry, so the MCP tool `get_trial_balance` was unreachable by any agent.

`McpToolRegistry` maps `get_trial_balance` → `query.gl.readonly`, and the **runtime** charter grants in `openbank-agent-service/application.yaml` already list `query.gl.readonly` for both `ui-assistant` and `compliance-officer`. But the **canonical** `openbank-libs/governance/agents.yaml` — the source the OPA sidecar (`agents.rego`) reads — never declared it. Result: the in-process gate allowed it, the PDP denied it (deny-by-default, capability in no charter's `tools.allow`), net **denied**. This PR reconciles agents.yaml to the already-deployed runtime; it is **not** a new grant.

## Type of change

- [x] security (authorization policy — governance)

## Linked issues

Refs #401 (part 2 of 2; part 1 — the `@Authorize`-on-reads sweep — is separate, see the issue comment)

## Changes

- `agents.yaml`: `query.gl.readonly` added to `tool_tiers.read` and to `ui-assistant` + `compliance-officer` `tools.allow` (both already grant it in `application.yaml`; updated the ui-assistant least-privilege comment to note GL is a ledger-family read carrying no PII beyond the ledger read it already holds).
- `agents.rego`: `rest_domains["query.gl.readonly"] = {"ledger", "gl"}`, per the map's own documented keep-in-sync invariant ("a new `query.<x>.readonly` tool … needs an entry here too").
- `agents_test.rego`: mock charter updated + two tests — allow for a chartered agent, deny-by-default for one without it.

## Definition of Done

- [x] `opa test openbank-infra/opa/policies openbank-libs/governance/policies` → **113/113** (was 111; +2).
- [x] `agents.yaml` valid YAML; `check-agent-charter-registry.sh` → full parity (7 agents).
- [x] `opa fmt --diff` clean; `check-duplicate-yaml-keys.sh` clean.
- [x] No Kotlin change — `McpToolRegistryTest` already asserts the `get_trial_balance` → `query.gl.readonly` mapping.

## Security checklist

- [x] No secrets/PII. This **narrows** the canonical/runtime drift rather than widening access — the capability was already deployed in `application.yaml`; making agents.yaml agree only removes a latent deny that contradicted the deployed intent. `query.gl.readonly` grants a GL aggregate (trial balance) read, PII-equivalent to the `query.ledger.readonly` both charters already hold.
- Governance change → deferred to human review by the agent-review workflow (not auto-merged).
