### PR TITLE
fix(admin-ui): reflect Temporal + platform control plane in infra/BCP/architecture views

### DIFF
--- a/openbank-admin-ui/src/app/api/infra/status/route.ts
+++ b/openbank-admin-ui/src/app/api/infra/status/route.ts
@@ -18,7 +18,7 @@ type InfraProbe =
   | { kind: 'tcp'; host: string; port: number }
   | { kind: 'absent' } // not deployed in this topology → UNKNOWN, never a false DOWN
 
-interface InfraDef {
+export interface InfraDef {
   id: string
   probe: InfraProbe
 }
@@ -29,7 +29,7 @@ interface InfraDef {
 // component that genuinely isn't part of the sandbox topology yet (loki, kafka-ui)
 // is marked `absent` ⇒ UNKNOWN, not a misleading red. Ids are stable contract
 // keys consumed by /docs/bcp and /infrastructure.
-const CLUSTER_INFRA: InfraDef[] = [
+export const CLUSTER_INFRA: InfraDef[] = [
   { id: 'postgres',        probe: { kind: 'tcp',  host: 'accounts-db-rw.accounts.svc',                       port: 5432 } },
   { id: 'kafka',           probe: { kind: 'tcp',  host: 'openbank-cluster-kafka-bootstrap.messaging.svc',    port: 9092 } },
   { id: 'keycloak',        probe: { kind: 'http', url: 'http://keycloak.iam.svc:8080/realms/master', okCodes: [200] } },
@@ -69,7 +69,7 @@ function containerHost(name: string): string {
   return process.env.SERVICES_HOST === 'container' ? name : 'localhost'
 }
 
-const LOCAL_INFRA: InfraDef[] = [
+export const LOCAL_INFRA: InfraDef[] = [
   { id: 'postgres',        probe: { kind: 'tcp',  host: containerHost('openbank-postgres'),         port: 5432 } },
   { id: 'kafka',           probe: { kind: 'tcp',  host: containerHost('openbank-kafka'),             port: process.env.SERVICES_HOST === 'container' ? 9092 : 29092 } },
   { id: 'keycloak',        probe: { kind: 'http', url: `http://${containerHost('openbank-keycloak')}:8080/realms/master`, okCodes: [200] } },
@@ -109,7 +109,7 @@ function tcpProbe(host: string, port: number, timeoutMs = 3000): Promise<number 
   })
 }
 
-async function probeInfra(def: InfraDef): Promise<InfraStatusResult> {
+export async function probeInfra(def: InfraDef): Promise<InfraStatusResult> {
   const now = new Date().toISOString()
   try {
     if (def.probe.kind === 'absent') {

--- a/openbank-admin-ui/src/app/api/infra/status/route.ts
+++ b/openbank-admin-ui/src/app/api/infra/status/route.ts
@@ -52,6 +52,16 @@ const CLUSTER_INFRA: InfraDef[] = [
   { id: 'glitchtip',       probe: { kind: 'tcp',  host: 'glitchtip-web.observability.svc',                    port: 80 } },
   { id: 'goalert',         probe: { kind: 'tcp',  host: 'goalert.observability.svc',                          port: 8080 } },
   { id: 'ntfy',            probe: { kind: 'tcp',  host: 'ntfy.observability.svc',                             port: 8080 } },
+  // Platform control plane + orchestration. TCP probes (port open ⇒ up) against
+  // the real Service DNS, verified against the live cluster. Temporal underpins
+  // payment/settlement/statement workflow orchestration; KEDA drives the
+  // scale-to-zero the rest of the fleet relies on (ADR-0057).
+  { id: 'temporal',        probe: { kind: 'tcp',  host: 'temporal-frontend.temporal.svc',                    port: 7233 } },
+  { id: 'keda',            probe: { kind: 'tcp',  host: 'keda-operator.keda.svc',                             port: 9666 } },
+  { id: 'argocd',          probe: { kind: 'tcp',  host: 'argocd-server.argocd.svc',                           port: 80 } },
+  { id: 'kyverno',         probe: { kind: 'tcp',  host: 'kyverno-svc-metrics.kyverno.svc',                    port: 8000 } },
+  { id: 'cert-manager',    probe: { kind: 'tcp',  host: 'cert-manager.cert-manager.svc',                      port: 9402 } },
+  { id: 'karpenter',       probe: { kind: 'tcp',  host: 'karpenter.kube-system.svc',                          port: 8080 } },
 ]
 
 // Off-cluster (local dev / docker-compose): legacy localhost/container probes.
@@ -72,6 +82,14 @@ const LOCAL_INFRA: InfraDef[] = [
   { id: 'loki',            probe: { kind: 'http', url: `http://${containerHost('openbank-loki')}:3100/ready`, okCodes: [200] } },
   { id: 'tempo',           probe: { kind: 'http', url: `http://${containerHost('openbank-tempo')}:3200/ready`, okCodes: [200] } },
   { id: 'kafka-ui',        probe: { kind: 'http', url: `http://${containerHost('openbank-kafka-ui')}:8080/`, okCodes: [200, 302] } },
+  // Platform control plane is Kubernetes-only — not part of the docker-compose
+  // topology. Report UNKNOWN off-cluster rather than a misleading DOWN.
+  { id: 'temporal',        probe: { kind: 'absent' } },
+  { id: 'keda',            probe: { kind: 'absent' } },
+  { id: 'argocd',          probe: { kind: 'absent' } },
+  { id: 'kyverno',         probe: { kind: 'absent' } },
+  { id: 'cert-manager',    probe: { kind: 'absent' } },
+  { id: 'karpenter',       probe: { kind: 'absent' } },
 ]
 
 const INFRA: InfraDef[] = inCluster() ? CLUSTER_INFRA : LOCAL_INFRA

--- a/openbank-admin-ui/src/app/docs/bcp/page.tsx
+++ b/openbank-admin-ui/src/app/docs/bcp/page.tsx
@@ -34,8 +34,9 @@ const TIERS: {
     regulatoryBasis: ['Prerekvizita všech ostatních tierů', 'Prerequisite for all other tiers'],
     icon: Database,
     services: [
-      { name: 'postgres',         label: 'PostgreSQL',       note: ['Primární datové úložiště', 'Primary data store'] },
+      { name: 'postgres',         label: 'PostgreSQL (CloudNativePG)', note: ['Primární datové úložiště (operátor CNPG)', 'Primary data store (CNPG operator)'] },
       { name: 'kafka',            label: 'Apache Kafka',     note: ['Event streaming, outbox pattern', 'Event streaming, outbox pattern'] },
+      { name: 'temporal',         label: 'Temporal',         note: ['Orchestrace platebních a závěrkových workflow (settlement, SEPA, EoM)', 'Payment & close workflow orchestration (settlement, SEPA, EoM)'] },
       { name: 'keycloak',         label: 'Keycloak (IAM)',   note: ['PSD2 Art. 97 — autentizace', 'PSD2 Art. 97 — authentication'] },
       { name: 'openbao',          label: 'OpenBao',          note: ['PCI DSS Req. 3.5 — správa klíčů', 'PCI DSS Req. 3.5 — key management'] },
       { name: 'valkey',           label: 'Valkey (Redis)',   note: ['Idempotency — prevence duplikátů', 'Idempotency — duplicate prevention'] },
@@ -133,6 +134,7 @@ const TIERS: {
       { name: 'dispute-service',  label: 'Dispute Service',  note: ['PCI DSS Req. 12 — chargebacks', 'PCI DSS Req. 12 — chargebacks'] },
       { name: 'interest-service', label: 'Interest Service', note: ['CNB — úrokové výpočty', 'CNB — interest calculations'] },
       { name: 'admin-ui',         label: 'Admin UI',         note: ['Operátorská konzole', 'Operator console'] },
+      { name: 'keda',             label: 'KEDA',             note: ['Scale-to-zero autoscaling — úspora nákladů (ADR-0057)', 'Scale-to-zero autoscaling — cost saving (ADR-0057)'] },
       { name: 'grafana',          label: 'Grafana',          note: ['DORA Art. 8 — monitoring', 'DORA Art. 8 — monitoring'] },
       { name: 'prometheus',       label: 'Prometheus',       note: ['Metriky', 'Metrics'] },
       { name: 'loki',             label: 'Loki',             note: ['DORA Art. 17 — log retention', 'DORA Art. 17 — log retention'] },

--- a/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
+++ b/openbank-admin-ui/src/app/docs/cloud-architecture/page.tsx
@@ -101,11 +101,12 @@ const NAMESPACES: NS[] = [
     ],
   },
   {
-    id: 'data', label: 'ns: cnpg-system / messaging / iam',
+    id: 'data', label: 'ns: cnpg-system / messaging / temporal / iam',
     note: ['OSS operátory pro data + identitu — in-cluster stavové jádro dle ADR-0027.', 'OSS data + identity operators — the in-cluster stateful core per ADR-0027.'],
     nodes: [
       node('cnpg', ['CloudNativePG (operátor)', 'CloudNativePG (operator)'], 'live', ['Postgres operátor Running v ns cnpg-system. Spravuje PG clustery podle domén (accounts-db, keycloak-db, apicurio-db).', 'Postgres operator Running in ns cnpg-system. Manages the per-domain PG clusters (accounts-db, keycloak-db, apicurio-db).']),
       node('kafka', ['Strimzi / Kafka', 'Strimzi / Kafka'], 'live', ['Strimzi operátor + Kafka broker (openbank-cluster) Running v ns messaging. ArgoCD app „kafka" je OutOfSync (config drift), byť Healthy.', 'Strimzi operator + Kafka broker (openbank-cluster) Running in ns messaging. ArgoCD app "kafka" is OutOfSync (config drift) though Healthy.']),
+      node('temporal', ['Temporal (workflow engine)', 'Temporal (workflow engine)'], 'live', ['Orchestrace platebních a závěrkových workflow (settlement, SEPA, statement EoM). Frontend :7233 v ns temporal + vlastní Postgres (CNPG); aplikační workery se připojují gRPC při startu (ADR-0057 app-plane).', 'Payment & close workflow orchestration (settlement, SEPA, statement EoM). Frontend :7233 in ns temporal + own Postgres (CNPG); app workers connect via gRPC at startup (ADR-0057 app-plane).']),
       node('apicurio', ['Apicurio (SQL storage)', 'Apicurio (SQL storage)'], 'live', ['Schema registry + vlastní Postgres (apicurio-db) Running v ns messaging — SQL storage, splňuje podmínku go-live ADR-0027 (ne in-memory).', 'Schema registry + its own Postgres (apicurio-db) Running in ns messaging — SQL storage, satisfying the ADR-0027 go-live condition (not in-memory).']),
       node('keycloak', ['Keycloak', 'Keycloak'], 'live', ['OIDC identity provider + keycloak-db Running v ns iam. ArgoCD app keycloak Synced + Healthy.', 'OIDC identity provider + keycloak-db Running in ns iam. ArgoCD app keycloak Synced + Healthy.']),
       node('valkey', ['Valkey / Redis', 'Valkey / Redis'], 'live', ['Cache/zámky (redis) Running v ns accounts vedle služby, která ji používá.', 'Cache/locks (redis) Running in ns accounts alongside the service that uses it.']),

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -53,7 +53,7 @@ const SERVICES = [
   { id: 'statement',   name: 'Statement Service',    port: 8136, group: 'core',    x: 625, y: 220,  color: '#2563eb', desc: 'Account statement generation (EoM)' },
   { id: 'onboarding',  name: 'Onboarding Service',   port: 8130, group: 'identity', x: 750, y: 220,  color: '#059669', desc: 'Customer onboarding journey (ADR-0069)' },
   { id: 'anacredit',   name: 'AnaCredit Service',    port: 8137, group: 'compliance', x: 1080, y: 500, color: '#dc2626', desc: 'AnaCredit regulatory reporting (ECB)' },
-  { id: 'sdd',         name: 'SEPA Direct Debit',    port: 8132, group: 'payment', x: 375, y: 500,  color: '#7c3aed', desc: 'SEPA Direct Debit mandates and collections' },
+  { id: 'sdd',         name: 'SEPA Direct Debit',    port: 8129, group: 'payment', x: 375, y: 500,  color: '#7c3aed', desc: 'SEPA Direct Debit mandates and collections' },
 ]
 
 // Service dependencies (edges)

--- a/openbank-admin-ui/src/app/infrastructure/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/page.tsx
@@ -8,7 +8,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import {
   Server, Database, Activity, RefreshCw, AlertTriangle,
-  Lock, Layers, HardDrive, CheckCircle2, XCircle, LayoutTemplate, Eye
+  Lock, Layers, HardDrive, CheckCircle2, XCircle, LayoutTemplate, Eye,
+  Workflow, Zap, GitBranch, ShieldCheck, Cpu
 } from 'lucide-react'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 import { LifecycleStrip, type CompLifecycle } from '@/components/infra/LifecycleStrip'
@@ -43,6 +44,13 @@ const INFRA_COMPONENTS: InfraComponent[] = [
   { id: 'glitchtip',       name: 'GlitchTip',          probeNote: 'TCP :80 · error tracking (Sentry API)', icon: <AlertTriangle size={20} /> },
   { id: 'goalert',         name: 'GoAlert',            probeNote: 'TCP :8080 · on-call escalation',       icon: <AlertTriangle size={20} /> },
   { id: 'ntfy',            name: 'ntfy',               probeNote: 'TCP :8080 · push notifications',       icon: <Activity size={20} /> },
+  // Platform control plane + orchestration (verified against the live cluster).
+  { id: 'temporal',        name: 'Temporal',           probeNote: 'TCP :7233 · workflow orchestration',   icon: <Workflow size={20} /> },
+  { id: 'keda',            name: 'KEDA',               probeNote: 'TCP :9666 · event-driven / scale-to-zero', icon: <Zap size={20} /> },
+  { id: 'argocd',          name: 'ArgoCD',             probeNote: 'TCP :80 · GitOps engine (app-of-apps)', icon: <GitBranch size={20} /> },
+  { id: 'kyverno',         name: 'Kyverno',            probeNote: 'TCP :8000 · admission policy',          icon: <ShieldCheck size={20} /> },
+  { id: 'cert-manager',    name: 'cert-manager',       probeNote: 'TCP :9402 · TLS certificate lifecycle', icon: <Lock size={20} /> },
+  { id: 'karpenter',       name: 'Karpenter',          probeNote: 'TCP :8080 · node autoscaler (Spot/arm64)', icon: <Cpu size={20} /> },
 ]
 
 interface StatusResult {

--- a/openbank-admin-ui/src/test/infra-status-probes.test.ts
+++ b/openbank-admin-ui/src/test/infra-status-probes.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect } from 'vitest'
+import { CLUSTER_INFRA, LOCAL_INFRA, probeInfra } from '@/app/api/infra/status/route'
+
+// The infra ids are a stable contract consumed by /docs/bcp and /infrastructure.
+// These checks give the probe map consistent coverage without depending on a live
+// cluster (the review ask on #764).
+
+describe('infra-status probe definitions', () => {
+  it('includes the platform control plane + orchestration ids in the cluster map', () => {
+    const ids = new Set(CLUSTER_INFRA.map(d => d.id))
+    for (const id of ['temporal', 'keda', 'argocd', 'kyverno', 'cert-manager', 'karpenter']) {
+      expect(ids.has(id), `CLUSTER_INFRA missing ${id}`).toBe(true)
+    }
+  })
+
+  it('probes Temporal on its verified frontend Service DNS + port', () => {
+    const temporal = CLUSTER_INFRA.find(d => d.id === 'temporal')
+    expect(temporal?.probe).toEqual({ kind: 'tcp', host: 'temporal-frontend.temporal.svc', port: 7233 })
+  })
+
+  it('registers the new platform ids in both maps (in-cluster + off-cluster)', () => {
+    // Off-cluster the control plane isn't deployed, so it must be present as an
+    // `absent` probe (→ UNKNOWN) rather than missing entirely (which would leave
+    // the /infrastructure card with no status at all).
+    const clusterIds = new Set(CLUSTER_INFRA.map(d => d.id))
+    const localMap = new Map(LOCAL_INFRA.map(d => [d.id, d.probe]))
+    for (const id of ['temporal', 'keda', 'argocd', 'kyverno', 'cert-manager', 'karpenter']) {
+      expect(clusterIds.has(id), `CLUSTER_INFRA missing ${id}`).toBe(true)
+      expect(localMap.get(id), `LOCAL_INFRA missing ${id}`).toEqual({ kind: 'absent' })
+    }
+  })
+
+  it('every probe has a valid kind and no duplicate ids', () => {
+    for (const map of [CLUSTER_INFRA, LOCAL_INFRA]) {
+      const ids = map.map(d => d.id)
+      expect(new Set(ids).size, 'duplicate infra id').toBe(ids.length)
+      for (const d of map) expect(['http', 'tcp', 'absent']).toContain(d.probe.kind)
+    }
+  })
+
+  it('an "absent" probe resolves to UNKNOWN without any network call', async () => {
+    const res = await probeInfra({ id: 'temporal', probe: { kind: 'absent' } })
+    expect(res.status).toBe('UNKNOWN')
+    expect(res.latencyMs).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Several inventory/topology views were missing technologies the platform actually runs — most conspicuously **Temporal** (workflow orchestration for settlement, SEPA and the EoM statement close), which was absent from BCP as reported.

## Type of change

- [x] Fix (stale/incorrect inventory) + small additions

## Linked issues

Refs #759

## Changes

- **Infrastructure**, **BCP**, **cloud-architecture** now include **Temporal**. Infrastructure additionally adds the platform control plane — **KEDA, ArgoCD, Kyverno, cert-manager, Karpenter** — with TCP health probes **verified against the live cluster** (`api/infra/status`: real Service DNS + ports; off-cluster they report UNKNOWN, never a false DOWN).
- **BCP**: Temporal → Tier 0 (runtime-critical orchestration); KEDA → Tier 5 (scale-to-zero, ADR-0057); PostgreSQL relabelled **CloudNativePG** (the operator).
- **cloud-architecture**: Temporal node added to the stateful-core namespace group.
- **service-map**: fixed a wrong port on sdd-service (`8129`, was `8132` — actually billing's port).

The **cluster** and **system-health** views are already data-driven (K8s discovery / generated `cluster-topology.json`) and needed no change. The service-map's existing **drift banner** continues to surface any services present in the catalog but not yet placed on the map (billing, finrep, settlement, copilot, customer-edge) — a follow-up placement, not a regression.

## Definition of Done

- [x] `tsc --noEmit` clean
- [x] `vitest run` green (414 tests incl. i18n / layout / graceful-state guards)
- [x] `next build` succeeds
- [x] eslint: no new errors
- [x] Every new infra probe target verified against the live cluster (`kubectl get svc`)

## Security / compliance impact

None. Read-only topology views; the new probes are in-cluster TCP reachability checks (no auth, no data). Off-cluster they degrade to UNKNOWN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)