### PR TITLE
security(standing-order,tpp-registry): add missing RBAC to fully-open endpoints

### DIFF
--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderResource.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderResource.kt
@@ -30,6 +30,7 @@ import java.util.UUID
 class StandingOrderResource(private val useCase: StandingOrderUseCase) {
 
     @POST
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun create(req: CreateStandingOrderRequest): Response {
         val order = useCase.create(
             CreateStandingOrderCommand(
@@ -43,29 +44,35 @@ class StandingOrderResource(private val useCase: StandingOrderUseCase) {
     }
 
     @GET
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listAll() = useCase.listAll().map { it.toResponse() }
 
     @GET
     @Path("/{id}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun get(@PathParam("id") id: UUID) = useCase.getById(id) ?: throw NotFoundException()
 
     @GET
     @Path("/party/{partyId}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listByParty(@PathParam("partyId") partyId: UUID) = useCase.listByParty(partyId).map { it.toResponse() }
 
     @POST
     @Path("/{id}/pause")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "standingOrder.pause", resource = "#id")
     suspend fun pause(@PathParam("id") id: UUID, @HeaderParam("X-Customer-Party-Id") actor: String?) =
         useCase.pause(id, actor(actor)).toResponse()
 
     @POST
     @Path("/{id}/resume")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun resume(@PathParam("id") id: UUID, @HeaderParam("X-Customer-Party-Id") actor: String?) =
         useCase.resume(id, actor(actor)).toResponse()
 
     @DELETE
     @Path("/{id}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun cancel(@PathParam("id") id: UUID, @HeaderParam("X-Customer-Party-Id") actor: String?): Response {
         useCase.cancel(id, actor(actor))
         return Response.noContent().build()

--- a/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderSecurityContractTest.kt
+++ b/openbank-standing-order-service/src/test/kotlin/com/openbank/standingorder/infrastructure/rest/StandingOrderSecurityContractTest.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.standingorder.infrastructure.rest
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Regression guard: every StandingOrderResource endpoint (create/list/get/pause/resume/cancel)
+ * was unauthenticated-accessible until this fix — no method carried @RolesAllowed and Quarkus's
+ * `quarkus.security.jaxrs.deny-unannotated-endpoints` defaults to false. Reflection, no boot needed.
+ */
+class StandingOrderSecurityContractTest {
+
+    private val httpVerbs =
+        listOf(GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
+
+    private fun Method.isHttpEndpoint() = httpVerbs.any { getAnnotation(it) != null }
+
+    @Test
+    fun `every standing-order endpoint is role-gated, never permit-all or unannotated`() {
+        val all = StandingOrderResource::class.java.declaredMethods.filter { it.isHttpEndpoint() }
+        assertThat(all).describedAs("expected to find HTTP endpoints by reflection").isNotEmpty
+
+        all.forEach { m ->
+            assertThat(m.getAnnotation(PermitAll::class.java))
+                .describedAs("%s must NOT be @PermitAll", m.name)
+                .isNull()
+            assertThat(m.getAnnotation(RolesAllowed::class.java))
+                .describedAs("%s must be @RolesAllowed", m.name)
+                .isNotNull()
+        }
+    }
+}

--- a/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistryResource.kt
+++ b/openbank-tpp-registry-service/src/main/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistryResource.kt
@@ -5,11 +5,25 @@
 package com.openbank.tppregistry.infrastructure.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.openbank.tppregistry.application.port.`in`.*
-import com.openbank.tppregistry.domain.model.*
 import com.openbank.libs.authz.Authorize
 import com.openbank.libs.idempotency.IdempotencyStore
-import jakarta.ws.rs.*
+import com.openbank.tppregistry.application.port.`in`.BlacklistTppCommand
+import com.openbank.tppregistry.application.port.`in`.CheckTppAuthorizationQuery
+import com.openbank.tppregistry.application.port.`in`.GetTppQuery
+import com.openbank.tppregistry.application.port.`in`.ListTppsQuery
+import com.openbank.tppregistry.application.port.`in`.RegisterTppCommand
+import com.openbank.tppregistry.application.port.`in`.TppRegistryUseCase
+import com.openbank.tppregistry.domain.model.TppRole
+import com.openbank.tppregistry.domain.model.TppStatus
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.HeaderParam
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 
@@ -19,25 +33,27 @@ import jakarta.ws.rs.core.Response
 class TppRegistryResource(
     private val svc: TppRegistryUseCase,
     private val idempotencyStore: IdempotencyStore,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
 ) {
     @GET
     @Path("/check")
-    suspend fun checkAuthorization(
-        @QueryParam("tppId") tppId: String,
-        @QueryParam("role") role: String
-    ): Response {
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    suspend fun checkAuthorization(@QueryParam("tppId") tppId: String, @QueryParam("role") role: String): Response {
         val result = svc.checkAuthorization(
-            CheckTppAuthorizationQuery(tppId, TppRole.valueOf(role.uppercase()))
+            CheckTppAuthorizationQuery(tppId, TppRole.valueOf(role.uppercase())),
         )
-        return if (result.authorized) Response.ok(result).build()
-        else Response.status(403).entity(result).build()
+        return if (result.authorized) {
+            Response.ok(result).build()
+        } else {
+            Response.status(403).entity(result).build()
+        }
     }
 
     @POST
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun registerTpp(
         cmd: RegisterTppCommand,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String?
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
         val cacheKey = idempotencyKey?.takeIf { it.isNotBlank() }?.let { registerKey(cmd.tppId, it) }
         cacheKey?.let { key ->
@@ -56,12 +72,13 @@ class TppRegistryResource(
     }
 
     @GET
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun listTpps(
         @QueryParam("countryCode") countryCode: String?,
         @QueryParam("role") role: String?,
         @QueryParam("status") status: String?,
         @QueryParam("limit") limit: Int?,
-        @QueryParam("afterCursor") afterCursor: String?
+        @QueryParam("afterCursor") afterCursor: String?,
     ): Response {
         val entries = svc.listTpps(
             ListTppsQuery(
@@ -69,24 +86,26 @@ class TppRegistryResource(
                 role = role?.let { TppRole.valueOf(it.uppercase()) },
                 status = status?.let { TppStatus.valueOf(it.uppercase()) },
                 limit = limit ?: 50,
-                afterCursor = afterCursor
-            )
+                afterCursor = afterCursor,
+            ),
         )
         return Response.ok(mapOf("tpps" to entries, "count" to entries.size)).build()
     }
 
     @GET
     @Path("/{tppId}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun getTpp(@PathParam("tppId") tppId: String): Response =
         Response.ok(svc.getTpp(GetTppQuery(tppId))).build()
 
     @POST
     @Path("/{tppId}/blacklist")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "tppRegistry.blacklist", resource = "#tppId")
     suspend fun blacklistTpp(
         @PathParam("tppId") tppId: String,
         body: Map<String, String>,
-        @HeaderParam("Idempotency-Key") idempotencyKey: String?
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
     ): Response {
         val reason = body["reason"] ?: "No reason provided"
         val cacheKey = idempotencyKey?.takeIf { it.isNotBlank() }?.let { blacklistKey(tppId, it) }
@@ -107,6 +126,7 @@ class TppRegistryResource(
 
     @POST
     @Path("/sync/eba")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun triggerEbaSync(@HeaderParam("Idempotency-Key") idempotencyKey: String?): Response {
         val cacheKey = idempotencyKey?.takeIf { it.isNotBlank() }?.let(::syncKey)
         cacheKey?.let { key ->
@@ -126,8 +146,8 @@ class TppRegistryResource(
 
     @GET
     @Path("/sync/state")
-    suspend fun getSyncState(): Response =
-        Response.ok(svc.getSyncState()).build()
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
+    suspend fun getSyncState(): Response = Response.ok(svc.getSyncState()).build()
 
     private fun registerKey(tppId: String, idempotencyKey: String) = "tpp:register:$tppId:$idempotencyKey"
     private fun blacklistKey(tppId: String, idempotencyKey: String) = "tpp:blacklist:$tppId:$idempotencyKey"

--- a/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistrySecurityContractTest.kt
+++ b/openbank-tpp-registry-service/src/test/kotlin/com/openbank/tppregistry/infrastructure/rest/TppRegistrySecurityContractTest.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.tppregistry.infrastructure.rest
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Regression guard: every TppRegistryResource endpoint was unauthenticated-accessible until this
+ * fix — a rogue TPP could be registered into the registry that EidasMtlsFilter (openbank-psd2-
+ * service) trusts, with no auth at all. Reflection, no boot needed.
+ */
+class TppRegistrySecurityContractTest {
+
+    private val httpVerbs =
+        listOf(GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
+
+    private fun Method.isHttpEndpoint() = httpVerbs.any { getAnnotation(it) != null }
+
+    @Test
+    fun `every tpp-registry endpoint is role-gated, never permit-all or unannotated`() {
+        val all = TppRegistryResource::class.java.declaredMethods.filter { it.isHttpEndpoint() }
+        assertThat(all).describedAs("expected to find HTTP endpoints by reflection").isNotEmpty
+
+        all.forEach { m ->
+            assertThat(m.getAnnotation(PermitAll::class.java))
+                .describedAs("%s must NOT be @PermitAll", m.name)
+                .isNull()
+            assertThat(m.getAnnotation(RolesAllowed::class.java))
+                .describedAs("%s must be @RolesAllowed", m.name)
+                .isNotNull()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Quarkus's `quarkus.security.jaxrs.deny-unannotated-endpoints` defaults to `false` (unset anywhere in this fleet) — a JAX-RS method with an HTTP-verb annotation but no `@RolesAllowed`/`@PermitAll`/`@DenyAll` is effectively open to any caller. Found via a fleet-wide follow-up audit after the same gap surfaced live in `openbank-aml-service` (#757).

- **`StandingOrderResource`**: `create`/`listAll`/`get`/`listByParty`/`resume`/`cancel` had zero security annotation. `pause` had `@Authorize` only, missing the `@RolesAllowed` pairing `Authorize.kt`'s own docs require. All six now carry the same `ROLE_SERVICE`/`ROLE_OPERATOR`/`ROLE_ADMIN` set already used on this resource's `recordExecution`/`recordFailure`.
- **`TppRegistryResource`**: `checkAuthorization`/`registerTpp`/`listTpps`/`getTpp`/`triggerEbaSync`/`getSyncState` had zero security annotation. `blacklistTpp` had the same `@Authorize`-only gap. Reads get `ROLE_SERVICE`+`ROLE_OPERATOR`+`ROLE_ADMIN`; the two mutations of the trust registry (`registerTpp`/`blacklistTpp`) get `ROLE_OPERATOR`+`ROLE_ADMIN` only.

Added a reflection-based regression guard per service — mirrors the existing hand-rolled `@PermitAll`-check pattern (not the shared `openbank-libs-testing` kit from #467, since that PR hasn't merged yet).

## Scope note

Neither `standing-order-service` nor `tpp-registry-service` is in `rules.yaml: money_path_services`, so this doesn't trigger the 2-approval gate procedurally — flagging for reviewer attention regardless, this is a live-vulnerability fix, not a refactor.

## Role assignment is a judgment call

I don't have deep domain context on exactly who should call each endpoint. I picked the most conservative option that (a) closes the anonymous-access gap and (b) matches the role set already used on adjacent, already-protected endpoints in the same file, so it shouldn't break any legitimate current caller. Please adjust roles in review if the actual access model differs (e.g. if some of these should be customer-scoped rather than service/operator-scoped).

## Test plan
- [x] `StandingOrderSecurityContractTest` / `TppRegistrySecurityContractTest` (new) — both pass, assert every endpoint carries `@RolesAllowed` and never `@PermitAll`.
- [x] Full `test` + `ktlintCheck` + `detekt` for both services — clean (isolated a Quarkus boot-smoke port-contention flake from concurrent local runs; passes standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)