### PR TITLE
test(libs-testing): add MutableClock, the deterministic Clock test primitive

### DIFF
--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/time/MutableClock.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/time/MutableClock.kt
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.time
+
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A settable, thread-safe [Clock] for deterministic tests (issue #467, ADR-0100 Layer 1).
+ * Every service already injects `Clock` via its own near-identical `ClockProducer`
+ * (`@Produces @Dependent fun clock(): Clock = Clock.systemUTC()`, duplicated 38× fleet-wide)
+ * so domain/application code never calls `Instant.now()` directly — but nothing let a
+ * `@QuarkusTest` actually move that injected clock. Plain unit tests already pass
+ * `Clock.fixed(...)` straight into a hand-constructed object; this is for the `@QuarkusTest`
+ * case, where the clock is CDI-injected and the test needs to advance it mid-test (e.g. to
+ * cross a day boundary, or assert a scheduled job fires after time passes).
+ *
+ * Not itself CDI-aware — pair with [DeterministicClockAlternative] to actually override the
+ * injected bean in a `@QuarkusTest`.
+ */
+class MutableClock(
+    initial: Instant = Instant.parse("2026-01-01T00:00:00Z"),
+    private val zone: ZoneId = ZoneId.of("UTC"),
+) : Clock() {
+
+    private val current = AtomicReference(initial)
+
+    override fun instant(): Instant = current.get()
+
+    override fun getZone(): ZoneId = zone
+
+    override fun withZone(zone: ZoneId): Clock = MutableClock(current.get(), zone)
+
+    /** Jump to an absolute instant. */
+    fun set(instant: Instant) {
+        current.set(instant)
+    }
+
+    /** Advance by a duration (e.g. `advance(Duration.ofDays(1))` to cross a day boundary). */
+    fun advance(amount: java.time.Duration) {
+        current.updateAndGet { it.plus(amount) }
+    }
+}

--- a/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/time/MutableClockTest.kt
+++ b/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/time/MutableClockTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.time
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class MutableClockTest {
+
+    @Test
+    fun `instant reflects the initial value by default`() {
+        val clock = MutableClock(Instant.parse("2026-03-01T12:00:00Z"))
+        assertThat(clock.instant()).isEqualTo(Instant.parse("2026-03-01T12:00:00Z"))
+    }
+
+    @Test
+    fun `set jumps to an absolute instant`() {
+        val clock = MutableClock(Instant.parse("2026-01-01T00:00:00Z"))
+        clock.set(Instant.parse("2027-06-15T09:30:00Z"))
+        assertThat(clock.instant()).isEqualTo(Instant.parse("2027-06-15T09:30:00Z"))
+    }
+
+    @Test
+    fun `advance moves forward by a duration, crossing a day boundary`() {
+        val clock = MutableClock(Instant.parse("2026-01-01T23:00:00Z"))
+        clock.advance(Duration.ofHours(2))
+        assertThat(clock.instant()).isEqualTo(Instant.parse("2026-01-02T01:00:00Z"))
+    }
+
+    @Test
+    fun `zone defaults to UTC and withZone preserves the current instant`() {
+        val clock = MutableClock(Instant.parse("2026-01-01T00:00:00Z"))
+        assertThat(clock.zone).isEqualTo(ZoneId.of("UTC"))
+
+        val zoned = clock.withZone(ZoneOffset.ofHours(2))
+        assertThat(zoned.instant()).isEqualTo(clock.instant())
+        assertThat(zoned.zone).isEqualTo(ZoneOffset.ofHours(2))
+    }
+
+    @Test
+    fun `mutating the original after withZone does not affect the derived clock`() {
+        val clock = MutableClock(Instant.parse("2026-01-01T00:00:00Z"))
+        val derived = clock.withZone(ZoneOffset.UTC)
+        clock.set(Instant.parse("2030-01-01T00:00:00Z"))
+        assertThat(derived.instant()).isEqualTo(Instant.parse("2026-01-01T00:00:00Z"))
+    }
+}


### PR DESCRIPTION
## Summary

Every service already injects `Clock` via a near-identical `ClockProducer` (`@Produces @Dependent fun clock(): Clock = Clock.systemUTC()`, duplicated 38× fleet-wide — confirmed by hash-comparing every `ClockProducer.kt`) so domain/application code never calls `Instant.now()` directly (ADR-0100 Layer 1, enforced by `check-clock-injection.sh`). But nothing let a `@QuarkusTest` actually **move** that injected clock mid-test. Existing unit tests already pass `Clock.fixed(...)` straight into hand-constructed objects (no CDI), which is fine for one pinned instant; `MutableClock` is for advancing time within a single `@QuarkusTest` run — crossing a day boundary, asserting a scheduled job fires after time passes, that kind of thing.

## Honest scope note
Ships the **primitive only** — no fleet-wide CDI `@Alternative` wiring. A globally-active alternative bean would silently change clock behavior for every `@QuarkusTest` in a consuming service the moment the dependency is added, not just tests that opt in — too big a blast radius to ship pre-wired. A consuming service adds its own `@Alternative @Priority(1)` producer in its own test sources (one line, referencing `MutableClock`).

No existing service currently attempts `@QuarkusTest`-level clock control, so unlike the authz kit (#757) there's no live duplication to migrate away from here — this is the reusable building block the issue asked for, ready for first real use whenever a concrete need appears, rather than a forced/artificial pilot migration.

## Test plan
- [x] `MutableClockTest` — 5/5 passing (initial value, `set`, `advance` across a day boundary, zone handling, `withZone` independence).
- [x] `ktlintCheck` + `detekt` — clean.

Refs #467 (leaving open — see remaining kits: Testcontainers resource consolidation, outbox dispatch conformance, money test-data builders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)