### PR TITLE
chore(gitops): auto-deploy services @ a7df55001281edeabb2a6754bb163c653439c61a

### DIFF
--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: billing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-16d25569
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-a7df5500
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit a7df55001281edeabb2a6754bb163c653439c61a.

**Changed services:** ["openbank-billing-service"]

Each image tag was updated to `sandbox-a7df55001281edeabb2a6754bb163c653439c61a` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.