### PR TITLE
feat(admin-ui): daily spend trend + fix security-scanner false positives on unreachable services

### DIFF
--- a/openbank-admin-ui/scripts/collect-aws-costs.mjs
+++ b/openbank-admin-ui/scripts/collect-aws-costs.mjs
@@ -54,6 +54,7 @@ function emptyReport(reason) {
     periodEnd: end,
     total: 0,
     services: [],
+    daily: [],
     collectedAt: now.toISOString(),
     source: 'aws-cost-explorer',
   }
@@ -63,7 +64,10 @@ function runCe() {
   const argv = [
     'ce', 'get-cost-and-usage',
     '--time-period', `Start=${start},End=${end}`,
-    '--granularity', 'MONTHLY',
+    // DAILY (not MONTHLY) so we can emit a per-day spend trend in addition to the
+    // per-service totals — the trend the team otherwise reads only in the console.
+    // Cost Explorer supports DAILY grouped by SERVICE within this window.
+    '--granularity', 'DAILY',
     '--metrics', 'UnblendedCost',
     '--group-by', 'Type=DIMENSION,Key=SERVICE',
     '--region', REGION,
@@ -77,13 +81,20 @@ let report
 try {
   const raw = runCe()
   const json = JSON.parse(raw)
-  const acc = new Map()
+  const acc = new Map()      // service name → total over the window
+  const daily = []           // one entry per day: { date, amount } (all services summed)
   for (const r of json.ResultsByTime ?? []) {
+    const date = r.TimePeriod?.Start ?? null
+    let dayTotal = 0
     for (const g of r.Groups ?? []) {
       const name = g.Keys?.[0] ?? 'Unknown'
       const amount = parseFloat(g.Metrics?.UnblendedCost?.Amount ?? '0')
-      if (!isNaN(amount)) acc.set(name, (acc.get(name) ?? 0) + amount)
+      if (!isNaN(amount)) {
+        acc.set(name, (acc.get(name) ?? 0) + amount)
+        dayTotal += amount
+      }
     }
+    if (date) daily.push({ date, amount: Math.round(dayTotal * 100) / 100 })
   }
   const services = [...acc.entries()]
     .map(([name, amount]) => ({ name, amount: Math.round(amount * 100) / 100 }))
@@ -98,10 +109,11 @@ try {
     periodEnd: end,
     total,
     services,
+    daily,
     collectedAt: now.toISOString(),
     source: 'aws-cost-explorer',
   }
-  console.log(`[collect-aws-costs] ${services.length} services, $${total} over ${start}..${end} → ${OUT}`)
+  console.log(`[collect-aws-costs] ${services.length} services, ${daily.length} days, $${total} over ${start}..${end} → ${OUT}`)
 } catch (e) {
   const msg = (e?.stderr || e?.message || String(e)).toString().split('\n')[0]
   report = emptyReport(msg.slice(0, 200))

--- a/openbank-admin-ui/src/app/api/finops/costs/route.ts
+++ b/openbank-admin-ui/src/app/api/finops/costs/route.ts
@@ -37,6 +37,7 @@ const AWS_DOMAIN: Record<string, string> = {
 function domainFor(name: string): string { return AWS_DOMAIN[name] ?? 'Platform' }
 
 export interface ServiceCost { name: string; amount: number; domain: string }
+export interface DailyCost { date: string; amount: number }
 
 interface CostReport {
   available: boolean
@@ -46,6 +47,8 @@ interface CostReport {
   periodEnd: string
   total: number
   services: ServiceCost[]
+  /** Per-day total spend over the window (spend trend). Empty on older snapshots. */
+  daily: DailyCost[]
   collectedAt: string | null
   source: string
 }
@@ -73,6 +76,7 @@ const UNAVAILABLE: CostReport = {
   periodEnd: '',
   total: 0,
   services: [],
+  daily: [],
   collectedAt: null,
   source: 'aws-cost-explorer',
 }
@@ -91,6 +95,13 @@ function normalize(parsed: unknown): CostReport | null {
     .filter(s => Number.isFinite(s.amount) && s.amount > 0)
     .sort((a, b) => b.amount - a.amount)
   const total = Math.round(services.reduce((sum, s) => sum + s.amount, 0) * 100) / 100
+  // Per-day trend — present on DAILY snapshots, absent on older ones (→ []).
+  const daily = Array.isArray(p.daily)
+    ? (p.daily as { date?: unknown; amount?: unknown }[])
+        .map(d => ({ date: String(d?.date ?? ''), amount: Math.round(Number(d?.amount) * 100) / 100 }))
+        .filter(d => d.date && Number.isFinite(d.amount))
+        .sort((a, b) => a.date.localeCompare(b.date))
+    : []
   return {
     available: services.length > 0 && p.available !== false,
     reason: typeof p.reason === 'string' ? p.reason : undefined,
@@ -99,6 +110,7 @@ function normalize(parsed: unknown): CostReport | null {
     periodEnd: typeof p.periodEnd === 'string' ? p.periodEnd : '',
     total,
     services,
+    daily,
     collectedAt: typeof p.collectedAt === 'string' ? p.collectedAt : null,
     source: typeof p.source === 'string' ? p.source : 'aws-cost-explorer',
   }

--- a/openbank-admin-ui/src/app/finops/page.tsx
+++ b/openbank-admin-ui/src/app/finops/page.tsx
@@ -7,8 +7,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import {
   RefreshCw, ShieldCheck, AlertTriangle, Clock, DollarSign,
-  Cpu, Server, Database, Zap, Info, Calendar, PieChart, TrendingDown,
-  Bot,
+  Cpu, Server, Database, Zap, Info, Calendar, PieChart, TrendingDown, TrendingUp,
+  Activity, Bot,
 } from 'lucide-react'
 import Link from 'next/link'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -80,6 +80,7 @@ interface ResourceData {
 }
 
 interface ServiceCost { name: string; amount: number; domain: string }
+interface DailyCost { date: string; amount: number }
 interface ServiceEfficiency {
   namespace: string
   displayName: string
@@ -107,6 +108,7 @@ interface CostReport {
   periodEnd: string
   total: number
   services: ServiceCost[]
+  daily: DailyCost[]
   collectedAt: string | null
   source: string
 }
@@ -222,6 +224,89 @@ function HeapBar({ pct, efficiency }: { pct: number | null; efficiency: string }
         <div style={{ width: `${pct}%`, height: '100%', background: color, borderRadius: '3px' }} />
       </div>
       <span style={{ fontSize: '11px', fontWeight: 700, color, minWidth: '34px', textAlign: 'right' }}>{pct}%</span>
+    </div>
+  )
+}
+
+// Per-day cloud spend trend — a hand-rolled inline SVG area chart (matches the
+// panel's other hand-rolled bars; no chart lib). This is the series the team
+// otherwise reads only in the AWS console. Higher spend is tinted as the
+// "concern" direction (red) per the FinOps framing.
+function DailySpendTrend({ daily, currency }: { daily: DailyCost[]; currency: string }) {
+  const { t, language } = useLanguage()
+  const locale = language === 'cs' ? 'cs-CZ' : 'en-US'
+  const fmt = (v: number) => v.toLocaleString(locale, { maximumFractionDigits: 0 })
+
+  if (!daily || daily.length < 2) {
+    return (
+      <div style={{ marginBottom: '20px', padding: '14px', borderRadius: '8px', background: 'var(--surface-2)', border: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: '8px' }}>
+        <Activity size={14} style={{ color: 'var(--text-tertiary)', flexShrink: 0 }} />
+        <span style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+          {t('Denní trend výdajů se objeví po příštím sběru nákladů (DAILY granularita).', 'The daily spend trend will appear after the next cost collection (DAILY granularity).')}
+        </span>
+      </div>
+    )
+  }
+
+  const W = 760, H = 150, padL = 6, padR = 6, padT = 14, padB = 22
+  const amounts = daily.map(d => d.amount)
+  const max = Math.max(...amounts)
+  const min = Math.min(...amounts, 0)
+  const n = daily.length
+  const span = max - min || 1
+  const xAt = (i: number) => padL + (i / (n - 1)) * (W - padL - padR)
+  const yAt = (v: number) => padT + (1 - (v - min) / span) * (H - padT - padB)
+  const pts = daily.map((d, i) => `${xAt(i).toFixed(1)},${yAt(d.amount).toFixed(1)}`)
+  const line = `M ${pts.join(' L ')}`
+  const area = `M ${xAt(0).toFixed(1)},${(H - padB).toFixed(1)} L ${pts.join(' L ')} L ${xAt(n - 1).toFixed(1)},${(H - padB).toFixed(1)} Z`
+  const avg = amounts.reduce((s, a) => s + a, 0) / n
+  const avgY = yAt(avg)
+  const last = daily[n - 1]
+  const prev = daily[n - 2]
+  const dod = prev.amount ? ((last.amount - prev.amount) / prev.amount) * 100 : 0
+  const up = last.amount >= prev.amount
+  const fmtDate = (s: string) => { try { return new Date(s).toLocaleDateString(locale, { day: 'numeric', month: 'numeric' }) } catch { return s } }
+
+  return (
+    <div style={{ marginBottom: '20px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px', flexWrap: 'wrap', gap: '8px' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <Activity size={14} style={{ color: '#6366f1' }} />
+          <span style={{ fontSize: '12px', fontWeight: 700, color: 'var(--text-secondary)' }}>
+            {t('Denní trend výdajů', 'Daily spend trend')}
+          </span>
+          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>({n} {t('dní', 'days')} · {currency})</span>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+            {t('poslední den', 'last day')}: <strong style={{ color: 'var(--text-primary)' }}>${fmt(last.amount)}</strong>
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', fontSize: '11px', fontWeight: 700,
+            color: up ? 'var(--danger-text)' : 'var(--success-text)' }}
+            title={t('Změna oproti předchozímu dni', 'Change vs. the previous day')}>
+            {up ? <TrendingUp size={12} /> : <TrendingDown size={12} />}
+            {up ? '+' : ''}{dod.toFixed(0)}%
+          </span>
+        </div>
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: '150px', display: 'block' }}
+        role="img" aria-label={t('Graf denních cloudových výdajů', 'Daily cloud spend chart')}>
+        <defs>
+          <linearGradient id="spendGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#6366f1" stopOpacity="0.28" />
+            <stop offset="100%" stopColor="#6366f1" stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+        <line x1={padL} y1={avgY} x2={W - padR} y2={avgY} stroke="var(--text-tertiary)" strokeWidth="1" strokeDasharray="4 4" opacity="0.5" />
+        <path d={area} fill="url(#spendGrad)" />
+        <path d={line} fill="none" stroke="#6366f1" strokeWidth="2" strokeLinejoin="round" strokeLinecap="round" />
+        <circle cx={xAt(n - 1)} cy={yAt(last.amount)} r="3.5" fill="#6366f1" />
+      </svg>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '2px' }}>
+        <span>{fmtDate(daily[0].date)}</span>
+        <span>{t(`prům. $${fmt(avg)}/den · max $${fmt(max)}`, `avg $${fmt(avg)}/day · max $${fmt(max)}`)}</span>
+        <span>{fmtDate(last.date)}</span>
+      </div>
     </div>
   )
 }
@@ -434,11 +519,28 @@ function FinOpsContent() {
                   {t('Celkové měsíční náklady — AWS Cost Explorer', 'Total Monthly Cloud Spend — AWS Cost Explorer')}
                 </span>
               </div>
-              {costs?.available && (
-                <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                  {costs.periodStart} → {costs.periodEnd} · {costs.collectedAt ? new Date(costs.collectedAt).toLocaleDateString(language === 'cs' ? 'cs-CZ' : 'en-GB') : '—'}
-                </span>
-              )}
+              {costs?.available && (() => {
+                // Honest snapshot age. The cost number is a point-in-time snapshot
+                // (baked at deploy, refreshed daily by the in-cluster CronJob), NOT a
+                // live figure — so surface how old it actually is. Use lastRefresh
+                // (a state Date) as "now" to keep render pure.
+                const collected = costs.collectedAt ? new Date(costs.collectedAt) : null
+                const ageDays = collected && lastRefresh
+                  ? Math.max(0, Math.floor((lastRefresh.getTime() - collected.getTime()) / 86_400_000))
+                  : null
+                const stale = ageDays != null && ageDays >= 2
+                return (
+                  <span title={t('Snapshot z AWS Cost Exploreru — obnovuje se při deployi a denním CronJobem.', 'AWS Cost Explorer snapshot — refreshed on deploy and by the daily CronJob.')}
+                    style={{ fontSize: '11px', fontWeight: stale ? 700 : 400,
+                      color: stale ? 'var(--warning-text)' : 'var(--text-tertiary)',
+                      background: stale ? 'var(--warning-bg)' : 'transparent',
+                      border: stale ? '1px solid var(--warning-border)' : 'none',
+                      borderRadius: '10px', padding: stale ? '2px 8px' : 0 }}>
+                    {t('Snapshot', 'Snapshot')}: {collected ? collected.toLocaleDateString(language === 'cs' ? 'cs-CZ' : 'en-GB') : '—'}
+                    {ageDays != null && ` · ${ageDays === 0 ? t('dnes', 'today') : t(`starý ${ageDays} d`, `${ageDays}d old`)}`}
+                  </span>
+                )
+              })()}
             </div>
             <p style={{ fontSize: '11px', color: 'var(--text-tertiary)', margin: '0 0 16px' }}>
               {t(
@@ -488,6 +590,9 @@ function FinOpsContent() {
                       </div>
                     </div>
                   </div>
+
+                  {/* DAILY SPEND TREND — the per-day series we otherwise only read in the console */}
+                  <DailySpendTrend daily={costs.daily} currency={costs.currency} />
 
                   {/* BY DOMAIN — process/business view */}
                   <div style={{ marginBottom: '20px' }}>

--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { Shield, RefreshCw, CheckCircle2, XCircle, AlertTriangle } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { summarizeReachable, serviceVerdict } from '@/lib/security/summary'
 
 // Envelope returned by /api/security (never 500s — see that route): either the
 // scanner answered with a report, or it's unavailable with a typed reason that
@@ -50,17 +51,6 @@ const SEVERITY_COLORS: Record<string, { bg: string; text: string; border: string
 
 const GRADE_COLORS: Record<string, string> = {
   'A+': '#059669', A: '#10b981', B: '#3b82f6', C: '#f59e0b', D: '#ef4444', F: '#991b1b'
-}
-
-// Standard letter-grade bands, used to derive the platform grade from the score
-// recomputed over only the reachable services (see below).
-function gradeFromScore(score: number): string {
-  if (score >= 95) return 'A+'
-  if (score >= 90) return 'A'
-  if (score >= 80) return 'B'
-  if (score >= 70) return 'C'
-  if (score >= 60) return 'D'
-  return 'F'
 }
 
 const OWASP_LABELS: Record<string, [string, string]> = {
@@ -119,16 +109,10 @@ export default function SecurityPage() {
   // Only services the scanner could actually reach have a meaningful verdict. An
   // unreachable service has NO known findings — counting it as a vulnerability, or
   // letting its upstream F-grade drag the platform score, is a false positive. So
-  // the headline counts/score are computed over reachable services only; the
-  // unreachable ones are surfaced separately as a coverage gap, not a failure.
-  const reachableResults = results.filter(r => r.reachable)
-  const unreachableCount = results.length - reachableResults.length
-  const criticalCount = reachableResults.reduce((n, r) => n + r.findings.filter(f => f.severity === 'CRITICAL').length, 0)
-  const highCount = reachableResults.reduce((n, r) => n + r.findings.filter(f => f.severity === 'HIGH').length, 0)
-  const avgScore = reachableResults.length
-    ? Math.round(reachableResults.reduce((s, r) => s + r.score, 0) / reachableResults.length)
-    : 0
-  const platformGrade = reachableResults.length ? gradeFromScore(avgScore) : 'N/A'
+  // the headline counts/score are computed over reachable services only (pure,
+  // unit-tested in src/lib/security/summary.ts); the unreachable ones are surfaced
+  // separately as a coverage gap, not a failure.
+  const { unreachableCount, criticalCount, highCount, avgScore, platformGrade } = summarizeReachable(results)
 
   const filteredResults = results.filter(r => {
     if (filter === 'ALL') return true
@@ -349,21 +333,22 @@ export default function SecurityPage() {
                             {formatDate(r.scannedAt)}
                           </td>
                           <td style={{ padding: '12px 16px' }}>
-                            {!r.reachable ? (
-                              // Not reachable during the scan = no verdict, NOT a failure.
-                              // Rendering this as a red "Fail" was the false positive.
-                              <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
-                                background: 'var(--info-bg)', color: 'var(--info-text)', border: '1px solid var(--info-border)' }}>
-                                {t('Nelze skenovat', 'Not scanned')}
-                              </span>
-                            ) : (
-                              <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
-                                background: ['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-bg)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-bg)' : 'var(--warning-bg)',
-                                color: ['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-text)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-text)' : 'var(--warning-text)',
-                                border: `1px solid ${['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-border)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-border)' : 'var(--warning-border)'}` }}>
-                                {['F', 'D', 'C'].includes(r.grade) ? t('Selhání', 'Fail') : ['A+', 'A'].includes(r.grade) ? t('V pořádku', 'Pass') : t('Ke kontrole', 'Review')}
-                              </span>
-                            )}
+                            {(() => {
+                              // Verdict is centralized + unit-tested; unreachable → "Not scanned",
+                              // never a red "Fail" (that mis-mapping was the false positive).
+                              const style = {
+                                not_scanned: { bg: 'var(--info-bg)',    fg: 'var(--info-text)',    bd: 'var(--info-border)',    label: t('Nelze skenovat', 'Not scanned') },
+                                fail:        { bg: 'var(--danger-bg)',  fg: 'var(--danger-text)',  bd: 'var(--danger-border)',  label: t('Selhání', 'Fail') },
+                                pass:        { bg: 'var(--success-bg)', fg: 'var(--success-text)', bd: 'var(--success-border)', label: t('V pořádku', 'Pass') },
+                                review:      { bg: 'var(--warning-bg)', fg: 'var(--warning-text)', bd: 'var(--warning-border)', label: t('Ke kontrole', 'Review') },
+                              }[serviceVerdict(r)]
+                              return (
+                                <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
+                                  background: style.bg, color: style.fg, border: `1px solid ${style.bd}` }}>
+                                  {style.label}
+                                </span>
+                              )
+                            })()}
                           </td>
                         </tr>
                       )

--- a/openbank-admin-ui/src/app/security/page.tsx
+++ b/openbank-admin-ui/src/app/security/page.tsx
@@ -52,6 +52,17 @@ const GRADE_COLORS: Record<string, string> = {
   'A+': '#059669', A: '#10b981', B: '#3b82f6', C: '#f59e0b', D: '#ef4444', F: '#991b1b'
 }
 
+// Standard letter-grade bands, used to derive the platform grade from the score
+// recomputed over only the reachable services (see below).
+function gradeFromScore(score: number): string {
+  if (score >= 95) return 'A+'
+  if (score >= 90) return 'A'
+  if (score >= 80) return 'B'
+  if (score >= 70) return 'C'
+  if (score >= 60) return 'D'
+  return 'F'
+}
+
 const OWASP_LABELS: Record<string, [string, string]> = {
   A01_BROKEN_ACCESS_CONTROL:       ['A01 Řízení přístupu',      'A01 Access Control'],
   A02_CRYPTOGRAPHIC_FAILURES:      ['A02 Kryptografie',          'A02 Cryptographic Failures'],
@@ -105,10 +116,19 @@ export default function SecurityPage() {
   useEffect(() => { load() }, [load])
 
   const results = report?.serviceResults ?? []
-  const criticalCount = report?.criticalFindings ?? 0
-  const highCount = report?.highFindings ?? 0
-  const avgScore = report?.platformScore ?? 0
-  const platformGrade = report?.platformGrade ?? 'N/A'
+  // Only services the scanner could actually reach have a meaningful verdict. An
+  // unreachable service has NO known findings — counting it as a vulnerability, or
+  // letting its upstream F-grade drag the platform score, is a false positive. So
+  // the headline counts/score are computed over reachable services only; the
+  // unreachable ones are surfaced separately as a coverage gap, not a failure.
+  const reachableResults = results.filter(r => r.reachable)
+  const unreachableCount = results.length - reachableResults.length
+  const criticalCount = reachableResults.reduce((n, r) => n + r.findings.filter(f => f.severity === 'CRITICAL').length, 0)
+  const highCount = reachableResults.reduce((n, r) => n + r.findings.filter(f => f.severity === 'HIGH').length, 0)
+  const avgScore = reachableResults.length
+    ? Math.round(reachableResults.reduce((s, r) => s + r.score, 0) / reachableResults.length)
+    : 0
+  const platformGrade = reachableResults.length ? gradeFromScore(avgScore) : 'N/A'
 
   const filteredResults = results.filter(r => {
     if (filter === 'ALL') return true
@@ -190,6 +210,20 @@ export default function SecurityPage() {
             </div>
           ))}
         </div>
+
+        {unreachableCount > 0 && (
+          <div style={{ marginBottom: '20px', padding: '10px 16px', borderRadius: '8px',
+            background: 'var(--info-bg)', border: '1px solid var(--info-border)',
+            display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <Shield size={15} style={{ color: 'var(--info-text)', flexShrink: 0 }} />
+            <span style={{ fontSize: '12px', color: 'var(--info-text)' }}>
+              {t(
+                `${unreachableCount} ${unreachableCount === 1 ? 'služba byla' : 'služeb bylo'} nedostupná při skenu (nejspíš scale-to-zero) — nebyla skenována. Chybějící sken není zranitelnost; skóre a počty výše vychází pouze z dosažitelných služeb.`,
+                `${unreachableCount} service${unreachableCount === 1 ? ' was' : 's were'} unreachable during the scan (likely scaled to zero) — not scanned. A missing scan is not a vulnerability; the score and counts above reflect only the reachable services.`,
+              )}
+            </span>
+          </div>
+        )}
 
         {report?.complianceStatus && (
           <div className="card" style={{ padding: '16px 20px', marginBottom: '20px', display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
@@ -299,24 +333,37 @@ export default function SecurityPage() {
                             {!r.reachable && <div style={{ fontSize: '10px', color: 'var(--danger-text)', fontWeight: 400 }}>{t('nedostupné', 'unreachable')}</div>}
                           </td>
                           <td style={{ padding: '12px 16px' }}>
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
-                              <span style={{ fontSize: '14px', fontWeight: 800, color: GRADE_COLORS[r.grade] ?? 'var(--text-secondary)' }}>{r.grade}</span>
-                              <span style={{ fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-tertiary)' }}>{r.score}</span>
-                            </div>
+                            {r.reachable ? (
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                <span style={{ fontSize: '14px', fontWeight: 800, color: GRADE_COLORS[r.grade] ?? 'var(--text-secondary)' }}>{r.grade}</span>
+                                <span style={{ fontSize: '11px', fontFamily: 'var(--font-mono)', color: 'var(--text-tertiary)' }}>{r.score}</span>
+                              </div>
+                            ) : (
+                              <span style={{ fontSize: '14px', fontWeight: 800, color: 'var(--text-tertiary)' }}>—</span>
+                            )}
                           </td>
                           <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>
-                            {r.findings.length}
+                            {r.reachable ? r.findings.length : '—'}
                           </td>
                           <td style={{ padding: '12px 16px', fontSize: '12px', color: 'var(--text-secondary)' }}>
                             {formatDate(r.scannedAt)}
                           </td>
                           <td style={{ padding: '12px 16px' }}>
-                            <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
-                              background: ['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-bg)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-bg)' : 'var(--warning-bg)',
-                              color: ['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-text)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-text)' : 'var(--warning-text)',
-                              border: `1px solid ${['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-border)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-border)' : 'var(--warning-border)'}` }}>
-                              {['F', 'D', 'C'].includes(r.grade) ? t('Selhání', 'Fail') : ['A+', 'A'].includes(r.grade) ? t('V pořádku', 'Pass') : t('Ke kontrole', 'Review')}
-                            </span>
+                            {!r.reachable ? (
+                              // Not reachable during the scan = no verdict, NOT a failure.
+                              // Rendering this as a red "Fail" was the false positive.
+                              <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
+                                background: 'var(--info-bg)', color: 'var(--info-text)', border: '1px solid var(--info-border)' }}>
+                                {t('Nelze skenovat', 'Not scanned')}
+                              </span>
+                            ) : (
+                              <span style={{ padding: '2px 8px', borderRadius: '10px', fontSize: '10px', fontWeight: 700,
+                                background: ['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-bg)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-bg)' : 'var(--warning-bg)',
+                                color: ['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-text)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-text)' : 'var(--warning-text)',
+                                border: `1px solid ${['F', 'D', 'C'].includes(r.grade) ? 'var(--danger-border)' : ['A+', 'A'].includes(r.grade) ? 'var(--success-border)' : 'var(--warning-border)'}` }}>
+                                {['F', 'D', 'C'].includes(r.grade) ? t('Selhání', 'Fail') : ['A+', 'A'].includes(r.grade) ? t('V pořádku', 'Pass') : t('Ke kontrole', 'Review')}
+                              </span>
+                            )}
                           </td>
                         </tr>
                       )
@@ -334,12 +381,32 @@ export default function SecurityPage() {
                     <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', fontFamily: 'var(--font-mono)' }}>{selected.serviceUrl}</div>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    <span style={{ fontSize: '20px', fontWeight: 900, color: GRADE_COLORS[selected.grade] ?? 'var(--text-secondary)' }}>{selected.grade}</span>
-                    <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{selected.score}/100</span>
+                    {selected.reachable ? (
+                      <>
+                        <span style={{ fontSize: '20px', fontWeight: 900, color: GRADE_COLORS[selected.grade] ?? 'var(--text-secondary)' }}>{selected.grade}</span>
+                        <span style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>{selected.score}/100</span>
+                      </>
+                    ) : (
+                      <span style={{ padding: '3px 10px', borderRadius: '12px', fontSize: '11px', fontWeight: 700,
+                        background: 'var(--info-bg)', color: 'var(--info-text)', border: '1px solid var(--info-border)' }}>
+                        {t('Nedostupné', 'Unreachable')}
+                      </span>
+                    )}
                   </div>
                 </div>
                 <div style={{ overflowY: 'auto', maxHeight: '540px' }}>
-                  {(selected.findings ?? []).length === 0 ? (
+                  {!selected.reachable ? (
+                    // Not reachable during the scan — no verdict either way. Do NOT
+                    // show the green "passed all checks" state (that would be a false
+                    // positive in the opposite direction).
+                    <div style={{ padding: '48px 32px', textAlign: 'center' }}>
+                      <Shield size={32} style={{ color: 'var(--info-text)', marginBottom: '12px', marginInline: 'auto' }} />
+                      <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--text-primary)' }}>{t('Služba nebyla skenována', 'Service was not scanned')}</div>
+                      <div style={{ fontSize: '13px', color: 'var(--text-secondary)', maxWidth: '360px', margin: '4px auto 0' }}>
+                        {t('Při skenu byla nedostupná (nejspíš scale-to-zero). Chybějící sken neznamená zranitelnost ani že služba prošla — jen že se nedala prověřit.', 'It was unreachable during the scan (likely scaled to zero). A missing scan means neither a vulnerability nor a pass — only that it could not be checked.')}
+                      </div>
+                    </div>
+                  ) : (selected.findings ?? []).length === 0 ? (
                     <div style={{ padding: '48px 32px', textAlign: 'center' }}>
                       <CheckCircle2 size={32} style={{ color: 'var(--success)', marginBottom: '12px', marginInline: 'auto' }} />
                       <div style={{ fontSize: '15px', fontWeight: 600, color: 'var(--text-primary)' }}>{t('Žádné nálezy', 'No findings')}</div>

--- a/openbank-admin-ui/src/lib/security/summary.ts
+++ b/openbank-admin-ui/src/lib/security/summary.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Pure security-report aggregation, extracted from the Security Scanner page so
+// the "unreachable service is not a vulnerability" rule is unit-testable rather
+// than living only in JSX. An unreachable service (typically scaled to zero) has
+// NO known findings — counting it as a failure, or letting its upstream F-grade
+// drag the platform score, is a false positive. These helpers compute the
+// headline numbers over REACHABLE services only and surface the unreachable ones
+// as a coverage gap.
+
+export interface ScanFindingLike { severity: string }
+export interface ScanResultLike {
+  reachable: boolean
+  score: number
+  grade: string
+  findings: ScanFindingLike[]
+}
+
+// Standard letter-grade bands, used to derive the platform grade from the score
+// recomputed over only the reachable services.
+export function gradeFromScore(score: number): string {
+  if (score >= 95) return 'A+'
+  if (score >= 90) return 'A'
+  if (score >= 80) return 'B'
+  if (score >= 70) return 'C'
+  if (score >= 60) return 'D'
+  return 'F'
+}
+
+export interface ReachableSummary {
+  reachableCount: number
+  unreachableCount: number
+  criticalCount: number
+  highCount: number
+  avgScore: number
+  platformGrade: string
+}
+
+export function summarizeReachable(results: ScanResultLike[]): ReachableSummary {
+  const reachable = results.filter(r => r.reachable)
+  const countSeverity = (sev: string) =>
+    reachable.reduce((n, r) => n + r.findings.filter(f => f.severity === sev).length, 0)
+  const avgScore = reachable.length
+    ? Math.round(reachable.reduce((s, r) => s + r.score, 0) / reachable.length)
+    : 0
+  return {
+    reachableCount: reachable.length,
+    unreachableCount: results.length - reachable.length,
+    criticalCount: countSeverity('CRITICAL'),
+    highCount: countSeverity('HIGH'),
+    avgScore,
+    platformGrade: reachable.length ? gradeFromScore(avgScore) : 'N/A',
+  }
+}
+
+export type ServiceVerdict = 'not_scanned' | 'fail' | 'pass' | 'review'
+
+// The per-row status pill. Unreachable → "not_scanned" (neutral), NEVER "fail" —
+// that mis-mapping was the reported false positive.
+export function serviceVerdict(r: { reachable: boolean; grade: string }): ServiceVerdict {
+  if (!r.reachable) return 'not_scanned'
+  if (['F', 'D', 'C'].includes(r.grade)) return 'fail'
+  if (['A+', 'A'].includes(r.grade)) return 'pass'
+  return 'review'
+}

--- a/openbank-admin-ui/src/test/security-summary.test.ts
+++ b/openbank-admin-ui/src/test/security-summary.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect } from 'vitest'
+import { summarizeReachable, serviceVerdict, gradeFromScore, type ScanResultLike } from '@/lib/security/summary'
+
+const svc = (over: Partial<ScanResultLike>): ScanResultLike => ({
+  reachable: true, score: 90, grade: 'A', findings: [], ...over,
+})
+const finding = (severity: string) => ({ severity })
+
+describe('serviceVerdict', () => {
+  it('maps an unreachable service to "not_scanned", never "fail"', () => {
+    // The reported false positive: an unreachable (scaled-to-zero) service came
+    // back graded F and was rendered as a red "Fail".
+    expect(serviceVerdict({ reachable: false, grade: 'F' })).toBe('not_scanned')
+    expect(serviceVerdict({ reachable: false, grade: 'A+' })).toBe('not_scanned')
+  })
+  it('maps reachable grades to fail / pass / review', () => {
+    expect(serviceVerdict({ reachable: true, grade: 'F' })).toBe('fail')
+    expect(serviceVerdict({ reachable: true, grade: 'D' })).toBe('fail')
+    expect(serviceVerdict({ reachable: true, grade: 'C' })).toBe('fail')
+    expect(serviceVerdict({ reachable: true, grade: 'A+' })).toBe('pass')
+    expect(serviceVerdict({ reachable: true, grade: 'A' })).toBe('pass')
+    expect(serviceVerdict({ reachable: true, grade: 'B' })).toBe('review')
+  })
+})
+
+describe('gradeFromScore', () => {
+  it('bands scores into letter grades', () => {
+    expect(gradeFromScore(100)).toBe('A+')
+    expect(gradeFromScore(92)).toBe('A')
+    expect(gradeFromScore(85)).toBe('B')
+    expect(gradeFromScore(72)).toBe('C')
+    expect(gradeFromScore(61)).toBe('D')
+    expect(gradeFromScore(40)).toBe('F')
+  })
+})
+
+describe('summarizeReachable', () => {
+  it('excludes unreachable services from counts and score (no false positives)', () => {
+    const results: ScanResultLike[] = [
+      svc({ reachable: true, score: 90, grade: 'A', findings: [finding('HIGH')] }),
+      // Unreachable + graded F with synthetic findings — must NOT be counted.
+      svc({ reachable: false, score: 10, grade: 'F', findings: [finding('CRITICAL'), finding('HIGH')] }),
+    ]
+    const s = summarizeReachable(results)
+    expect(s.unreachableCount).toBe(1)
+    expect(s.reachableCount).toBe(1)
+    expect(s.criticalCount).toBe(0) // the unreachable service's CRITICAL is not counted
+    expect(s.highCount).toBe(1)     // only the reachable service's HIGH
+    expect(s.avgScore).toBe(90)     // the F(10) does not drag the score
+    expect(s.platformGrade).toBe('A')
+  })
+
+  it('counts findings across all reachable services and averages their scores', () => {
+    const results: ScanResultLike[] = [
+      svc({ reachable: true, score: 80, grade: 'B', findings: [finding('CRITICAL'), finding('CRITICAL')] }),
+      svc({ reachable: true, score: 100, grade: 'A+', findings: [] }),
+    ]
+    const s = summarizeReachable(results)
+    expect(s.criticalCount).toBe(2)
+    expect(s.avgScore).toBe(90)
+    expect(s.platformGrade).toBe('A')
+  })
+
+  it('reports N/A grade and zero score when nothing is reachable', () => {
+    const results: ScanResultLike[] = [
+      svc({ reachable: false, grade: 'F', findings: [finding('CRITICAL')] }),
+      svc({ reachable: false, grade: 'D', findings: [finding('HIGH')] }),
+    ]
+    const s = summarizeReachable(results)
+    expect(s.reachableCount).toBe(0)
+    expect(s.unreachableCount).toBe(2)
+    expect(s.criticalCount).toBe(0)
+    expect(s.highCount).toBe(0)
+    expect(s.avgScore).toBe(0)
+    expect(s.platformGrade).toBe('N/A')
+  })
+
+  it('handles an empty report', () => {
+    const s = summarizeReachable([])
+    expect(s).toEqual({ reachableCount: 0, unreachableCount: 0, criticalCount: 0, highCount: 0, avgScore: 0, platformGrade: 'N/A' })
+  })
+})


### PR DESCRIPTION
## Summary

Two of the reported issues: the **security scanner** flags an unreachable (scaled-to-zero) service as a red *Fail* / vulnerability even though it has no findings — a false positive; and **FinOps** shows a stale, frozen cost snapshot with no per-day trend.

## Type of change

- [x] Feature (daily spend trend) + bug fix (security false positives)

## Linked issues

Refs #759

## Changes

**Security scanner** (`src/app/security/page.tsx`)
- Per-service status: unreachable → neutral **"Not scanned"**, never a red *Fail*. The detail panel says *"service was not scanned"* instead of the green *"passed all checks"*.
- CRITICAL/HIGH counts + platform score are computed over **reachable services only** — an unreachable F-grade no longer inflates the vulnerability counts or drags the score.
- A coverage note explains how many services were unreachable (*"a missing scan is not a vulnerability"*).

**FinOps** (`scripts/collect-aws-costs.mjs`, `src/app/api/finops/costs/route.ts`, `src/app/finops/page.tsx`)
- **Daily spend trend** — the collector now queries Cost Explorer at `DAILY` granularity and emits a per-day series (`daily[]`); the route passes it through; the page renders a hand-rolled inline-SVG area chart with a day-over-day delta + window average. Validated against real CE data (30 days, \$2,288 total).
- **Snapshot-age honesty** — the cost panel shows how old the baked snapshot actually is (amber when ≥ 2 days), instead of implying freshness via the ticking "Updated" clock.
- Backward compatible: snapshots without `daily` degrade to a calm "trend appears after the next collection" note.

## Definition of Done

- [x] `tsc --noEmit` clean
- [x] `vitest run` green (incl. finops taxonomy/allocation route tests)
- [x] `next build` succeeds
- [x] eslint: no new errors (pre-existing warnings only)
- [x] Collector validated end-to-end against real AWS Cost Explorer (DAILY series well-formed)

## Notes / follow-up

- The in-cluster live cost-collector CronJob (`openbank-infra/gitops/components/admin-ui/cost-collector.yaml`) still aggregates at MONTHLY; the **baked** snapshot (rebuilt on this deploy) carries the daily series immediately, so the trend appears after merge. Teaching the CronJob's `agg.py` to emit `daily[]` for the live path is a small gitops follow-up.
- Visual preview is auth-gated (no Keycloak outside a deployed env, per admin-ui CLAUDE.md); verification was via the real collector run + build + tests.

## Security / compliance impact

None. Read-only consumer; the cost query is `ce:GetCostAndUsage` run at build time (no runtime billing IAM). No new writes or endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)