### PR TITLE
security(party): require authentication on the GDPR export endpoint

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -191,8 +191,14 @@ class PartyResource {
         return Response.noContent().build()
     }
 
+    // @Authenticated (not @RolesAllowed) because this endpoint accepts three different valid
+    // caller shapes — ROLE_ADMIN, ROLE_DPO, or the subject's own JWT — which the method body
+    // below already checks; @RolesAllowed alone can't express "self OR one of these roles".
+    // Previously carried no annotation at all — reachable with no identity whatsoever, unlike
+    // every other endpoint on this resource.
     @GET
     @Path("/{id}/gdpr-export")
+    @Authenticated
     @Operation(summary = "Export all PII held for a party — GDPR Art. 15 Right of Access (ADR-0118)")
     suspend fun exportPartyGdpr(@PathParam("id") id: UUID): Response {
         val isAdmin = securityIdentity.hasRole("ROLE_ADMIN")

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyApiIT.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/integration/PartyApiIT.kt
@@ -286,6 +286,20 @@ class PartyApiIT {
         }
     }
 
+    @Test
+    @Order(16)
+    fun `GET gdpr-export with no identity at all returns 401`() {
+        // Previously this endpoint carried no @Authenticated/@RolesAllowed annotation and an
+        // anonymous caller reached the handler's own manual role check; now @Authenticated
+        // rejects it before that.
+        val id = createdPartyId ?: return
+        Given { this } When {
+            get("/api/v1/parties/$id/gdpr-export")
+        } Then {
+            statusCode(401)
+        }
+    }
+
     // ── ADR-0055 name search ──────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

`exportPartyGdpr` (`GET /{id}/gdpr-export`) carried no JAX-RS security annotation at all — reachable with zero identity, unlike every other endpoint on `PartyResource`. A manual role/self-ownership check in the method body (`ROLE_ADMIN`, `ROLE_DPO`, or the JWT subject matching the party) was the only gate, silently opting out of the framework-level RBAC layer.

Uses `@Authenticated` (not `@RolesAllowed`) since the endpoint accepts three different valid caller shapes plain role-listing can't express — "self OR ROLE_ADMIN OR ROLE_DPO" — which the existing method body already implements correctly. `@Authenticated` only closes the "zero identity at all" gap, matching `getMyParty`'s existing pattern on the same resource.

## Test plan
- [x] New test: a fully anonymous request now gets 401. None of the existing `gdpr-export` tests exercised the truly-anonymous case — all three already authenticated via `@TestSecurity`.
- [x] Full `PartyApiIT` — 20/20 passing.
- [x] `ktlintCheck` + `detekt` — clean.

Found via the fleet-wide unauthenticated-endpoint sweep (#757, #758).

🤖 Generated with [Claude Code](https://claude.com/claude-code)