### PR TITLE
fix(ledger,psd2): dedicated exception types, no more mapper collision (#526)

### DIFF
--- a/.github/scripts/check-exception-mapper-collision.sh
+++ b/.github/scripts/check-exception-mapper-collision.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Guard: no service may register its own jakarta.ws.rs.ext.ExceptionMapper for a JDK
+# exception type openbank-libs-runtime already maps
+# (com/openbank/libs/api/error/CommonExceptionMappers.kt): IllegalArgumentException,
+# IllegalStateException, NoSuchElementException, Exception, WebApplicationException.
+#
+# JAX-RS provider selection between two ExceptionMapper<T>s registered for the identical
+# type T is not deterministically ordered — a second local mapper for a libs-owned type
+# does not "override" it, it wins or loses per-request at random. Found live: ledger-service
+# had ExceptionMapper<IllegalArgumentException> (422) and ExceptionMapper<IllegalStateException>
+# (409) racing libs' 400/422, and psd2-service had ExceptionMapper<IllegalArgumentException>
+# (Berlin Group tppMessages envelope) racing libs' generic ApiError envelope for the same
+# 400 status — a TPP client could get either response SHAPE non-deterministically (issue #526).
+#
+# Fix: introduce a dedicated exception type + mapper (see
+# openbank-ledger-service's LedgerValidationException/LedgerConflictException, or
+# openbank-psd2-service's Psd2RequestFormatException, for the pattern) instead of
+# re-mapping the JDK type directly. A service needing a different status code for what
+# would otherwise be an IllegalArgumentException/IllegalStateException throws the
+# dedicated type from the call site (Kotlin's require()/check() cannot be redirected —
+# see requireValid()/checkConflict() in LedgerExceptions.kt for a drop-in replacement).
+#
+# stdlib-only (grep); no Kotlin-parser dependency, matching
+# check-no-service-principal-type.sh / check-domain-purity.sh. ENFORCED.
+# Usage: check-exception-mapper-collision.sh [root]   (default root: .)
+set -euo pipefail
+root="${1:-.}"
+fail=0
+checked=0
+
+# Anchored to an actual supertype declaration (": ExceptionMapper<Type>"), not just any
+# mention of the string — explanatory comments about this exact defect class (including
+# this script's own error message, and the fix's inline documentation) legitimately
+# reference these type names in prose and must not self-trigger.
+pattern=': *ExceptionMapper<(IllegalArgumentException|IllegalStateException|NoSuchElementException|Exception|WebApplicationException)>'
+
+while IFS= read -r f; do
+  checked=$((checked + 1))
+  # Exclude Kotlin line-comments (// ...) so prose mentioning the pattern doesn't self-trigger.
+  hits=$(grep -nE "$pattern" "$f" | grep -vE '^[0-9]+:[[:space:]]*//' || true)
+  if [ -n "$hits" ]; then
+    fail=1
+    while IFS= read -r hit; do
+      lineno="${hit%%:*}"
+      echo "::error file=$f,line=$lineno::a service-local ExceptionMapper for a libs-runtime-owned JDK exception type collides non-deterministically (issue #526) — introduce a dedicated exception type + mapper instead."
+    done <<< "$hits"
+  fi
+done < <(find "$root"/openbank-*/src/main/kotlin -name '*.kt' \
+  -not -path '*/openbank-libs-runtime/*' \
+  -not -path '*/build/*' | sort)
+
+echo "check-exception-mapper-collision: $checked service source file(s) checked, $( [ "$fail" -eq 0 ] && echo "none collide with a libs-runtime-owned ExceptionMapper type." || echo "VIOLATIONS above." )"
+exit "$fail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,22 @@ jobs:
       - name: "no dead-code SERVICE-principal rego rule (enforced)"
         run: bash .github/scripts/check-no-service-principal-type.sh .
 
+      # No service may register its own ExceptionMapper for a JDK type
+      # openbank-libs-runtime already maps (IllegalArgumentException,
+      # IllegalStateException, NoSuchElementException, Exception,
+      # WebApplicationException) — JAX-RS provider selection between two
+      # mappers for the identical type is not deterministically ordered, so a
+      # second local mapper does not "override" the libs one, it races it
+      # per-request. Found live in ledger-service (422/409 racing libs'
+      # 400/422) and psd2-service (a different response BODY SHAPE racing
+      # libs' generic envelope for the same 400 status), issue #526. 0
+      # violations on origin/main at introduction — this is a regression
+      # guard; see LedgerValidationException/LedgerConflictException and
+      # Psd2RequestFormatException for the dedicated-exception-type fix
+      # pattern. ENFORCED.
+      - name: "no service-local ExceptionMapper collision with libs-runtime (enforced)"
+        run: bash .github/scripts/check-exception-mapper-collision.sh .
+
       # openbank.outbox.dispatch-enabled guard (the CLAUDE.md "outbox footgun":
       # a service whose OutboxDispatcher actually gates on this flag silently
       # never dispatches if it's left at its false default — no error,

--- a/docs/adr/0049-openbank-libs-consolidation-phase-4.md
+++ b/docs/adr/0049-openbank-libs-consolidation-phase-4.md
@@ -5,12 +5,37 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): jiri.raska
 
-**Delivery note (updated 2026-06-30):**
+**Delivery note (updated 2026-07-11):**
 - **D3 (outbox abstraction)** — ✅ Shipped: all 29 services migrated to `AbstractOutboxDispatcher`; 20 PRs merged.
-- **D4 (exception-mapper cleanup)** — ✅ Shipped: duplicate generic mappers removed; 2 intentional overrides documented.
+- **D4 (exception-mapper cleanup)** — ✅ Shipped, corrected 2026-07-11: the 2026-06-19 amendment's "2 intentional overrides" were not safe overrides — they were a non-deterministic JAX-RS provider collision (issue #526). Fixed with dedicated exception types; see the 2026-07-11 amendment below.
 - **D1 (convention plugin rollout)** — ✅ Shipped: all 37 modules with a `build.gradle.kts` apply `openbank.quarkus-service` or `openbank.static-analysis`; rollout complete.
 - **D2 (`version.txt` adoption)** — ✅ Shipped: all 43 releasable components enrolled in release-please with `version.txt` + manifest entry (see ADR-0029 D2); 4 modules excluded by design.
 - **D5 (observability/metrics in libs)** — ⬜ Not started.
+
+> **Amendment 2026-07-11 — D4 correction: the "intentional overrides" were a collision bug, not a safe pattern.**
+>
+> The 2026-06-19 amendment below documented ledger's `IllegalArgumentExceptionMapper`/
+> `IllegalStateExceptionMapper` and psd2's `Psd2IllegalArgMapper` as deliberate, safe overrides of
+> the libs `CommonExceptionMappers` defaults. This was wrong: JAX-RS provider selection between two
+> `ExceptionMapper<T>`s registered for the **identical** type `T` is not deterministically ordered —
+> a second local mapper does not "override" the libs one, it races it per-request (found live while
+> building issue #669's write benchmark; ledger's 422/409 status codes and psd2's Berlin-Group
+> `tppMessages` response *shape* were both a per-request lottery against libs' defaults, not a
+> reliable override).
+>
+> Fix (issue #526): each service's colliding mapper is replaced by a **dedicated exception type**
+> that libs cannot also claim — `LedgerValidationException`/`LedgerConflictException` (ledger,
+> replacing bare `IllegalArgumentException`/`IllegalStateException` at every `require()`/`check()`
+> call site) and `Psd2RequestFormatException` (psd2). The status codes and response shapes are
+> unchanged; only the exception *type* changed, so JAX-RS now resolves the mapper unambiguously.
+> `check-exception-mapper-collision.sh` (CI, enforced) guards against this defect class recurring —
+> extends the "no second `ExceptionMapper<Exception>`" rule below to every libs-owned type
+> (`IllegalArgumentException`, `IllegalStateException`, `NoSuchElementException`, `Exception`,
+> `WebApplicationException`), closing the gap the 2026-06-19 sweep left open.
+>
+> **D4 rule, corrected:** a service must never register `ExceptionMapper<T>` for a JDK type libs
+> already maps. A service needing a different status code or response shape introduces a dedicated
+> domain exception + mapper instead — never re-maps the JDK type directly, "intentionally" or not.
 
 > **Amendment 2026-06-19 — D3 outbox abstraction sweep complete; D4 exception-mapper sweep complete.**
 >

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/LedgerService.kt
@@ -28,6 +28,7 @@ import com.openbank.ledger.domain.model.JournalLine
 import com.openbank.ledger.domain.model.JournalStatus
 import com.openbank.ledger.domain.model.SubLedgerBalance
 import com.openbank.ledger.domain.model.TrialBalance
+import com.openbank.ledger.domain.model.checkConflict
 import com.openbank.libs.api.pagination.CursorEncoder
 import com.openbank.libs.api.pagination.CursorPage
 import com.openbank.libs.api.pagination.PageInfo
@@ -115,7 +116,7 @@ class LedgerService(
         ).post()
 
         // Cross-check that we actually validated every account that the entry references.
-        check(glAccounts.keys.containsAll(entry.lines.map { it.glAccountId }.toSet())) {
+        checkConflict(glAccounts.keys.containsAll(entry.lines.map { it.glAccountId }.toSet())) {
             "Unvalidated GL account referenced in journal entry"
         }
 

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/YearCloseService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/YearCloseService.kt
@@ -18,6 +18,7 @@ import com.openbank.ledger.domain.model.FiscalYearTrialBalance
 import com.openbank.ledger.domain.model.YearCloseRecord
 import com.openbank.ledger.domain.model.YearCloseStatus
 import com.openbank.ledger.domain.model.YearCloseVerification
+import com.openbank.ledger.domain.model.requireValid
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -171,7 +172,7 @@ class YearCloseService(
     }
 
     private suspend fun computeTrialBalance(fiscalYear: Int): FiscalYearTrialBalance {
-        require(fiscalYear in YearCloseRecord.MIN_FISCAL_YEAR..YearCloseRecord.MAX_FISCAL_YEAR) {
+        requireValid(fiscalYear in YearCloseRecord.MIN_FISCAL_YEAR..YearCloseRecord.MAX_FISCAL_YEAR) {
             "fiscalYear out of range: $fiscalYear"
         }
         val year = Year.of(fiscalYear)

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/FxConversionPosting.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/FxConversionPosting.kt
@@ -36,16 +36,16 @@ object FxConversionPosting {
         customerBuyAmount: Money,
         fxRate: BigDecimal,
     ): List<JournalLine> {
-        require(sellAmount.isPositive()) { "sellAmount must be positive" }
-        require(grossBuyAmount.isPositive()) { "grossBuyAmount must be positive" }
-        require(sellAmount.currency != grossBuyAmount.currency) {
+        requireValid(sellAmount.isPositive()) { "sellAmount must be positive" }
+        requireValid(grossBuyAmount.isPositive()) { "grossBuyAmount must be positive" }
+        requireValid(sellAmount.currency != grossBuyAmount.currency) {
             "FX conversion must cross currencies: both legs are ${sellAmount.currency.code}"
         }
-        require(customerBuyAmount.currency == grossBuyAmount.currency) {
+        requireValid(customerBuyAmount.currency == grossBuyAmount.currency) {
             "customerBuyAmount currency ${customerBuyAmount.currency.code} must match buy currency ${grossBuyAmount.currency.code}"
         }
         val margin = grossBuyAmount - customerBuyAmount
-        require(margin.isNonNegative()) {
+        requireValid(margin.isNonNegative()) {
             "Customer cannot receive more than the gross converted amount (negative margin: $margin)"
         }
 

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/FxRevaluationPosting.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/FxRevaluationPosting.kt
@@ -54,7 +54,7 @@ object FxRevaluationPosting {
         val lines = mutableListOf<JournalLine>()
         var seq = 0
         for (input in inputs) {
-            require(input.cnbRate.signum() > 0) {
+            requireValid(input.cnbRate.signum() > 0) {
                 "ČNB rate must be positive for ${input.currency}, was ${input.cnbRate}"
             }
             val delta = movement(input)

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/JournalEntry.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/JournalEntry.kt
@@ -25,7 +25,7 @@ data class JournalEntry(
     val reversalOf: UUID? = null,
 ) {
     init {
-        require(lines.size >= 2) { "Journal entry must have at least 2 lines" }
+        requireValid(lines.size >= 2) { "Journal entry must have at least 2 lines" }
         validateBalance()
     }
 
@@ -40,14 +40,14 @@ data class JournalEntry(
                 .sumOf { it.baseAmount.amount }
             val credits = lines.filter { it.side == JournalSide.CREDIT && it.baseAmount.currency == currency }
                 .sumOf { it.baseAmount.amount }
-            require(debits.compareTo(credits) == 0) {
+            requireValid(debits.compareTo(credits) == 0) {
                 "Journal entry is not balanced in ${currency.code}: debits=$debits credits=$credits"
             }
         }
     }
 
     fun post(): JournalEntry {
-        check(status == JournalStatus.PENDING) { "Can only post PENDING journal entries, current: $status" }
+        checkConflict(status == JournalStatus.PENDING) { "Can only post PENDING journal entries, current: $status" }
         return copy(status = JournalStatus.POSTED)
     }
 
@@ -73,7 +73,7 @@ data class JournalEntry(
         }
 
     fun reverse(reversalId: UUID, reversedBy: UUID, lineIdProvider: (UUID) -> UUID = { Ids.newId() }): JournalEntry {
-        check(status == JournalStatus.POSTED) { "Can only reverse POSTED journal entries" }
+        checkConflict(status == JournalStatus.POSTED) { "Can only reverse POSTED journal entries" }
         val reversalLines = lines.map { line ->
             line.copy(
                 id = lineIdProvider(line.id),

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/LedgerExceptions.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/LedgerExceptions.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.domain.model
+
+/**
+ * Ledger-wide validation failure (422), replacing bare `IllegalArgumentException` / `require()`
+ * across the domain and application layers (issue #526). A service-local
+ * `ExceptionMapper<IllegalArgumentException>` collided non-deterministically with
+ * `openbank-libs-runtime`'s own mapper for the identical JDK type — JAX-RS has no defined
+ * tie-breaker between two providers registered for the same type, so the status code (422 here
+ * vs libs' 400) was a per-request lottery, not the "intentional override" the removed mapper's
+ * comment claimed. A dedicated type is unambiguous: JAX-RS always picks the most specific
+ * matching provider.
+ */
+class LedgerValidationException(message: String) : RuntimeException(message)
+
+/**
+ * Ledger-wide conflict / invariant violation (409), replacing bare `IllegalStateException` /
+ * `check()` across the domain and application layers (issue #526). Same collision class as
+ * [LedgerValidationException], against libs-runtime's `ExceptionMapper<IllegalStateException>`
+ * (422). Distinct from [com.openbank.ledger.application.usecase.JournalReversalConflictException]
+ * and the other already-dedicated conflict types (#465-era), which stay separate because their
+ * response bodies/semantics are more specific than a generic conflict.
+ */
+class LedgerConflictException(message: String) : RuntimeException(message)
+
+/** `require()`-equivalent that throws [LedgerValidationException] instead of the JDK type. */
+inline fun requireValid(condition: Boolean, lazyMessage: () -> String) {
+    if (!condition) throw LedgerValidationException(lazyMessage())
+}
+
+/** `check()`-equivalent that throws [LedgerConflictException] instead of the JDK type. */
+inline fun checkConflict(condition: Boolean, lazyMessage: () -> String) {
+    if (!condition) throw LedgerConflictException(lazyMessage())
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/YearClose.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/YearClose.kt
@@ -135,7 +135,7 @@ data class YearCloseRecord(
     val attestedAt: Instant? = null,
 ) {
     init {
-        require(fiscalYear in MIN_FISCAL_YEAR..MAX_FISCAL_YEAR) { "fiscalYear out of range: $fiscalYear" }
+        requireValid(fiscalYear in MIN_FISCAL_YEAR..MAX_FISCAL_YEAR) { "fiscalYear out of range: $fiscalYear" }
     }
 
     /**
@@ -147,9 +147,11 @@ data class YearCloseRecord(
      * line so a future caller cannot bypass the control by going straight at the aggregate.
      */
     fun attest(attestedBy: String, attestedAt: Instant): YearCloseRecord {
-        check(status == YearCloseStatus.DRAFT) { "Year close $fiscalYear is not DRAFT (status=$status)" }
-        check(draftedBy != null) { "Year close $fiscalYear draft has no recorded author — cannot attest (four-eyes)" }
-        check(draftedBy != attestedBy) {
+        checkConflict(status == YearCloseStatus.DRAFT) { "Year close $fiscalYear is not DRAFT (status=$status)" }
+        checkConflict(draftedBy != null) {
+            "Year close $fiscalYear draft has no recorded author — cannot attest (four-eyes)"
+        }
+        checkConflict(draftedBy != attestedBy) {
             "Four-eyes violation: attestor $attestedBy must differ from the draft author for year $fiscalYear"
         }
         return copy(status = YearCloseStatus.ATTESTED, attestedBy = attestedBy, attestedAt = attestedAt)

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
@@ -12,6 +12,7 @@ import com.openbank.ledger.domain.model.JournalEntry
 import com.openbank.ledger.domain.model.JournalLine
 import com.openbank.ledger.domain.model.JournalSide
 import com.openbank.ledger.domain.model.JournalStatus
+import com.openbank.ledger.domain.model.LedgerConflictException
 import com.openbank.ledger.domain.model.SubLedgerBalance
 import com.openbank.ledger.domain.model.TrialBalanceLine
 import com.openbank.ledger.infrastructure.persistence.entity.JournalEntryEntity
@@ -368,7 +369,7 @@ class PanacheJournalRepository(
 
     private fun Any?.toUuid(): UUID = when (this) {
         is UUID -> this
-        null -> throw IllegalStateException("null UUID in trial balance row")
+        null -> throw LedgerConflictException("null UUID in trial balance row")
         else -> UUID.fromString(this.toString())
     }
 

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ExceptionMappers.kt
@@ -10,6 +10,8 @@ import com.openbank.ledger.application.usecase.JournalNotFoundException
 import com.openbank.ledger.application.usecase.JournalReversalConflictException
 import com.openbank.ledger.application.usecase.YearCloseConflictException
 import com.openbank.ledger.application.usecase.YearCloseNotFoundException
+import com.openbank.ledger.domain.model.LedgerConflictException
+import com.openbank.ledger.domain.model.LedgerValidationException
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.core.Response.Status.CONFLICT
@@ -17,6 +19,9 @@ import jakarta.ws.rs.core.Response.Status.NOT_FOUND
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
 import org.jboss.logging.Logger
+
+// Not in jakarta.ws.rs.core.Response.Status (JAX-RS's base enum stops short of 422).
+private const val UNPROCESSABLE_ENTITY = 422
 
 @Provider
 class JournalNotFoundExceptionMapper : ExceptionMapper<JournalNotFoundException> {
@@ -28,26 +33,32 @@ class JournalNotFoundExceptionMapper : ExceptionMapper<JournalNotFoundException>
 
 @Provider
 class GlAccountValidationExceptionMapper : ExceptionMapper<GlAccountValidationException> {
-    override fun toResponse(exception: GlAccountValidationException): Response = Response.status(422)
+    override fun toResponse(exception: GlAccountValidationException): Response = Response.status(UNPROCESSABLE_ENTITY)
         .entity(mapOf("error" to (exception.message ?: "Invalid GL account")))
         .type(MediaType.APPLICATION_JSON)
         .build()
 }
 
+// LedgerValidationException/LedgerConflictException (domain layer) replace bare
+// IllegalArgumentException/IllegalStateException (issue #526): a service-local
+// ExceptionMapper for a JDK type openbank-libs-runtime already maps collides
+// non-deterministically (JAX-RS has no defined tie-breaker between two same-type
+// providers) — the 422/409 below were a per-request lottery against libs' 400/422, not
+// the "intentional override" this file previously claimed.
 @Provider
-class IllegalArgumentExceptionMapper : ExceptionMapper<IllegalArgumentException> {
-    override fun toResponse(exception: IllegalArgumentException): Response = Response.status(422)
+class LedgerValidationExceptionMapper : ExceptionMapper<LedgerValidationException> {
+    override fun toResponse(exception: LedgerValidationException): Response = Response.status(UNPROCESSABLE_ENTITY)
         .entity(mapOf("error" to (exception.message ?: "Unprocessable entity")))
         .type(MediaType.APPLICATION_JSON)
         .build()
 }
 
 @Provider
-class IllegalStateExceptionMapper : ExceptionMapper<IllegalStateException> {
-    private val log = Logger.getLogger(IllegalStateExceptionMapper::class.java)
+class LedgerConflictExceptionMapper : ExceptionMapper<LedgerConflictException> {
+    private val log = Logger.getLogger(LedgerConflictExceptionMapper::class.java)
 
-    override fun toResponse(exception: IllegalStateException): Response {
-        log.errorf(exception, "Illegal state: %s", exception.message)
+    override fun toResponse(exception: LedgerConflictException): Response {
+        log.errorf(exception, "Ledger conflict: %s", exception.message)
         return Response.status(Response.Status.CONFLICT)
             .entity(mapOf("error" to (exception.message ?: "Conflict")))
             .type(MediaType.APPLICATION_JSON)
@@ -97,9 +108,9 @@ class ClosedFiscalPeriodExceptionMapper : ExceptionMapper<ClosedFiscalPeriodExce
 // ExceptionMapper<Exception> (GlobalExceptionMapper) is intentionally NOT declared here.
 // openbank-libs auto-registers GenericExceptionMapper (Exception → 500, correlation-aware) and
 // WebApplicationExceptionMapper (WebApplicationException → pass-through) via Jandex. A second
-// @Provider for the same type would collide non-deterministically (ADR-0049 D4).
-//
-// Ledger-specific status codes:
-//   IllegalArgumentException → 422 (GL validation failure, not a generic 400)
-//   IllegalStateException    → 409 Conflict (double-entry invariant violation)
-// These override libs' defaults intentionally and are kept above.
+// @Provider for the same type would collide non-deterministically (ADR-0049 D4, issue #526) —
+// the same reason IllegalArgumentException/IllegalStateException are no longer mapped directly
+// here either (see LedgerValidationException/LedgerConflictException above): a service-local
+// mapper for a libs-owned JDK type is a per-request lottery, not a reliable override. Ledger's
+// 422/409 status codes are still ledger-specific — they're just reached through a dedicated
+// domain exception type now, which JAX-RS resolves unambiguously.

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceTest.kt
@@ -23,6 +23,7 @@ import com.openbank.ledger.domain.model.JournalEntry
 import com.openbank.ledger.domain.model.JournalLine
 import com.openbank.ledger.domain.model.JournalSide
 import com.openbank.ledger.domain.model.JournalStatus
+import com.openbank.ledger.domain.model.LedgerValidationException
 import com.openbank.libs.domain.money.CurrencyCode
 import com.openbank.libs.domain.money.Money
 import com.openbank.libs.observability.DomainMetrics
@@ -242,7 +243,7 @@ class LedgerServiceTest {
             )
 
             assertThatThrownBy { runBlocking { service.postJournal(command) } }
-                .isInstanceOf(IllegalArgumentException::class.java)
+                .isInstanceOf(LedgerValidationException::class.java)
         }
 
         @Test

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/YearCloseServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/YearCloseServiceTest.kt
@@ -15,6 +15,7 @@ import com.openbank.ledger.application.port.out.JournalRepository
 import com.openbank.ledger.application.port.out.YearCloseRepository
 import com.openbank.ledger.domain.model.FiscalYearTrialBalance
 import com.openbank.ledger.domain.model.GlAccountType
+import com.openbank.ledger.domain.model.LedgerValidationException
 import com.openbank.ledger.domain.model.TrialBalanceLine
 import com.openbank.ledger.domain.model.YearCloseRecord
 import com.openbank.ledger.domain.model.YearCloseStatus
@@ -116,7 +117,7 @@ class YearCloseServiceTest {
         @Test
         fun `rejects a fiscal year outside the supported range`(): Unit = runBlocking {
             assertThatThrownBy { runBlocking { service.getTrialBalance(GetFiscalYearTrialBalanceQuery(42)) } }
-                .isInstanceOf(IllegalArgumentException::class.java)
+                .isInstanceOf(LedgerValidationException::class.java)
             Unit
         }
     }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/FiscalYearTrialBalanceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/FiscalYearTrialBalanceTest.kt
@@ -216,14 +216,14 @@ class FiscalYearTrialBalanceTest {
         fun `attesting an already attested record fails`() {
             val attested = draft().attest("operator-sub", Instant.now())
             assertThatThrownBy { attested.attest("someone-else", Instant.now()) }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("not DRAFT")
         }
 
         @Test
         fun `four-eyes - the maker cannot self-attest (domain check)`() {
             assertThatThrownBy { draft().attest("maker-sub", Instant.now()) }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("Four-eyes")
         }
 
@@ -235,7 +235,7 @@ class FiscalYearTrialBalanceTest {
                 draftedBy = null,
             )
             assertThatThrownBy { nullMaker.attest("checker-sub", Instant.now()) }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("no recorded author")
         }
 
@@ -243,7 +243,7 @@ class FiscalYearTrialBalanceTest {
         fun `fiscal year outside the supported range is rejected`() {
             assertThatThrownBy {
                 YearCloseRecord.draftOf(FiscalYearTrialBalance(1999, emptyList()), Instant.now())
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
         }
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/FxConversionPostingTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/FxConversionPostingTest.kt
@@ -92,7 +92,7 @@ class FxConversionPostingTest {
                 customerBuyAmount = money("1000.00", "EUR"),
                 fxRate = BigDecimal.ONE,
             )
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
             .hasMessageContaining("must cross currencies")
     }
 
@@ -111,7 +111,7 @@ class FxConversionPostingTest {
                 customerBuyAmount = money("25100.00", "CZK"),
                 fxRate = BigDecimal("25.00"),
             )
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
             .hasMessageContaining("negative margin")
     }
 
@@ -130,7 +130,7 @@ class FxConversionPostingTest {
                 customerBuyAmount = money("25000.00", "CZK"),
                 fxRate = BigDecimal("25.00"),
             )
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
             .hasMessageContaining("sellAmount must be positive")
     }
 
@@ -149,7 +149,7 @@ class FxConversionPostingTest {
                 customerBuyAmount = money("0.00", "CZK"),
                 fxRate = BigDecimal("25.00"),
             )
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
             .hasMessageContaining("grossBuyAmount must be positive")
     }
 
@@ -168,7 +168,7 @@ class FxConversionPostingTest {
                 customerBuyAmount = money("25000.00", "EUR"), // wrong currency
                 fxRate = BigDecimal("25.00"),
             )
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
             .hasMessageContaining("must match buy currency")
     }
 

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/FxRevaluationPostingTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/FxRevaluationPostingTest.kt
@@ -101,6 +101,6 @@ class FxRevaluationPostingTest {
     fun `rejects a non-positive rate`() {
         assertThatThrownBy {
             FxRevaluationPosting.build(journalId, pnl, listOf(input("EUR", eurCv, "1000000", "0", "0.00")))
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/JournalEntryPropertyTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/JournalEntryPropertyTest.kt
@@ -115,7 +115,7 @@ class JournalEntryPropertyTest {
 
             assertThatThrownBy {
                 balanced.copy(lines = brokenLines)
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
                 .hasMessageContaining("not balanced")
         }
     }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/JournalEntryTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/domain/model/JournalEntryTest.kt
@@ -103,7 +103,7 @@ class JournalEntryTest {
                     createdBy = userId,
                     version = 0L,
                 )
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
                 .hasMessageContaining("at least 2 lines")
         }
 
@@ -116,7 +116,7 @@ class JournalEntryTest {
                         line(accountLiability, JournalSide.CREDIT, "999.99", sequence = 2),
                     ),
                 )
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
                 .hasMessageContaining("not balanced")
         }
 
@@ -129,7 +129,7 @@ class JournalEntryTest {
                         line(accountLiability, JournalSide.CREDIT, "600.00", sequence = 2),
                     ),
                 )
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
                 .hasMessageContaining("not balanced")
         }
 
@@ -215,7 +215,7 @@ class JournalEntryTest {
                         line(accountLiability, JournalSide.CREDIT, "1000.00", currency = "CZK", sequence = 2),
                     ),
                 )
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
                 .hasMessageContaining("not balanced in EUR")
         }
 
@@ -247,7 +247,7 @@ class JournalEntryTest {
                         line(accountLiability, JournalSide.CREDIT, "24900.00", currency = "CZK", sequence = 4),
                     ),
                 )
-            }.isInstanceOf(IllegalArgumentException::class.java)
+            }.isInstanceOf(LedgerValidationException::class.java)
                 .hasMessageContaining("not balanced in CZK")
         }
     }
@@ -270,7 +270,7 @@ class JournalEntryTest {
             val posted = balancedEntry(status = JournalStatus.POSTED)
 
             assertThatThrownBy { posted.post() }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("PENDING")
         }
 
@@ -279,7 +279,7 @@ class JournalEntryTest {
             val reversed = balancedEntry(status = JournalStatus.REVERSED)
 
             assertThatThrownBy { reversed.post() }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("PENDING")
         }
     }
@@ -433,7 +433,7 @@ class JournalEntryTest {
             val pending = balancedEntry(status = JournalStatus.PENDING)
 
             assertThatThrownBy { pending.reverse(UUID.randomUUID(), UUID.randomUUID()) }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("POSTED")
         }
 
@@ -442,7 +442,7 @@ class JournalEntryTest {
             val reversed = balancedEntry(status = JournalStatus.REVERSED)
 
             assertThatThrownBy { reversed.reverse(UUID.randomUUID(), UUID.randomUUID()) }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(LedgerConflictException::class.java)
                 .hasMessageContaining("POSTED")
         }
     }

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/application/usecase/Psd2Services.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/application/usecase/Psd2Services.kt
@@ -41,6 +41,14 @@ class PaymentNotFoundException(id: String) : RuntimeException("Payment not found
 class TppNotAuthorizedException(tppId: String) : RuntimeException("TPP not authorized: $tppId")
 class InvalidPaymentProductException(msg: String) : RuntimeException(msg)
 
+// Replaces bare IllegalArgumentException (issue #526): a service-local
+// ExceptionMapper<IllegalArgumentException> collided non-deterministically with
+// openbank-libs-runtime's own mapper for the identical JDK type — both happen to answer 400,
+// but the response BODY shapes differ (this service's Berlin Group NextGenPSD2 `tppMessages`
+// array vs libs' generic ApiError envelope), so a TPP client could non-deterministically get
+// either shape depending on which provider JAX-RS happened to pick.
+class Psd2RequestFormatException(msg: String) : RuntimeException(msg)
+
 @ApplicationScoped
 class AccountInformationService(
     private val accountClient: AccountServiceClient,

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/ExceptionMappers.kt
@@ -7,6 +7,7 @@ package com.openbank.psd2.infrastructure.rest
 import com.openbank.psd2.application.usecase.ConsentNotFoundException
 import com.openbank.psd2.application.usecase.ConsentUnauthorizedException
 import com.openbank.psd2.application.usecase.InvalidPaymentProductException
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.application.usecase.TppNotAuthorizedException
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
@@ -39,8 +40,13 @@ class InvalidPaymentProductMapper : ExceptionMapper<InvalidPaymentProductExcepti
         Response.status(400).entity(tppMsg("ERROR", "PRODUCT_INVALID", e.message ?: "Invalid payment product")).build()
 }
 
+// Replaces ExceptionMapper<IllegalArgumentException> (issue #526): a service-local mapper for a
+// JDK type openbank-libs-runtime already maps to a DIFFERENT response shape (its generic
+// ApiError, not this service's Berlin Group tppMessages envelope) collides non-deterministically
+// — both happen to answer 400, but which body shape a TPP client got was a per-request lottery.
 @Provider
-class Psd2IllegalArgMapper : ExceptionMapper<IllegalArgumentException> {
-    override fun toResponse(e: IllegalArgumentException): Response =
-        Response.status(400).entity(tppMsg("ERROR", "FORMAT_ERROR", e.message ?: "Bad request")).build()
+class Psd2RequestFormatMapper : ExceptionMapper<Psd2RequestFormatException> {
+    override fun toResponse(e: Psd2RequestFormatException): Response = Response.status(Response.Status.BAD_REQUEST)
+        .entity(tppMsg("ERROR", "FORMAT_ERROR", e.message ?: "Bad request"))
+        .build()
 }

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/ObConsentResource.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/ObConsentResource.kt
@@ -11,6 +11,7 @@ import com.openbank.psd2.application.port.`in`.ConsentManagementUseCase
 import com.openbank.psd2.application.port.`in`.CreateConsentCommand
 import com.openbank.psd2.application.port.`in`.DeleteConsentCommand
 import com.openbank.psd2.application.port.`in`.GetConsentQuery
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.domain.model.ObConsentRequest
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.DELETE
@@ -45,7 +46,7 @@ class ConsentResource(
             ?: return tppMissing()
         val tppName = ctx.getHeaderString("TPP-Name") ?: tppId
 
-        require(!xRequestId.isNullOrBlank()) { "X-Request-ID header is required" }
+        if (xRequestId.isNullOrBlank()) throw Psd2RequestFormatException("X-Request-ID header is required")
 
         val idempotencyKey = consentCreateKey(tppId, xRequestId)
         idempotencyStore.get(idempotencyKey)?.let { cached ->

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/PisResource.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/rest/PisResource.kt
@@ -10,6 +10,7 @@ import com.openbank.libs.idempotency.IdempotencyStore
 import com.openbank.psd2.application.port.`in`.GetPaymentStatusQuery
 import com.openbank.psd2.application.port.`in`.InitiatePaymentCommand
 import com.openbank.psd2.application.port.`in`.PaymentInitiationUseCase
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.domain.model.DomesticCzPayment
 import com.openbank.psd2.domain.model.PaymentInitiation
 import com.openbank.psd2.domain.model.PaymentProduct
@@ -97,7 +98,7 @@ class PisResource(
         ctx: ContainerRequestContext,
     ): Response {
         val tppId = ctx.getProperty("tppId") as? String ?: return tppMissing()
-        require(idempotencyKey.isNotBlank()) { "Idempotency-Key header is required" }
+        if (idempotencyKey.isBlank()) throw Psd2RequestFormatException("Idempotency-Key header is required")
 
         val cacheKey = paymentCreateKey(tppId, product, idempotencyKey)
         idempotencyStore.get(cacheKey)?.let { cached ->

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/rest/ConsentResourceTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/rest/ConsentResourceTest.kt
@@ -12,6 +12,7 @@ import com.openbank.psd2.application.port.`in`.ConsentManagementUseCase
 import com.openbank.psd2.application.port.`in`.CreateConsentCommand
 import com.openbank.psd2.application.port.`in`.DeleteConsentCommand
 import com.openbank.psd2.application.port.`in`.GetConsentQuery
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.domain.model.ConsentStatusOb
 import com.openbank.psd2.domain.model.ObAccess
 import com.openbank.psd2.domain.model.ObConsentRequest
@@ -75,7 +76,7 @@ class ConsentResourceTest {
     fun `createConsent requires a non-blank X-Request-ID`(): Unit = runBlocking {
         assertThatThrownBy {
             runBlocking { resource.createConsent(sampleRequest(), null, "", ctxWithTpp("tpp-1")) }
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(Psd2RequestFormatException::class.java)
     }
 
     @Test

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/rest/ExceptionMappersTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/rest/ExceptionMappersTest.kt
@@ -7,6 +7,7 @@ package com.openbank.psd2.infrastructure.rest
 import com.openbank.psd2.application.usecase.ConsentNotFoundException
 import com.openbank.psd2.application.usecase.ConsentUnauthorizedException
 import com.openbank.psd2.application.usecase.InvalidPaymentProductException
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.application.usecase.TppNotAuthorizedException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -68,14 +69,12 @@ class ExceptionMappersTest {
     }
 
     @Test
-    fun `Psd2IllegalArgMapper returns 400 with FORMAT_ERROR and defaults message when null`() {
-        val withMessage = Psd2IllegalArgMapper().toResponse(IllegalArgumentException("bad format"))
-        assertThat(withMessage.status).isEqualTo(400)
-        assertThat(tppCode(withMessage.entity)).isEqualTo("FORMAT_ERROR")
-        assertThat(tppText(withMessage.entity)).isEqualTo("bad format")
+    fun `Psd2RequestFormatMapper returns 400 with FORMAT_ERROR`() {
+        val response = Psd2RequestFormatMapper().toResponse(Psd2RequestFormatException("bad format"))
 
-        val withoutMessage = Psd2IllegalArgMapper().toResponse(IllegalArgumentException())
-        assertThat(tppText(withoutMessage.entity)).isEqualTo("Bad request")
+        assertThat(response.status).isEqualTo(400)
+        assertThat(tppCode(response.entity)).isEqualTo("FORMAT_ERROR")
+        assertThat(tppText(response.entity)).isEqualTo("bad format")
     }
 
     @Test

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/rest/PisResourceTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/rest/PisResourceTest.kt
@@ -11,6 +11,7 @@ import com.openbank.libs.idempotency.IdempotencyStore
 import com.openbank.psd2.application.port.`in`.GetPaymentStatusQuery
 import com.openbank.psd2.application.port.`in`.InitiatePaymentCommand
 import com.openbank.psd2.application.port.`in`.PaymentInitiationUseCase
+import com.openbank.psd2.application.usecase.Psd2RequestFormatException
 import com.openbank.psd2.domain.model.ObAccountRef
 import com.openbank.psd2.domain.model.ObAmount
 import com.openbank.psd2.domain.model.ObLinks
@@ -76,7 +77,7 @@ class PisResourceTest {
     fun `initiateSepa requires a non-blank Idempotency-Key`(): Unit = runBlocking {
         assertThatThrownBy {
             runBlocking { resource.initiateSepa(samplePayment(), "consent-1", "", ctxWithTpp("tpp-1")) }
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(Psd2RequestFormatException::class.java)
             .hasMessageContaining("Idempotency-Key")
     }
 

--- a/openbank-simulation/src/test/kotlin/com/openbank/simulation/model/LedgerModelTest.kt
+++ b/openbank-simulation/src/test/kotlin/com/openbank/simulation/model/LedgerModelTest.kt
@@ -9,6 +9,7 @@ import com.openbank.ledger.domain.model.JournalEntry
 import com.openbank.ledger.domain.model.JournalLine
 import com.openbank.ledger.domain.model.JournalSide
 import com.openbank.ledger.domain.model.JournalStatus
+import com.openbank.ledger.domain.model.LedgerValidationException
 import com.openbank.libs.domain.money.Money
 import com.openbank.simulation.adapters.AuditLog
 import org.assertj.core.api.Assertions.assertThat
@@ -98,7 +99,7 @@ class LedgerModelTest {
                 credit = "50.00",
                 status = JournalStatus.PENDING,
             )
-        }.isInstanceOf(IllegalArgumentException::class.java)
+        }.isInstanceOf(LedgerValidationException::class.java)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes issue #526. `ledger-service` and `psd2-service` each registered a service-local `ExceptionMapper` for a JDK type `openbank-libs-runtime` already maps — JAX-RS has no defined tie-breaker between two providers for the identical type, so the status code (ledger) or response body shape (psd2) was a per-request lottery, not the "intentional override" both services' own comments (and ADR-0049's delivery note) claimed.

## Type of change

- [x] fix (bug fix)

## Linked issues

Closes #526

## Changes

- **ledger-service**: new `LedgerValidationException` (422) / `LedgerConflictException` (409) in the domain layer (`LedgerExceptions.kt`), with `requireValid()`/`checkConflict()` drop-in replacements for `require()`/`check()` (Kotlin's stdlib versions throw the JDK type directly and can't be redirected). Every bare `require()`/`check()`/`throw IllegalArgumentException`/`throw IllegalStateException` call site across `JournalEntry`, `YearClose`, `FxConversionPosting`, `FxRevaluationPosting`, `LedgerService`, `YearCloseService`, and `PanacheJournalRepository` now throws the dedicated type. Status codes are unchanged (422/409) — only the exception type changed.
- **psd2-service**: new `Psd2RequestFormatException`, replacing the 2 `require()` call sites (Idempotency-Key / X-Request-ID header presence). This collision was actually worse than ledger's: the two mappers emit **different response body shapes** — psd2's Berlin Group NextGenPSD2 `tppMessages` array vs libs' generic `ApiError` envelope — so a TPP client could non-deterministically get either shape for the same 400 status. Both are plausibly valid regulatory-compliance concerns depending on which provider JAX-RS happened to pick.
- **`.github/scripts/check-exception-mapper-collision.sh`** (new, wired into `ci.yml`, enforced): fleet-wide guard — no service may declare `ExceptionMapper<T>` for `IllegalArgumentException`, `IllegalStateException`, `NoSuchElementException`, `Exception`, or `WebApplicationException` outside `openbank-libs-runtime` itself. Anchored to the actual supertype-declaration syntax (excludes comment lines) so explanatory prose about this exact defect doesn't self-trigger. 0 violations on `origin/main` at introduction — regression guard, not a backlog.
- **ADR-0049**: the 2026-06-19 delivery note documented these two mappers as "2 intentional overrides." Added a dated amendment correcting that claim and explaining the actual fix, per this repo's own knowledge-capture convention.

## How this was tested

`./gradlew test ktlintCheck detekt` for both `openbank-ledger-service` and `openbank-psd2-service` — all green locally. All existing tests that asserted on the old JDK exception types (`isInstanceOf(IllegalArgumentException::class.java)` etc.) updated to assert the new dedicated types instead; no test logic changed beyond the type reference. Ran `check-exception-mapper-collision.sh` locally against the full fleet (1286 source files, ~4s) — confirmed 0 remaining violations, and verified it actually catches a real collision by temporarily reintroducing one in a throwaway test file.

## Definition of Done

- [x] Hexagonal layering preserved — `LedgerValidationException`/`LedgerConflictException` live in `domain.model` (framework-free), not `application.usecase`, so domain-layer files (`JournalEntry.kt` etc.) can throw them without an inverted dependency. Verified: `check-domain-purity.sh` passes (these are plain `RuntimeException` subclasses, no framework imports).
- [x] Unit tests added/updated — every affected assertion across both services' test suites.
- [ ] Integration tests added/updated. — N/A, no I/O-affecting behavior changed; existing ITs (`LedgerConcurrencyIT`) already exercise the conflict paths and continue to pass unchanged (that file only had a *comment* mentioning the old type name, not an assertion).
- [ ] Contract tests updated. — N/A, response status codes and (for psd2) body shapes are unchanged — this fixes non-determinism, not the intended contract.
- [x] `./gradlew detekt ktlintCheck koverVerify build` — ran `test`, `ktlintCheck`, `detekt` for both services locally; all green.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated. — N/A, no API surface changed.
- [ ] Flyway migration added. — N/A.
- [ ] Avro schema versioned. — N/A.
- [x] Docs updated — ADR-0049 amendment.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress("...")` without justification.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — this touches ledger-service (money-path) error handling, but only the exception *type* thrown for existing validation/conflict conditions — no new validation logic, no changed business rule, no changed status code. Flagging for visibility given it's ledger domain code, though the actual change is mechanical.
- [ ] PII path changed? — N/A.
- [ ] Cardholder data path changed? — N/A.

## Compliance impact

- [ ] None directly, though the psd2 fix closes a live risk to reliably meeting the Berlin Group NextGenPSD2 `tppMessages` error-envelope requirement (previously non-deterministic).

## Rollout / Rollback

- Deployment strategy: standard code deploy for both services, no data/schema change.
- Rollback plan: revert the PR.
- Data migration reversible: N/A.

## Reviewer notes

ledger-service is money-path — this needs a second approver per `rules.yaml`. The mechanical part (require→requireValid, check→checkConflict) is a large diff by line count but should be fast to review: every substitution is a 1:1 rename with unchanged condition/message, verifiable by the ktlint/detekt/test-suite green run. The two lines that changed *shape* rather than just name are `YearClose.kt`'s attest() (wrapped one message onto its own line to stay under 120 chars — `checkConflict` is longer than `check`) and `PanacheJournalRepository.kt`'s `toUuid()` (a defensive "should never happen" assertion, mapped to `LedgerConflictException`/409 for consistency with the rest of this sweep, though 409 isn't a perfect semantic fit for corrupted-row data — flagging that as a judgment call, not hidden).