### PR TITLE
feat(agent): propagate a service token to product-catalog reads (#401 rollout)

### DIFF
--- a/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/client/ServiceClients.kt
+++ b/openbank-agent-service/src/main/kotlin/com/openbank/agent/infrastructure/client/ServiceClients.kt
@@ -94,9 +94,11 @@ interface ConsentServiceClient {
     fun getConsent(@PathParam("id") id: String): JsonNode
 }
 
-// product-catalog reads are public (the admin-ui fee page already proxies them), so the
-// bearer is harmless but not required — these tools return real data without service auth.
+// product-catalog now authenticates its callers (issue #401, #743): its reads require a valid
+// token, so propagate the openbank-services bearer like every other client here. The MCP
+// list_products/get_product/get_product_fees tools would otherwise 401 once #743 deploys.
 @RegisterRestClient(configKey = "product-catalog")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
 @Path("/api/v1")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## Summary

Prerequisite for #743 (product-catalog becoming `@Authenticated`). agent-service's `ProductCatalogClient` (the `list_products`/`get_product`/`get_product_fees` MCP tools) was the only client in `ServiceClients.kt` without an `OidcClientRequestReactiveFilter` — add it so the reads carry an `openbank-services` bearer.

Backward-compatible now; required once #743 deploys.

## Type of change
- [x] feat

## Linked issues
Refs #401

## Changes
- `ServiceClients.kt`: `@RegisterProvider(OidcClientRequestReactiveFilter::class)` on `ProductCatalogClient` + refreshed the now-stale 'reads are public' comment.

## Definition of Done
- [x] `:openbank-agent-service:compileKotlin ktlintCheck` pass locally.
- **Rollout:** deploy this BEFORE #743, or the product-catalog MCP tools 401.

## Security checklist
- [x] No secrets/PII. Sends the existing openbank-services M2M token; no new credential.
