### PR TITLE
feat(billing): propagate a service token to product-catalog (#401 rollout)

### DIFF
--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/client/BillingRestClients.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/client/BillingRestClients.kt
@@ -39,8 +39,13 @@ data class AccountDto(val id: String, val productId: String, val currencyCode: S
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class BalanceDto(val accountId: String, val currency: String, val currentBalance: BigDecimal)
 
-/** Product-catalog fee definitions (public read; the catalog is the fee source-of-truth). */
+/**
+ * Product-catalog fee definitions (the catalog is the fee source-of-truth). product-catalog now
+ * authenticates its callers (issue #401), so propagate an openbank-services bearer like the other
+ * clients below — a fee assessment cannot silently fall back to "no fees" on a 401.
+ */
 @RegisterRestClient(configKey = "product-catalog")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
 @Path("/api/v1")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## Summary

Prerequisite for #743 (product-catalog becoming `@Authenticated`). billing's `ProductCatalogRestClient` (`GET /products/{id}/fees`, fee assessment) was the only product-catalog client without an `OidcClientRequestReactiveFilter` — add it so the call carries an `openbank-services` bearer like the account/balance/ledger clients already do.

Backward-compatible: sending a bearer to the currently-public catalog is harmless; it becomes *required* once #743 deploys.

## Type of change
- [x] feat

## Linked issues
Refs #401

## Changes
- `BillingRestClients.kt`: `@RegisterProvider(OidcClientRequestReactiveFilter::class)` on `ProductCatalogRestClient` (import already present).

## Definition of Done
- [x] `:openbank-billing-service:compileKotlin ktlintCheck` pass locally.
- **Rollout:** deploy this BEFORE #743, or billing's fee assessment 401s on the catalog read.

## Security checklist
- [x] No secrets/PII. Money-path service (billing) → 2 approvals + threat model per ADR-0030; threat model already exists.
