### PR TITLE
feat(admin-ui): honest scale-to-zero states, clickable payment/SWIFT detail, Closings check log

### DIFF
--- a/openbank-admin-ui/src/app/aml/page.tsx
+++ b/openbank-admin-ui/src/app/aml/page.tsx
@@ -3,10 +3,13 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect, useCallback } from 'react'
-import { ShieldAlert, Search, CheckCircle2, XCircle, Clock, RefreshCw, AlertTriangle, User, Play, AlertOctagon } from 'lucide-react'
+import { useState } from 'react'
+import { ShieldAlert, Search, Clock, RefreshCw, AlertTriangle, User, Play, AlertOctagon } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
+import { svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 interface AmlCase {
@@ -36,28 +39,22 @@ const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }
 
 export default function AmlPage() {
   const { t, language } = useLanguage()
-  const [cases, setCases] = useState<AmlCase[]>([])
-  const [loading, setLoading] = useState(true)
   const [scanning, setScanning] = useState(false)
   const [search, setSearch] = useState('')
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
-
-  const load = useCallback(async () => {
-    setLoading(true)
-    fetch('/api/svc/aml-service/q/health/ready').then(r => setServiceUp(r.ok)).catch(() => setServiceUp(false))
-    fetch('/api/svc/aml-service/api/v1/aml/cases').then(r => r.json())
-      .then(d => setCases(Array.isArray(d) ? d : d.cases ?? []))
-      .catch(() => setCases([]))
-      .finally(() => setLoading(false))
-  }, [])
-
-  useEffect(() => { load() }, [load])
+  const { data, loading, unavailable, waking, reload } = useServiceResource<AmlCase[]>(
+    svcUrl('aml-service', '/api/v1/aml/cases'),
+    { select: (raw) => (Array.isArray(raw) ? (raw as AmlCase[]) : ((raw as { cases?: AmlCase[] }).cases ?? [])) },
+  )
+  const cases = data ?? []
+  // The service can still be scanned when it's merely idle (a POST wakes it);
+  // only a hard-down state blocks the button.
+  const serviceReachable = !unavailable || unavailable.kind === 'no_data' || unavailable.kind === 'scaled_to_zero'
 
   const triggerScan = async () => {
     setScanning(true)
     try {
-      await fetch('/api/svc/aml-service/api/v1/aml/scan', { method: 'POST' })
-      setTimeout(() => { load(); setScanning(false) }, 3000)
+      await fetch(svcUrl('aml-service', '/api/v1/aml/scan'), { method: 'POST' })
+      setTimeout(() => { reload(); setScanning(false) }, 3000)
     } catch { setScanning(false) }
   }
 
@@ -84,15 +81,19 @@ export default function AmlPage() {
             </p>
           </div>
           <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-            <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
-              padding: '4px 10px', borderRadius: '20px',
-              background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-              color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-              border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-              {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-              aml-service :8117
-            </span>
-            <button onClick={triggerScan} disabled={scanning || serviceUp === false} className="btn btn-primary btn-sm" style={{ background: 'var(--accent)', color: 'white', border: 'none', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', fontWeight: 600, cursor: scanning || serviceUp === false ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', gap: '6px', opacity: scanning || serviceUp === false ? 0.6 : 1 }}>
+            <ServiceStatusBadge
+              label="aml-service :8117"
+              loading={loading}
+              waking={waking}
+              unavailable={unavailable}
+              copy={{
+                up: t('aml-service běží', 'aml-service is up'),
+                idle: t('aml-service spí (scale-to-zero), probouzí se…', 'aml-service idle (scaled to zero), waking…'),
+                down: t('aml-service neodpovídá', 'aml-service is not responding'),
+                checking: t('Zjišťuji stav služby…', 'Checking service…'),
+              }}
+            />
+            <button onClick={triggerScan} disabled={scanning || !serviceReachable} className="btn btn-primary btn-sm" style={{ background: 'var(--accent)', color: 'white', border: 'none', padding: '6px 12px', borderRadius: '6px', fontSize: '13px', fontWeight: 600, cursor: scanning || !serviceReachable ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', gap: '6px', opacity: scanning || !serviceReachable ? 0.6 : 1 }}>
               <Play size={13} style={{ animation: scanning ? 'pulse 1s infinite' : 'none' }} />
               {scanning ? t('Kontroluji…', 'Scanning…') : t('Spustit AML kontrolu', 'Run AML scan')}
             </button>
@@ -105,7 +106,15 @@ export default function AmlPage() {
             display: 'flex', alignItems: 'center', gap: '10px' }}>
             <AlertOctagon size={16} style={{ color: 'var(--danger)', flexShrink: 0 }} />
             <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--danger-text)' }}>
-              {escalated.length} AML případ{escalated.length > 1 && escalated.length < 5 ? 'y byly eskalovány' : escalated.length >= 5 ? 'ů bylo eskalováno' : ' byl eskalován'} na compliance officera
+              {escalated.length}{' '}
+              {t(
+                escalated.length > 1 && escalated.length < 5
+                  ? 'AML případy byly eskalovány na compliance officera'
+                  : escalated.length >= 5
+                    ? 'AML případů bylo eskalováno na compliance officera'
+                    : 'AML případ byl eskalován na compliance officera',
+                escalated.length === 1 ? 'AML case escalated to a compliance officer' : 'AML cases escalated to a compliance officer',
+              )}
             </span>
           </div>
         )}
@@ -139,12 +148,11 @@ export default function AmlPage() {
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám případy…', 'Loading cases…')}</div>
             </div>
-          ) : serviceUp === false ? (
-            // aml-service is not reachable through the BFF — almost always means
-            // it isn't deployed in this sandbox (most of the fleet isn't). Explain
-            // it calmly instead of the old "Mikroservisa běží na portu 8117" copy,
-            // which falsely claimed the service was up.
-            <DataUnavailable kind="not_deployed" service="AML-service" feature={t('AML monitoring', 'AML monitoring')} lang={language} />
+          ) : unavailable ? (
+            // aml-service didn't answer through the BFF. Classify honestly — idle
+            // (scale-to-zero, ADR-0057), not deployed, or a real outage — instead
+            // of the old copy that falsely claimed the service was up.
+            <DataUnavailable kind={unavailable.kind} service={t('AML-service', 'AML-service')} feature={t('AML monitoring', 'AML monitoring')} lang={language} />
           ) : filtered.length === 0 ? (
             <DataUnavailable
               kind="no_data"

--- a/openbank-admin-ui/src/app/cards/page.tsx
+++ b/openbank-admin-ui/src/app/cards/page.tsx
@@ -3,10 +3,14 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { CreditCard, Plus, Search, RefreshCw, CheckCircle2, XCircle, Clock } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 
 interface Card {
   id: string; partyId: string; accountId: string; maskedPan: string
@@ -21,18 +25,17 @@ const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }
 }
 
 export default function CardsPage() {
-  const [cards, setCards] = useState<Card[]>([])
-  const { t } = useLanguage()
-  const [loading, setLoading] = useState(true)
+  const { t, language } = useLanguage()
   const [search, setSearch] = useState('')
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
 
-  useEffect(() => {
-    fetch('/api/svc/card-issuance-service/q/health/ready').then(r => setServiceUp(r.ok)).catch(() => setServiceUp(false))
-    fetch('/api/svc/card-issuance-service/api/v1/cards').then(r => r.json()).then(d => {
-      setCards(Array.isArray(d) ? d : d.cards ?? [])
-    }).catch(() => setCards([])).finally(() => setLoading(false))
-  }, [])
+  // Single graceful data path (admin-ui rule #1): the hook classifies a non-OK
+  // BFF response and auto-wakes a scaled-to-zero pod (KEDA, ADR-0057) instead of
+  // showing a cold 503 as "not responding".
+  const { data, loading, unavailable, waking } = useServiceResource<Card[]>(
+    svcUrl('card-issuance-service', '/api/v1/cards'),
+    { select: (raw) => (Array.isArray(raw) ? (raw as Card[]) : ((raw as { cards?: Card[] }).cards ?? [])) },
+  )
+  const cards = data ?? []
 
   const filtered = cards.filter(c =>
     c.maskedPan?.includes(search) || c.cardType?.toLowerCase().includes(search.toLowerCase()) ||
@@ -52,14 +55,18 @@ export default function CardsPage() {
             </p>
           </div>
           <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-            <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
-              padding: '4px 10px', borderRadius: '20px',
-              background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-              color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-              border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-              {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-              card-issuance :8118
-            </span>
+            <ServiceStatusBadge
+              label="card-issuance :8118"
+              loading={loading}
+              waking={waking}
+              unavailable={unavailable}
+              copy={{
+                up: t('card-issuance běží', 'card-issuance is up'),
+                idle: t('card-issuance spí (scale-to-zero), probouzí se…', 'card-issuance idle (scaled to zero), waking…'),
+                down: t('card-issuance neodpovídá', 'card-issuance is not responding'),
+                checking: t('Zjišťuji stav služby…', 'Checking service…'),
+              }}
+            />
             <button className="btn btn-primary btn-sm"><Plus size={13} /> {t('Vydat kartu', 'Issue Card')}</button>
           </div>
         </div>
@@ -98,18 +105,13 @@ export default function CardsPage() {
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} />
               <div>{t('Načítám karty…', 'Loading cards…')}</div>
             </div>
+          ) : unavailable ? (
+            <DataUnavailable kind={unavailable.kind} service={t('Card-issuance-service', 'Card-issuance-service')} feature={t('Karty', 'Cards')} lang={language} />
           ) : filtered.length === 0 ? (
-            <div style={{ padding: '48px', textAlign: 'center' }}>
-              <CreditCard size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px' }} />
-              <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné karty', 'No cards')}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
-                {cards.length === 0 ? t('Mikroservisa běží. Zatím nebyly vydány žádné karty.', 'Microservice is running. No cards have been issued yet.') : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')}
-              </div>
-              <a href="/api/svc/card-issuance-service/api/docs" target="_blank" rel="noreferrer"
-                style={{ display: 'inline-block', marginTop: '12px', fontSize: '12px', color: 'var(--accent)', textDecoration: 'none' }}>
-                → Swagger UI (port 8118)
-              </a>
-            </div>
+            <DataUnavailable kind="no_data" feature={t('Karty', 'Cards')} lang={language}
+              detail={cards.length === 0
+                ? t('Služba běží, zatím nebyly vydány žádné karty.', 'The service is running; no cards have been issued yet.')
+                : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>

--- a/openbank-admin-ui/src/app/clearing/page.tsx
+++ b/openbank-admin-ui/src/app/clearing/page.tsx
@@ -3,10 +3,14 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
-import { Layers, Search, CheckCircle2, XCircle, Clock, RefreshCw, ArrowRightLeft, Banknote } from 'lucide-react'
+import { useState } from 'react'
+import { Layers, Search, CheckCircle2, Clock, RefreshCw, Banknote } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 
 interface ClearingBatch {
   id: string; batchReference: string; paymentRail: string; status: string
@@ -14,19 +18,13 @@ interface ClearingBatch {
 }
 
 export default function ClearingPage() {
-  const { t } = useLanguage()
-  const [batches, setBatches] = useState<ClearingBatch[]>([])
-  const [loading, setLoading] = useState(true)
+  const { t, language } = useLanguage()
   const [search, setSearch] = useState('')
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    fetch('/api/svc/clearing-service/q/health/ready').then(r => setServiceUp(r.ok)).catch(() => setServiceUp(false))
-    fetch('/api/svc/clearing-service/api/v1/clearing/batches').then(r => r.json())
-      .then(d => setBatches(Array.isArray(d) ? d : d.batches ?? []))
-      .catch(() => setBatches([]))
-      .finally(() => setLoading(false))
-  }, [])
+  const { data, loading, unavailable, waking } = useServiceResource<ClearingBatch[]>(
+    svcUrl('clearing-service', '/api/v1/clearing/batches'),
+    { select: (raw) => (Array.isArray(raw) ? (raw as ClearingBatch[]) : ((raw as { batches?: ClearingBatch[] }).batches ?? [])) },
+  )
+  const batches = data ?? []
 
   const filtered = batches.filter(b =>
     b.batchReference?.toLowerCase().includes(search.toLowerCase()) ||
@@ -56,14 +54,18 @@ export default function ClearingPage() {
               {t('Mezibankovní zúčtování — SEPA · SWIFT · Domestic netting', 'Interbank clearing — SEPA · SWIFT · Domestic netting')}
             </p>
           </div>
-          <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
-            padding: '4px 10px', borderRadius: '20px',
-            background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-            color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-            border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-            {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-            clearing-service :8124
-          </span>
+          <ServiceStatusBadge
+            label="clearing-service :8124"
+            loading={loading}
+            waking={waking}
+            unavailable={unavailable}
+            copy={{
+              up: t('clearing-service běží', 'clearing-service is up'),
+              idle: t('clearing-service spí (scale-to-zero), probouzí se…', 'clearing-service idle (scaled to zero), waking…'),
+              down: t('clearing-service neodpovídá', 'clearing-service is not responding'),
+              checking: t('Zjišťuji stav služby…', 'Checking service…'),
+            }}
+          />
         </div>
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
@@ -95,14 +97,13 @@ export default function ClearingPage() {
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
+          ) : unavailable ? (
+            <DataUnavailable kind={unavailable.kind} service={t('Clearing-service', 'Clearing-service')} feature={t('Clearing dávky', 'Clearing batches')} lang={language} />
           ) : filtered.length === 0 ? (
-            <div style={{ padding: '48px', textAlign: 'center' }}>
-              <ArrowRightLeft size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px' }} />
-              <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné clearing dávky', 'No clearing batches')}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{t('Mikroservisa běží na portu 8124.', 'Microservice is running on port 8124.')}</div>
-              <a href="/api/svc/clearing-service/api/docs" target="_blank" rel="noreferrer"
-                style={{ display: 'inline-block', marginTop: '12px', fontSize: '12px', color: 'var(--accent)', textDecoration: 'none' }}>→ Swagger UI</a>
-            </div>
+            <DataUnavailable kind="no_data" feature={t('Clearing dávky', 'Clearing batches')} lang={language}
+              detail={batches.length === 0
+                ? t('Služba běží, zatím žádné clearing dávky.', 'The service is running; no clearing batches yet.')
+                : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>

--- a/openbank-admin-ui/src/app/day-end/page.tsx
+++ b/openbank-admin-ui/src/app/day-end/page.tsx
@@ -23,10 +23,11 @@ import { useSession } from 'next-auth/react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   RefreshCw, Clock, CheckCircle2, AlertTriangle, Scale, CalendarClock, Coins,
-  ArrowRightLeft, CalendarCheck2, Play, ChevronDown, ChevronRight, History,
+  ArrowRightLeft, CalendarCheck2, Play, ChevronDown, ChevronRight, History, FileClock,
 } from 'lucide-react'
 import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
 import { hasPermission } from '@/lib/auth/roles'
+import { useCheckLog, type CheckLogEntry } from '@/lib/services/useCheckLog'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 
 const POLL = 30_000
@@ -402,6 +403,10 @@ function EomPanel() {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const [failures, setFailures] = useState<Record<string, FailuresState>>({})
   const busyRef = useRef(false)
+  // Operator-local check trail — survives reloads and (crucially) statement-service
+  // outages, so a later operator/agent can see WHEN the close was checked and what
+  // state it was in, even when the live run history isn't answering.
+  const { entries: checkLog, record: recordCheck } = useCheckLog('closings-eom')
 
   const load = useCallback(async (spinner = false) => {
     if (busyRef.current) return
@@ -440,6 +445,20 @@ function EomPanel() {
     return () => clearInterval(id)
   }, [load, running])
 
+  // Record each distinct observed state (deduped by signature) so the check trail
+  // reflects genuine transitions, not every poll.
+  useEffect(() => {
+    if (loading) return
+    if (unavailable) { recordCheck('error', 'unavailable', `unavail:${unavailable.kind}`, { kind: unavailable.kind }); return }
+    if (empty || !latest) { recordCheck('warn', 'no_run', 'no_run'); return }
+    recordCheck(
+      latest.status === 'COMPLETED_WITH_FAILURES' ? 'warn' : 'ok',
+      'run',
+      `run:${latest.status}:${runs.length}:${latest.pocketsFailed}`,
+      { status: latest.status, runs: runs.length, failed: latest.pocketsFailed },
+    )
+  }, [loading, unavailable, empty, latest, runs.length, recordCheck])
+
   const trigger = useCallback(async () => {
     setTriggering(true); setNotice(null)
     try {
@@ -455,13 +474,14 @@ function EomPanel() {
       setRuns(prev => [accepted, ...prev.filter(r => r.id !== accepted.id)])
       setEmpty(false)
       setNotice({ ok: true, text: t('Catch-up uzávěrka přijata.', 'Catch-up close run accepted.') })
+      recordCheck('ok', 'trigger', `trigger:${accepted.id}`)
       void load()
     } catch {
       setNotice({ ok: false, text: t('Spuštění catch-up uzávěrky se nezdařilo.', 'Could not start the catch-up close run.') })
     } finally {
       setTriggering(false)
     }
-  }, [t, load])
+  }, [t, load, recordCheck])
 
   const toggleFailures = useCallback(async (run: CloseRun) => {
     const open = !expanded[run.id]
@@ -511,6 +531,29 @@ function EomPanel() {
     UPSTREAM: t('Výpadek závislé služby', 'Upstream dependency failed'),
     UNKNOWN: t('Neznámá chyba', 'Unknown error'),
   }[reason] ?? reason)
+
+  const logLabel = (e: CheckLogEntry): string => {
+    switch (e.code) {
+      case 'unavailable': {
+        const k = String(e.meta?.kind ?? '')
+        return t(`Uzávěrka nedostupná (${k})`, `Close unavailable (${k})`)
+      }
+      case 'no_run':
+        return t('Uzávěrka zatím neproběhla', 'No close run yet')
+      case 'run': {
+        const s = String(e.meta?.status ?? '')
+        const failed = Number(e.meta?.failed ?? 0)
+        return t(
+          `Poslední běh: ${s}${failed ? ` · ${failed} selhalo` : ''}`,
+          `Latest run: ${s}${failed ? ` · ${failed} failed` : ''}`,
+        )
+      }
+      case 'trigger':
+        return t('Ručně spuštěna catch-up uzávěrka', 'Catch-up close triggered manually')
+      default:
+        return e.code
+    }
+  }
 
   return (
     <div>
@@ -661,6 +704,39 @@ function EomPanel() {
           </div>
         </>
       )}
+
+      {/* Operator check log — a local breadcrumb trail of observed close states.
+          Always visible, so even when statement-service is down there's a record
+          that the close was checked, when, and what state it was in. */}
+      <div style={{ marginTop: '20px', background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 'var(--r-lg)', overflow: 'hidden', boxShadow: 'var(--shadow-xs)' }}>
+        <div style={{ padding: '12px 16px', borderBottom: '1px solid var(--border)', background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <FileClock size={14} style={{ color: 'var(--text-tertiary)' }} />
+          <span style={{ fontSize: '13px', fontWeight: 600, color: 'var(--text-primary)' }}>
+            {t('Záznam kontrol', 'Check log')}
+          </span>
+          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            {t('lokální stopa pozorovaných stavů', 'local trail of observed states')}
+          </span>
+        </div>
+        {checkLog.length === 0 ? (
+          <div style={{ padding: '16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>
+            {t('Zatím žádné záznamy. Každá kontrola této obrazovky sem zapíše pozorovaný stav.', 'No entries yet. Each check of this screen records the observed state here.')}
+          </div>
+        ) : (
+          <ul style={{ listStyle: 'none', margin: 0, padding: '6px 0', maxHeight: '220px', overflowY: 'auto' }}>
+            {checkLog.slice(0, 15).map((e, i) => (
+              <li key={`${e.at}-${i}`} style={{ display: 'flex', alignItems: 'center', gap: '10px', padding: '6px 16px', fontSize: '12px' }}>
+                <span style={{ width: '7px', height: '7px', borderRadius: '50%', flexShrink: 0,
+                  background: e.kind === 'error' ? 'var(--danger)' : e.kind === 'warn' ? 'var(--warning)' : 'var(--success)' }} />
+                <span style={{ color: 'var(--text-tertiary)', fontFamily: 'JetBrains Mono, monospace', whiteSpace: 'nowrap' }}>
+                  {new Date(e.at).toLocaleString(locale)}
+                </span>
+                <span style={{ color: 'var(--text-secondary)' }}>{logLabel(e)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   )
 }

--- a/openbank-admin-ui/src/app/disputes/page.tsx
+++ b/openbank-admin-ui/src/app/disputes/page.tsx
@@ -3,10 +3,14 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { MessageSquareWarning, Search, CheckCircle2, XCircle, Clock, RefreshCw, AlertTriangle, Timer } from 'lucide-react'
+import { MessageSquareWarning, Search, CheckCircle2, Clock, RefreshCw, AlertTriangle, Timer } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 
 interface Dispute {
   id: string; referenceNumber: string; disputeType: string; status: string
@@ -15,19 +19,13 @@ interface Dispute {
 }
 
 export default function DisputesPage() {
-  const [disputes, setDisputes] = useState<Dispute[]>([])
-  const { t } = useLanguage()
-  const [loading, setLoading] = useState(true)
+  const { t, language } = useLanguage()
   const [search, setSearch] = useState('')
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    fetch('/api/svc/dispute-service/q/health/ready').then(r => setServiceUp(r.ok)).catch(() => setServiceUp(false))
-    fetch('/api/svc/dispute-service/api/v1/disputes').then(r => r.json())
-      .then(d => setDisputes(Array.isArray(d) ? d : d.disputes ?? []))
-      .catch(() => setDisputes([]))
-      .finally(() => setLoading(false))
-  }, [])
+  const { data, loading, unavailable, waking } = useServiceResource<Dispute[]>(
+    svcUrl('dispute-service', '/api/v1/disputes'),
+    { select: (raw) => (Array.isArray(raw) ? (raw as Dispute[]) : ((raw as { disputes?: Dispute[] }).disputes ?? [])) },
+  )
+  const disputes = data ?? []
 
   const filtered = disputes.filter(d =>
     d.referenceNumber?.toLowerCase().includes(search.toLowerCase()) ||
@@ -67,10 +65,18 @@ export default function DisputesPage() {
               {t('Správa sporů — chargeback · SLA 45 dní · PSD2 čl. 73', 'Dispute management — chargeback · SLA 45 days · PSD2 Art. 73')}
             </p>
           </div>
-          <span className={serviceUp === true ? 'badge badge-success' : serviceUp === false ? 'badge badge-danger' : 'badge badge-neutral'} style={{ padding: '4px 10px', fontSize: '11px' }}>
-            {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-            dispute-service :8135
-          </span>
+          <ServiceStatusBadge
+            label="dispute-service :8135"
+            loading={loading}
+            waking={waking}
+            unavailable={unavailable}
+            copy={{
+              up: t('dispute-service běží', 'dispute-service is up'),
+              idle: t('dispute-service spí (scale-to-zero), probouzí se…', 'dispute-service idle (scaled to zero), waking…'),
+              down: t('dispute-service neodpovídá', 'dispute-service is not responding'),
+              checking: t('Zjišťuji stav služby…', 'Checking service…'),
+            }}
+          />
         </div>
 
         {slaBreached.length > 0 && (
@@ -111,14 +117,13 @@ export default function DisputesPage() {
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} className="animate-spin" style={{ marginBottom: '8px', margin: '0 auto', display: 'block' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
+          ) : unavailable ? (
+            <DataUnavailable kind={unavailable.kind} service={t('Dispute-service', 'Dispute-service')} feature={t('Spory', 'Disputes')} lang={language} />
           ) : filtered.length === 0 ? (
-            <div style={{ padding: '48px', textAlign: 'center' }}>
-              <MessageSquareWarning size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px', margin: '0 auto', display: 'block' }} />
-              <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné spory', 'No disputes')}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{t('Mikroservisa běží na portu 8135.', 'Microservice is running on port 8135.')}</div>
-              <a href="/api/svc/dispute-service/api/docs" target="_blank" rel="noreferrer"
-                style={{ display: 'inline-block', marginTop: '12px', fontSize: '12px', color: 'var(--accent)', textDecoration: 'none' }}>→ Swagger UI</a>
-            </div>
+            <DataUnavailable kind="no_data" feature={t('Spory', 'Disputes')} lang={language}
+              detail={disputes.length === 0
+                ? t('Služba běží, zatím žádné spory.', 'The service is running; no disputes yet.')
+                : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
             <div style={{ overflowX: 'auto' }}>
               <table className="table">

--- a/openbank-admin-ui/src/app/interest/page.tsx
+++ b/openbank-admin-ui/src/app/interest/page.tsx
@@ -3,10 +3,14 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
-import { TrendingUp, Search, CheckCircle2, XCircle, Clock, RefreshCw, Percent, Calendar } from 'lucide-react'
+import { useState } from 'react'
+import { TrendingUp, Search, CheckCircle2, RefreshCw, Percent, Calendar } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 
 interface AccrualRecord {
   id: string; accountId: string; accrualDate: string; accruedAmount: number
@@ -14,19 +18,13 @@ interface AccrualRecord {
 }
 
 export default function InterestPage() {
-  const { t } = useLanguage()
-  const [accruals, setAccruals] = useState<AccrualRecord[]>([])
-  const [loading, setLoading] = useState(true)
+  const { t, language } = useLanguage()
   const [search, setSearch] = useState('')
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    fetch('/api/svc/interest-service/q/health/ready').then(r => setServiceUp(r.ok)).catch(() => setServiceUp(false))
-    fetch('/api/svc/interest-service/api/v1/interest/accruals').then(r => r.json())
-      .then(d => setAccruals(Array.isArray(d) ? d : d.accruals ?? []))
-      .catch(() => setAccruals([]))
-      .finally(() => setLoading(false))
-  }, [])
+  const { data, loading, unavailable, waking } = useServiceResource<AccrualRecord[]>(
+    svcUrl('interest-service', '/api/v1/interest/accruals'),
+    { select: (raw) => (Array.isArray(raw) ? (raw as AccrualRecord[]) : ((raw as { accruals?: AccrualRecord[] }).accruals ?? [])) },
+  )
+  const accruals = data ?? []
 
   const filtered = accruals.filter(a =>
     a.accountId?.toLowerCase().includes(search.toLowerCase()) ||
@@ -50,14 +48,18 @@ export default function InterestPage() {
               {t('Akruální účetnictví — ACT/365 · ACT/360 · kapitalizace', 'Accrual accounting — ACT/365 · ACT/360 · capitalisation')}
             </p>
           </div>
-          <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
-            padding: '4px 10px', borderRadius: '20px',
-            background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-            color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-            border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-            {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-            interest-service :8125
-          </span>
+          <ServiceStatusBadge
+            label="interest-service :8125"
+            loading={loading}
+            waking={waking}
+            unavailable={unavailable}
+            copy={{
+              up: t('interest-service běží', 'interest-service is up'),
+              idle: t('interest-service spí (scale-to-zero), probouzí se…', 'interest-service idle (scaled to zero), waking…'),
+              down: t('interest-service neodpovídá', 'interest-service is not responding'),
+              checking: t('Zjišťuji stav služby…', 'Checking service…'),
+            }}
+          />
         </div>
 
         <div className="grid-4" style={{ marginBottom: '24px' }}>
@@ -89,14 +91,13 @@ export default function InterestPage() {
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
+          ) : unavailable ? (
+            <DataUnavailable kind={unavailable.kind} service={t('Interest-service', 'Interest-service')} feature={t('Úrokové záznamy', 'Interest records')} lang={language} />
           ) : filtered.length === 0 ? (
-            <div style={{ padding: '48px', textAlign: 'center' }}>
-              <TrendingUp size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px' }} />
-              <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné úrokové záznamy', 'No interest records')}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{t('Mikroservisa běží na portu 8125.', 'Microservice is running on port 8125.')}</div>
-              <a href="/api/svc/interest-service/api/docs" target="_blank" rel="noreferrer"
-                style={{ display: 'inline-block', marginTop: '12px', fontSize: '12px', color: 'var(--accent)', textDecoration: 'none' }}>→ Swagger UI</a>
-            </div>
+            <DataUnavailable kind="no_data" feature={t('Úrokové záznamy', 'Interest records')} lang={language}
+              detail={accruals.length === 0
+                ? t('Služba běží, zatím žádné úrokové záznamy.', 'The service is running; no interest records yet.')
+                : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>

--- a/openbank-admin-ui/src/app/payments/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/payments/[id]/page.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useParams, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { classifyBffFailure } from '@/lib/services/bff'
+import { readStashedRow } from '@/lib/services/rowHandoff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+
+// Mirrors the list-row shape on the payments page. The record can carry more
+// fields than the table showed — the detail view surfaces all of them.
+interface Payment {
+  id: string
+  type?: 'SEPA' | 'DOMESTIC'
+  status?: string
+  amount?: number
+  currency?: string
+  debtorIban?: string
+  creditorIban?: string
+  creditorAccountNumber?: string
+  creditorBankCode?: string
+  creditorName?: string
+  remittanceInfo?: string
+  endToEndId?: string
+  createdAt?: string
+  [k: string]: unknown
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  SETTLED: 'var(--success)', RECEIVED: 'var(--info-text)', SENT_TO_CLEARING: 'var(--warning)',
+  PENDING: 'var(--warning)', PROCESSING: 'var(--warning)', REJECTED: 'var(--danger)', FAILED: 'var(--danger)',
+}
+
+// The list route is the source of truth (no by-id backend endpoint exists);
+// refresh re-fetches the list and picks this id out of it.
+const LIST_ROUTE: Record<string, string> = {
+  SEPA: '/api/sepa-payments',
+  DOMESTIC: '/api/domestic-payments',
+}
+
+export default function PaymentDetailPage() {
+  return (
+    <Suspense fallback={null}>
+      <PaymentDetailContent />
+    </Suspense>
+  )
+}
+
+function PaymentDetailContent() {
+  const { id } = useParams<{ id: string }>()
+  const params = useSearchParams()
+  const type = (params.get('type') ?? '').toUpperCase()
+  const { t, language } = useLanguage()
+
+  const [payment, setPayment] = useState<Payment | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [showRaw, setShowRaw] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    // Show the handed-off row immediately (no round-trip); refresh in the background.
+    const stashed = readStashedRow<Payment>('payments', id)
+    if (stashed) { setPayment(stashed); setUnavailable(null) }
+
+    const route = LIST_ROUTE[type]
+    if (!route) {
+      // Direct URL with no/unknown type and no stash — we can't know which service to ask.
+      if (!stashed) setUnavailable({ kind: 'not_found' })
+      setLoading(false)
+      return
+    }
+    try {
+      const res = await fetch(route, { signal: AbortSignal.timeout(10_000), cache: 'no-store' })
+      if (!res.ok) {
+        if (!stashed) setUnavailable({ kind: await classifyBffFailure(res) })
+        setLoading(false)
+        return
+      }
+      const body = (await res.json()) as unknown
+      const items = (Array.isArray(body) ? body : ((body as { items?: unknown[] }).items ?? [])) as Payment[]
+      const found = items.find(p => p.id === id)
+      if (found) { setPayment({ ...found, type: type as Payment['type'] }); setUnavailable(null) }
+      else if (!stashed) setUnavailable({ kind: 'not_found' })
+    } catch {
+      if (!stashed) setUnavailable({ kind: 'unreachable' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [id, type])
+
+  const svcLabel = type === 'SEPA' ? t('SEPA-payment', 'SEPA-payment') : t('Domestic-payment', 'Domestic-payment')
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <div className="breadcrumb">
+            <span>OpenBank</span>
+            <span className="breadcrumb-sep">/</span>
+            <Link href="/payments" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('Platby', 'Payments')}</Link>
+            <span className="breadcrumb-sep">/</span>
+            <span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{id.slice(0, 12)}…</span>
+          </div>
+          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <span className="mono" style={{ fontSize: '18px' }}>{id.slice(0, 8)}…</span>
+            {payment?.status && (
+              <span className="pill" style={{ background: `${STATUS_COLOR[payment.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[payment.status] ?? 'var(--text-muted)' }}>
+                {payment.status}
+              </span>
+            )}
+            {payment?.type && <span className="tag">{payment.type}</span>}
+          </h1>
+          <p className="page-subtitle">{t('Detail platebního příkazu', 'Payment order detail')}</p>
+        </div>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <Link href="/payments" className="btn btn-secondary"><ArrowLeft size={13} /> {t('Zpět', 'Back')}</Link>
+          <button className="btn btn-secondary" onClick={load} disabled={loading}>
+            <RefreshCw size={13} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+          </button>
+        </div>
+      </div>
+
+      {loading && !payment ? (
+        <div style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <RefreshCw size={14} className="animate-spin" /> {t('Načítám platbu…', 'Loading payment…')}
+        </div>
+      ) : !payment && unavailable ? (
+        <div className="card"><DataUnavailable kind={unavailable.kind} service={svcLabel} feature={t('Platba', 'Payment')} lang={language} /></div>
+      ) : payment ? (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
+          <div className="card">
+            <div className="card-header"><span className="card-header-title">{t('Platba', 'Payment')}</span></div>
+            <DetailRows rows={[
+              { label: t('ID platby', 'Payment ID'), value: payment.id, mono: true },
+              { label: t('Typ', 'Type'), value: payment.type ?? '—' },
+              { label: t('Stav', 'Status'), value: payment.status ?? '—' },
+              { label: t('Částka', 'Amount'), value: payment.amount != null ? `${Number(payment.amount).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-US', { minimumFractionDigits: 2 })} ${payment.currency ?? ''}` : '—' },
+              { label: 'End-to-End ID', value: (payment.endToEndId as string) ?? '—', mono: true },
+              { label: t('Vytvořeno', 'Created'), value: payment.createdAt ? new Date(payment.createdAt).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB') : '—' },
+            ]} />
+          </div>
+          <div className="card">
+            <div className="card-header"><span className="card-header-title">{t('Strany & směrování', 'Parties & routing')}</span></div>
+            <DetailRows rows={[
+              { label: t('Plátce IBAN', 'Debtor IBAN'), value: payment.debtorIban ?? '—', mono: true },
+              { label: t('Příjemce', 'Creditor'), value: payment.creditorName ?? '—' },
+              { label: t('Příjemce IBAN', 'Creditor IBAN'), value: payment.creditorIban ?? '—', mono: true },
+              { label: t('Účet / kód banky příjemce', 'Creditor account / bank'), value: payment.creditorAccountNumber ? `${payment.creditorAccountNumber}${payment.creditorBankCode ? '/' + payment.creditorBankCode : ''}` : '—', mono: true },
+              { label: t('Zpráva pro příjemce', 'Remittance info'), value: payment.remittanceInfo ?? '—' },
+            ]} />
+          </div>
+          <div className="card" style={{ gridColumn: '1 / -1' }}>
+            <button onClick={() => setShowRaw(s => !s)}
+              style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '6px', padding: '12px 18px', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600 }}>
+              {showRaw ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              {t('Surová data (JSON)', 'Raw payload (JSON)')}
+            </button>
+            {showRaw && (
+              <pre style={{ margin: 0, padding: '0 18px 18px', fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflowX: 'auto' }}>
+                {JSON.stringify(payment, null, 2)}
+              </pre>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function DetailRows({ rows }: { rows: { label: string; value: string; mono?: boolean }[] }) {
+  return (
+    <div style={{ padding: '4px 0' }}>
+      {rows.map((row, i, arr) => (
+        <div key={row.label} style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px',
+          padding: '10px 18px', borderBottom: i < arr.length - 1 ? '1px solid var(--border)' : 'none',
+        }}>
+          <span style={{ fontSize: '12px', color: 'var(--text-secondary)', flexShrink: 0 }}>{row.label}</span>
+          <span style={{
+            fontSize: '12px', fontWeight: 500, color: 'var(--text-primary)', textAlign: 'right',
+            fontFamily: row.mono ? 'var(--font-mono)' : 'inherit',
+            maxWidth: '320px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{row.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -9,8 +9,9 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   Banknote, Search, RefreshCw, Plus, Zap, Globe, CheckCircle2, XCircle,
-  Clock, AlertTriangle, Timer, ShieldCheck, AlertCircle
+  Clock, AlertTriangle, Timer, ShieldCheck, AlertCircle, ChevronRight
 } from 'lucide-react'
+import { stashRow } from '@/lib/services/rowHandoff'
 
 // ADR-0080 P1 (pentest FIND-S3-03/04): all backend access goes through same-origin BFF
 // routes — never NEXT_PUBLIC_ localhost URLs, which leaked the internal port map into the
@@ -853,19 +854,22 @@ function PaymentsContent() {
                   <th>{t('Příjemce', 'Creditor')}</th>
                   <th>{t('IBAN / Účet příjemce', 'Creditor IBAN / Account')}</th>
                   <th>{t('Vytvořeno', 'Created')}</th>
+                  <th aria-label={t('Detail', 'Detail')} style={{ width: '36px' }} />
                 </tr>
               </thead>
               <tbody>
                 {loading && Array.from({ length: 5 }).map((_, i) => (
-                  <tr key={i}>{Array.from({ length: 7 }).map((_, j) => <td key={j}><div className="skeleton" style={{ height: '14px', width: j === 0 ? '120px' : '80px' }} /></td>)}</tr>
+                  <tr key={i}>{Array.from({ length: 8 }).map((_, j) => <td key={j}><div className="skeleton" style={{ height: '14px', width: j === 0 ? '120px' : '80px' }} /></td>)}</tr>
                 ))}
                 {!loading && filtered.length === 0 && (
-                  <tr><td colSpan={7} style={{ textAlign: 'center', padding: '40px', color: 'var(--text-muted)' }}>
+                  <tr><td colSpan={8} style={{ textAlign: 'center', padding: '40px', color: 'var(--text-muted)' }}>
                     {t('Nebyly nalezeny žádné platby', 'No payments found')}
                   </td></tr>
                 )}
                 {!loading && filtered.map(p => (
-                  <tr key={`${p.type}-${p.id}`}>
+                  <tr key={`${p.type}-${p.id}`} style={{ cursor: 'pointer' }}
+                    title={t('Zobrazit detail platby', 'View payment detail')}
+                    onClick={() => { stashRow('payments', p.id, p); router.push(`/payments/${p.id}?type=${p.type}`) }}>
                     <td style={{ fontFamily: 'var(--font-mono)', fontSize: '11px' }}>{p.id.slice(0, 8)}…</td>
                     <td><span className="tag" style={{ color: p.type === 'SEPA' ? 'var(--accent)' : 'var(--green)' }}>{p.type}</span></td>
                     <td>
@@ -879,6 +883,7 @@ function PaymentsContent() {
                       {p.creditorIban ? p.creditorIban : (p.creditorAccountNumber && p.creditorBankCode ? `${p.creditorAccountNumber}/${p.creditorBankCode}` : '—')}
                     </td>
                     <td style={{ color: 'var(--text-muted)', fontSize: '12px' }}>{new Date(p.createdAt).toLocaleDateString()}</td>
+                    <td style={{ textAlign: 'right', paddingRight: '8px' }}><ChevronRight size={14} style={{ color: 'var(--text-muted)' }} /></td>
                   </tr>
                 ))}
               </tbody>

--- a/openbank-admin-ui/src/app/sanctions/page.tsx
+++ b/openbank-admin-ui/src/app/sanctions/page.tsx
@@ -5,11 +5,14 @@
 'use client'
 import { useState, useEffect, useCallback } from 'react'
 import {
-  ShieldAlert, Search, CheckCircle2, XCircle, Clock, RefreshCw,
+  ShieldAlert, Search, CheckCircle2, Clock, RefreshCw,
   AlertTriangle, User, Play, List, ChevronDown, ChevronUp,
   ToggleLeft, ToggleRight, ExternalLink, Download, Loader2
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
+import { classifyBffFailure } from '@/lib/services/bff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 
 interface SanctionCheck {
@@ -155,13 +158,13 @@ function ListCard({ list, onToggle, onRefresh, onSave }: {
 }
 
 export default function SanctionsPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
   const [tab, setTab] = useState<'checks'|'search'|'lists'>('checks')
   const [checks, setChecks] = useState<SanctionCheck[]>([])
   const [lists, setLists] = useState<SanctionsList[]>([])
   const [loading, setLoading] = useState(true)
   const [listsLoading, setListsLoading] = useState(true)
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
+  const [checksUnavail, setChecksUnavail] = useState<{ kind: UnavailableKind } | null>(null)
   const [search, setSearch] = useState('')
   const [refreshingAll, setRefreshingAll] = useState(false)
 
@@ -173,29 +176,27 @@ export default function SanctionsPage() {
   const [screenResult, setScreenResult] = useState<SanctionCheck | null>(null)
   const [screenError, setScreenError] = useState('')
   const [listsError, setListsError] = useState('')
-  const [checksError, setChecksError] = useState('')
   // Selected list types for manual screening — initialised to all enabled lists once loaded
   const [selectedListTypes, setSelectedListTypes] = useState<string[]>([])
   const [listScopeInitialised, setListScopeInitialised] = useState(false)
 
   const loadChecks = useCallback(async () => {
     setLoading(true)
-    setChecksError('')
     try {
       const res = await fetch('/api/sanctions/checks', { cache: 'no-store' })
-      setServiceUp(res.ok)
-      const data = await res.json().catch(() => ([]))
       if (!res.ok) {
-        const errorPayload = data as ApiError
+        // Classify honestly (idle / not deployed / unreachable) instead of leaking
+        // a raw "HTTP <status>" string — admin-ui graceful-state rule.
         setChecks([])
-        setChecksError(errorPayload.error ?? t(`Načtení kontrol selhalo (HTTP ${res.status})`, `Failed to load checks (HTTP ${res.status})`))
+        setChecksUnavail({ kind: await classifyBffFailure(res) })
         return
       }
+      const data = await res.json().catch(() => ([]))
       setChecks(Array.isArray(data) ? data : [])
-    } catch (error) {
-      setServiceUp(false)
+      setChecksUnavail(null)
+    } catch {
       setChecks([])
-      setChecksError(error instanceof Error ? error.message : t('Spojení se službou selhalo', 'Connection to the service failed'))
+      setChecksUnavail({ kind: 'unreachable' })
     }
     finally { setLoading(false) }
   }, [])
@@ -333,14 +334,17 @@ export default function SanctionsPage() {
               {t('OFAC SDN · EU Consolidated · UN · HM Treasury · PEP · ČNB', 'OFAC SDN · EU Consolidated · UN · HM Treasury · PEP · ČNB')}
             </p>
           </div>
-          <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
-            padding: '4px 10px', borderRadius: '20px',
-            background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-            color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-            border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-            {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-            sanctions-service :8123
-          </span>
+          <ServiceStatusBadge
+            label="sanctions-service :8123"
+            loading={loading}
+            unavailable={checksUnavail}
+            copy={{
+              up: t('sanctions-service běží', 'sanctions-service is up'),
+              idle: t('sanctions-service spí (scale-to-zero), probouzí se…', 'sanctions-service idle (scaled to zero), waking…'),
+              down: t('sanctions-service neodpovídá', 'sanctions-service is not responding'),
+              checking: t('Zjišťuji stav služby…', 'Checking service…'),
+            }}
+          />
         </div>
 
         {hits.length > 0 && (
@@ -400,12 +404,11 @@ export default function SanctionsPage() {
                 <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
                   <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
                 </div>
+              ) : checksUnavail ? (
+                <DataUnavailable kind={checksUnavail.kind} service={t('Sanctions-service', 'Sanctions-service')} feature={t('Sankční kontroly', 'Sanctions checks')} lang={language} />
               ) : filtered.length === 0 ? (
-                <div style={{ padding: '48px', textAlign: 'center' }}>
-                  <ShieldAlert size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px' }} />
-                  <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné záznamy', 'No records')}</div>
-                  <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{checksError || t('Použijte záložku Manuální vyhledávání pro první kontrolu.', 'Use the Manual Search tab to run a first check.')}</div>
-                </div>
+                <DataUnavailable kind="no_data" feature={t('Sankční kontroly', 'Sanctions checks')} lang={language}
+                  detail={t('Použijte záložku Manuální vyhledávání pro první kontrolu.', 'Use the Manual Search tab to run a first check.')} />
               ) : (
                 <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                   <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>

--- a/openbank-admin-ui/src/app/swift/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/swift/[id]/page.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
+import { readStashedRow } from '@/lib/services/rowHandoff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+
+interface SwiftMessage {
+  id: string
+  messageType?: string
+  senderBic?: string
+  receiverBic?: string
+  amount?: number
+  currency?: string
+  status?: string
+  reference?: string
+  createdAt?: string
+  [k: string]: unknown
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  SENT: 'var(--success)', PROCESSING: 'var(--info-text)', PENDING: 'var(--warning)', FAILED: 'var(--danger)',
+}
+
+export default function SwiftDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const { t, language } = useLanguage()
+
+  const [message, setMessage] = useState<SwiftMessage | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [showRaw, setShowRaw] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    const stashed = readStashedRow<SwiftMessage>('swift', id)
+    if (stashed) { setMessage(stashed); setUnavailable(null) }
+    try {
+      // No by-id backend endpoint — re-fetch the list and pick this id out.
+      const res = await fetch(svcUrl('swift-service', '/api/v1/swift/messages'), { signal: AbortSignal.timeout(10_000), cache: 'no-store' })
+      if (!res.ok) {
+        if (!stashed) setUnavailable({ kind: await classifyBffFailure(res) })
+        setLoading(false)
+        return
+      }
+      const body = (await res.json()) as unknown
+      const items = (Array.isArray(body) ? body : ((body as { messages?: unknown[] }).messages ?? [])) as SwiftMessage[]
+      const found = items.find(m => m.id === id)
+      if (found) { setMessage(found); setUnavailable(null) }
+      else if (!stashed) setUnavailable({ kind: 'not_found' })
+    } catch {
+      if (!stashed) setUnavailable({ kind: 'unreachable' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [id])
+
+  return (
+    <div>
+      <div className="page-header">
+        <div>
+          <div className="breadcrumb">
+            <span>OpenBank</span>
+            <span className="breadcrumb-sep">/</span>
+            <Link href="/swift" style={{ color: 'var(--text-tertiary)', textDecoration: 'none' }}>{t('SWIFT zprávy', 'SWIFT')}</Link>
+            <span className="breadcrumb-sep">/</span>
+            <span className="breadcrumb-current mono" style={{ fontSize: '12px' }}>{id.slice(0, 12)}…</span>
+          </div>
+          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            {message?.messageType && <span className="mono" style={{ fontSize: '18px', color: 'var(--accent)' }}>{message.messageType}</span>}
+            {message?.status && (
+              <span className="pill" style={{ background: `${STATUS_COLOR[message.status] ?? 'var(--text-muted)'}22`, color: STATUS_COLOR[message.status] ?? 'var(--text-muted)' }}>
+                {message.status}
+              </span>
+            )}
+          </h1>
+          <p className="page-subtitle">{t('Detail SWIFT zprávy — ISO 20022', 'SWIFT message detail — ISO 20022')}</p>
+        </div>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <Link href="/swift" className="btn btn-secondary"><ArrowLeft size={13} /> {t('Zpět', 'Back')}</Link>
+          <button className="btn btn-secondary" onClick={load} disabled={loading}>
+            <RefreshCw size={13} className={loading ? 'animate-spin' : ''} /> {t('Obnovit', 'Refresh')}
+          </button>
+        </div>
+      </div>
+
+      {loading && !message ? (
+        <div style={{ padding: '40px 0', color: 'var(--text-tertiary)', fontSize: '13px', display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <RefreshCw size={14} className="animate-spin" /> {t('Načítám zprávu…', 'Loading message…')}
+        </div>
+      ) : !message && unavailable ? (
+        <div className="card"><DataUnavailable kind={unavailable.kind} service={t('SWIFT-service', 'SWIFT-service')} feature={t('SWIFT zpráva', 'SWIFT message')} lang={language} /></div>
+      ) : message ? (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '14px' }}>
+          <div className="card">
+            <div className="card-header"><span className="card-header-title">{t('Zpráva', 'Message')}</span></div>
+            <DetailRows rows={[
+              { label: t('ID zprávy', 'Message ID'), value: message.id, mono: true },
+              { label: t('Typ zprávy', 'Message type'), value: message.messageType ?? '—', mono: true },
+              { label: t('Reference', 'Reference'), value: message.reference ?? '—', mono: true },
+              { label: t('Stav', 'Status'), value: message.status ?? '—' },
+              { label: t('Vytvořeno', 'Created'), value: message.createdAt ? new Date(message.createdAt).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-GB') : '—' },
+            ]} />
+          </div>
+          <div className="card">
+            <div className="card-header"><span className="card-header-title">{t('Směrování & částka', 'Routing & amount')}</span></div>
+            <DetailRows rows={[
+              { label: t('Odesílatel BIC', 'Sender BIC'), value: message.senderBic ?? '—', mono: true },
+              { label: t('Příjemce BIC', 'Receiver BIC'), value: message.receiverBic ?? '—', mono: true },
+              { label: t('Částka', 'Amount'), value: message.amount != null ? `${Number(message.amount).toLocaleString(language === 'cs' ? 'cs-CZ' : 'en-US', { minimumFractionDigits: 2 })} ${message.currency ?? ''}` : '—' },
+            ]} />
+          </div>
+          <div className="card" style={{ gridColumn: '1 / -1' }}>
+            <button onClick={() => setShowRaw(s => !s)}
+              style={{ width: '100%', display: 'flex', alignItems: 'center', gap: '6px', padding: '12px 18px', background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-secondary)', fontSize: '13px', fontWeight: 600 }}>
+              {showRaw ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              {t('Surová data (JSON)', 'Raw payload (JSON)')}
+            </button>
+            {showRaw && (
+              <pre style={{ margin: 0, padding: '0 18px 18px', fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)', overflowX: 'auto' }}>
+                {JSON.stringify(message, null, 2)}
+              </pre>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function DetailRows({ rows }: { rows: { label: string; value: string; mono?: boolean }[] }) {
+  return (
+    <div style={{ padding: '4px 0' }}>
+      {rows.map((row, i, arr) => (
+        <div key={row.label} style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '16px',
+          padding: '10px 18px', borderBottom: i < arr.length - 1 ? '1px solid var(--border)' : 'none',
+        }}>
+          <span style={{ fontSize: '12px', color: 'var(--text-secondary)', flexShrink: 0 }}>{row.label}</span>
+          <span style={{
+            fontSize: '12px', fontWeight: 500, color: 'var(--text-primary)', textAlign: 'right',
+            fontFamily: row.mono ? 'var(--font-mono)' : 'inherit',
+            maxWidth: '320px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{row.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/swift/page.tsx
+++ b/openbank-admin-ui/src/app/swift/page.tsx
@@ -3,10 +3,16 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
-import { Globe, Send, Search, CheckCircle2, XCircle, Clock, RefreshCw, AlertTriangle } from 'lucide-react'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Globe, Send, Search, CheckCircle2, Clock, RefreshCw, AlertTriangle, ChevronRight } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { svcUrl } from '@/lib/services/bff'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+import { stashRow } from '@/lib/services/rowHandoff'
+import { DataUnavailable } from '@/components/feedback/DataUnavailable'
+import { ServiceStatusBadge } from '@/components/feedback/ServiceStatusBadge'
 
 interface SwiftMessage {
   id: string; messageType: string; senderBic: string; receiverBic: string
@@ -21,19 +27,14 @@ const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }
 }
 
 export default function SwiftPage() {
-  const { t } = useLanguage()
-  const [messages, setMessages] = useState<SwiftMessage[]>([])
-  const [loading, setLoading] = useState(true)
+  const { t, language } = useLanguage()
+  const router = useRouter()
   const [search, setSearch] = useState('')
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    fetch('/api/svc/swift-service/q/health/ready').then(r => setServiceUp(r.ok)).catch(() => setServiceUp(false))
-    fetch('/api/svc/swift-service/api/v1/swift/messages').then(r => r.json())
-      .then(d => setMessages(Array.isArray(d) ? d : d.messages ?? []))
-      .catch(() => setMessages([]))
-      .finally(() => setLoading(false))
-  }, [])
+  const { data, loading, unavailable, waking } = useServiceResource<SwiftMessage[]>(
+    svcUrl('swift-service', '/api/v1/swift/messages'),
+    { select: (raw) => (Array.isArray(raw) ? (raw as SwiftMessage[]) : ((raw as { messages?: SwiftMessage[] }).messages ?? [])) },
+  )
+  const messages = data ?? []
 
   const filtered = messages.filter(m =>
     m.senderBic?.toLowerCase().includes(search.toLowerCase()) ||
@@ -55,14 +56,18 @@ export default function SwiftPage() {
             </p>
           </div>
           <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-            <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
-              padding: '4px 10px', borderRadius: '20px',
-              background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-              color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-              border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-              {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-              swift-service :8122
-            </span>
+            <ServiceStatusBadge
+              label="swift-service :8122"
+              loading={loading}
+              waking={waking}
+              unavailable={unavailable}
+              copy={{
+                up: t('swift-service běží', 'swift-service is up'),
+                idle: t('swift-service spí (scale-to-zero), probouzí se…', 'swift-service idle (scaled to zero), waking…'),
+                down: t('swift-service neodpovídá', 'swift-service is not responding'),
+                checking: t('Zjišťuji stav služby…', 'Checking service…'),
+              }}
+            />
             <button className="btn btn-primary btn-sm"><Send size={13} /> {t('Nová zpráva', 'New Message')}</button>
           </div>
         </div>
@@ -96,25 +101,27 @@ export default function SwiftPage() {
             <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: '13px' }}>
               <RefreshCw size={20} style={{ animation: 'spin 0.8s linear infinite', marginBottom: '8px' }} /><div>{t('Načítám…', 'Loading…')}</div>
             </div>
+          ) : unavailable ? (
+            <DataUnavailable kind={unavailable.kind} service={t('SWIFT-service', 'SWIFT-service')} feature={t('SWIFT zprávy', 'SWIFT messages')} lang={language} />
           ) : filtered.length === 0 ? (
-            <div style={{ padding: '48px', textAlign: 'center' }}>
-              <Globe size={32} style={{ color: 'var(--text-tertiary)', marginBottom: '12px' }} />
-              <div style={{ fontSize: '14px', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>{t('Žádné SWIFT zprávy', 'No SWIFT messages')}</div>
-              <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{t('Mikroservisa běží na portu 8122.', 'Microservice is running on port 8122.')}</div>
-              <a href="/api/svc/swift-service/api/docs" target="_blank" rel="noreferrer"
-                style={{ display: 'inline-block', marginTop: '12px', fontSize: '12px', color: 'var(--accent)', textDecoration: 'none' }}>→ Swagger UI</a>
-            </div>
+            <DataUnavailable kind="no_data" feature={t('SWIFT zprávy', 'SWIFT messages')} lang={language}
+              detail={messages.length === 0
+                ? t('Služba běží, zatím žádné SWIFT zprávy.', 'The service is running; no SWIFT messages yet.')
+                : t('Žádné výsledky pro zadaný filtr.', 'No results for the applied filter.')} />
           ) : (
             <table style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead><tr style={{ borderBottom: '1px solid var(--border)' }}>
                 {[t('Typ', 'Type'), t('Odesílatel BIC', 'Sender BIC'), t('Příjemce BIC', 'Recipient BIC'), t('Částka', 'Amount'), t('Reference', 'Reference'), t('Status', 'Status'), t('Datum', 'Date')].map(h => (
                   <th key={h} style={{ padding: '10px 16px', textAlign: 'left', fontSize: '11px', fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>{h}</th>
                 ))}
+                <th aria-label={t('Detail', 'Detail')} style={{ width: '36px' }} />
               </tr></thead>
               <tbody>{filtered.map(m => {
                 const sc = STATUS_COLORS[m.status] ?? STATUS_COLORS.PENDING
                 return (
-                  <tr key={m.id} style={{ borderBottom: '1px solid var(--border)' }}
+                  <tr key={m.id} style={{ borderBottom: '1px solid var(--border)', cursor: 'pointer' }}
+                    onClick={() => { stashRow('swift', m.id, m); router.push(`/swift/${m.id}`) }}
+                    title={t('Zobrazit detail zprávy', 'View message detail')}
                     onMouseEnter={e => (e.currentTarget.style.background = 'var(--surface-2)')}
                     onMouseLeave={e => (e.currentTarget.style.background = '')}>
                     <td style={{ padding: '12px 16px', fontFamily: 'var(--font-mono)', fontSize: '12px', fontWeight: 700, color: 'var(--accent)' }}>{m.messageType}</td>
@@ -129,6 +136,7 @@ export default function SwiftPage() {
                         background: sc.bg, color: sc.text, border: `1px solid ${sc.border}` }}>{m.status}</span>
                     </td>
                     <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{m.createdAt ? new Date(m.createdAt).toLocaleDateString('cs-CZ') : '—'}</td>
+                    <td style={{ padding: '12px 8px', textAlign: 'right' }}><ChevronRight size={14} style={{ color: 'var(--text-tertiary)' }} /></td>
                   </tr>
                 )
               })}</tbody>

--- a/openbank-admin-ui/src/components/feedback/ServiceStatusBadge.tsx
+++ b/openbank-admin-ui/src/components/feedback/ServiceStatusBadge.tsx
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// A small, honest status pill for the "<service> :<port>" badge that several
+// operator pages show in their header. The legacy pages drove it off a bare
+// `serviceUp` boolean, so a service that was merely *idle* (KEDA scale-to-zero,
+// ADR-0057) rendered an alarming red "down" badge identical to a real outage.
+// This component maps the graceful `unavailable` kind onto four honest visual
+// states — up / idle(waking) / down / checking — so the badge never lies.
+
+'use client'
+
+import { CheckCircle2, XCircle, Clock, Moon } from 'lucide-react'
+import type { ServiceUnavailable } from '@/lib/services/useServiceResource'
+
+interface Props {
+  /** e.g. "card-issuance :8118" — kept as-is (technical token, not translated). */
+  label: string
+  loading?: boolean
+  /** True while an automatic wake-retry is in flight. */
+  waking?: boolean
+  unavailable?: ServiceUnavailable | null
+  /** Bilingual labels for the state, supplied by the page (it owns the language). */
+  copy: { up: string; idle: string; down: string; checking: string }
+}
+
+export function ServiceStatusBadge({ label, loading, waking, unavailable, copy }: Props) {
+  // idle = deployed but asleep (scale-to-zero) or actively waking; visually calm
+  // (blue moon), never the red "down" treatment.
+  const idle = waking || unavailable?.kind === 'scaled_to_zero'
+  const down = !idle && !!unavailable && unavailable.kind !== 'no_data'
+  const checking = loading && !unavailable
+
+  const state = checking ? 'checking' : idle ? 'idle' : down ? 'down' : 'up'
+  const style = {
+    up:       { bg: 'var(--success-bg)', fg: 'var(--success-text)', bd: 'var(--success-border)', icon: <CheckCircle2 size={10} /> },
+    idle:     { bg: 'var(--info-bg, var(--surface-3))', fg: 'var(--info-text, var(--text-secondary))', bd: 'var(--info-border, var(--border))', icon: <Moon size={10} /> },
+    down:     { bg: 'var(--danger-bg)', fg: 'var(--danger-text)', bd: 'var(--danger-border)', icon: <XCircle size={10} /> },
+    checking: { bg: 'var(--surface-3)', fg: 'var(--text-tertiary)', bd: 'var(--border)', icon: <Clock size={10} /> },
+  }[state]
+
+  const title = copy[state]
+
+  return (
+    <span
+      title={title}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600,
+        padding: '4px 10px', borderRadius: '20px',
+        background: style.bg, color: style.fg, border: `1px solid ${style.bd}`,
+      }}
+    >
+      {style.icon}
+      {label}
+    </span>
+  )
+}

--- a/openbank-admin-ui/src/lib/services/rowHandoff.ts
+++ b/openbank-admin-ui/src/lib/services/rowHandoff.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Hand a list row to its detail page without a round-trip.
+//
+// When an operator clicks a row we already hold the full record the list
+// fetched. Rather than force the detail page to re-fetch (and depend on a
+// by-id backend endpoint that may not exist for every service), we stash the
+// row in sessionStorage keyed by namespace+id and read it back on the detail
+// page. The detail page still attempts a best-effort by-id refresh, so a direct
+// URL / hard refresh (empty stash) degrades gracefully instead of breaking.
+//
+// sessionStorage (not localStorage): the handoff is meant to live for the
+// navigation, not to persist across sessions, and it is per-tab.
+
+const KEY = (ns: string, id: string) => `ob:row:${ns}:${id}`
+
+export function stashRow(ns: string, id: string, row: unknown): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(KEY(ns, id), JSON.stringify(row))
+  } catch {
+    // Quota / private-mode / serialization failure — the detail page falls back
+    // to its by-id fetch, so a missing stash is never fatal.
+  }
+}
+
+export function readStashedRow<T>(ns: string, id: string): T | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(KEY(ns, id))
+    return raw ? (JSON.parse(raw) as T) : null
+  } catch {
+    return null
+  }
+}

--- a/openbank-admin-ui/src/lib/services/useCheckLog.ts
+++ b/openbank-admin-ui/src/lib/services/useCheckLog.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// A small operator-local "what did I observe when I checked this" log.
+//
+// Why: some cockpit screens (e.g. Closings) read live state from a backend that
+// is frequently idle or down in the sandbox. When it is down there is nothing to
+// show — the run history lives in the service that isn't answering — so an
+// operator (or a future agent doing a check-up) has no breadcrumb that the screen
+// WAS checked and what state it was in at the time. This hook records each
+// distinct observed state to localStorage (per-browser, capped, deduped against
+// the immediately-preceding entry) so the page can render a compact trail that
+// survives reloads and outages.
+//
+// It is deliberately NOT a governance data source (admin-ui read-only-consumer
+// rule): it never writes to any backend and holds only the operator's own local
+// observations. The authoritative run history still comes from the service.
+
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+export type CheckLogKind = 'ok' | 'warn' | 'error'
+
+export interface CheckLogEntry {
+  /** ISO timestamp the observation was recorded. */
+  at: string
+  kind: CheckLogKind
+  /** Stable machine code the consumer maps to localized copy (keeps i18n in the page). */
+  code: string
+  /** Optional structured detail rendered by the consumer (counts, kind, …). */
+  meta?: Record<string, string | number>
+  /** Stable signature of the observed state, used to dedupe consecutive polls. */
+  sig: string
+}
+
+const CAP = 40
+const keyFor = (scope: string) => `ob:checklog:${scope}`
+
+function read(scope: string): CheckLogEntry[] {
+  if (typeof window === 'undefined') return []
+  try {
+    const raw = window.localStorage.getItem(keyFor(scope))
+    return raw ? (JSON.parse(raw) as CheckLogEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+export function useCheckLog(scope: string) {
+  // Start empty and hydrate from localStorage in an effect so server and first
+  // client render agree (no hydration mismatch).
+  const [entries, setEntries] = useState<CheckLogEntry[]>([])
+  useEffect(() => { setEntries(read(scope)) }, [scope])
+
+  /**
+   * Record an observation. `sig` is a stable signature of the observed state;
+   * a repeat of the same signature as the newest entry is ignored so a 30s poll
+   * loop doesn't flood the log — only genuine transitions are appended.
+   */
+  const record = useCallback((kind: CheckLogKind, code: string, sig: string, meta?: Record<string, string | number>) => {
+    setEntries(prev => {
+      if (prev[0]?.sig === sig) return prev
+      const entry: CheckLogEntry = { at: new Date().toISOString(), kind, code, meta, sig }
+      const next = [entry, ...prev].slice(0, CAP)
+      try { window.localStorage.setItem(keyFor(scope), JSON.stringify(next)) } catch { /* quota / private mode */ }
+      return next
+    })
+  }, [scope])
+
+  return { entries, record }
+}

--- a/openbank-admin-ui/src/lib/services/useServiceResource.ts
+++ b/openbank-admin-ui/src/lib/services/useServiceResource.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// One shared data-fetch hook for BFF-backed list/detail screens, so every page
+// degrades identically instead of re-inventing (and re-breaking) the same
+// fetch → classify → empty-state dance. It encodes three things the sandbox
+// makes non-negotiable:
+//
+//  1. Graceful states (admin-ui CLAUDE.md rule #1): a non-OK BFF response is
+//     classified with `classifyBffFailure()` into a typed `kind`, never leaked
+//     as a raw "HTTP 404". The page renders <DataUnavailable kind=…>.
+//
+//  2. Auto-wake (ADR-0057, KEDA scale-to-zero + the FinOps off-hours scaledown).
+//     Most of the fleet is idle at zero replicas to save cost; the FIRST request
+//     wakes the pod but often returns 503 `scaled_to_zero` / 502 while it boots.
+//     Historically the page showed that first cold response as a hard failure and
+//     the operator saw "not responding" for a service that was simply waking up.
+//     This hook instead keeps polling (a few attempts, a few seconds apart) so the
+//     screen fills in on its own once the pod is ready — the wake request the
+//     operator implicitly made by opening the page actually completes.
+//
+//  3. A stable `reload()` and a `waking` flag so a page can show a calm
+//     "waking…" affordance distinct from a genuine outage.
+
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { classifyBffFailure, type BffFailure } from './bff'
+
+export type ServiceUnavailable = { kind: BffFailure | 'no_data' }
+
+export interface ServiceResource<T> {
+  data: T | null
+  loading: boolean
+  /** Non-null when the resource could not be loaded — drives <DataUnavailable>. */
+  unavailable: ServiceUnavailable | null
+  /** True while an automatic wake-retry is in flight (scaled-to-zero / cold pod). */
+  waking: boolean
+  /** Re-run the fetch from scratch (e.g. a manual "Refresh" button). */
+  reload: () => void
+}
+
+export interface ServiceResourceOptions<T> {
+  /** Map the raw JSON body into the shape the page wants (e.g. pick `.cards`). */
+  select?: (raw: unknown) => T
+  /**
+   * Retry `scaled_to_zero` / `unreachable` / network failures this many times
+   * before giving up, to let a cold KEDA pod finish waking. Set 0 to disable.
+   */
+  maxWakeRetries?: number
+  /** Delay between wake retries (ms). */
+  retryDelayMs?: number
+  /** Per-request timeout (ms). */
+  timeoutMs?: number
+}
+
+const WAKE_KINDS: ReadonlySet<BffFailure> = new Set(['scaled_to_zero', 'unreachable'])
+
+/**
+ * Fetch a BFF resource with graceful states and KEDA-wake auto-retry.
+ *
+ * @param url Same-origin BFF URL (build with `svcUrl(...)`), or `null` to skip.
+ */
+export function useServiceResource<T = unknown>(
+  url: string | null,
+  options: ServiceResourceOptions<T> = {},
+): ServiceResource<T> {
+  const [data, setData] = useState<T | null>(null)
+  const [loading, setLoading] = useState<boolean>(!!url)
+  const [unavailable, setUnavailable] = useState<ServiceUnavailable | null>(null)
+  const [waking, setWaking] = useState<boolean>(false)
+  const [nonce, setNonce] = useState<number>(0)
+
+  // Keep the latest options in a ref so an inline `select`/config object doesn't
+  // change effect identity every render (which would re-fetch on a loop).
+  const optsRef = useRef(options)
+  optsRef.current = options
+
+  const reload = useCallback(() => setNonce(n => n + 1), [])
+
+  useEffect(() => {
+    if (!url) {
+      setLoading(false)
+      return
+    }
+    const { select, maxWakeRetries = 3, retryDelayMs = 4000, timeoutMs = 10_000 } = optsRef.current
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    let attempt = 0
+
+    const scheduleRetry = (kind: BffFailure) => {
+      attempt += 1
+      setWaking(true)
+      // Show the calm "idle / waking" panel while we keep polling.
+      setUnavailable({ kind })
+      timer = setTimeout(run, retryDelayMs)
+    }
+
+    async function run() {
+      try {
+        const res = await fetch(url!, { signal: AbortSignal.timeout(timeoutMs), cache: 'no-store' })
+        if (cancelled) return
+        if (!res.ok) {
+          const kind = await classifyBffFailure(res)
+          if (cancelled) return
+          if (WAKE_KINDS.has(kind) && attempt < maxWakeRetries) {
+            scheduleRetry(kind)
+            return
+          }
+          setUnavailable({ kind })
+          setWaking(false)
+          setLoading(false)
+          return
+        }
+        const raw = (await res.json()) as unknown
+        if (cancelled) return
+        setData((select ? select(raw) : (raw as T)))
+        setUnavailable(null)
+        setWaking(false)
+        setLoading(false)
+      } catch {
+        // Timeout / abort / network — treat like a cold-pod unreachable and retry.
+        if (cancelled) return
+        if (attempt < maxWakeRetries) {
+          scheduleRetry('unreachable')
+          return
+        }
+        setUnavailable({ kind: 'unreachable' })
+        setWaking(false)
+        setLoading(false)
+      }
+    }
+
+    setLoading(true)
+    setUnavailable(null)
+    setWaking(false)
+    run()
+
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+    // `url` + `nonce` are the only real inputs; options are read via ref.
+  }, [url, nonce])
+
+  return { data, loading, unavailable, waking, reload }
+}

--- a/openbank-admin-ui/src/lib/services/useServiceResource.ts
+++ b/openbank-admin-ui/src/lib/services/useServiceResource.ts
@@ -73,9 +73,11 @@ export function useServiceResource<T = unknown>(
   const [nonce, setNonce] = useState<number>(0)
 
   // Keep the latest options in a ref so an inline `select`/config object doesn't
-  // change effect identity every render (which would re-fetch on a loop).
+  // change effect identity every render (which would re-fetch on a loop). The ref
+  // is seeded with the first options via useRef(options) and refreshed in an
+  // effect — never mutated during render (React purity rule).
   const optsRef = useRef(options)
-  optsRef.current = options
+  useEffect(() => { optsRef.current = options })
 
   const reload = useCallback(() => setNonce(n => n + 1), [])
 

--- a/openbank-admin-ui/src/test/use-service-resource.test.ts
+++ b/openbank-admin-ui/src/test/use-service-resource.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useServiceResource } from '@/lib/services/useServiceResource'
+
+function jsonRes(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('useServiceResource', () => {
+  it('loads and exposes the raw body when no select is given', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(200, [{ id: 'a' }, { id: 'b' }])))
+    const { result } = renderHook(() => useServiceResource<Array<{ id: string }>>('/api/svc/x/api/v1/items'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.unavailable).toBeNull()
+    expect(result.current.data).toEqual([{ id: 'a' }, { id: 'b' }])
+  })
+
+  it('applies select() to the raw body', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(200, { cards: [{ id: 'c1' }] })))
+    const { result } = renderHook(() =>
+      useServiceResource('/api/svc/x/api/v1/cards', {
+        select: (raw) => (raw as { cards: unknown[] }).cards,
+      }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toEqual([{ id: 'c1' }])
+  })
+
+  it('classifies a 404 Unknown service as not_deployed and does not retry', async () => {
+    const fetchMock = vi.fn(async () => jsonRes(404, { error: 'Unknown service: x' }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useServiceResource('/api/svc/x/api/v1/items'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.unavailable).toEqual({ kind: 'not_deployed' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-wakes a scaled-to-zero service: retries the 503 then fills in', async () => {
+    let call = 0
+    const fetchMock = vi.fn(async () => {
+      call += 1
+      return call < 2 ? jsonRes(503, { error: 'scaled_to_zero' }) : jsonRes(200, [{ id: 'woke' }])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() =>
+      useServiceResource<Array<{ id: string }>>('/api/svc/x/api/v1/items', { retryDelayMs: 120 }),
+    )
+    // While waking, it shows the calm scaled_to_zero panel, not a hard failure.
+    await waitFor(() => expect(result.current.waking).toBe(true))
+    expect(result.current.unavailable).toEqual({ kind: 'scaled_to_zero' })
+    // Then the retry succeeds and the data lands.
+    await waitFor(() => expect(result.current.data).toEqual([{ id: 'woke' }]))
+    expect(result.current.unavailable).toBeNull()
+    expect(result.current.waking).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up as scaled_to_zero after exhausting wake retries', async () => {
+    const fetchMock = vi.fn(async () => jsonRes(503, { error: 'scaled_to_zero' }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() =>
+      useServiceResource('/api/svc/x/api/v1/items', { retryDelayMs: 5, maxWakeRetries: 2 }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.unavailable).toEqual({ kind: 'scaled_to_zero' })
+    // initial attempt + 2 retries
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('does nothing when url is null', async () => {
+    const fetchMock = vi.fn(async () => jsonRes(200, []))
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => useServiceResource(null))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.data).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Most "service X isn't working" reports in the sandbox are actually **KEDA scale-to-zero** (ADR-0057) + the **FinOps off-hours scaledown** doing their job — which the legacy operator pages misrepresented as an outage, or (via a missing `r.ok` check) as a false *"Microservice is running"* empty state. This PR makes the console tell the truth, and adds the requested clickable detail views and a Closings check-log.

## Type of change

- [x] Feature / enhancement (non-breaking)

## Linked issues

Refs #759

## Changes

- **`useServiceResource` hook** — classifies a non-OK BFF response (`classifyBffFailure`) and **auto-wakes** a cold / scaled-to-zero pod with a few short retries, so the screen fills in on its own instead of showing the first `503 scaled_to_zero` as "not responding". Unit-tested.
- **`ServiceStatusBadge`** — an honest `up / idle(waking) / down / checking` pill; an idle service no longer paints alarming red.
- **Legacy page migration** — `cards`, `clearing`, `interest`, `disputes`, `swift`, `aml`, `sanctions` now use the shared `DataUnavailable` + classifier (graceful-state rule #1) instead of the misleading "Microservice is running on port …" empty state.
- **Clickable detail views** — Payments and SWIFT rows navigate to new `/payments/[id]` and `/swift/[id]` detail pages (via a `sessionStorage` row handoff + list refetch; no by-id backend endpoint needed, degrades gracefully on a direct URL).
- **Closings check log** — the EoM tab now keeps a local, operator-visible trail of observed close states, so there's a breadcrumb even when statement-service is down (read-only; never a governance data source).
- Fixed a Czech-only AML escalation banner (now bilingual).

## Definition of Done

- [x] `tsc --noEmit` clean
- [x] `vitest run` green (428 tests, incl. graceful-state / i18n / layout / agent-insights guards + new hook test)
- [x] `next build` succeeds (new `/payments/[id]`, `/swift/[id]` routes present)
- [x] eslint: no new errors (pre-existing warnings only)
- [x] Signed commit, branched from `origin/main`

## Security / compliance impact

None. Read-only operator console; no new backend writes, no new endpoints reachable, no auth changes. The Closings check-log is browser-local (`localStorage`) and never written to a backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)