### PR TITLE
fix(transaction,ledger): per-currency cash-clearing GL accounts (#747)

### DIFF
--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -96,6 +96,18 @@ reference/counterparty/amount/date). Holds customer financial movement data.
 
 ## 6. Change log
 
+- **2026-07-11** — #747: `PaymentJournalFactory`'s cash-clearing leg (the bank-side leg of a
+  one-sided inbound/outbound payment) was hardcoded to the CZK-only GL account regardless of the
+  transaction's actual currency, so ledger-service rejected any non-CZK one-sided payment (422,
+  currency mismatch) — confirmed live while building the issue #669 write benchmark. Added a
+  per-currency `CASH_CLEARING` map (EUR/USD/GBP, mirroring the existing `DEPOSIT_CONTROL`/
+  `FX_POSITION` pattern) and the corresponding `gl_accounts` seed
+  (`V14__cash_clearing_accounts_per_currency.sql`, ledger-service). Purely additive reference
+  data + a lookup-by-currency change; no new trust boundary, no change to the CZK path (same
+  account id as before). Risk class = **integrity** (correct GL routing, not money-direction —
+  the D-2 direction invariant from 2026-06-17 below is untouched). Mitigated by two new
+  `PaymentJournalFactoryTest` cases asserting the EUR cash-clearing leg resolves to the new
+  per-currency account, not the CZK one.
 - **2026-06-28** — ADR-0120 Phase 1: Temporal payment orchestration scaffolding (flag-gated, default
   OFF). Additive `PaymentWorkflow` + activities mirroring `PaymentSagaOrchestrator`; no cutover, no saga
   removal. Risk class = **integrity** (must preserve the §4 money-direction + D-2 invariant) + new

--- a/openbank-ledger-service/src/main/resources/db/migration/V14__cash_clearing_accounts_per_currency.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V14__cash_clearing_accounts_per_currency.sql
@@ -1,0 +1,15 @@
+-- Per-currency cash-clearing accounts (issue #747). PaymentJournalFactory's cash-clearing leg
+-- (the bank-side leg of a one-sided inbound/outbound payment, i.e. anything that isn't a
+-- same-currency internal transfer between two customer pockets) posted against the single
+-- CZK-only 'Customer Cash Clearing' account (1100, seeded in V3) regardless of the payment's
+-- actual currency. LedgerService.postJournal rejects a line whose currencyCode doesn't match its
+-- GL account's declared currency (422) — confirmed live: a EUR CREDIT transaction fails there,
+-- the identical CZK one succeeds. V5 already established this exact per-currency pattern for
+-- deposit-control and FX-position accounts; cash-clearing was the one leaf that never got it.
+--
+-- Same numbering convention as V5's deposit-control accounts (XX01/XX02/XX03 = EUR/USD/GBP).
+
+INSERT INTO gl_accounts (id, code, name, type, currency_code, is_leaf, is_enabled) VALUES
+    ('a0000000-0000-0000-0000-000000001101', '1101', 'Customer Cash Clearing EUR', 'ASSET', 'EUR', true, true),
+    ('a0000000-0000-0000-0000-000000001102', '1102', 'Customer Cash Clearing USD', 'ASSET', 'USD', true, true),
+    ('a0000000-0000-0000-0000-000000001103', '1103', 'Customer Cash Clearing GBP', 'ASSET', 'GBP', true, true);

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/PaymentJournalFactory.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/application/usecase/PaymentJournalFactory.kt
@@ -44,8 +44,17 @@ object PaymentJournalFactory {
     // Well-known leaf GL accounts seeded by the ledger service.
     // V3__ledger_governance.sql: 1100 Customer Cash Clearing (ASSET, CZK), 2100 Customer Deposit
     // Control (LIABILITY, CZK). V5__fx_position_accounts.sql: per-currency deposit control and
-    // FX position accounts. Stable UUIDs let the saga reference them deterministically.
-    private val CUSTOMER_CASH_CLEARING_CZK = UUID.fromString("a0000000-0000-0000-0000-000000000001")
+    // FX position accounts. V14__cash_clearing_accounts_per_currency.sql: per-currency cash
+    // clearing (issue #747 — the CZK-only account was previously used for every currency's
+    // cash-clearing leg, rejected by LedgerService's line/account currency-match check (422) for
+    // anything non-CZK — confirmed live, a EUR CREDIT transaction failed where CZK succeeded).
+    // Stable UUIDs let the saga reference them deterministically.
+    private val CASH_CLEARING: Map<String, UUID> = mapOf(
+        "CZK" to UUID.fromString("a0000000-0000-0000-0000-000000000001"),
+        "EUR" to UUID.fromString("a0000000-0000-0000-0000-000000001101"),
+        "USD" to UUID.fromString("a0000000-0000-0000-0000-000000001102"),
+        "GBP" to UUID.fromString("a0000000-0000-0000-0000-000000001103"),
+    )
 
     private val DEPOSIT_CONTROL: Map<String, UUID> = mapOf(
         "CZK" to UUID.fromString("a0000000-0000-0000-0000-000000000002"),
@@ -112,7 +121,7 @@ object PaymentJournalFactory {
         )
 
     private fun cashClearingLeg(transaction: Transaction, ccy: String, side: String) = JournalLineRequest(
-        glAccountId = CUSTOMER_CASH_CLEARING_CZK,
+        glAccountId = cashClearing(ccy),
         side = side,
         amount = transaction.amount.amount,
         currencyCode = ccy,
@@ -152,6 +161,9 @@ object PaymentJournalFactory {
             ),
         )
     }
+
+    private fun cashClearing(currency: String): UUID = CASH_CLEARING[currency]
+        ?: error("No cash-clearing GL account seeded for currency $currency")
 
     private fun depositControl(currency: String): UUID = DEPOSIT_CONTROL[currency]
         ?: error("No deposit-control GL account seeded for currency $currency")

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/PaymentJournalFactoryTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/application/usecase/PaymentJournalFactoryTest.kt
@@ -20,6 +20,7 @@ import java.util.UUID
 class PaymentJournalFactoryTest {
 
     private val cashClearingCzk = UUID.fromString("a0000000-0000-0000-0000-000000000001")
+    private val cashClearingEur = UUID.fromString("a0000000-0000-0000-0000-000000001101")
     private val depositControlCzk = UUID.fromString("a0000000-0000-0000-0000-000000000002")
     private val depositControlEur = UUID.fromString("a0000000-0000-0000-0000-000000002101")
     private val fxPositionCzk = UUID.fromString("a0000000-0000-0000-0000-000000001990")
@@ -116,6 +117,48 @@ class PaymentJournalFactoryTest {
 
         assertThatThrownBy { PaymentJournalFactory.buildLines(tx) }
             .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    // --- Non-CZK same-currency cash-clearing leg (issue #747): the cash-clearing account used to
+    // be hardcoded to the CZK-only leaf regardless of the payment's currency, which LedgerService
+    // rejects (422, currency mismatch between the line and its GL account) for anything non-CZK. ---
+
+    @Test
+    fun `outbound payment in EUR credits EUR cash-clearing, not the CZK-only account`() {
+        val source = UUID.randomUUID()
+        val tx = transaction(
+            amount = Money.of("40.00", "EUR"),
+            baseAmount = Money.of("40.00", "EUR"),
+            sourceAccountId = source,
+            targetAccountId = null,
+        )
+
+        val lines = PaymentJournalFactory.buildLines(tx)
+
+        assertThat(lines).hasSize(2)
+        val cash = lines.single { it.side == "CREDIT" }
+        assertThat(cash.glAccountId).isEqualTo(cashClearingEur)
+        assertThat(cash.currencyCode).isEqualTo("EUR")
+        assertPerCurrencyBalanced(lines)
+    }
+
+    @Test
+    fun `incoming credit in EUR debits EUR cash-clearing, not the CZK-only account`() {
+        val target = UUID.randomUUID()
+        val tx = transaction(
+            amount = Money.of("40.00", "EUR"),
+            baseAmount = Money.of("40.00", "EUR"),
+            sourceAccountId = null,
+            targetAccountId = target,
+        )
+
+        val lines = PaymentJournalFactory.buildLines(tx)
+
+        assertThat(lines).hasSize(2)
+        val cash = lines.single { it.side == "DEBIT" }
+        assertThat(cash.glAccountId).isEqualTo(cashClearingEur)
+        assertThat(cash.currencyCode).isEqualTo("EUR")
+        assertPerCurrencyBalanced(lines)
     }
 
     // --- Cross-currency (ADR-0025): four-legged FX entry, unchanged by the direction fix. ---


### PR DESCRIPTION
## Summary

Closes issue #747. `PaymentJournalFactory`'s cash-clearing leg was hardcoded to a single CZK-only GL account regardless of the transaction's actual currency — confirmed live while building the issue #669 write benchmark (a EUR payment fails with 422, the identical CZK one succeeds).

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #747

## Changes

- `openbank-transaction-service/.../PaymentJournalFactory.kt`: replaced the single `CUSTOMER_CASH_CLEARING_CZK` constant with a `CASH_CLEARING` per-currency map (EUR/USD/GBP), mirroring the existing `DEPOSIT_CONTROL`/`FX_POSITION` lookup pattern already used elsewhere in the same file. `cashClearingLeg()` now resolves the account for the leg's actual currency instead of always using the CZK one.
- `openbank-ledger-service/.../V14__cash_clearing_accounts_per_currency.sql` (new): seeds the three new leaf GL accounts, following V5's exact numbering convention (`XX01/XX02/XX03` = EUR/USD/GBP). Numbered V14, not V13, to avoid colliding with the V13 repair migration in the paired #527 PR.
- `PaymentJournalFactoryTest`: two new cases asserting a EUR outbound/inbound payment's cash-clearing leg resolves to the new per-currency account, not the CZK one. Existing CZK-only tests are unaffected (same account id as before — purely additive).
- `docs/threat-models/openbank-transaction-service.md`: change-log entry.

Internal transfers (both source and target set, same currency) were never affected — they only use `depositLeg` on both sides, no cash-clearing leg at all.

## Definition of Done

- [x] Hexagonal layering preserved — the map lives in the same application-layer factory as the existing per-currency maps, no framework coupling added.
- [x] Unit tests added/updated — two new `PaymentJournalFactoryTest` cases.
- [ ] Integration tests added/updated. — not added; this is exactly the kind of thing best covered at the unit level (a pure `buildLines()` factory, no I/O) — see the perf/k6/money-path-write-benchmark.js in issue #669's PR #734 for the live end-to-end confirmation of the actual bug this fixes.
- [ ] Contract tests updated. — N/A, no API changed.
- [x] `./gradlew detekt ktlintCheck koverVerify build` — ran `ktlintCheck`, `detekt`, and the full `PaymentJournalFactoryTest` suite locally; all green.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated. — N/A, no API changed.
- [x] Flyway migration added + rollback note. — rollback: `DELETE FROM gl_accounts WHERE id IN ('a0000000-0000-0000-0000-000000001101','...1102','...1103')`, safe as long as no journal_lines reference them yet (true immediately after this deploys; check before rolling back later).
- [ ] Avro schema versioned. — N/A.
- [x] Docs updated — threat model change log.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — **yes, tag `security-review-required`**: money-path (transaction-service + ledger-service), needs 2 approvals per `rules.yaml`. The change is narrow (GL account routing by currency) and purely additive on the ledger side (new reference rows, no schema/behavior change to existing accounts).
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [ ] None — correct GL account routing is a books-of-account accuracy concern (CNB §4), not a new compliance surface.

## Rollout / Rollback

- Deployment strategy: standard Flyway auto-migrate for the new `gl_accounts` rows, standard code deploy for the factory change. Both services need to deploy together for non-CZK payments to actually start working (the factory change alone would post against accounts that don't exist yet without the migration; the migration alone is a no-op without the factory change).
- Rollback plan: revert the code change; the new `gl_accounts` rows can stay (harmless, unreferenced) or be removed per the rollback note above.
- Data migration reversible: yes, see above.

## Reviewer notes

This pairs with #748 (the V13 ledger reversal-repair migration) — both were split out of the same investigation (issue #669's write benchmark) but are otherwise independent; either can merge first. I deliberately numbered this one V14 to avoid a Flyway version collision regardless of merge order.