### PR TITLE
ci(admin-ui): enforce Playwright E2E as a real merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,12 @@ jobs:
         run: npm run test:e2e
         # ADR-0076 Phase 2: Playwright E2E for /services docs-coverage page.
         # Mocks all BFF endpoints via page.route() — no live services required.
-        # continue-on-error: true until every pool member has browser system deps.
-        # Layer 1 (Vitest) and Layer 3 (Kotlin) are the regression gate; E2E is
-        # an advisory signal until runner infrastructure is fully provisioned.
-        continue-on-error: true
+        # Enforced (issue #653): this job runs solely on hosted ubuntu-latest (a single,
+        # uniform pool member — no ARC/self-hosted split for Admin UI build), the deps
+        # step above installs cleanly every run, and #646 fixed the suite from silently
+        # testing /auth/login (every route redirected there, no Keycloak in CI) to
+        # actually exercising /services via a minted session cookie. Verified stable:
+        # 5/5 passing across 3 consecutive main-branch runs, locally with --repeat-each=3.
         env:
           CI: "true"
           NEXTAUTH_URL: "http://localhost:3001"


### PR DESCRIPTION
## Summary
- Removes `continue-on-error: true` from the `E2E tests (Playwright)` step in `.github/workflows/ci.yml`, promoting it from advisory to an enforced merge gate (ADR-0076).

## Why now
- #646 fixed the suite from silently testing `/auth/login` (every route was redirecting there — no Keycloak in the CI environment) to actually exercising `/services` via a minted session cookie. 5/5 tests now pass for real.
- The Admin UI build job runs solely on hosted `ubuntu-latest` (`runs-on: ubuntu-latest`, no ARC/self-hosted split for this job) — a single, uniform pool member, not the mixed fleet the original advisory comment was guarding against.
- 3 consecutive `main`-branch CI runs show both "Install Playwright system dependencies" and "E2E tests (Playwright)" genuinely succeeding (not masked).

## Test plan
- [x] Verified 3 recent `main` CI runs (29123600329, 29091333804, 29077604322): E2E step conclusion `success` in all three.
- [x] YAML syntax validated locally.
- [ ] This PR's own CI run should show the same E2E step now enforced (no `continue-on-error`) and still green.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)