### PR TITLE
fix(gitops): restore product-catalog (JVM) and statement-service so Fees and Closings work

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -19,6 +19,20 @@
 # (minReplicas: 0) stays; JVM cold-start is slower but the admin-ui auto-wakes it. The
 # native pilot work is preserved (Dockerfile.native); it is simply not deployed to the fleet.
 # Do NOT declare `openbank-product-catalog: T1` in `rules.yaml:finops_tiers.declared`.
+#
+# Verification of this rollback:
+#  - sandbox-a407c3ae is the STANDARD JVM fast-jar build (build-push-service.sh),
+#    the same pipeline the other ~40 fleet services run in production — not a
+#    bespoke image. It carries a valid SBOM attestation (.att/.sig in ECR), so
+#    Kyverno verify-openbank-image-sbom-attestation admits it (the exact policy
+#    that was blocking statement-service on an un-attested tag).
+#  - Probe budget: startupProbe 5s + 30×5s = 155s, well above a JVM boot + Flyway
+#    migration; identical to the pre-native manifest that ran green. Resources
+#    (256Mi req / 512Mi limit) are unchanged from that JVM baseline.
+#  - Runtime SLA is only observable post-deploy: after merge, watch the ArgoCD
+#    `accounts` app roll the new ReplicaSet, confirm the pod reaches Ready and
+#    GET /api/v1/fees serves, and roll back this tag on failure. KEDA keeps it at
+#    0 replicas until a request wakes it (the admin-ui auto-wake covers cold start).
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -7,17 +7,18 @@
 # Quarkus management endpoints (health, metrics) bind to a separate port (8085).
 # QUARKUS_MANAGEMENT_HOST=0.0.0.0 is required so kubelet probes can reach them.
 #
-# ADR-0083 T1 native cutover (2026-07-06, #253). This Deployment now runs the
-# Mandrel/GraalVM native image (openbank-product-catalog/Dockerfile.native), not the
-# JVM fast-jar image every other service in the fleet still uses — the first native
-# cutover in the repo. startupProbe/readinessProbe are tuned to match (initialDelaySeconds:
-# 0, periodSeconds: 1 — a ~0.2-0.3s native process doesn't need the ~5s of JVM-scoped
-# headroom the previous probe carried). Do NOT copy this probe config onto a JVM-image
-# service without re-adding that headroom. The existing `product-catalog-http-scaledobject.yaml`
-# HTTPScaledObject (minReplicas: 0) was already live against the old JVM image; this
-# cutover is what actually makes its cold-start assumption true. Burn-in window before
-# declaring `openbank-product-catalog: T1` in `rules.yaml:finops_tiers.declared` per the
-# ADR's own Pilot plan step 5 — do not declare T1 from this manifest alone.
+# ADR-0083 T1 native pilot — ROLLED BACK to the JVM fast-jar image (open-bank-oss#253).
+# The native image compiled and cold-started, but every HTTP request 500s at runtime
+# (root cause still open in #253), so Fees / the fee-schedule vertical never served. Until
+# #253 is fixed, this Deployment runs the standard JVM fast-jar image like the rest of the
+# fleet. The startupProbe/readinessProbe are therefore restored to JVM-scoped headroom
+# (a JVM + Flyway-at-start needs far more than the ~10s the native-tuned probe allowed, or
+# the pod is killed before it becomes ready). The native-tuning was: startupProbe
+# initialDelaySeconds 0 / periodSeconds 1 / failureThreshold 10 — do NOT reinstate without
+# the native image. The `product-catalog-http-scaledobject.yaml` HTTPScaledObject
+# (minReplicas: 0) stays; JVM cold-start is slower but the admin-ui auto-wakes it. The
+# native pilot work is preserved (Dockerfile.native); it is simply not deployed to the fleet.
+# Do NOT declare `openbank-product-catalog: T1` in `rules.yaml:finops_tiers.declared`.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,7 +55,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:native-a2e14752
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-a407c3ae
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -81,15 +82,17 @@ spec:
             httpGet:
               path: /q/health/ready
               port: management
-            initialDelaySeconds: 0
-            periodSeconds: 1
-            failureThreshold: 10
+            # JVM-scoped headroom (restored from the pre-native manifest): a JVM
+            # cold start + Flyway-at-start needs well over the native-tuned 10s.
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
           readinessProbe:
             httpGet:
               path: /q/health/ready
               port: management
-            periodSeconds: 1
-            failureThreshold: 10
+            periodSeconds: 10
+            failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /q/health/live

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -36,7 +36,12 @@ spec:
           type: RuntimeDefault
       containers:
         - name: statement-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-statement-service:sandbox-40e0c9d1c
+          # Re-pinned to an SBOM-attested image (open-bank-oss#759). The previous tag
+          # sandbox-40e0c9d1c (a non-main build) had no valid SBOM attestation, so
+          # Kyverno's verify-openbank-image-sbom-attestation policy blocked every pod
+          # (Deployment stuck at 0/1) → the EoM close / Closings screen read "not
+          # responding". sandbox-a407c3ae is the #706 main build with a valid attestation.
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-statement-service:sandbox-a407c3ae
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary

The backend half of #759. Two services were genuinely down (not just scaled to zero), which the admin console honestly reported as *"Product-catalog is not responding"* (Fees) and *"Statement-service is not responding"* (Closings). Both root causes are deploy-config, not code.

## Type of change

- [x] Fix (deploy config / image re-pin)

## Linked issues

Refs #759

## Changes

**product-catalog → JVM** (`accounts/product-catalog.yaml`)
- Was running the ADR-0083 **native** image (`native-a2e14752`), which cold-starts but **500s on every HTTP request** (open-bank-oss#253) — Fees never populated. Rolled back to the **JVM fast-jar** image `sandbox-a407c3ae` (#706, SBOM-attested).
- Restored **JVM-scoped probe headroom** — the native-tuned `startupProbe` (`initialDelaySeconds 0 / periodSeconds 1 / failureThreshold 10` ≈ 10s) would kill a JVM + Flyway-at-start pod before it becomes ready. Now `5 / 5 / 30` (≈155s), matching the pre-native manifest. Resources unchanged (it already ran JVM at 256Mi/512Mi).
- The native pilot work (`Dockerfile.native`) is preserved — just not deployed — pending #253.

**statement-service** (`statements/statement-service.yaml`)
- Was pinned to `sandbox-40e0c9d1c`, a **non-main build with no valid SBOM attestation**, so Kyverno's `verify-openbank-image-sbom-attestation` policy blocked every pod (Deployment stuck at **0/1**, ArgoCD `statements` Progressing). Re-pinned to `sandbox-a407c3ae` (#706, attested). statement-service code is unchanged since #134, so #706 carries current code.

## Verification

- Both image tags verified present in ECR with a `.att` (SBOM attestation) + `.sig` (2026-07-09).
- Commit `a407c3ae` confirmed on `origin/main` (#706).
- Both manifests parse cleanly (`yaml.safe_load_all`).
- Post-merge, ArgoCD (apps `accounts`, `statements`) will roll the new images; watch for Ready pods, then Fees + Closings should serve. product-catalog wakes on demand (KEDA HTTP scale-to-zero); the admin-ui auto-wake (PR #760) covers the JVM cold start.

## Notes

- **Please review before merge** — do not admin-merge past the review gate. If auto-merge is blocked, that is the correct final state.
- No `rules.yaml` T1 native declaration (never declared; #253 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)