### PR TITLE
governance(dispute): @Authorize dispute + complaint reads for the AI-agent bridge (#401)

### DIFF
--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/ComplaintResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/ComplaintResource.kt
@@ -47,12 +47,14 @@ class ComplaintResource(
             .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
+    @Authorize(action = "complaint.list")
     @Operation(summary = "List complaints, optionally filtered by status")
     fun list(@QueryParam("status") status: String?): Uni<List<Complaint>> =
         if (status != null) getUseCase.listByStatus(ComplaintStatus.valueOf(status)) else getUseCase.listAll()
 
     @GET
     @Path("/{id}")
+    @Authorize(action = "complaint.read", resource = "#id")
     @Operation(summary = "Get complaint by ID")
     fun get(@PathParam("id") id: UUID): Uni<Response> = getUseCase.getComplaint(id).map {
         it?.let { c -> Response.ok(c).build() }

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
@@ -34,6 +34,7 @@ class DisputeResource(
             .onFailure().recoverWithItem { e -> Response.serverError().entity(mapOf("error" to e.message)).build() }
 
     @GET
+    @Authorize(action = "dispute.list")
     @Operation(summary = "List disputes by status")
     fun list(@QueryParam("status") status: String?): Uni<List<Dispute>> = if (status != null) {
         getUseCase.listByStatus(DisputeStatus.valueOf(status))
@@ -43,18 +44,21 @@ class DisputeResource(
 
     @GET
     @Path("/{id}")
+    @Authorize(action = "dispute.read", resource = "#id")
     @Operation(summary = "Get dispute by ID")
     fun get(@PathParam("id") id: UUID): Uni<Response> =
         getUseCase.getDispute(id).map { it?.let { d -> Response.ok(d).build() } ?: Response.status(404).build() }
 
     @GET
     @Path("/reference/{ref}")
+    @Authorize(action = "dispute.read", resource = "#ref")
     @Operation(summary = "Get dispute by reference")
     fun getByRef(@PathParam("ref") ref: String): Uni<Response> =
         getUseCase.getByReference(ref).map { it?.let { d -> Response.ok(d).build() } ?: Response.status(404).build() }
 
     @GET
     @Path("/account/{accountId}")
+    @Authorize(action = "dispute.list", resource = "#accountId")
     @Operation(summary = "List disputes for an account")
     fun listByAccount(@PathParam("accountId") accountId: UUID): Uni<List<Dispute>> = getUseCase.listByAccount(accountId)
 
@@ -109,11 +113,13 @@ class DisputeResource(
 
     @GET
     @Path("/{id}/timeline")
+    @Authorize(action = "dispute.read", resource = "#id")
     @Operation(summary = "Get dispute timeline")
     fun getTimeline(@PathParam("id") id: UUID): Uni<List<DisputeTimelineEvent>> = getUseCase.getTimeline(id)
 
     @GET
     @Path("/{id}/evidence")
+    @Authorize(action = "dispute.read", resource = "#id")
     @Operation(summary = "Get dispute evidence")
     fun getEvidence(@PathParam("id") id: UUID): Uni<List<DisputeEvidence>> = getUseCase.getEvidence(id)
 

--- a/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
+++ b/openbank-dispute-service/src/main/kotlin/com/openbank/dispute/infrastructure/rest/DisputeResource.kt
@@ -126,6 +126,7 @@ class DisputeResource(
     @GET
     @Path("/{id}/evidence/verify")
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_SERVICE")
+    @Authorize(action = "dispute.read", resource = "#id")
     @Operation(summary = "Walk and verify a dispute's evidence hash chain (ADR-0117/ADR-0133 pattern)")
     fun verifyEvidenceChain(@PathParam("id") id: UUID): Uni<EvidenceChainVerification> =
         getUseCase.verifyEvidenceChain(id)

--- a/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/infrastructure/rest/DisputeAuthorizeContractTest.kt
+++ b/openbank-dispute-service/src/test/kotlin/com/openbank/dispute/infrastructure/rest/DisputeAuthorizeContractTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.dispute.infrastructure.rest
+
+import com.openbank.libs.authz.Authorize
+import jakarta.ws.rs.GET
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Contract guard for the AI-agent read-authorization bridge (ADR-0034, issue #401): every read
+ * (`@GET`) endpoint on the dispute + complaint resources must carry an `@Authorize` action so the
+ * `query.disputes.readonly` OPA capability has a REST enforcement point to bridge to. A read left
+ * un-annotated is exactly the gap #401 tracks — it would silently re-open the bridge hole.
+ *
+ * Pure reflection (annotations are RUNTIME-retained) — no Quarkus boot. The end-to-end deny/allow
+ * behaviour of the bridge itself is asserted in `agents_test.rego`
+ * (`test_allow_rest_action_via_disputes_readonly_*`, `test_deny_rest_action_complaint_write_not_bridged`);
+ * here we prove the enforcement points those policy tests assume actually exist on the endpoints.
+ */
+class DisputeAuthorizeContractTest {
+
+    private fun getEndpoints(clazz: Class<*>): List<Method> =
+        clazz.declaredMethods.filter { it.getAnnotation(GET::class.java) != null }
+
+    private fun assertReadActions(clazz: Class<*>, allowedPrefixes: Set<String>) {
+        val reads = getEndpoints(clazz)
+        assertThat(reads).describedAs("expected @GET endpoints on ${clazz.simpleName}").isNotEmpty
+        reads.forEach { m ->
+            val authorize = m.getAnnotation(Authorize::class.java)
+            assertThat(authorize)
+                .describedAs("%s.%s (a read) must carry @Authorize (issue #401 bridge)", clazz.simpleName, m.name)
+                .isNotNull
+            val action = authorize.action
+            assertThat(allowedPrefixes.any { action.startsWith("$it.") })
+                .describedAs(
+                    "%s.%s @Authorize action '%s' must be in %s",
+                    clazz.simpleName,
+                    m.name,
+                    action,
+                    allowedPrefixes,
+                )
+                .isTrue
+            // The bridge is read-only (rest_read_verbs): the action must end in a read verb, never a write.
+            assertThat(action.substringAfterLast('.'))
+                .describedAs("%s.%s @Authorize action '%s' must be a read verb", clazz.simpleName, m.name, action)
+                .isIn("read", "list", "search")
+        }
+    }
+
+    @Test
+    fun `every DisputeResource read carries a dispute read-verb Authorize action`() {
+        assertReadActions(DisputeResource::class.java, setOf("dispute"))
+    }
+
+    @Test
+    fun `every ComplaintResource read carries a complaint read-verb Authorize action`() {
+        assertReadActions(ComplaintResource::class.java, setOf("complaint"))
+    }
+}

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "166ef68f5afd07a9"
+    openbank.tech/policy-checksum: "6ee9534b9ef6e8d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -455,14 +455,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -470,7 +470,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "166ef68f5afd07a9"
+        openbank.tech/policy-checksum: "6ee9534b9ef6e8d5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "7edd3202daada422"
+    openbank.tech/policy-checksum: "08748ecfb547e85e"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -94,14 +94,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -109,7 +109,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "7edd3202daada422"
+        openbank.tech/policy-checksum: "08748ecfb547e85e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "004d3cec7bee1e08"
+    openbank.tech/policy-checksum: "363ecd4754d6d9bc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -499,14 +499,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -514,7 +514,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "004d3cec7bee1e08"
+        openbank.tech/policy-checksum: "363ecd4754d6d9bc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "869661641fc0ad77"
+    openbank.tech/policy-checksum: "e3e44ea329747d9d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -404,14 +404,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -419,7 +419,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "869661641fc0ad77"
+        openbank.tech/policy-checksum: "e3e44ea329747d9d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "0daa13c5a3d35bc2"
+    openbank.tech/policy-checksum: "3128b4236d286a51"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -422,14 +422,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -437,7 +437,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0daa13c5a3d35bc2"
+        openbank.tech/policy-checksum: "3128b4236d286a51"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "26ae634548d16ea1"
+    openbank.tech/policy-checksum: "7e535ab651bf2bc5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -487,14 +487,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -502,7 +502,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "26ae634548d16ea1"
+        openbank.tech/policy-checksum: "7e535ab651bf2bc5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "19b8391829116927"
+    openbank.tech/policy-checksum: "deb6c71645a3f6d0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -367,14 +367,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -382,7 +382,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19b8391829116927"
+        openbank.tech/policy-checksum: "deb6c71645a3f6d0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "99c9f80e40d9b8aa"
+    openbank.tech/policy-checksum: "03d237310a4c83f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -415,14 +415,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -430,7 +430,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "99c9f80e40d9b8aa"
+        openbank.tech/policy-checksum: "03d237310a4c83f3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "ce2d96e3e646e5dd"
+    openbank.tech/policy-checksum: "0b978f9fcd38b38e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -452,14 +452,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -467,7 +467,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ce2d96e3e646e5dd"
+        openbank.tech/policy-checksum: "0b978f9fcd38b38e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "5e65eaa943e58690"
+    openbank.tech/policy-checksum: "fd03e5c79bd5d8b7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -511,14 +511,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -526,7 +526,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5e65eaa943e58690"
+        openbank.tech/policy-checksum: "fd03e5c79bd5d8b7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "2009e802a03f0791"
+    openbank.tech/policy-checksum: "d3508b335201f102"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -468,14 +468,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -483,7 +483,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2009e802a03f0791"
+        openbank.tech/policy-checksum: "d3508b335201f102"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "19b8391829116927"
+    openbank.tech/policy-checksum: "deb6c71645a3f6d0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -367,14 +367,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -382,7 +382,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "19b8391829116927"
+        openbank.tech/policy-checksum: "deb6c71645a3f6d0"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "09d01a58df8601ad"
+    openbank.tech/policy-checksum: "79404aab0e40d0a3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -458,14 +458,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -473,7 +473,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "eb100fe8f035d0f7"
+    openbank.tech/policy-checksum: "bbe3e7e5c719a07e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -443,14 +443,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -458,7 +458,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "19cdb5fcdde9a4c0" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "f0b0d714ab5fe016" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8c87eee714dd5558"
+        openbank.tech/policy-checksum: "c5d55b969d23c34f"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "eb100fe8f035d0f7" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "bbe3e7e5c719a07e" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "de49a342fcd578ab"
+        openbank.tech/policy-checksum: "c45f495d5812b599"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "09d01a58df8601ad" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "79404aab0e40d0a3" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1943,7 +1943,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "73ec81f7d8ff042e" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "53a11364f418dd19" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2333,7 +2333,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f40c7cf9f468463e"
+        openbank.tech/policy-checksum: "2307277d44ae0f83"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "de49a342fcd578ab"
+    openbank.tech/policy-checksum: "c45f495d5812b599"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -416,14 +416,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -431,7 +431,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8c87eee714dd5558"
+    openbank.tech/policy-checksum: "c5d55b969d23c34f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -437,14 +437,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -452,7 +452,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "73ec81f7d8ff042e"
+    openbank.tech/policy-checksum: "53a11364f418dd19"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -417,14 +417,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -432,7 +432,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f40c7cf9f468463e"
+    openbank.tech/policy-checksum: "2307277d44ae0f83"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -420,14 +420,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -435,7 +435,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "19cdb5fcdde9a4c0"
+    openbank.tech/policy-checksum: "f0b0d714ab5fe016"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -473,14 +473,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -488,7 +488,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "6ba3ee1a9a59c5dd"
+    openbank.tech/policy-checksum: "4dd4409364137618"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -426,14 +426,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -441,7 +441,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6ba3ee1a9a59c5dd"
+        openbank.tech/policy-checksum: "4dd4409364137618"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "12c12878dd3c0d4e"
+    openbank.tech/policy-checksum: "140d33d3995ca014"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -440,14 +440,14 @@ data:
     # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
     # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
     # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-    # the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-    # dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-    # their entries are forward-looking and inert until that service adopts @Authorize on its
-    # reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-    # WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-    # sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-    # the bare service name, since a future read endpoint may reuse either convention and both
-    # are inert until then anyway.
+    # the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+    # (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+    # aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+    # inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+    # service's only real @Authorize action today is a WRITE (e.g. aml-service's
+    # amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+    # service name, since a future read endpoint may reuse either convention and both are inert
+    # until then anyway.
     rest_domains := {
     	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
     	"query.gl.readonly": {"ledger", "gl"},
@@ -455,7 +455,7 @@ data:
     	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
     	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
     	"query.interest.readonly": {"interest"},
-    	"query.disputes.readonly": {"dispute"},
+    	"query.disputes.readonly": {"dispute", "complaint"},
     	"query.balance.readonly": {"balance"},
     	"query.transaction.readonly": {"transaction"},
     }

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "12c12878dd3c0d4e"
+        openbank.tech/policy-checksum: "140d33d3995ca014"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/opa/policies/agents.rego
+++ b/openbank-infra/opa/policies/agents.rego
@@ -80,14 +80,14 @@ charter_allowed if rest_action_allowed
 # MCP capability is meant to cover (e.g. query.ledger.readonly also backs the
 # account/transaction/balance read tools, not just ledger). Keep the two in sync: a new
 # query.<x>.readonly tool, or a domain added to an existing one, needs an entry here too, or
-# the fleet regains this exact gap. Some domains (catalog, aml, clearing, sepa-instant,
-# dispute, balance-via-query.balance.readonly) have no @Authorize-gated read endpoint yet --
-# their entries are forward-looking and inert until that service adopts @Authorize on its
-# reads (tracked in issue #401). Where a service's only real @Authorize action today is a
-# WRITE (e.g. aml-service's amlCase.updateDecision, clearing-service's clearingBatch.settle,
-# sepa-instant's sctInstPayment.recall), the verified write-action prefix is listed alongside
-# the bare service name, since a future read endpoint may reuse either convention and both
-# are inert until then anyway.
+# the fleet regains this exact gap. dispute + complaint reads are now @Authorize-gated
+# (dispute.read/.list, complaint.read/.list) so query.disputes.readonly is live; catalog and
+# aml still have no @Authorize-gated read endpoint yet -- their entries are forward-looking and
+# inert until that service adopts @Authorize on its reads (tracked in issue #401). Where a
+# service's only real @Authorize action today is a WRITE (e.g. aml-service's
+# amlCase.updateDecision), the verified write-action prefix is listed alongside the bare
+# service name, since a future read endpoint may reuse either convention and both are inert
+# until then anyway.
 rest_domains := {
 	"query.ledger.readonly": {"ledger", "account", "transaction", "balance"},
 	"query.gl.readonly": {"ledger", "gl"},
@@ -95,7 +95,7 @@ rest_domains := {
 	"query.compliance.readonly": {"aml", "amlCase", "sanctions"},
 	"query.payments.readonly": {"fx", "clearing", "clearingBatch", "sepa-instant", "sctInstPayment"},
 	"query.interest.readonly": {"interest"},
-	"query.disputes.readonly": {"dispute"},
+	"query.disputes.readonly": {"dispute", "complaint"},
 	"query.balance.readonly": {"balance"},
 	"query.transaction.readonly": {"transaction"},
 }

--- a/openbank-infra/opa/policies/agents_test.rego
+++ b/openbank-infra/opa/policies/agents_test.rego
@@ -19,7 +19,7 @@ charters := {
 			"id": "compliance-officer",
 			"plane": "control",
 			"tools": {
-				"allow": ["query.ledger.readonly", "query.gl.readonly", "query.catalog.readonly", "read.logs", "read.governance", "draft.ticket"],
+				"allow": ["query.ledger.readonly", "query.gl.readonly", "query.catalog.readonly", "query.disputes.readonly", "read.logs", "read.governance", "draft.ticket"],
 				"deny": ["money.*", "gh.pr.*", "*.write"],
 			},
 		},
@@ -218,6 +218,29 @@ test_allow_rest_action_via_readonly_tool_ledger_list if {
 test_allow_rest_action_via_readonly_tool_ledger_read if {
 	agents.allow with data.agents as charters
 		with input as {"agent": "compliance-officer", "tool": "ledger.read", "resource": null}
+}
+
+# query.disputes.readonly now bridges to dispute AND complaint reads (issue #401 part 1):
+# dispute-service adopted @Authorize on both resources (dispute.read/.list, complaint.read/.list),
+# so the previously-inert bucket entry is live.
+test_allow_rest_action_via_disputes_readonly_dispute if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "dispute.list", "resource": null}
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "dispute.read", "resource": "d-1"}
+}
+
+test_allow_rest_action_via_disputes_readonly_complaint if {
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "complaint.list", "resource": null}
+	agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "complaint.read", "resource": "c-1"}
+}
+
+# Still read-only: a complaint WRITE verb is not bridged by the readonly capability.
+test_deny_rest_action_complaint_write_not_bridged if {
+	not agents.allow with data.agents as charters
+		with input as {"agent": "compliance-officer", "tool": "complaint.update", "resource": "c-1"}
 }
 
 # The bridge is read-only: a write verb in the same domain is NOT granted by the readonly


### PR DESCRIPTION
## Summary

Closes the **dispute-service** slice of #401 part 1: its read endpoints were RBAC-gated (class-level `@RolesAllowed`) but had no `@Authorize` action, so `query.disputes.readonly` had no REST enforcement point and its `rest_domains` bridge entry in `agents.rego` was inert.

## Type of change

- [x] security (authorization policy)

## Linked issues

Refs #401 (dispute-service slice of part 1)

## Changes

- `DisputeResource`: `@Authorize(action = "dispute.read"/"dispute.list")` on the six reads (`list`, `get`, `getByRef`, `listByAccount`, `getTimeline`, `getEvidence`). RBAC was already enforced by the class-level `@RolesAllowed(VIEWER, OPERATOR, ADMIN, SERVICE)`.
- `ComplaintResource`: `@Authorize(action = "complaint.read"/"complaint.list")` on `list` + `get`.
- `agents.rego`: `rest_domains["query.disputes.readonly"] = {"dispute", "complaint"}` (was `{"dispute"}`) so both resources bridge; updated the inert-domains comment.
- `agents_test.rego`: compliance-officer mock gains `query.disputes.readonly`; three bridge tests (dispute read/list, complaint read/list allowed; complaint write verb still denied). **opa test 111 → 114.**

## Definition of Done

- [x] `opa test` 114/114; `opa fmt --diff` clean.
- [x] `:openbank-dispute-service:compileKotlin ktlintCheck detekt test` pass locally.
- [x] `ComplaintSecurityTest` (no-@PermitAll guard) still green.
- No DB/API/event change.

## Security checklist

- [x] No secrets/PII. Net effect is *more* enforcement, not less — reads that were only RBAC-gated now also carry an OPA action, and the AI-agent bridge is read-verb-only (`complaint.update` stays denied to a readonly capability, asserted by test).
- **Note — overlapping OPA edits:** #737 (query.gl.readonly) also edits `agents.rego` `rest_domains` (a different line) and the `agents_test.rego` compliance-officer mock allow (same line). Whichever merges second needs a trivial one-line rebase; no logic conflict. A follow-up PR for aml-service reads will touch the `query.compliance.readonly` bucket similarly.
