### PR TITLE
feat(product-catalog): authenticate the catalog — @Authenticated reads, role-gated writes (#401)

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -77,6 +77,11 @@ spec:
               valueFrom: {secretKeyRef: {name: product-catalog-db-app, key: username}}
             - name: QUARKUS_DATASOURCE_PASSWORD
               valueFrom: {secretKeyRef: {name: product-catalog-db-app, key: password}}
+            # Resource-server auth (issue #401): validate caller bearer tokens against the realm's
+            # JWKS. Pure resource server — no client secret needed. Egress to keycloak (iam ns) is
+            # already permitted (accounts ns has no egress policy; account-service validates here too).
+            - name: QUARKUS_OIDC_AUTH_SERVER_URL
+              value: http://keycloak.iam.svc:8080/realms/openbank
           startupProbe:
             httpGet:
               path: /q/health/ready

--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -15,6 +15,10 @@ dependencies {
     implementation(libs.quarkus.micrometer.registry.prometheus)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
+    // Resource-server auth (issue #401): validate caller tokens for @Authenticated / @RolesAllowed.
+    // The @Authorize interceptor, Roles and the Authorize annotation already arrive transitively via
+    // :openbank-libs (which api-exports :openbank-libs-runtime + :openbank-libs-domain).
+    implementation(libs.quarkus.oidc)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
 
@@ -39,6 +43,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
     testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.quarkus.test.security)
 }
 
 // Coverage floor (ADR-0020, ratchet-only — sweep #466: this module previously had NO

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/FeesResource.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/FeesResource.kt
@@ -4,7 +4,9 @@
 
 package com.openbank.productcatalog.infrastructure.rest
 
+import com.openbank.libs.authz.Authorize
 import com.openbank.productcatalog.application.ProductCatalogService
+import io.quarkus.security.Authenticated
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
@@ -25,10 +27,12 @@ import jakarta.ws.rs.core.Response
 class FeesResource(private val service: ProductCatalogService) {
 
     @GET
+    @Authenticated
+    @Authorize(action = "catalog.list")
     suspend fun list(
         @QueryParam("type") type: String?,
         @QueryParam("currency") currency: String?,
-        @QueryParam("productCode") productCode: String?
+        @QueryParam("productCode") productCode: String?,
     ): Response {
         var items = service.listFeeSchedule()
         if (!type.isNullOrBlank()) items = items.filter { it.type == type }

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogResource.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogResource.kt
@@ -4,10 +4,21 @@
 
 package com.openbank.productcatalog.infrastructure.rest
 
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.security.Roles
 import com.openbank.productcatalog.application.ProductCatalogService
 import com.openbank.productcatalog.application.ProductRequest
+import io.quarkus.security.Authenticated
+import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.ws.rs.*
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 
@@ -17,6 +28,8 @@ import jakarta.ws.rs.core.Response
 class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @GET
+    @Authenticated
+    @Authorize(action = "catalog.list")
     suspend fun list(
         @QueryParam("type") type: String?,
         @QueryParam("status") status: String?,
@@ -31,18 +44,24 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @GET
     @Path("/{id}")
+    @Authenticated
+    @Authorize(action = "catalog.read", resource = "#id")
     suspend fun getById(@PathParam("id") id: String): Response = service.findById(id)?.let { Response.ok(it).build() }
         ?: Response.status(404).entity(mapOf("error" to "Product $id not found")).build()
 
     // ADR-0105: resolve a product by its semantic code (e.g. SAVINGS_STANDARD) or prod-NNN legacy alias.
     @GET
     @Path("/by-code/{code}")
+    @Authenticated
+    @Authorize(action = "catalog.read", resource = "#code")
     suspend fun getByCode(@PathParam("code") code: String): Response =
         service.findByCode(code)?.let { Response.ok(it).build() }
             ?: Response.status(404).entity(mapOf("error" to "Product with code '$code' not found")).build()
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "catalog.create")
     suspend fun create(req: ProductRequest): Response = try {
         val product = service.create(req)
         Response.status(201).entity(product).build()
@@ -53,6 +72,8 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
     @PUT
     @Path("/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "catalog.update", resource = "#id")
     suspend fun update(@PathParam("id") id: String, req: ProductRequest): Response = try {
         Response.ok(service.update(id, req)).build()
     } catch (e: NoSuchElementException) {
@@ -63,6 +84,8 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @POST
     @Path("/{id}/activate")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "catalog.update", resource = "#id")
     suspend fun activate(@PathParam("id") id: String): Response = try {
         Response.ok(service.activate(id)).build()
     } catch (e: NoSuchElementException) {
@@ -71,6 +94,8 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @POST
     @Path("/{id}/deactivate")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "catalog.update", resource = "#id")
     suspend fun deactivate(@PathParam("id") id: String): Response = try {
         Response.ok(service.deactivate(id)).build()
     } catch (e: NoSuchElementException) {
@@ -79,6 +104,8 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @GET
     @Path("/{id}/fees")
+    @Authenticated
+    @Authorize(action = "catalog.read", resource = "#id")
     suspend fun getFees(@PathParam("id") id: String): Response = service.findById(id)
         ?.let { Response.ok(it.fees).build() }
         ?: Response.status(404).entity(mapOf("error" to "Product $id not found")).build()

--- a/openbank-product-catalog/src/main/resources/application.yaml
+++ b/openbank-product-catalog/src/main/resources/application.yaml
@@ -48,14 +48,12 @@ quarkus:
     path: /api/docs
   # Resource-server: product-catalog now authenticates its callers (issue #401). Reads require a
   # valid token (@Authenticated); writes require ROLE_OPERATOR/ROLE_ADMIN. Every in-cluster caller
-  # already presents (or now presents) an openbank-services / openbank-edge service token; the
-  # admin-ui relays the operator's token via its BFF. The client-id/secret are reused only to
-  # resolve the issuer — this service is a resource server, it does not mint tokens.
+  # presents (or now presents) an openbank-services / openbank-edge service token; the admin-ui
+  # relays the operator's token via its BFF. This is a PURE resource server (application-type
+  # `service`, the default): it validates bearer tokens against the realm's JWKS and does not mint
+  # tokens, so it needs NO client secret — only the issuer URL.
   oidc:
     auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
-    client-id: ${OIDC_CLIENT_ID:openbank-services}
-    credentials:
-      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: ${OIDC_TLS_VERIFICATION:none}
 

--- a/openbank-product-catalog/src/main/resources/application.yaml
+++ b/openbank-product-catalog/src/main/resources/application.yaml
@@ -46,8 +46,37 @@ quarkus:
   swagger-ui:
     always-include: true
     path: /api/docs
+  # Resource-server: product-catalog now authenticates its callers (issue #401). Reads require a
+  # valid token (@Authenticated); writes require ROLE_OPERATOR/ROLE_ADMIN. Every in-cluster caller
+  # already presents (or now presents) an openbank-services / openbank-edge service token; the
+  # admin-ui relays the operator's token via its BFF. The client-id/secret are reused only to
+  # resolve the issuer — this service is a resource server, it does not mint tokens.
+  oidc:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: ${OIDC_CLIENT_ID:openbank-services}
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    tls:
+      verification: ${OIDC_TLS_VERIFICATION:none}
+
+# OPA sidecar (ADR-0034) for the AI-agent read bridge (query.catalog.readonly). Advisory by
+# default — a denied/unreachable decision is logged at WARN and the request proceeds; product
+# catalog has no sidecar yet, so this stays advisory until one is deployed and AUTHZ_ENFORCE=true.
+opa:
+  url: "${OPA_URL:http://localhost:8181}"
+  path: "${OPA_PATH:/v1/data/openbank/rest/allow}"
+  timeout-ms: "${OPA_TIMEOUT_MS:500}"
+authz:
+  enforce: "${AUTHZ_ENFORCE:false}"
 
 "%test":
   quarkus:
     management:
       enabled: false
+    # No Keycloak on the test stack — disable the resource server so @QuarkusTest boots, and let
+    # @TestSecurity mock the identity for the security-annotated endpoints (quarkus-test-security).
+    oidc:
+      enabled: false
+  # OPA sidecar is absent in CI — keep @Authorize advisory so the reads proceed under test.
+  authz:
+    enforce: "false"

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
@@ -3,19 +3,28 @@ package com.openbank.productcatalog
 
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
+// product-catalog now authenticates its callers (issue #401): reads need a valid token, writes need
+// ROLE_OPERATOR. OIDC is disabled under test (%test) and @TestSecurity mocks the operator identity
+// every real caller carries (openbank-services / openbank-edge service token, or the admin-ui operator).
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
+@TestSecurity(user = "test-operator", roles = ["ROLE_OPERATOR"])
 class ProductCatalogResourceTest {
 
     @Test
     fun `GET products returns seed data`() {
-        val body = (Given { this } When { get("/api/v1/products") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/products") } Then { statusCode(200) }
+            ).extract().body().asString()
         assertThat(body).contains("SAVINGS_STANDARD")
     }
 
@@ -32,7 +41,11 @@ class ProductCatalogResourceTest {
     @Test
     fun `POST create product returns 201`() {
         val payload = """{"code":"TEST_PROD","name":"Test","type":"SAVINGS","currency":"EUR"}"""
-        Given { contentType("application/json"); body(payload) } When { post("/api/v1/products") } Then { statusCode(201) }
+        Given {
+            contentType("application/json")
+            body(payload)
+        } When { post("/api/v1/products") } Then
+            { statusCode(201) }
     }
 
     @Test
@@ -42,7 +55,11 @@ class ProductCatalogResourceTest {
 
     @Test
     fun `CZK current account is seeded as a multi-currency CZK-base product`() {
-        val body = (Given { this } When { get("/api/v1/products/prod-014") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/products/prod-014") } Then { statusCode(200) }
+            ).extract().body().asString()
         assertThat(body).contains("CURRENT_CZK")
         assertThat(body).contains("\"currency\":\"CZK\"")
         assertThat(body).contains("\"defaultCurrency\":\"CZK\"")
@@ -52,15 +69,25 @@ class ProductCatalogResourceTest {
     fun `GET product by canonical account UUID resolves the seeded product (ADR-0105)`() {
         // account-service references the CZK current/savings products by the UUID it stamps on
         // accounts.product_id; the catalogue must resolve those UUIDs to the same products.
-        val current = (Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then { statusCode(200) }).extract().body().asString()
+        val current = (
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then
+                { statusCode(200) }
+            ).extract().body().asString()
         assertThat(current).contains("CURRENT_CZK")
-        val savings = (Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then { statusCode(200) }).extract().body().asString()
+        val savings = (
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then
+                { statusCode(200) }
+            ).extract().body().asString()
         assertThat(savings).contains("SAVINGS_CZK")
     }
 
     @Test
     fun `multi-currency umbrella account is seeded with a broad currency set`() {
-        val body = (Given { this } When { get("/api/v1/products/prod-015") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/products/prod-015") } Then { statusCode(200) }
+            ).extract().body().asString()
         assertThat(body).contains("CURRENT_MULTICURRENCY_UMBRELLA")
         assertThat(body).contains("\"enabled\":true")
         // 12-currency pocket umbrella: assert a representative spread is present.
@@ -79,7 +106,11 @@ class ProductCatalogResourceTest {
 
     @Test
     fun `GET fees filters by currency`() {
-        val body = (Given { this } When { get("/api/v1/fees?currency=CZK") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/fees?currency=CZK") } Then { statusCode(200) }
+            ).extract().body().asString()
         // CZK-base products contribute CZK fees; EUR-only fees must be filtered out.
         assertThat(body).contains("\"currency\":\"CZK\"")
         assertThat(body).doesNotContain("\"currency\":\"EUR\"")

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogSecurityTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogSecurityTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog
+
+import com.openbank.libs.authz.Authorize
+import com.openbank.productcatalog.infrastructure.rest.FeesResource
+import com.openbank.productcatalog.infrastructure.rest.ProductCatalogResource
+import io.quarkus.security.Authenticated
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Security contract for the newly-authenticated product catalog (issue #401). product-catalog was
+ * public-by-design and carried ZERO security annotations; this locks in the cutover so a future
+ * edit cannot silently re-open it:
+ *   - every read (`@GET`) requires a valid token (`@Authenticated`) and carries an `@Authorize`
+ *     `catalog.<read-verb>` action for the query.catalog.readonly OPA bridge;
+ *   - every write (`@POST`/`@PUT`) is `@RolesAllowed(ROLE_OPERATOR|ROLE_ADMIN)`;
+ *   - nothing is `@PermitAll`.
+ * Pure reflection — no Quarkus boot. The functional path (operator token succeeds) is covered by
+ * ProductCatalogResourceTest under `@TestSecurity`.
+ */
+class ProductCatalogSecurityTest {
+
+    private val resources = listOf(ProductCatalogResource::class.java, FeesResource::class.java)
+
+    private fun endpoints(clazz: Class<*>, vararg verbs: Class<out Annotation>): List<Method> =
+        clazz.declaredMethods.filter { m -> verbs.any { m.getAnnotation(it) != null } }
+
+    @Test
+    fun `no product-catalog endpoint is @PermitAll`() {
+        resources.forEach { clazz ->
+            endpoints(clazz, GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
+                .forEach { m ->
+                    assertThat(m.getAnnotation(PermitAll::class.java))
+                        .describedAs("%s.%s must not be @PermitAll", clazz.simpleName, m.name)
+                        .isNull()
+                }
+        }
+    }
+
+    @Test
+    fun `every read requires auth and carries a catalog read-verb Authorize action`() {
+        val reads = resources.flatMap { endpoints(it, GET::class.java) }
+        assertThat(reads).describedAs("expected @GET reads").isNotEmpty
+        reads.forEach { m ->
+            assertThat(m.getAnnotation(Authenticated::class.java))
+                .describedAs("read %s must be @Authenticated (issue #401)", m.name)
+                .isNotNull
+            val authorize = m.getAnnotation(Authorize::class.java)
+            assertThat(authorize).describedAs("read %s must carry @Authorize", m.name).isNotNull
+            assertThat(authorize.action)
+                .describedAs("read %s @Authorize action must be a catalog read verb", m.name)
+                .isIn("catalog.read", "catalog.list", "catalog.search")
+        }
+    }
+
+    @Test
+    fun `every write is role-gated to operator or admin`() {
+        val writes = resources.flatMap { endpoints(it, POST::class.java, PUT::class.java) }
+        assertThat(writes).describedAs("expected write endpoints").isNotEmpty
+        writes.forEach { m ->
+            val roles = m.getAnnotation(RolesAllowed::class.java)
+            assertThat(roles).describedAs("write %s must be @RolesAllowed", m.name).isNotNull
+            assertThat(roles.value.toList())
+                .describedAs("write %s must be restricted to operator/admin", m.name)
+                .containsExactlyInAnyOrder("ROLE_OPERATOR", "ROLE_ADMIN")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Authenticate `openbank-product-catalog` (issue #401). The service was public-by-design with **zero** security annotations; this onboards it to the resource-server stack.

**Safe-for-customers design:** reads use `@Authenticated` (any valid token), **not** a specific role, because **customer-edge** (customer-facing) is a caller and reaches the catalog with its `openbank-edge` service token whose realm role is not verifiable from this repo. `@Authenticated` accepts any valid token, so no caller is 401'd on a role mismatch. Writes are `@RolesAllowed(ROLE_OPERATOR, ROLE_ADMIN)`.

## ⚠️ Rollout ordering (hard dependency)

`@Authenticated` reads reject **anonymous** callers. Every caller must present a token BEFORE this deploys:
- **agent-service**, **billing-service** — currently send no token → companion PRs add the OIDC filter (deploy first).
- **customer-edge** — already sends a service token (`UpstreamClient`). ✅
- **admin-ui** — relays the operator token via its BFF. ✅
- **#725 (interest)** / **#727 (account)** — in-flight, ADD new catalog callers → must send a token before merging past this. Flagged on those PRs.

## Changes

- `build.gradle.kts`: `+quarkus-oidc` (resource server), `+quarkus-test-security`. The `@Authorize` interceptor / `Roles` / `Authorize` arrive transitively via `:openbank-libs`.
- `application.yaml`: `quarkus.oidc` (pure resource server — no client secret), top-level `opa`/`authz` (advisory: `AUTHZ_ENFORCE:false`), `%test` disables OIDC.
- `ProductCatalogResource` + `FeesResource`: `@Authenticated` + `@Authorize(catalog.read/.list)` on reads; `@RolesAllowed(OPERATOR,ADMIN)` + `@Authorize(catalog.create/.update)` on writes. (`agents.rego` `rest_domains["query.catalog.readonly"]={"catalog"}` already exists — this turns that inert entry live; no rego change.)
- gitops: `QUARKUS_OIDC_AUTH_SERVER_URL` env. No NetworkPolicy change (accounts ns egress is default-allow; account-service validates the same way).
- Tests: `ProductCatalogResourceTest` gains `@TestSecurity(operator)`; new `ProductCatalogSecurityTest` (reflection contract). `ProductCatalogBootSmokeIT` boots the app **with OIDC on the classpath** against Testcontainers Postgres.

## Definition of Done

- [x] `:openbank-product-catalog:compileKotlin ktlintCheck detekt test` pass locally — including the **boot smoke IT** (verifies the first-time-auth onboarding boots, per the "released but never booted" rule). `@Authorize` logs `advisory … enforce=false` (no sidecar) rather than 503.

## Security checklist

- [x] No secrets/PII. Pure resource server — no client secret handled. OPA stays advisory (no sidecar) so the AI-bridge is established without a hard OPA cutover.
