### PR TITLE
security(security-scanner): add missing RBAC and OIDC config

### DIFF
--- a/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/infrastructure/rest/IctIncidentResource.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/infrastructure/rest/IctIncidentResource.kt
@@ -5,10 +5,20 @@
 package com.openbank.securityscanner.infrastructure.rest
 
 import com.openbank.securityscanner.application.IctIncidentService
-import com.openbank.securityscanner.application.IctIncidentNotFoundException
 import com.openbank.securityscanner.application.ReportIncidentCommand
-import com.openbank.securityscanner.domain.*
-import jakarta.ws.rs.*
+import com.openbank.securityscanner.domain.IncidentCategory
+import com.openbank.securityscanner.domain.IncidentSeverity
+import com.openbank.securityscanner.domain.IncidentStatus
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
@@ -20,6 +30,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "ICT Incidents")
+@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
 class IctIncidentResource(private val service: IctIncidentService, private val clock: Clock) {
 
     @POST

--- a/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/infrastructure/rest/SecurityScannerResource.kt
+++ b/openbank-security-scanner/src/main/kotlin/com/openbank/securityscanner/infrastructure/rest/SecurityScannerResource.kt
@@ -8,9 +8,17 @@ import com.openbank.securityscanner.application.SecurityScannerService
 import io.quarkus.scheduler.Scheduled
 import io.smallrye.config.ConfigMapping
 import io.smallrye.config.WithName
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.ws.rs.*
-import jakarta.ws.rs.core.MediaType; import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
 
@@ -18,7 +26,8 @@ data class ServiceConfig(val name: String, val url: String, val port: Int)
 
 @ConfigMapping(prefix = "openbank.security-scanner")
 interface SecurityScannerConfig {
-    @WithName("scan-interval-minutes") fun scanIntervalMinutes(): Int
+    @WithName("scan-interval-minutes")
+    fun scanIntervalMinutes(): Int
     fun services(): List<ServiceEntry>
     interface ServiceEntry {
         fun name(): String
@@ -32,41 +41,55 @@ interface SecurityScannerConfig {
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Security Scanner", description = "OWASP Top 10 security scanning for all microservices")
-class SecurityScannerResource(
-    private val scanner: SecurityScannerService,
-    private val config: SecurityScannerConfig
-) {
+class SecurityScannerResource(private val scanner: SecurityScannerService, private val config: SecurityScannerConfig) {
     private fun serviceList() = config.services().map { it.name() to it.url() }
 
-    @GET @Path("/report")
+    @GET
+    @Path("/report")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Get latest security scan report")
-    fun getReport(): Response =
-        scanner.getLastReport()?.let { Response.ok(it).build() }
-            ?: Response.status(404).entity(mapOf("message" to "No scan completed yet. POST /api/v1/security/scan to trigger.")).build()
+    fun getReport(): Response = scanner.getLastReport()?.let { Response.ok(it).build() }
+        ?: Response.status(404).entity(
+            mapOf(
+                "message" to "No scan completed yet. POST /api/v1/security/scan to trigger.",
+            ),
+        ).build()
 
-    @POST @Path("/scan")
+    @POST
+    @Path("/scan")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Trigger a full security scan of all services")
     fun triggerScan(): Response = Response.ok(scanner.scanAll(serviceList())).build()
 
-    @GET @Path("/services/{name}")
+    @GET
+    @Path("/services/{name}")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Get security scan result for a specific service")
     fun getServiceResult(@PathParam("name") name: String): Response =
         scanner.getServiceResult(name)?.let { Response.ok(it).build() }
             ?: Response.status(404).entity(mapOf("error" to "No scan result for service: $name")).build()
 
-    @GET @Path("/services")
+    @GET
+    @Path("/services")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     @Operation(summary = "Get all service scan results")
     fun getAllResults(): Response = Response.ok(scanner.getAllResults()).build()
 
-    @GET @Path("/info")
+    // Intentionally public: static capability/standards metadata, no scan data. Explicit
+    // @PermitAll (not just unannotated) documents that this is a deliberate choice.
+    @GET
+    @Path("/info")
+    @PermitAll
     @Operation(summary = "Security scanner info")
     fun info() = mapOf(
         "service" to "openbank-security-scanner",
         "version" to "0.1.0",
         "capabilities" to listOf("owasp-top10", "security-headers", "cors-check", "actuator-exposure", "tls-check"),
-        "standards" to listOf("OWASP Top 10 2021", "EBA ICT Risk Guidelines", "PSD2 RTS", "NIST SP 800-53")
+        "standards" to listOf("OWASP Top 10 2021", "EBA ICT Risk Guidelines", "PSD2 RTS", "NIST SP 800-53"),
     )
 
     @Scheduled(every = "30m", delayed = "2m")
-    fun scheduledScan() { scanner.scanAll(serviceList()) }
+    fun scheduledScan() {
+        scanner.scanAll(serviceList())
+    }
 }

--- a/openbank-security-scanner/src/main/resources/application.yaml
+++ b/openbank-security-scanner/src/main/resources/application.yaml
@@ -43,6 +43,16 @@ quarkus:
     root-path: /q
   dev-ui:
     enabled: false
+  # quarkus-oidc was already a build dependency but never configured — every REST endpoint
+  # was reachable with no authentication at all (issue found alongside the AmlCaseResource /
+  # StandingOrderResource / TppRegistryResource unauthenticated-endpoint sweep).
+  oidc:
+    auth-server-url: http://localhost:8080/realms/openbank
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    tls:
+      verification: none
 
 "%dev":
   quarkus:
@@ -50,6 +60,11 @@ quarkus:
       level: DEBUG
       console:
         json: false
+
+"%test":
+  quarkus:
+    oidc:
+      enabled: false
 
 mp:
   messaging:

--- a/openbank-security-scanner/src/test/kotlin/com/openbank/securityscanner/infrastructure/rest/SecurityScannerAuthzTest.kt
+++ b/openbank-security-scanner/src/test/kotlin/com/openbank/securityscanner/infrastructure/rest/SecurityScannerAuthzTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.securityscanner.infrastructure.rest
+
+import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.DELETE
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Regression guard: SecurityScannerResource and IctIncidentResource had zero security
+ * annotations (and the service had no quarkus.oidc config at all) — every endpoint was
+ * unauthenticated-accessible, exposing fleet-wide OWASP scan results (an attack roadmap) and
+ * letting anyone falsify DORA regulator-facing incident status. Reflection, no boot needed.
+ */
+class SecurityScannerAuthzTest {
+
+    private val httpVerbs =
+        listOf(GET::class.java, POST::class.java, PUT::class.java, DELETE::class.java, PATCH::class.java)
+
+    private fun Method.isHttpEndpoint() = httpVerbs.any { getAnnotation(it) != null }
+
+    private fun assertEveryEndpointRoleGatedOrExplicitlyPublic(resourceClass: Class<*>) {
+        val classLevelRoles = resourceClass.getAnnotation(RolesAllowed::class.java)
+        val all = resourceClass.declaredMethods.filter { it.isHttpEndpoint() }
+        assertThat(all)
+            .describedAs("expected to find HTTP endpoints by reflection on %s", resourceClass.simpleName)
+            .isNotEmpty
+
+        all.forEach { m ->
+            val methodRoles = m.getAnnotation(RolesAllowed::class.java)
+            val permitAll = m.getAnnotation(PermitAll::class.java)
+            assertThat(methodRoles != null || classLevelRoles != null || permitAll != null)
+                .describedAs(
+                    "%s.%s must be @RolesAllowed (method or class level) or explicitly @PermitAll",
+                    resourceClass.simpleName,
+                    m.name,
+                )
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `every SecurityScannerResource endpoint is role-gated or explicitly public`() {
+        assertEveryEndpointRoleGatedOrExplicitlyPublic(SecurityScannerResource::class.java)
+    }
+
+    @Test
+    fun `every IctIncidentResource endpoint is role-gated`() {
+        assertEveryEndpointRoleGatedOrExplicitlyPublic(IctIncidentResource::class.java)
+    }
+}


### PR DESCRIPTION
## Summary

`quarkus-oidc` was a build dependency but never configured — combined with `quarkus.security.jaxrs.deny-unannotated-endpoints` defaulting to `false`, every endpoint on `SecurityScannerResource` and `IctIncidentResource` was unauthenticated-accessible. Found via the fleet-wide sweep that started with `openbank-aml-service` (#757) and `standing-order-service`/`tpp-registry-service` (#758).

- **`SecurityScannerResource`**: `getReport`/`triggerScan`/`getServiceResult`/`getAllResults` now require `ROLE_OPERATOR`/`ROLE_ADMIN` — these expose OWASP scan results across the whole fleet (an attack roadmap) and let anyone trigger a scan. `info()` (static capability metadata, no scan data) gets an explicit `@PermitAll` instead of staying unannotated — documents the openness as deliberate rather than an oversight.
- **`IctIncidentResource`**: class-level `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")` — this is DORA-relevant regulator-facing ICT incident reporting; `markReportedToRegulator`/`updateStatus` were previously forgeable by anyone.
- Added the standard OIDC config block, matching every other service's pattern.

## Test plan
- [x] `SecurityScannerAuthzTest` (new) — 2/2 passing, asserts every endpoint is role-gated or explicitly `@PermitAll`.
- [x] Full `test` + `ktlintCheck` + `detekt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)