### PR TITLE
security(product-catalog): add RBAC to mutating catalog endpoints

### DIFF
--- a/openbank-product-catalog/build.gradle.kts
+++ b/openbank-product-catalog/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.jackson.module.kotlin)
     implementation(libs.jackson.datatype.jsr310)
+    // OIDC for the mutating catalog endpoints (create/update/activate/deactivate) — this
+    // service had no security extension at all until this fix.
+    implementation(libs.quarkus.oidc)
 
     // Persistence: reactive Panache + Postgres + Flyway, the fleet standard (ADR-0009/0105 P1).
     // openbank-libs is built on reactive Panache, so a service that depends on it must use reactive
@@ -35,6 +38,7 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.quarkus.junit5)
+    testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogResource.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogResource.kt
@@ -6,8 +6,16 @@ package com.openbank.productcatalog.infrastructure.rest
 
 import com.openbank.productcatalog.application.ProductCatalogService
 import com.openbank.productcatalog.application.ProductRequest
+import jakarta.annotation.security.RolesAllowed
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.ws.rs.*
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 
@@ -16,6 +24,8 @@ import jakarta.ws.rs.core.Response
 @Produces(MediaType.APPLICATION_JSON)
 class ProductCatalogResource(private val service: ProductCatalogService) {
 
+    // Public reference data by design (no auth) — the admin UI and other services read the
+    // live catalog without credentials.
     @GET
     suspend fun list(
         @QueryParam("type") type: String?,
@@ -43,6 +53,7 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun create(req: ProductRequest): Response = try {
         val product = service.create(req)
         Response.status(201).entity(product).build()
@@ -53,6 +64,7 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
     @PUT
     @Path("/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun update(@PathParam("id") id: String, req: ProductRequest): Response = try {
         Response.ok(service.update(id, req)).build()
     } catch (e: NoSuchElementException) {
@@ -63,6 +75,7 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @POST
     @Path("/{id}/activate")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun activate(@PathParam("id") id: String): Response = try {
         Response.ok(service.activate(id)).build()
     } catch (e: NoSuchElementException) {
@@ -71,6 +84,7 @@ class ProductCatalogResource(private val service: ProductCatalogService) {
 
     @POST
     @Path("/{id}/deactivate")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
     suspend fun deactivate(@PathParam("id") id: String): Response = try {
         Response.ok(service.deactivate(id)).build()
     } catch (e: NoSuchElementException) {

--- a/openbank-product-catalog/src/main/resources/application.yaml
+++ b/openbank-product-catalog/src/main/resources/application.yaml
@@ -46,8 +46,20 @@ quarkus:
   swagger-ui:
     always-include: true
     path: /api/docs
+  # Guards create/update/activate/deactivate (mutating the live product/fee catalog). The
+  # read endpoints (list/getById/getByCode/getFees) stay open by design — public reference
+  # data the admin UI's pricing screens read without auth.
+  oidc:
+    auth-server-url: http://localhost:8080/realms/openbank
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    tls:
+      verification: none
 
 "%test":
   quarkus:
     management:
+      enabled: false
+    oidc:
       enabled: false

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/ProductCatalogResourceTest.kt
@@ -3,19 +3,28 @@ package com.openbank.productcatalog
 
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
 import io.restassured.module.kotlin.extensions.Given
 import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
+// @RolesAllowed added to create/update/activate/deactivate (this class's own security fix);
+// authenticate as an operator so those calls don't 403. The reads stay unauthenticated by
+// design, and @TestSecurity is a no-op for them either way.
 @QuarkusTest
 @QuarkusTestResource(PostgresTestResource::class)
+@TestSecurity(user = "test-operator", roles = ["ROLE_OPERATOR"])
 class ProductCatalogResourceTest {
 
     @Test
     fun `GET products returns seed data`() {
-        val body = (Given { this } When { get("/api/v1/products") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/products") } Then { statusCode(200) }
+            ).extract().body().asString()
         assertThat(body).contains("SAVINGS_STANDARD")
     }
 
@@ -32,7 +41,11 @@ class ProductCatalogResourceTest {
     @Test
     fun `POST create product returns 201`() {
         val payload = """{"code":"TEST_PROD","name":"Test","type":"SAVINGS","currency":"EUR"}"""
-        Given { contentType("application/json"); body(payload) } When { post("/api/v1/products") } Then { statusCode(201) }
+        Given {
+            contentType("application/json")
+            body(payload)
+        } When { post("/api/v1/products") } Then
+            { statusCode(201) }
     }
 
     @Test
@@ -42,7 +55,11 @@ class ProductCatalogResourceTest {
 
     @Test
     fun `CZK current account is seeded as a multi-currency CZK-base product`() {
-        val body = (Given { this } When { get("/api/v1/products/prod-014") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/products/prod-014") } Then { statusCode(200) }
+            ).extract().body().asString()
         assertThat(body).contains("CURRENT_CZK")
         assertThat(body).contains("\"currency\":\"CZK\"")
         assertThat(body).contains("\"defaultCurrency\":\"CZK\"")
@@ -52,15 +69,25 @@ class ProductCatalogResourceTest {
     fun `GET product by canonical account UUID resolves the seeded product (ADR-0105)`() {
         // account-service references the CZK current/savings products by the UUID it stamps on
         // accounts.product_id; the catalogue must resolve those UUIDs to the same products.
-        val current = (Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then { statusCode(200) }).extract().body().asString()
+        val current = (
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c2") } Then
+                { statusCode(200) }
+            ).extract().body().asString()
         assertThat(current).contains("CURRENT_CZK")
-        val savings = (Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then { statusCode(200) }).extract().body().asString()
+        val savings = (
+            Given { this } When { get("/api/v1/products/00000000-0000-0000-0000-0000000000c3") } Then
+                { statusCode(200) }
+            ).extract().body().asString()
         assertThat(savings).contains("SAVINGS_CZK")
     }
 
     @Test
     fun `multi-currency umbrella account is seeded with a broad currency set`() {
-        val body = (Given { this } When { get("/api/v1/products/prod-015") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/products/prod-015") } Then { statusCode(200) }
+            ).extract().body().asString()
         assertThat(body).contains("CURRENT_MULTICURRENCY_UMBRELLA")
         assertThat(body).contains("\"enabled\":true")
         // 12-currency pocket umbrella: assert a representative spread is present.
@@ -79,7 +106,11 @@ class ProductCatalogResourceTest {
 
     @Test
     fun `GET fees filters by currency`() {
-        val body = (Given { this } When { get("/api/v1/fees?currency=CZK") } Then { statusCode(200) }).extract().body().asString()
+        val body = (
+            Given {
+                this
+            } When { get("/api/v1/fees?currency=CZK") } Then { statusCode(200) }
+            ).extract().body().asString()
         // CZK-base products contribute CZK fees; EUR-only fees must be filtered out.
         assertThat(body).contains("\"currency\":\"CZK\"")
         assertThat(body).doesNotContain("\"currency\":\"EUR\"")

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogAuthzTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/infrastructure/rest/ProductCatalogAuthzTest.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.infrastructure.rest
+
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard: ProductCatalogResource had zero security annotations anywhere — including
+ * create/update/activate/deactivate, which mutate the live product/fee catalog. The reads
+ * (list/getById/getByCode/getFees) stay intentionally open (public reference data for the admin
+ * UI's pricing screens); this test pins that split so a future PR can't silently widen or
+ * narrow it without a visible diff here.
+ */
+class ProductCatalogAuthzTest {
+
+    private val mutatingMethodNames = setOf("create", "update", "activate", "deactivate")
+
+    @Test
+    fun `every mutating endpoint is role-gated`() {
+        val methods = ProductCatalogResource::class.java.declaredMethods
+            .filter { it.name in mutatingMethodNames }
+            .filter { it.getAnnotation(POST::class.java) != null || it.getAnnotation(PUT::class.java) != null }
+
+        assertThat(methods).describedAs("expected to find the 4 mutating endpoints by reflection").hasSize(4)
+        methods.forEach { m ->
+            assertThat(m.getAnnotation(RolesAllowed::class.java))
+                .describedAs("%s must be @RolesAllowed", m.name)
+                .isNotNull()
+        }
+    }
+
+    @Test
+    fun `read endpoints stay intentionally open`() {
+        listOf("list", "getById", "getByCode", "getFees").forEach { name ->
+            val m = ProductCatalogResource::class.java.declaredMethods.single { it.name == name }
+            assertThat(m.getAnnotation(RolesAllowed::class.java))
+                .describedAs("%s is public reference data by design — should NOT carry @RolesAllowed", name)
+                .isNull()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`openbank-product-catalog` had no OIDC dependency or configuration at all. `create`/`update`/`activate`/`deactivate` on `ProductCatalogResource` are now `ROLE_OPERATOR`/`ROLE_ADMIN`-gated — previously anyone could tamper with the live product/fee catalog with no authentication.

Reads (`list`/`getById`/`getByCode`/`getFees`, and all of `FeesResource`) stay intentionally open — public reference data the admin UI's pricing screens read without credentials, per `FeesResource`'s own existing docstring. Not changing that split without confirming it's actually the intended design.

## Test plan
- [x] Existing `ProductCatalogResourceTest` needed `@TestSecurity(roles = ["ROLE_OPERATOR"])` at the class level to keep exercising the now-gated `create`/`activate` calls — updated.
- [x] `ProductCatalogAuthzTest` (new) — pins the open/gated split via reflection so it can't silently drift.
- [x] Full `test` + `ktlintCheck` + `detekt` — clean, including the pre-existing `ProductCatalogBootSmokeIT`.

Found via the fleet-wide unauthenticated-endpoint sweep (#757, #758).

🤖 Generated with [Claude Code](https://claude.com/claude-code)