### PR TITLE
test(pact): commit uncommitted consumer pacts, add fraud provider test, add drift gate

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Contract-drift gate (ADR-0063 Phase 2, issue #468). Committed pacts are derived data — regenerated
+# from the consumer tests, never hand-edited (same principle as the catalog/NetworkPolicy generators).
+# This re-runs every consumer pact test and fails if the regenerated JSON differs from what's
+# committed in pacts/, catching exactly the class of bug #370 found as a "bonus" (a stale committed
+# pact missing an interaction the consumer test had already moved past).
+#
+# Consumer pact tests are pure JVM (an embedded mock server, no Testcontainers/Quarkus boot), so
+# this is cheap enough to run on every PR that touches a contract test or the pacts/ dir itself.
+
+name: Pact drift check
+
+on:
+  pull_request:
+    paths:
+      - "pacts/**"
+      - "**/src/test/kotlin/**/contract/*PactConsumerTest.kt"
+      - ".github/workflows/pact-drift-check.yml"
+  push:
+    branches: [main]
+    paths:
+      - "pacts/**"
+      - "**/src/test/kotlin/**/contract/*PactConsumerTest.kt"
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    name: Regenerate consumer pacts and diff against committed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
+        with:
+          java-version: "25"
+          distribution: temurin
+          cache: gradle
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      # One Gradle invocation, every consumer pact test module — each writes to the shared
+      # pacts/ dir (systemProperty("pact.rootDir", ...) in the consuming service's
+      # build.gradle.kts). --continue so one module's failure doesn't hide drift elsewhere.
+      - name: Regenerate every consumer pact
+        run: |
+          ./gradlew --continue \
+            :openbank-account-service:test --tests "com.openbank.account.contract.*PactConsumerTest" \
+            :openbank-balance-service:test --tests "com.openbank.balance.contract.*PactConsumerTest" \
+            :openbank-consent-service:test --tests "com.openbank.consent.contract.*PactConsumerTest" \
+            :openbank-domestic-payment:test --tests "com.openbank.domestic.contract.*PactConsumerTest" \
+            :openbank-fraud-service:test --tests "com.openbank.fraud.contract.*PactConsumerTest" \
+            :openbank-lending-service:test --tests "com.openbank.lending.contract.*PactConsumerTest" \
+            :openbank-notification-service:test --tests "com.openbank.notification.contract.*PactConsumerTest" \
+            :openbank-sepa-payment:test --tests "com.openbank.sepa.contract.*PactConsumerTest" \
+            :openbank-swift-service:test --tests "com.openbank.swift.contract.*PactConsumerTest" \
+            :openbank-transaction-service:test --tests "com.openbank.transaction.contract.*PactConsumerTest"
+
+      - name: Fail on drift between regenerated and committed pacts
+        run: |
+          if ! git diff --exit-code -- pacts/; then
+            echo "::error::Committed pacts/*.json differ from what the consumer tests generate right now."
+            echo "::error::Regenerate and commit: run the *PactConsumerTest* class for the affected service and commit the updated pacts/<consumer>-<provider>.json in the same PR."
+            git status --porcelain -- pacts/
+            exit 1
+          fi
+          echo "No drift — every committed pact matches its consumer test."
+
+      - name: Upload regenerated pacts on drift (for local diffing)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: regenerated-pacts
+          path: pacts/
+          retention-days: 7

--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -45,6 +45,12 @@ jobs:
       # One Gradle invocation, every consumer pact test module — each writes to the shared
       # pacts/ dir (systemProperty("pact.rootDir", ...) in the consuming service's
       # build.gradle.kts). --continue so one module's failure doesn't hide drift elsewhere.
+      #
+      # openbank-swift-service is deliberately excluded here: its own build.gradle.kts
+      # statically excludes SwiftEventPactConsumerTest whenever CI=true (PactConsumerTestExt
+      # auto-publishes to pactbroker.url in CI and hangs/401s — issue #2404), so it can never
+      # run in a CI job regardless of --tests filtering. openbank-transaction-service-
+      # openbank-swift-service.json is NOT covered by this drift gate until #2404 re-enables it.
       - name: Regenerate every consumer pact
         run: |
           ./gradlew --continue \
@@ -56,7 +62,6 @@ jobs:
             :openbank-lending-service:test --tests "com.openbank.lending.contract.*PactConsumerTest" \
             :openbank-notification-service:test --tests "com.openbank.notification.contract.*PactConsumerTest" \
             :openbank-sepa-payment:test --tests "com.openbank.sepa.contract.*PactConsumerTest" \
-            :openbank-swift-service:test --tests "com.openbank.swift.contract.*PactConsumerTest" \
             :openbank-transaction-service:test --tests "com.openbank.transaction.contract.*PactConsumerTest"
 
       - name: Fail on drift between regenerated and committed pacts

--- a/openbank-fraud-service/build.gradle.kts
+++ b/openbank-fraud-service/build.gradle.kts
@@ -41,6 +41,10 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.redpanda)
     testImplementation(libs.pact.consumer)
+    // fraud-service is now also a pact PROVIDER (FraudPactProviderVerificationTest, #468) —
+    // sepa-payment's fraud-score contract needs a provider-side replay, same as every other
+    // service that carries both directions.
+    testImplementation(libs.pact.provider)
 }
 
 // Pact: write generated consumer contracts to pacts/ and forward broker config.

--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactProviderVerificationTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactProviderVerificationTest.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fraud.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider-side verification for the `POST /api/v1/fraud/score` contract
+ * (`SepaPaymentFraudServicePactConsumerTest`, openbank-sepa-payment, ADR-0063 P2 Batch C /
+ * ADR-0084 §1). This class was named in that consumer test's own doc comment ("The provider
+ * verification lives in FraudPactProviderVerificationTest") but never existed (issue #468) —
+ * the consumer contract was committed and generated, but nothing on the provider side replayed it.
+ *
+ * git-pact (`@PactFolder`), mirroring `LedgerPactProviderVerificationTest` /
+ * `AccountEventPactProviderVerificationTest`: always runs, no broker/CI secret required.
+ *
+ * IMPORTANT: if `SepaPaymentFraudServicePactConsumerTest` changes the contract, regenerate
+ * (`./gradlew :openbank-sepa-payment:test --tests "*SepaPaymentFraudServicePactConsumerTest*"`)
+ * and commit the updated `pacts/openbank-sepa-payment-openbank-fraud-service.json` in the same PR.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-fraud-service")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class FraudPactProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("the fraud scoring engine is available")
+    fun stateScoringEngineAvailable() {
+        // No setup needed: the stub rule set (ADR-0084 §1 Phase 1) always returns ALLOW,
+        // which satisfies the contract's type matchers on verdict/score.
+    }
+}

--- a/pacts/openbank-account-service-openbank-balance-service.json
+++ b/pacts/openbank-account-service-openbank-balance-service.json
@@ -1,0 +1,342 @@
+{
+  "consumer": {
+    "name": "openbank-account-service"
+  },
+  "interactions": [
+    {
+      "description": "GET single CZK balance for an account",
+      "providerStates": [
+        {
+          "name": "a CZK balance exists for the balance account"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/balances/d5d5d5d5-d5d5-d5d5-d5d5-d5d5d5d5d5d5/CZK"
+      },
+      "response": {
+        "body": {
+          "accountId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "arrangedOverdraftLimit": 0.0,
+          "availableAmount": 4900.0,
+          "bookedAmount": 5000.0,
+          "currency": "CZK",
+          "pendingAmount": 0.0,
+          "reservedAmount": 100.0,
+          "updatedAt": "2026-01-15T10:00:00Z"
+        },
+        "generators": {
+          "body": {
+            "$.accountId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.accountId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.arrangedOverdraftLimit": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.availableAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.bookedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.pendingAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.reservedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.updatedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "GET all balances for an account",
+      "providerStates": [
+        {
+          "name": "balances exist for the balance account"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/balances/d4d4d4d4-d4d4-d4d4-d4d4-d4d4d4d4d4d4"
+      },
+      "response": {
+        "body": {
+          "balances": [
+            {
+              "accountId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+              "arrangedOverdraftLimit": 0.0,
+              "availableAmount": 4900.0,
+              "bookedAmount": 5000.0,
+              "currency": "CZK",
+              "pendingAmount": 0.0,
+              "reservedAmount": 100.0,
+              "updatedAt": "2026-01-15T10:00:00Z"
+            }
+          ]
+        },
+        "generators": {
+          "body": {
+            "$.balances[0].accountId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.balances[0].accountId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.balances[0].arrangedOverdraftLimit": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.balances[0].availableAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.balances[0].bookedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.balances[0].currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.balances[0].pendingAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.balances[0].reservedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.balances[0].updatedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "POST initialize opening balance for an account",
+      "providerStates": [
+        {
+          "name": "no CZK balance exists for the initialize account"
+        }
+      ],
+      "request": {
+        "body": {
+          "arrangedOverdraftLimit": 0.00,
+          "currency": "CZK",
+          "initialAmount": 0.00
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/balances/e5e5e5e5-e5e5-e5e5-e5e5-e5e5e5e5e5e5/initialize"
+      },
+      "response": {
+        "body": {
+          "accountId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "arrangedOverdraftLimit": 0.0,
+          "availableAmount": 0.0,
+          "bookedAmount": 0.0,
+          "currency": "CZK",
+          "pendingAmount": 0.0,
+          "reservedAmount": 0.0,
+          "updatedAt": "2026-01-15T10:00:00Z"
+        },
+        "generators": {
+          "body": {
+            "$.accountId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.accountId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.arrangedOverdraftLimit": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.availableAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.bookedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.currency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.pendingAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.reservedAmount": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.updatedAt": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-balance-service"
+  }
+}

--- a/pacts/openbank-account-service-openbank-party-service.json
+++ b/pacts/openbank-account-service-openbank-party-service.json
@@ -147,7 +147,7 @@
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.6.17"
+      "version": "4.7.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/pacts/openbank-account-service-openbank-transaction-service.json
+++ b/pacts/openbank-account-service-openbank-transaction-service.json
@@ -1,0 +1,80 @@
+{
+  "consumer": {
+    "name": "openbank-account-service"
+  },
+  "interactions": [
+    {
+      "description": "POST initiate a CREDIT welcome bonus transaction",
+      "providerStates": [
+        {
+          "name": "the transaction service is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "amount": 50.00,
+          "currencyCode": "CZK",
+          "description": "V\u00EDtac\u00ED bonus za zalo\u017Een\u00ED \u00FA\u010Dtu",
+          "idempotencyKey": "welcome-bonus-f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6",
+          "targetAccountId": "f6f6f6f6-f6f6-f6f6-f6f6-f6f6f6f6f6f6",
+          "type": "CREDIT",
+          "valueDate": "2026-01-15"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/transactions"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "PENDING"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-transaction-service"
+  }
+}

--- a/pacts/openbank-balance-service-openbank-account-service.json
+++ b/pacts/openbank-balance-service-openbank-account-service.json
@@ -50,7 +50,7 @@
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.6.17"
+      "version": "4.7.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/pacts/openbank-balance-service-openbank-ledger-service.json
+++ b/pacts/openbank-balance-service-openbank-ledger-service.json
@@ -158,7 +158,7 @@
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.6.17"
+      "version": "4.7.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/pacts/openbank-consent-service-openbank-sca-service.json
+++ b/pacts/openbank-consent-service-openbank-sca-service.json
@@ -1,0 +1,90 @@
+{
+  "consumer": {
+    "name": "openbank-consent-service"
+  },
+  "interactions": [
+    {
+      "description": "GET SCA challenge by id",
+      "providerStates": [
+        {
+          "name": "a PENDING SCA challenge exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/sca/challenges/99999999-9999-9999-9999-999999999999"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "purpose": "CONSENT_GRANT",
+          "status": "PENDING"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            },
+            "$.partyId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.partyId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.purpose": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-sca-service"
+  }
+}

--- a/pacts/openbank-domestic-payment-openbank-transaction-service.json
+++ b/pacts/openbank-domestic-payment-openbank-transaction-service.json
@@ -1,0 +1,81 @@
+{
+  "consumer": {
+    "name": "openbank-domestic-payment"
+  },
+  "interactions": [
+    {
+      "description": "POST initiate domestic transaction",
+      "providerStates": [
+        {
+          "name": "a valid source account exists"
+        }
+      ],
+      "request": {
+        "body": {
+          "amount": 1000.00,
+          "currencyCode": "CZK",
+          "description": "pact contract domestic payment",
+          "idempotencyKey": "pact-domestic-txn-001",
+          "rail": "DOMESTIC",
+          "sourceAccountId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "type": "DOMESTIC_CREDIT_TRANSFER",
+          "valueDate": "2026-01-20"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/transactions"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "PROCESSING"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-transaction-service"
+  }
+}

--- a/pacts/openbank-fraud-service-openbank-transaction-service.json
+++ b/pacts/openbank-fraud-service-openbank-transaction-service.json
@@ -1,0 +1,97 @@
+{
+  "consumer": {
+    "name": "openbank-fraud-service"
+  },
+  "messages": [
+    {
+      "contents": {
+        "aggregateId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "amount": 250.0,
+        "currencyCode": "CZK",
+        "sourceAccountId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "targetAccountId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+      },
+      "description": "a transaction.initiated event for fraud screening",
+      "generators": {
+        "body": {
+          "$.aggregateId": {
+            "type": "Uuid"
+          },
+          "$.sourceAccountId": {
+            "type": "Uuid"
+          },
+          "$.targetAccountId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.aggregateId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.amount": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "decimal"
+              }
+            ]
+          },
+          "$.currencyCode": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[A-Z]{3}"
+              }
+            ]
+          },
+          "$.sourceAccountId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.targetAccountId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "transaction-service has initiated a payment transaction"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-transaction-service"
+  }
+}

--- a/pacts/openbank-lending-service-openbank-ledger-service.json
+++ b/pacts/openbank-lending-service-openbank-ledger-service.json
@@ -102,7 +102,7 @@
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.6.17"
+      "version": "4.7.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/pacts/openbank-notification-service-openbank-account-service.json
+++ b/pacts/openbank-notification-service-openbank-account-service.json
@@ -1,0 +1,103 @@
+{
+  "consumer": {
+    "name": "openbank-notification-service"
+  },
+  "messages": [
+    {
+      "contents": {
+        "channel": "PUSH",
+        "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+        "recipient": "string",
+        "template": "TRANSACTION_COMPLETED",
+        "variables": {
+          "amount": "50.00",
+          "currency": "CZK"
+        }
+      },
+      "description": "a TRANSACTION_COMPLETED notification request",
+      "generators": {
+        "body": {
+          "$.partyId": {
+            "type": "Uuid"
+          },
+          "$.recipient": {
+            "size": 20,
+            "type": "RandomString"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.channel": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.partyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          },
+          "$.recipient": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.template": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.variables.amount": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.variables.currency": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "account-service has posted an incoming credit"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-account-service"
+  }
+}

--- a/pacts/openbank-sepa-payment-openbank-fraud-service.json
+++ b/pacts/openbank-sepa-payment-openbank-fraud-service.json
@@ -1,0 +1,70 @@
+{
+  "consumer": {
+    "name": "openbank-sepa-payment"
+  },
+  "interactions": [
+    {
+      "description": "POST fraud score for SEPA payment",
+      "providerStates": [
+        {
+          "name": "the fraud scoring engine is available"
+        }
+      ],
+      "request": {
+        "body": {
+          "accountId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "amount": 250.00,
+          "counterpartyId": null,
+          "currency": "EUR",
+          "rail": "SEPA"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/fraud/score"
+      },
+      "response": {
+        "body": {
+          "score": 10,
+          "verdict": "ACCEPT"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.score": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.verdict": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-fraud-service"
+  }
+}

--- a/pacts/openbank-sepa-payment-openbank-transaction-service.json
+++ b/pacts/openbank-sepa-payment-openbank-transaction-service.json
@@ -1,0 +1,81 @@
+{
+  "consumer": {
+    "name": "openbank-sepa-payment"
+  },
+  "interactions": [
+    {
+      "description": "POST initiate SEPA transaction",
+      "providerStates": [
+        {
+          "name": "a valid source account exists"
+        }
+      ],
+      "request": {
+        "body": {
+          "amount": 250.00,
+          "currencyCode": "EUR",
+          "description": "pact contract SEPA payment",
+          "idempotencyKey": "pact-sepa-txn-001",
+          "rail": "SEPA",
+          "sourceAccountId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          "type": "SEPA_CREDIT_TRANSFER",
+          "valueDate": "2026-01-20"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/transactions"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "PROCESSING"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-transaction-service"
+  }
+}

--- a/pacts/openbank-transaction-service-openbank-balance-service.json
+++ b/pacts/openbank-transaction-service-openbank-balance-service.json
@@ -1,0 +1,110 @@
+{
+  "consumer": {
+    "name": "openbank-transaction-service"
+  },
+  "interactions": [
+    {
+      "description": "POST placeHold to reserve funds for a payment",
+      "providerStates": [
+        {
+          "name": "a CZK balance exists for the holds account with sufficient funds"
+        }
+      ],
+      "request": {
+        "body": {
+          "amount": 100.00,
+          "currency": "CZK",
+          "reason": "payment-cover",
+          "referenceId": "pact-tx-00000001",
+          "ttlSeconds": 3600
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/balances/a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1/holds"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    },
+    {
+      "description": "DELETE releaseHold to release the payment cover",
+      "providerStates": [
+        {
+          "name": "a CZK hold exists for the holds account"
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "path": "/api/v1/balances/holds/b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-balance-service"
+  }
+}

--- a/pacts/openbank-transaction-service-openbank-fx-service.json
+++ b/pacts/openbank-transaction-service-openbank-fx-service.json
@@ -1,0 +1,78 @@
+{
+  "consumer": {
+    "name": "openbank-transaction-service"
+  },
+  "interactions": [
+    {
+      "description": "GET EUR/CZK FX rate",
+      "providerStates": [
+        {
+          "name": "an EUR/CZK rate exists"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/fx/rates/EUR/CZK"
+      },
+      "response": {
+        "body": {
+          "askRate": 25.2,
+          "baseCurrency": "EUR",
+          "bidRate": 24.8,
+          "quoteCurrency": "CZK"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.askRate": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.baseCurrency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.bidRate": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.quoteCurrency": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-fx-service"
+  }
+}

--- a/pacts/openbank-transaction-service-openbank-ledger-service.json
+++ b/pacts/openbank-transaction-service-openbank-ledger-service.json
@@ -102,7 +102,7 @@
   ],
   "metadata": {
     "pact-jvm": {
-      "version": "4.6.17"
+      "version": "4.7.3"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/pacts/openbank-transaction-service-openbank-swift-service.json
+++ b/pacts/openbank-transaction-service-openbank-swift-service.json
@@ -1,0 +1,118 @@
+{
+  "consumer": {
+    "name": "openbank-transaction-service"
+  },
+  "messages": [
+    {
+      "contents": {
+        "amount": 1000.0,
+        "currency": "EUR",
+        "messageType": "MT103",
+        "occurredAt": "2000-01-31T14:00:00Z",
+        "paymentSagaRef": "string",
+        "status": "SETTLED",
+        "swiftMessageId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+      },
+      "description": "a swift.message.status-changed event with status SETTLED",
+      "generators": {
+        "body": {
+          "$.occurredAt": {
+            "format": "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            "type": "DateTime"
+          },
+          "$.paymentSagaRef": {
+            "size": 20,
+            "type": "RandomString"
+          },
+          "$.swiftMessageId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.amount": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "decimal"
+              }
+            ]
+          },
+          "$.currency": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[A-Z]{3}"
+              }
+            ]
+          },
+          "$.messageType": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "MT103|MT202|MX_PACS_008"
+              }
+            ]
+          },
+          "$.occurredAt": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "format": "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                "match": "timestamp"
+              }
+            ]
+          },
+          "$.paymentSagaRef": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.status": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "VALIDATED|SENT|SETTLED|REJECTED"
+              }
+            ]
+          },
+          "$.swiftMessageId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "swift-service has processed an MT103 and submitted to scheme gateway"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-swift-service"
+  }
+}


### PR DESCRIPTION
## Summary
- Regenerates and commits **11 consumer pacts that already had a passing test but no committed JSON** — the fleet's real gap for #468 turned out to be "test exists, output was never committed," not "no contract test exists." Verified each by actually running its `*PactConsumerTest` class.
- Adds `FraudPactProviderVerificationTest` (openbank-fraud-service) — the `sepa-payment→fraud` contract had zero provider verification anywhere; the consumer test's own doc comment named this class but it never existed. Wires `pact-provider` into fraud-service's `build.gradle.kts` for the first time. Runs green: replays the real `POST /api/v1/fraud/score` interaction against the live endpoint.
- Adds `.github/workflows/pact-drift-check.yml` — the literal ADR-0063 Phase 2 ask: regenerates every consumer pact on any PR touching a `*PactConsumerTest` or `pacts/`, fails if regenerated JSON differs from committed. Same "derived data is never hand-edited" pattern as the catalog/NetworkPolicy generators.

## A second, adjacent gap found — documented, not fixed here
5 of 8 pact provider verification tests (`balance/fx/sca/swift/transaction-service`) still use `@PactBroker`, gated on `pactbroker.url` (unset on regular PRs, per ADR-0056 — broker has no public ingress). Their contracts — including several of the 11 committed here — aren't actually replayed until the broker-connected CI lane runs at main-push deploy time. Only `account-service`/`ledger-service`/`party-service` (and now `fraud-service`, this PR) use the git-pact `@PactFolder` pattern that runs on every PR. Migrating the remaining 5 is comparable effort to this PR's fraud-service addition, ×5 — scoping as separate follow-up on #468 rather than bundling here.

Also noted: `SwiftEventPactConsumerTest` (consumer=`transaction-service`, provider=`swift-service`) physically lives in `openbank-swift-service`'s test source, not `openbank-transaction-service`'s — functionally fine (Gradle just compiles/runs it where it sits) but an odd location for a consumer-owned test; not touched here.

## Test plan
- [x] Ran each of the 11 previously-uncommitted `*PactConsumerTest` classes locally — all pass, pact JSON committed as generated.
- [x] `FraudPactProviderVerificationTest` — 1/1 passing, replays against the live `/api/v1/fraud/score` endpoint.
- [x] `ktlintCheck` + `detekt` on `openbank-account-service` and `openbank-fraud-service` — clean.
- [x] `pact-drift-check.yml` YAML validated locally.
- [ ] This PR's own CI run exercises the new drift-check workflow for the first time (no drift expected — the committed pacts are exactly what was just regenerated).

Refs #468 (leaving open — see the broker-vs-folder gap above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)