### PR TITLE
fix(infra): protect ArgoCD application-controller from Karpenter consolidation

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -247,6 +247,22 @@ resource "helm_release" "argocd" {
       name  = "configs.params.controller\\.diff\\.server\\.side"
       value = "true"
     },
+    # Keep Karpenter from consolidating the node out from under the singleton
+    # application-controller. Root cause of a ~7h ArgoCD outage (2026-07-11): the
+    # controller's node was Evicted "Underutilized" by Karpenter, went NotReady,
+    # and the StatefulSet pod (ordinal 0, at-most-one) got stuck Terminating — so
+    # no app synced for hours (deploys silently stopped updating). `do-not-disrupt`
+    # tells Karpenter not to voluntarily drain a node running this pod; the
+    # priority class keeps it from being preempted. Same footgun class as the
+    # DaemonSet/critical-pod priority note in CLAUDE.md.
+    {
+      name  = "controller.podAnnotations.karpenter\\.sh/do-not-disrupt"
+      value = "true"
+    },
+    {
+      name  = "controller.priorityClassName"
+      value = "system-cluster-critical"
+    },
   ]
 }
 
@@ -384,7 +400,7 @@ resource "helm_release" "keda" {
 resource "helm_release" "keda_http_add_on" {
   name             = "keda-add-ons-http"
   namespace        = "keda"
-  create_namespace = false   # already created by helm_release.keda above
+  create_namespace = false # already created by helm_release.keda above
   repository       = "https://kedacore.github.io/charts"
   chart            = "keda-add-ons-http"
   version          = var.keda_http_add_on_version


### PR DESCRIPTION
## Summary

The durable fix for the ArgoCD instability found while shipping #759. A ~7-hour ArgoCD outage on 2026-07-11 (deploys + admin-UI silently stopped updating) traced to **Karpenter evicting the node running the singleton `argocd-application-controller`** as *"Underutilized"* → node went `NotReady` → the StatefulSet pod (ordinal 0, at-most-one) got stuck `Terminating` → **no Application synced for hours**. GitOps deploys were built but never applied — the real reason "the admin UI hasn't updated in days".

## Type of change

- [x] Fix (platform infra hardening)

## Linked issues

Refs #759

## Changes

In the `argo-cd` Helm release (`aws/envs/sandbox-platform/main.tf`), add two controller protections:
- **`controller.podAnnotations."karpenter.sh/do-not-disrupt": "true"`** — Karpenter will not *voluntarily* drain a node while the controller pod runs on it (directly prevents the "Underutilized" consolidation that caused the outage).
- **`controller.priorityClassName: system-cluster-critical`** — keeps the controller from being preempted.

Same footgun class as the DaemonSet/critical-pod priority note in the root `CLAUDE.md`. `tofu fmt` also normalized one adjacent comment's whitespace.

## Verification

- `tofu fmt` clean (the only reformat was the adjacent comment; my additions need none).
- The live controller was already recovered manually during the incident (force-recreated onto a healthy node); this change prevents recurrence.

## Deploy note

`aws/envs/sandbox-platform` has **no CI apply pipeline** — this needs a `tofu apply` in that env to take effect. Until applied, the live controller remains unprotected (I can also add a live stopgap annotation on the running StatefulSet on request). Per the repo convention, this PR is the bookkeeping for that infra change and should be **merged even though it's applied out-of-band**.

## Security / compliance impact

None. Scheduling/consolidation hint on a platform controller; no data, RBAC, or network changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)