### PR TITLE
security(libs-testing,aml,ledger): add shared authz conformance kit, fix live AML gap

### DIFF
--- a/openbank-aml-service/build.gradle.kts
+++ b/openbank-aml-service/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+
+    // Shared authz conformance kit (issue #467) — AmlCaseSecurityTest pilot migration.
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 kover {

--- a/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt
+++ b/openbank-aml-service/src/main/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseResource.kt
@@ -70,11 +70,13 @@ class AmlCaseResource(
 
     @GET
     @Path("/{caseId}")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")
     @Operation(summary = "Get AML case by ID")
     suspend fun getCase(@PathParam("caseId") caseId: UUID): Response =
         Response.ok(amlCaseUseCase.getCase(caseId).toResponse()).build()
 
     @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")
     @Operation(summary = "List AML screening cases")
     suspend fun listCases(
         @QueryParam("status") status: String?,

--- a/openbank-aml-service/src/test/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseSecurityTest.kt
+++ b/openbank-aml-service/src/test/kotlin/com/openbank/aml/infrastructure/rest/AmlCaseSecurityTest.kt
@@ -4,35 +4,17 @@
 
 package com.openbank.aml.infrastructure.rest
 
-import jakarta.annotation.security.PermitAll
-import jakarta.ws.rs.DELETE
-import jakarta.ws.rs.GET
-import jakarta.ws.rs.PATCH
-import jakarta.ws.rs.POST
-import jakarta.ws.rs.PUT
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import com.openbank.libs.testing.authz.RestAuthzConformanceTest
 
 /**
- * Regression guard (C7/ADR-0030): no AML endpoint must be opened without role-gating.
- * Pure reflection — no Quarkus boot needed.
+ * Regression guard (C7/ADR-0030): no AML endpoint must be opened without role-gating. Migrated
+ * to the shared `openbank-libs-testing` kit (issue #467) — stricter than the original hand-rolled
+ * version it replaces, which only checked for an explicit `@PermitAll` and missed that
+ * `getCase`/`listCases` had NO security annotation at all. Quarkus treats an unannotated JAX-RS
+ * method as unauthenticated-accessible by default (`quarkus.security.jaxrs.deny-unannotated-
+ * endpoints` defaults to `false`, unset anywhere in this fleet) — so those two endpoints were
+ * live and open with no role check. Fixed alongside this migration.
  */
-class AmlCaseSecurityTest {
-
-    @Test
-    fun `no AmlCaseResource endpoint is @PermitAll`() {
-        val methods = AmlCaseResource::class.java.declaredMethods.filter { m ->
-            m.getAnnotation(GET::class.java) != null ||
-                m.getAnnotation(POST::class.java) != null ||
-                m.getAnnotation(PUT::class.java) != null ||
-                m.getAnnotation(DELETE::class.java) != null ||
-                m.getAnnotation(PATCH::class.java) != null
-        }
-        assertThat(methods).isNotEmpty()
-        methods.forEach { m ->
-            assertThat(m.getAnnotation(PermitAll::class.java))
-                .describedAs("${m.name} must not be @PermitAll — use @RolesAllowed")
-                .isNull()
-        }
-    }
+class AmlCaseSecurityTest : RestAuthzConformanceTest() {
+    override val resourceClasses = listOf(AmlCaseResource::class)
 }

--- a/openbank-ledger-service/build.gradle.kts
+++ b/openbank-ledger-service/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.redpanda)
+
+    // Shared authz conformance kit (issue #467) — LedgerAuthzConformanceTest pilot migration.
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 kover {

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerAuthzConformanceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerAuthzConformanceTest.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.rest
+
+import com.openbank.libs.testing.authz.RestAuthzConformanceTest
+
+/**
+ * The generic half of the K7/ADR-0018 regression guard (issue #467, `openbank-libs-testing`
+ * pilot): no endpoint on either ledger resource may be `@PermitAll`, and every endpoint must
+ * carry `@RolesAllowed`. Service-specific role assertions (which roles a given endpoint must
+ * carry) stay local — see [LedgerSecurityContractTest] and [YearCloseSecurityContractTest].
+ */
+class LedgerAuthzConformanceTest : RestAuthzConformanceTest() {
+    override val resourceClasses = listOf(LedgerResource::class, YearCloseResource::class)
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerSecurityContractTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerSecurityContractTest.kt
@@ -4,49 +4,21 @@
 
 package com.openbank.ledger.infrastructure.rest
 
-import jakarta.annotation.security.PermitAll
 import jakarta.annotation.security.RolesAllowed
-import jakarta.ws.rs.DELETE
-import jakarta.ws.rs.GET
-import jakarta.ws.rs.PATCH
-import jakarta.ws.rs.POST
-import jakarta.ws.rs.PUT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.lang.reflect.Method
 
 /**
- * Regression guard (K7 / ADR-0018): the general ledger is the book of record; its read endpoints once
- * carried `@PermitAll`. This test locks the declarative access-control contract so a silent revert to
- * `@PermitAll` (or a new unannotated endpoint) fails the build. `@RolesAllowed` / `@PermitAll` are
- * RUNTIME-retained, so the contract is asserted by reflection without booting JAX-RS — end-to-end
- * enforcement is Quarkus OIDC's job.
+ * Regression guard (K7 / ADR-0018): the general ledger is the book of record. The generic
+ * "no endpoint is @PermitAll, every endpoint is @RolesAllowed" check moved to
+ * [LedgerAuthzConformanceTest] (issue #467, `openbank-libs-testing`); this class keeps the
+ * service-specific assertions — which roles a given endpoint must carry.
  */
 class LedgerSecurityContractTest {
-
-    private val httpVerbs =
-        listOf(GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
-
-    private fun Method.isHttpEndpoint() = httpVerbs.any { getAnnotation(it) != null }
 
     private fun rolesOf(name: String): List<String> {
         val m = LedgerResource::class.java.declaredMethods.single { it.name == name }
         return m.getAnnotation(RolesAllowed::class.java)?.value?.toList() ?: emptyList()
-    }
-
-    @Test
-    fun `every ledger endpoint is role-gated, never permit-all`() {
-        val all = LedgerResource::class.java.declaredMethods.filter { it.isHttpEndpoint() }
-        assertThat(all).describedAs("expected to find HTTP endpoints by reflection").isNotEmpty
-
-        all.forEach { m ->
-            assertThat(m.getAnnotation(PermitAll::class.java))
-                .describedAs("%s must NOT be @PermitAll (K7 — money-path)", m.name)
-                .isNull()
-            assertThat(m.getAnnotation(RolesAllowed::class.java))
-                .describedAs("%s must be @RolesAllowed", m.name)
-                .isNotNull()
-        }
     }
 
     @Test

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/YearCloseSecurityContractTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/YearCloseSecurityContractTest.kt
@@ -4,49 +4,24 @@
 
 package com.openbank.ledger.infrastructure.rest
 
-import jakarta.annotation.security.PermitAll
 import jakarta.annotation.security.RolesAllowed
-import jakarta.ws.rs.DELETE
-import jakarta.ws.rs.GET
-import jakarta.ws.rs.PATCH
-import jakarta.ws.rs.POST
-import jakarta.ws.rs.PUT
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.lang.reflect.Method
 
 /**
  * Regression guard (K7 / ADR-0018), mirroring [LedgerSecurityContractTest]: the year close is
- * statutory book-of-record evidence (ADR-0078 D5), so no endpoint may be `@PermitAll` and the
- * two state changes (draft creation, attestation) stay operator-only like posting a journal.
+ * statutory book-of-record evidence (ADR-0078 D5). The generic "no endpoint is @PermitAll, every
+ * endpoint is @RolesAllowed" check moved to [LedgerAuthzConformanceTest] (issue #467,
+ * `openbank-libs-testing`); this class keeps the service-specific role assertions — the two
+ * state changes (draft creation, attestation) stay operator-only like posting a journal.
  * Note: this locks the DECLARATIVE access contract; it intentionally does not pin the OpenAPI
  * info.version (the API-contract axis is independent of version.txt, ADR-0048).
  */
 class YearCloseSecurityContractTest {
 
-    private val httpVerbs =
-        listOf(GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
-
-    private fun Method.isHttpEndpoint() = httpVerbs.any { getAnnotation(it) != null }
-
     private fun rolesOf(name: String): List<String> {
         val m = YearCloseResource::class.java.declaredMethods.single { it.name == name }
         return m.getAnnotation(RolesAllowed::class.java)?.value?.toList() ?: emptyList()
-    }
-
-    @Test
-    fun `every year-close endpoint is role-gated, never permit-all`() {
-        val all = YearCloseResource::class.java.declaredMethods.filter { it.isHttpEndpoint() }
-        assertThat(all).describedAs("expected to find HTTP endpoints by reflection").isNotEmpty
-
-        all.forEach { m ->
-            assertThat(m.getAnnotation(PermitAll::class.java))
-                .describedAs("%s must NOT be @PermitAll (K7 — statutory close evidence)", m.name)
-                .isNull()
-            assertThat(m.getAnnotation(RolesAllowed::class.java))
-                .describedAs("%s must be @RolesAllowed", m.name)
-                .isNotNull()
-        }
     }
 
     @Test

--- a/openbank-libs-testing/build.gradle.kts
+++ b/openbank-libs-testing/build.gradle.kts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    id("openbank.static-analysis")
+    `java-library`
+    `maven-publish`
+}
+
+group = "com.openbank"
+version = "0.1.0-SNAPSHOT"
+
+repositories {
+    maven("https://maven-central.storage-download.googleapis.com/maven2/")
+    mavenCentral()
+}
+
+dependencies {
+    api(libs.kotlin.stdlib)
+    api(libs.kotlin.reflect)
+
+    // Test-framework surface the conformance kits expose in their public abstract classes —
+    // `api` so a consuming service's testImplementation(project(":openbank-libs-testing"))
+    // pulls these transitively without redeclaring them.
+    api(platform(libs.junit.bom))
+    api(libs.junit.jupiter)
+    api(libs.assertj)
+
+    // JAX-RS + CDI security annotation types the authz conformance kit reflects over
+    // (jakarta.ws.rs.GET/POST/.../jakarta.annotation.security.PermitAll/RolesAllowed).
+    // No Quarkus BOM here (this module isn't a Quarkus service), so pinned directly —
+    // same coordinates openbank-libs-runtime already uses for the identical types.
+    api("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
+    api("jakarta.annotation:jakarta.annotation-api:3.0.0")
+
+    testImplementation(libs.mockk)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+kotlin {
+    jvmToolchain(25)
+    compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict", "-Xannotation-default-target=param-property") }
+}

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/authz/RestAuthzConformanceTest.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/authz/RestAuthzConformanceTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.authz
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+import kotlin.reflect.KClass
+
+/**
+ * Shared authz conformance kit (issue #467) generalising the `@PermitAll` reflection guard that
+ * was independently copy-pasted into ~25 services (`LedgerSecurityContractTest`,
+ * `AmlCaseSecurityTest`, etc. — each re-implementing the identical `isHttpEndpoint()` reflection
+ * and the identical two assertions against a locally hardcoded resource class). Pure reflection —
+ * `@RolesAllowed`/`@PermitAll` are RUNTIME-retained JAX-RS annotations, so this never boots
+ * Quarkus; end-to-end enforcement is still Quarkus OIDC's job at runtime.
+ *
+ * A consuming service inherits this in one line:
+ * ```
+ * class MyResourceAuthzConformanceTest : RestAuthzConformanceTest() {
+ *     override val resourceClasses = listOf(MyResource::class)
+ * }
+ * ```
+ * Service-specific assertions (which roles a given endpoint must carry) stay local to the
+ * service — this kit only enforces the fleet-wide invariant: every endpoint is role-gated, never
+ * `@PermitAll`.
+ */
+// detekt's FunctionNaming excludes **/test/** by default, but these @Test methods must live in
+// src/main so testImplementation(project(":openbank-libs-testing")) can pull and inherit them —
+// Gradle project dependencies expose a module's main artifact, not its test classes.
+@Suppress("FunctionNaming")
+abstract class RestAuthzConformanceTest {
+
+    /** Every `@Path`-annotated JAX-RS resource class this service exposes. */
+    protected abstract val resourceClasses: List<KClass<*>>
+
+    private val httpVerbs =
+        listOf(GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
+
+    private fun Method.isHttpEndpoint() = httpVerbs.any { getAnnotation(it) != null }
+
+    private fun endpoints(): List<Method> =
+        resourceClasses.flatMap { it.java.declaredMethods.filter { m -> m.isHttpEndpoint() } }
+
+    @Test
+    fun `no REST endpoint is PermitAll`() {
+        val all = endpoints()
+        assertThat(all)
+            .describedAs(
+                "expected to find HTTP endpoints by reflection across %s",
+                resourceClasses.map { it.simpleName },
+            )
+            .isNotEmpty()
+        all.forEach { m ->
+            assertThat(m.getAnnotation(PermitAll::class.java))
+                .describedAs("%s.%s must NOT be @PermitAll", m.declaringClass.simpleName, m.name)
+                .isNull()
+        }
+    }
+
+    @Test
+    fun `every REST endpoint carries RolesAllowed`() {
+        endpoints().forEach { m ->
+            assertThat(m.getAnnotation(RolesAllowed::class.java))
+                .describedAs("%s.%s must be @RolesAllowed", m.declaringClass.simpleName, m.name)
+                .isNotNull()
+        }
+    }
+}

--- a/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/authz/RestAuthzConformanceTestSelfTest.kt
+++ b/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/authz/RestAuthzConformanceTestSelfTest.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.authz
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+private class CompliantResource {
+    @GET
+    @RolesAllowed("ROLE_VIEWER")
+    fun read(): Unit = Unit
+
+    @POST
+    @RolesAllowed("ROLE_OPERATOR")
+    fun write(): Unit = Unit
+}
+
+private class PermitAllResource {
+    @GET
+    @PermitAll
+    fun read(): Unit = Unit
+}
+
+private class UnannotatedResource {
+    @GET
+    fun read(): Unit = Unit
+}
+
+private class CompliantConformanceTest : RestAuthzConformanceTest() {
+    override val resourceClasses = listOf(CompliantResource::class)
+}
+
+// @Disabled: these two intentionally violate the rule (that's what the self-test below exercises
+// via direct method calls) — without it, JUnit5's classpath scan also auto-discovers and runs
+// them as their own top-level test classes, which then genuinely fail the build.
+@Disabled("fixture for RestAuthzConformanceTestSelfTest — intentionally non-compliant")
+private class PermitAllConformanceTest : RestAuthzConformanceTest() {
+    override val resourceClasses = listOf(PermitAllResource::class)
+}
+
+@Disabled("fixture for RestAuthzConformanceTestSelfTest — intentionally non-compliant")
+private class UnannotatedConformanceTest : RestAuthzConformanceTest() {
+    override val resourceClasses = listOf(UnannotatedResource::class)
+}
+
+/** Proves the kit itself actually catches what it claims to, before any service inherits it. */
+class RestAuthzConformanceTestSelfTest {
+
+    @Test
+    fun `passes for a fully role-gated resource`() {
+        val test = CompliantConformanceTest()
+        test.`no REST endpoint is PermitAll`()
+        test.`every REST endpoint carries RolesAllowed`()
+    }
+
+    @Test
+    fun `fails for a PermitAll endpoint`() {
+        assertThatThrownBy { PermitAllConformanceTest().`no REST endpoint is PermitAll`() }
+            .isInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    fun `fails for an endpoint missing RolesAllowed`() {
+        assertThatThrownBy { UnannotatedConformanceTest().`every REST endpoint carries RolesAllowed`() }
+            .isInstanceOf(AssertionError::class.java)
+    }
+
+    @Test
+    fun `fails fast when a resource class has no HTTP-verb-annotated methods`() {
+        class Empty
+        class EmptyConformanceTest : RestAuthzConformanceTest() {
+            override val resourceClasses = listOf(Empty::class)
+        }
+        assertThatThrownBy { EmptyConformanceTest().`no REST endpoint is PermitAll`() }
+            .isInstanceOf(AssertionError::class.java)
+    }
+}


### PR DESCRIPTION
## Summary
- New `openbank-libs-testing` module (issue #467 pilot slice) with `RestAuthzConformanceTest`, a shared abstract base class generalizing the `@PermitAll` reflection guard that ~25 services independently copy-pasted. A consuming service inherits it in one line.
- **Real security fix surfaced by the migration**: migrating `aml-service` to the new (stricter) kit found that `AmlCaseResource.getCase()` and `listCases()` (`GET /api/v1/aml/cases/{id}` and the list endpoint) carried **no security annotation at all**. Quarkus defaults `quarkus.security.jaxrs.deny-unannotated-endpoints` to `false` (confirmed unset anywhere in this fleet), so an unannotated JAX-RS method is effectively open — same exposure as an explicit `@PermitAll`. The old hand-rolled test only checked for the explicit annotation, never "missing entirely." Fixed both endpoints with the same `ROLE_OPERATOR`/`ROLE_ADMIN`/`ROLE_COMPLIANCE` roles this resource's write endpoints already use.
- `ledger-service` migrated as the second pilot (the issue's own proposed "donor" service) — `LedgerAuthzConformanceTest` covers both `LedgerResource` and `YearCloseResource` generically; the existing `LedgerSecurityContractTest`/`YearCloseSecurityContractTest` keep only their service-specific role assertions.

## Scope note
`aml-service` is not in `rules.yaml: money_path_services`, so this doesn't trigger the 2-approval/threat-model gate — but it's a genuine unauthenticated-read fix on AML case data, not a refactor. Flagging clearly for reviewer attention.

## Remaining, tracked on #467
- The other 4 kits the issue names (Testcontainers resource, deterministic Clock producer, outbox dispatch conformance, money test-data builders) — not attempted here.
- The fleet sweep migrating the other ~23 services off their duplicated `@PermitAll`-only test. Given what this PR found in `aml-service`, each migration should be treated as a potential live-gap finder, not a pure refactor — I'd recommend a dedicated follow-up issue for the sweep with that framing, rather than bundling it into a single mechanical PR.

## Test plan
- [x] `openbank-libs-testing` self-test (`RestAuthzConformanceTestSelfTest`) — 4/4 passing, proves the kit catches a `@PermitAll` endpoint, catches a missing-annotation endpoint, passes a compliant resource, and fails fast on an empty resource class.
- [x] `AmlCaseSecurityTest` (migrated) — 2/2 passing against the now-fixed `AmlCaseResource`.
- [x] `LedgerAuthzConformanceTest` + existing `LedgerSecurityContractTest`/`YearCloseSecurityContractTest` — all passing.
- [x] `ktlintCheck` + `detekt` on `openbank-libs-testing`, `openbank-aml-service`, `openbank-ledger-service` — clean.

Refs #467 (leaving open — see remaining scope above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)