### PR TITLE
fix(governance): authorize the M2M sanctions.create call (#746)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "9966b567a3ebada5"
+    openbank.tech/policy-checksum: "01be934e0f75013d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9966b567a3ebada5"
+        openbank.tech/policy-checksum: "01be934e0f75013d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "649015f2590013a3"
+    openbank.tech/policy-checksum: "687411bf3099256e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "649015f2590013a3"
+        openbank.tech/policy-checksum: "687411bf3099256e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "e4acb7570fa3d4b3"
+    openbank.tech/policy-checksum: "d3a76e3c4747b8d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e4acb7570fa3d4b3"
+        openbank.tech/policy-checksum: "d3a76e3c4747b8d5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "1b75a2fd778ad900"
+    openbank.tech/policy-checksum: "7975c9cb4c3c962c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b75a2fd778ad900"
+        openbank.tech/policy-checksum: "7975c9cb4c3c962c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "87d04e15342c06f4"
+    openbank.tech/policy-checksum: "a4f25d81b30dac48"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "87d04e15342c06f4"
+        openbank.tech/policy-checksum: "a4f25d81b30dac48"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "c6595ba0beffb780"
+    openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -193,6 +193,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c6595ba0beffb780"
+        openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "5fdb458cf4901218"
+    openbank.tech/policy-checksum: "173648a856944eeb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5fdb458cf4901218"
+        openbank.tech/policy-checksum: "173648a856944eeb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "32aa1c734eb20800"
+    openbank.tech/policy-checksum: "b48903e02a49e9a8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "32aa1c734eb20800"
+        openbank.tech/policy-checksum: "b48903e02a49e9a8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "eda80599ab7c83be"
+    openbank.tech/policy-checksum: "6275cbdbdc086bfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "eda80599ab7c83be"
+        openbank.tech/policy-checksum: "6275cbdbdc086bfd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9a701761e8bae8ad"
+    openbank.tech/policy-checksum: "9a3e5514ffe17b72"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9a701761e8bae8ad"
+        openbank.tech/policy-checksum: "9a3e5514ffe17b72"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "c6595ba0beffb780"
+    openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -193,6 +193,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "c6595ba0beffb780"
+        openbank.tech/policy-checksum: "8fa9a37a00d73fc6"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7a6f39e65a177d9a"
+    openbank.tech/policy-checksum: "afab1ba3087d8686"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2cb10ba1e7fa3ca9"
+    openbank.tech/policy-checksum: "7cb5ff301ec1ff39"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7a046a1eca4aa600" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "dd121175d5f34544" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc374fc12b7728c1"
+        openbank.tech/policy-checksum: "b92444643d679d9d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "2cb10ba1e7fa3ca9" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "7cb5ff301ec1ff39" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e9af05ac6c3126bc"
+        openbank.tech/policy-checksum: "ffa71f4a0a61e039"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7a6f39e65a177d9a" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "afab1ba3087d8686" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1943,7 +1943,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ac68f22e41856296" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "dd361bf4e2accc6a" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2333,7 +2333,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "51ab79f6d6cf7123"
+        openbank.tech/policy-checksum: "65e608db51285a5b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e9af05ac6c3126bc"
+    openbank.tech/policy-checksum: "ffa71f4a0a61e039"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cc374fc12b7728c1"
+    openbank.tech/policy-checksum: "b92444643d679d9d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ac68f22e41856296"
+    openbank.tech/policy-checksum: "dd361bf4e2accc6a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "51ab79f6d6cf7123"
+    openbank.tech/policy-checksum: "65e608db51285a5b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7a046a1eca4aa600"
+    openbank.tech/policy-checksum: "dd121175d5f34544"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "53c93d6e3120bd61"
+    openbank.tech/policy-checksum: "f755ad7f487d4725"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "53c93d6e3120bd61"
+        openbank.tech/policy-checksum: "f755ad7f487d4725"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "9b559425dc9b799f"
+    openbank.tech/policy-checksum: "1654fa1203ade0e5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -192,6 +192,40 @@ data:
     	some family in {"notification.", "device."}
     	startswith(input.action, family)
     }
+
+    # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+    # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+    # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+    # input.resource) can never fire for it, and no other rule covers a resourceless write.
+    # Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+    # identity account-service uses to call ledger/balance) got 403 policy-denied calling
+    # sanctions.create directly, once AUTHZ_ENFORCE=true.
+    #
+    # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+    # judgment calls, not a service-to-service compliance check, and must stay behind a human
+    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    #
+    # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+    # sanctions.create is "run a compliance check" — not an account-takeover primitive like
+    # device.enroll — and more than one service legitimately screens entities (account-service
+    # today; kyc/onboarding/party are plausible future callers). Gating on the
+    # "service-account-*" preferred_username prefix (deterministic for any Keycloak
+    # client_credentials token, per the edge-service-notification note above — not forgeable by
+    # a human password-grant session, whose preferred_username is the human's own username)
+    # covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+    # staff sessions from this specific carve-out.
+    allowed_reasons contains "m2m-sanctions-screening" if {
+    	input.principal.type == "HUMAN"
+    	startswith(input.principal.id, "service-account-")
+    	input.action == "sanctions.create"
+    }
+
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b559425dc9b799f"
+        openbank.tech/policy-checksum: "1654fa1203ade0e5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -179,6 +179,40 @@ allowed_reasons contains "edge-service-notification" if {
 	startswith(input.action, family)
 }
 
+# Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
+# (issue #746, found via issue #669's load benchmark). sanctions.create is called with
+# resource = "" — a resourceless system action — so operator-on-own-tenant (which requires
+# input.resource) can never fire for it, and no other rule covers a resourceless write.
+# Confirmed live: a client_credentials token from openbank-services (ROLE_OPERATOR, the same
+# identity account-service uses to call ledger/balance) got 403 policy-denied calling
+# sanctions.create directly, once AUTHZ_ENFORCE=true.
+#
+# Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
+# sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
+# judgment calls, not a service-to-service compliance check, and must stay behind a human
+# session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+#
+# Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
+# sanctions.create is "run a compliance check" — not an account-takeover primitive like
+# device.enroll — and more than one service legitimately screens entities (account-service
+# today; kyc/onboarding/party are plausible future callers). Gating on the
+# "service-account-*" preferred_username prefix (deterministic for any Keycloak
+# client_credentials token, per the edge-service-notification note above — not forgeable by
+# a human password-grant session, whose preferred_username is the human's own username)
+# covers any M2M caller without a per-caller rule, while still excluding real operator/admin
+# staff sessions from this specific carve-out.
+allowed_reasons contains "m2m-sanctions-screening" if {
+	input.principal.type == "HUMAN"
+	startswith(input.principal.id, "service-account-")
+	input.action == "sanctions.create"
+}
+
+# NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
+# gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
+# same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
+# exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
+# the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+
 # ---------------------------------------------------------------------------------------
 # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
 # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -652,3 +652,58 @@ test_allow_edge_identity_without_explicit_operator_role_check if {
 
 	decision.allow == true
 }
+
+# ---------------------------------------------------------------------------------------
+# m2m-sanctions-screening (issue #746, found via issue #669's load benchmark): a resourceless
+# M2M sanctions.create call has no other matching rule (operator-on-own-tenant requires
+# input.resource; sanctions.create has none). account-service's client_credentials token
+# (client "openbank-services") is the confirmed real-world caller.
+# ---------------------------------------------------------------------------------------
+test_allow_m2m_sanctions_create if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-services", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "sanctions.create",
+		"resource": "",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "m2m-sanctions-screening"
+}
+
+# Any service-account caller works, not just openbank-services — the rule is deliberately
+# not pinned to one client id (see rest.rego comment): more than one service may screen
+# entities. This is the "different caller, same carve-out" counterpart to the identity-
+# pinned edge-service-notification rule above.
+test_allow_m2m_sanctions_create_from_a_different_service_account if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-kyc", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "sanctions.create",
+		"resource": "",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+}
+
+# Deny-by-default still holds outside sanctions.create — an M2M caller does NOT gain the
+# whole "sanctions." family. sanctions.review lets an operator dismiss/confirm a hit; a
+# service self-clearing its own screening result would defeat the compliance control.
+test_deny_m2m_sanctions_review_not_covered if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-services", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "sanctions.review",
+		"resource": "",
+	}
+}
+
+# A real human operator session (not a service-account principal) does NOT gain this rule's
+# reach via ROLE_OPERATOR alone — it gates on the "service-account-" identity prefix, not
+# the role, mirroring the edge-service-notification invariant above.
+test_deny_human_operator_sanctions_create_via_m2m_rule if {
+	not rest.allow with input as {
+		"principal": {"id": "operator-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "sanctions.create",
+		"resource": "",
+	}
+}


### PR DESCRIPTION
## Summary

Closes issue #746. OPA's `rest.rego` had no `allowed_reasons` rule that could authorize account-service's M2M call to sanctions-service's `sanctions.create` — confirmed live while building the issue #669 write benchmark (`403 policy denied` once `AUTHZ_ENFORCE=true`).

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #746
Follow-up filed: #750 (the same resourceless-M2M-`.create` gap exists fleet-wide — `ledger.create`, `fx.create`, `lending.create`, `settlement.create`, and others — deliberately NOT bundled into this PR since each needs its own case-by-case safety analysis)

## Changes

- `openbank-libs/governance/policies/rest.rego`: new `m2m-sanctions-screening` rule. Gates on the `service-account-*` `preferred_username` prefix (deterministic for any Keycloak `client_credentials` token, not forgeable by a human password-grant session) rather than one hardcoded client id — more than one service may legitimately screen entities. Deliberately scoped to the single `sanctions.create` action, not a `sanctions.` family prefix: `sanctions.review` is a human judgment call (dismiss/confirm a hit) and must stay behind a real operator session.
- `openbank-libs/governance/policies/rest_test.rego`: 4 new cases — allow from the confirmed real caller identity, allow from a *different* service-account identity (proving it's not pinned to one caller), deny `sanctions.review` via the same rule, deny a real human operator session via `ROLE_OPERATOR` alone.
- Regenerated all 17 affected OPA bundle ConfigMaps + pod-roll checksum annotations (`rules.yaml`/`rest.rego` is baked verbatim into each service's sidecar bundle).

## How this was tested

`./openbank-infra/opa/build-bundle.sh` locally: `opa test` 115/115 passing (was 111 before this change), `opa check --strict` clean, decision assertions against the real `agents.yaml` all pass, bundle builds.

## Definition of Done

- [x] Hexagonal layering preserved — N/A, pure policy + generated-artifact change, no service code touched.
- [x] Unit tests added/updated — 4 new `rest_test.rego` cases (`opa test`).
- [ ] Integration tests added/updated. — N/A, this is exercised end-to-end by the k6 write benchmark in #734 once `AUTHZ_ENFORCE` is on for a live run; not repeated here.
- [ ] Contract tests updated. — N/A, no REST API changed.
- [ ] `./gradlew detekt ktlintCheck koverVerify build` — N/A, no Kotlin/Gradle module touched.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated. — N/A.
- [ ] Flyway migration added. — N/A.
- [ ] Avro schema versioned. — N/A.
- [x] Docs updated — inline `rest.rego` comments explain the reasoning at the rule site (this repo's convention for policy docs).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed? — **yes, tag `security-review-required`**: this is an authorization-policy change. Deliberately narrow (one action, identity-pattern-gated, not a blanket role grant) — see the reasoning inline in `rest.rego` for why it doesn't repeat the "any operator gets `device.enroll`" account-takeover class of mistake this file already documents a fix for.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [ ] None — this closes a gap in the enforcement path for sanctions/AML screening authorization (5AMLD-adjacent), making the *existing* screening requirement enforceable once `AUTHZ_ENFORCE` graduates, rather than introducing a new compliance surface.

## Rollout / Rollback

- Deployment strategy: standard OPA bundle ConfigMap rollout — the regenerated ConfigMaps + pod-roll checksum annotations in this PR trigger a pod restart on the affected services when this merges and gitops syncs (subPath mounts don't hot-reload, hence the checksum-annotation mechanism already in place).
- Rollback plan: revert the PR; the previous bundle content (and checksums) come back, regenerating the same ConfigMaps.
- Data migration reversible: N/A, no data change.

## Reviewer notes

Not a live incident today (sanctions-service already runs `AUTHZ_ENFORCE=false` in the real deployment), but it IS a blocking pre-condition for that gate's advisory→enforce graduation — I checked `check-gate-graduation.sh` and confirmed it doesn't apply here (that script tracks `rules.yaml: enforced: advisory|planned` gates with `target_enforce_date`, not per-service `AUTHZ_ENFORCE` env vars in gitops manifests — a different, unrelated mechanism), so there's nothing to wire up there.

Money-path-adjacent (sanctions-service gates account/payment flows) — happy to add more test scenarios if the identity-prefix-vs-hardcoded-id tradeoff needs more scrutiny.