### PR TITLE
chore(gitops): auto-deploy services @ c5e2b41e17f1ec2349357d9138b631092e2cced3

### DIFF
--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: agent-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-agent-service:sandbox-76168369
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-agent-service:sandbox-c5e2b41e
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: billing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-16d25569
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-c5e2b41e
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit c5e2b41e17f1ec2349357d9138b631092e2cced3.

**Changed services:** ["openbank-billing-service","openbank-agent-service"]

Each image tag was updated to `sandbox-c5e2b41e17f1ec2349357d9138b631092e2cced3` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.