### PR TITLE
security(consent,sca): pair @Authorize with @RolesAllowed on every endpoint

### DIFF
--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -23,6 +23,7 @@ import com.openbank.libs.authz.Authorize
 import com.openbank.libs.idempotency.IdempotencyStore
 import org.eclipse.microprofile.openapi.annotations.Operation
 import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
@@ -38,10 +39,14 @@ import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.core.UriInfo
 import java.util.UUID
 
+// @Authorize alone is the fine-grained per-resource check; it must be paired with the coarse
+// @RolesAllowed gate (libs-domain's own Authorize.kt docs) — every method here was previously
+// missing that pairing, so an anonymous caller reached the @Authorize interceptor at all.
 @Tag(name = "Consents", description = "PSD2 / GDPR consent lifecycle management (ADR-0126)")
 @Path("/api/v1/consents")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
+@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
 class ConsentResource(
     private val createConsent: CreateConsentUseCase,
     private val revokeConsent: RevokeConsentUseCase,

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/rest/ConsentResourceAuthzTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/rest/ConsentResourceAuthzTest.kt
@@ -24,6 +24,10 @@ import java.util.UUID
  * is enforced (that is the shared `AuthorizeInterceptor`'s own suite in
  * openbank-libs-runtime, plus the decision assertions in
  * openbank-infra/gitops/components/consent/gen-consent-opa-bundle.sh).
+ *
+ * `ConsentResource` now carries a class-level `@RolesAllowed` (the coarse gate `@Authorize`
+ * was always meant to pair with, per libs-domain's own docs) — an anonymous request is
+ * rejected before it ever reaches the `@Authorize` interceptor.
  */
 @QuarkusTest
 @QuarkusTestResource(ConsentResourceAuthzTest.InMemoryKafkaResource::class)
@@ -38,14 +42,13 @@ class ConsentResourceAuthzTest {
     }
 
     @Test
-    fun `anonymous request still reaches the handler in advisory mode`() {
-        // The test profile runs without enforced OIDC, so the request carries no identity
-        // at all — the strictest input the interceptor can see. Advisory mode must not
-        // 403/500 it; the handler's own not-found path answers.
+    fun `anonymous request is rejected before it reaches the Authorize interceptor`() {
+        // Previously this reached the handler (404) — the class had @Authorize but no
+        // @RolesAllowed pairing, so JAX-RS never rejected an unauthenticated caller.
         Given { this } When {
             get("/api/v1/consents/${UUID.randomUUID()}")
         } Then {
-            statusCode(404)
+            statusCode(401)
         }
     }
 

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/rest/ScaResource.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/rest/ScaResource.kt
@@ -160,6 +160,7 @@ class ScaResource(
 
     @POST
     @Path("/challenges")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.initiate")
     suspend fun initiate(
         request: InitiateScaRequest,
@@ -200,6 +201,7 @@ class ScaResource(
 
     @POST
     @Path("/challenges/{id}/verify")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.verify", resource = "#id")
     suspend fun verify(@PathParam("id") id: UUID, request: VerifyScaRequest): ScaChallengeResponse {
         val challenge = verifySca.verify(VerifyScaCommand(id, request.partyId, request.otp))
@@ -208,13 +210,19 @@ class ScaResource(
 
     @GET
     @Path("/challenges/{id}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")
     @Authorize(action = "scaChallenge.read", resource = "#id")
     suspend fun get(@PathParam("id") id: UUID): ScaChallengeResponse =
         ScaChallengeResponse.from(getSca.getChallenge(id))
 
-    /** List device credentials enrolled to a party (ADR-0021, ADR-0068 onboarding cockpit). */
+    /**
+     * List device credentials enrolled to a party (ADR-0021, ADR-0068 onboarding cockpit).
+     * Includes ROLE_CUSTOMER (unlike the other endpoints here) because this one carries its
+     * own ownership check below — a customer-realm caller can only ever list their own devices.
+     */
     @GET
     @Path("/parties/{partyId}/devices")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "device.list", resource = "#partyId")
     suspend fun listDevices(@PathParam("partyId") partyId: UUID): List<EnrolledDeviceResponse> {
         val principalName = identity.principal?.name
@@ -226,9 +234,14 @@ class ScaResource(
         return listDevices.listDevices(ListDevicesQuery(partyId)).map { EnrolledDeviceResponse.from(it) }
     }
 
-    /** Enrol a device credential to a party (ADR-0021). */
+    /**
+     * Enrol a device credential to a party (ADR-0021). Includes ROLE_CUSTOMER for the same
+     * reason as [listDevices] — the ownership check below is the real gate for a customer
+     * caller.
+     */
     @POST
     @Path("/parties/{partyId}/devices")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "device.enroll", resource = "#partyId")
     suspend fun enroll(@PathParam("partyId") partyId: UUID, request: EnrollDeviceRequest): Response {
         // P1 ownership enforcement (defense-in-depth over OPA advisory mode, ADR-0021 security review):
@@ -256,11 +269,15 @@ class ScaResource(
 
     /**
      * Record an out-of-band approval/denial from the enrolled device. Authenticated as the
-     * device/party (a different principal from the verify caller). The signed assertion is
-     * verified against the challenge's dynamic-linking data before it is stored.
+     * device/party (a different principal from the verify caller). Includes ROLE_CUSTOMER: the
+     * real security boundary here is the signature check inside [recordDecision] (verified
+     * against the challenge's dynamic-linking data), not caller identity — an attacker can't
+     * forge a decision without the enrolled device's private key even with a valid ROLE_CUSTOMER
+     * token for a different party.
      */
     @POST
     @Path("/challenges/{id}/decision")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
     @Authorize(action = "scaChallenge.decide", resource = "#id")
     suspend fun decide(@PathParam("id") id: UUID, request: RecordDecisionRequest): ScaChallengeResponse {
         val challenge = recordDecision.recordDecision(

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/rest/ScaResourceAuthzTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/infrastructure/rest/ScaResourceAuthzTest.kt
@@ -21,20 +21,23 @@ import java.util.UUID
  * correct no-op in that state — not that a real policy decision is enforced (that is
  * the shared `AuthorizeInterceptor`'s own suite in openbank-libs-runtime, plus the
  * decision assertions in openbank-infra/gitops/components/sca/gen-sca-opa-bundle.sh).
+ *
+ * `get`/`verify` now carry a class-appropriate `@RolesAllowed` pairing (the coarse gate
+ * `@Authorize` was always meant to sit behind, per libs-domain's own docs) — an anonymous
+ * request is rejected before it ever reaches the `@Authorize` interceptor.
  */
 @QuarkusTest
 @QuarkusTestResource(PostgresRedisTestResource::class)
 class ScaResourceAuthzTest {
 
     @Test
-    fun `anonymous request still reaches the handler in advisory mode`() {
-        // The test profile runs without enforced OIDC, so the request carries no identity
-        // at all — the strictest input the interceptor can see. Advisory mode must not
-        // 403/500 it; the handler's own not-found path answers.
+    fun `anonymous request is rejected before it reaches the Authorize interceptor`() {
+        // Previously this reached the handler (404) — get() had @Authorize but no
+        // @RolesAllowed pairing, so JAX-RS never rejected an unauthenticated caller.
         Given { this } When {
             get("/api/v1/sca/challenges/${UUID.randomUUID()}")
         } Then {
-            statusCode(404)
+            statusCode(401)
         }
     }
 


### PR DESCRIPTION
## Summary

`libs-domain`'s own `Authorize.kt` documents that `@Authorize` (the OPA-backed fine-grained check) is meant to sit BEHIND the coarse `@RolesAllowed` gate, not replace it. Every method on `ConsentResource` and most on `ScaResource` had `@Authorize` alone — an anonymous caller reached the interceptor (and, if `authz.enforce` were ever flipped `true` with a permissive Rego policy, the handler) with zero identity.

- **`ConsentResource`**: class-level `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")` — all 8 methods.
- **`ScaResource`**: `initiate`/`verify`/`get`/`decide` get the same 3-role set (edge-proxied only, matching `consume`'s pre-existing pattern — "Called by the customer edge, an M2M operator-realm principal"). `listDevices`/`enroll` additionally include `ROLE_CUSTOMER`: both already carry an in-code ownership check (JWT `sub` must equal the `partyId` path param, or `ROLE_OPERATOR`/`ROLE_ADMIN`) as their real IDOR defense, so a direct customer-realm caller is safe. `decide` also gets `ROLE_CUSTOMER` — its real security boundary is the device-signature verification inside `recordDecision`, not caller identity, so a valid-but-wrong-party `ROLE_CUSTOMER` token still can't forge a decision without the enrolled device's private key.

## ⚠️ Money-path service — needs 2 approvals + threat model
Both `sca-service` and `consent-service` are in `rules.yaml: money_path_services`. Per repo rules this needs 2 approvals and isn't self-mergeable. Flagging explicitly since it's easy to miss on a security-labeled PR.

## Role assignment is a judgment call
I inferred the `ROLE_CUSTOMER` inclusion from in-code evidence (the ownership checks on `listDevices`/`enroll`, the `decide` docstring describing "the device/party" as caller) rather than confirmed knowledge of the customer-realm's actual JWT scopes. Please verify against ADR-0065 / the real Keycloak customer-realm role config before merging — if `initiate`/`verify`/`get` are ALSO meant to accept direct customer-realm calls (not just via customer-edge), this PR under-scopes them and would need `ROLE_CUSTOMER` added there too, but only once an equivalent ownership/ownership-safe check exists (there isn't one today for those three).

## Test plan
- [x] Both services had an existing `*AuthzTest` asserting an anonymous request reaches the handler (proving `@Authorize`'s advisory-mode is a correct no-op) — updated both to assert 401 instead, which is now correct.
- [x] Full `test` + `ktlintCheck` + `detekt` for both services — clean.

Found via the fleet-wide unauthenticated-endpoint sweep (#757, #758).

🤖 Generated with [Claude Code](https://claude.com/claude-code)