### PR TITLE
test(libs-testing): add money test-data builders

### DIFF
--- a/openbank-libs-testing/build.gradle.kts
+++ b/openbank-libs-testing/build.gradle.kts
@@ -35,6 +35,13 @@ dependencies {
     api("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")
     api("jakarta.annotation:jakarta.annotation-api:3.0.0")
 
+    // Money test-data builders (issue #467) — Money/CurrencyCode are genuinely shared domain
+    // types (openbank-libs-domain), unlike JournalEntry/JournalLine which live per-service.
+    api(project(":openbank-libs-domain"))
+    // Same version pin as openbank-ledger-service/openbank-balance-service's own property
+    // suites and openbank-libs-domain's MoneyPropertyTest — kept a direct GAV like theirs.
+    api("io.kotest:kotest-property:5.9.1")
+
     testImplementation(libs.mockk)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/money/MoneyArb.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/money/MoneyArb.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.money
+
+import com.openbank.libs.domain.money.Money
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import java.math.BigDecimal
+
+/**
+ * Shared kotest-property generators for [Money] (issue #467). The cents-based-`Long` generation
+ * trick — so every generated amount lands on a valid 2-fraction-digit scale — is already
+ * duplicated in `openbank-ledger-service`'s `JournalEntryPropertyTest` and `openbank-libs-domain`'s
+ * own `MoneyPropertyTest`; this is the shared version for any *new* property suite.
+ */
+object MoneyArb {
+
+    private const val DEFAULT_CENTS_BOUND = 999_999_999L
+    private val DEFAULT_CENTS_RANGE = -DEFAULT_CENTS_BOUND..DEFAULT_CENTS_BOUND
+
+    /** A generated [Money] in the given currency, amounts in cents so the scale is always valid. */
+    fun money(currencyCode: String, centsRange: LongRange = DEFAULT_CENTS_RANGE): Arb<Money> =
+        Arb.long(centsRange.first, centsRange.last).map { Money.of(BigDecimal(it).movePointLeft(2), currencyCode) }
+
+    /** One of [MoneyTestData.COMMON_CURRENCIES], for tests that need to vary currency too. */
+    fun currency(): Arb<String> = Arb.element(MoneyTestData.COMMON_CURRENCIES)
+}

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/money/MoneyTestData.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/money/MoneyTestData.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.money
+
+import com.openbank.libs.domain.money.Money
+import java.math.BigDecimal
+
+/**
+ * Shared money edge-case fixtures (issue #467). Every money-path service's own tests hand-roll
+ * the same boundary values — a large near-overflow amount, the smallest representable unit, a
+ * balanced debit/credit pair — independently (e.g. `MoneyTest.kt`'s `"99999999999999.99"` case,
+ * `JournalEntryPropertyTest`'s cents-based amount generator). This does NOT provide a
+ * `JournalEntry`/`JournalLine` builder: those types live in each service's own domain model
+ * (`openbank-ledger-service`, `openbank-transaction-service`, ...), not in a shared library, so a
+ * generic builder for them would invert the dependency direction. What's genuinely shared is the
+ * `Money` value itself — this fixture set, plus [MoneyArb] for property-based generation.
+ */
+object MoneyTestData {
+
+    /** The currencies exercised across the fleet's property/unit tests (all 2 fraction digits). */
+    val COMMON_CURRENCIES = listOf("CZK", "EUR", "USD", "GBP", "CHF")
+
+    /** The smallest positive representable amount for a 2-fraction-digit currency. */
+    fun minPositive(currencyCode: String): Money = Money.of(BigDecimal("0.01"), currencyCode)
+
+    fun minNegative(currencyCode: String): Money = Money.of(BigDecimal("-0.01"), currencyCode)
+
+    /**
+     * A large amount just below the 17-digit precision boundary this fleet has already hit in
+     * production code (`MoneyTest.kt`'s own `"handles large amounts without overflow"` case).
+     */
+    fun largePositive(currencyCode: String): Money = Money.of(BigDecimal("99999999999999.99"), currencyCode)
+
+    fun largeNegative(currencyCode: String): Money = Money.of(BigDecimal("-99999999999999.99"), currencyCode)
+
+    fun zero(currencyCode: String): Money = Money.zero(currencyCode)
+
+    /**
+     * The boundary set a money-path test should assert against for a given currency: zero, the
+     * smallest positive/negative unit, and the largest amount this fleet's own precision ceiling
+     * allows in both directions.
+     */
+    fun boundaryAmounts(currencyCode: String): List<Money> = listOf(
+        zero(currencyCode),
+        minPositive(currencyCode),
+        minNegative(currencyCode),
+        largePositive(currencyCode),
+        largeNegative(currencyCode),
+    )
+
+    /**
+     * A same-currency (value, -value) pair — the minimal shape a balanced double-entry leg pair
+     * needs. Callers map this into their own service's JournalLine-equivalent debit/credit legs.
+     */
+    fun balancedPair(amount: String, currencyCode: String): Pair<Money, Money> {
+        val positive = Money.of(BigDecimal(amount), currencyCode)
+        return positive to -positive
+    }
+}

--- a/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/money/MoneyTestDataTest.kt
+++ b/openbank-libs-testing/src/test/kotlin/com/openbank/libs/testing/money/MoneyTestDataTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.money
+
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class MoneyTestDataTest {
+
+    @Test
+    fun `zero is zero`() {
+        assertThat(MoneyTestData.zero("CZK").isZero()).isTrue()
+    }
+
+    @Test
+    fun `minPositive and minNegative are exact negations`() {
+        val pos = MoneyTestData.minPositive("EUR")
+        val neg = MoneyTestData.minNegative("EUR")
+        assertThat((pos + neg).amount).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `largePositive and largeNegative are exact negations`() {
+        val pos = MoneyTestData.largePositive("USD")
+        val neg = MoneyTestData.largeNegative("USD")
+        assertThat((pos + neg).amount).isEqualByComparingTo(BigDecimal.ZERO)
+    }
+
+    @Test
+    fun `boundaryAmounts covers zero, both min and both max`() {
+        val amounts = MoneyTestData.boundaryAmounts("GBP")
+        assertThat(amounts).hasSize(5)
+        assertThat(amounts.count { it.isZero() }).isEqualTo(1)
+        assertThat(amounts.count { it.isPositive() }).isEqualTo(2)
+        assertThat(amounts.count { it.isNegative() }).isEqualTo(2)
+    }
+
+    @Test
+    fun `balancedPair sums to zero for any generated amount`(): Unit = runBlocking {
+        checkAll(MoneyArb.currency(), MoneyArb.money("CZK")) { currency, generated ->
+            val (a, b) = MoneyTestData.balancedPair(generated.amount.abs().toPlainString(), currency)
+            assertThat((a + b).amount).isEqualByComparingTo(BigDecimal.ZERO)
+            assertThat(a.currency.code).isEqualTo(currency)
+            assertThat(b.currency.code).isEqualTo(currency)
+        }
+    }
+
+    @Test
+    fun `MoneyArb money always lands on a valid scale for every common currency`(): Unit = runBlocking {
+        MoneyTestData.COMMON_CURRENCIES.forEach { currency ->
+            checkAll(MoneyArb.money(currency)) { generated ->
+                assertThat(generated.amount.scale()).isLessThanOrEqualTo(generated.currency.defaultFractionDigits)
+                assertThat(generated.currency.code).isEqualTo(currency)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`MoneyTestData`** — shared boundary-value fixtures: zero, the smallest positive/negative unit, the largest amount this fleet's own precision ceiling allows in both directions (`MoneyTest.kt`'s own `"99999999999999.99"` case), and `balancedPair()` for a same-currency `(value, -value)` pair.
- **`MoneyArb`** — the cents-based-`Long` kotest-property generation trick that guarantees a valid scale is already duplicated in `openbank-ledger-service`'s `JournalEntryPropertyTest` and `openbank-libs-domain`'s own `MoneyPropertyTest` (#755); this is the shared version for any *new* property suite.

## Scope note — no `JournalEntry`/`JournalLine` builder
`JournalEntry`/`JournalLine` live in each service's own domain model (`openbank-ledger-service`, `openbank-transaction-service`, ...), not a shared library. A generic builder for them in `openbank-libs-testing` would invert the dependency direction — every consumer of the testing kit would transitively depend on one specific service's domain classes. What's genuinely shared is the `Money` value itself; each service still constructs its own debit/credit legs from a `MoneyTestData.balancedPair()`.

## No pilot migration this time
Swapping `JournalEntryPropertyTest`'s existing `amountArb` for `MoneyArb.money()` would require restructuring its `Arb.bind(currency, amount, subAccount)` tuple shape for no behavioral gain — real risk to an already-working property suite for no benefit. `openbank-libs-domain` (where `MoneyPropertyTest` lives) also can't depend on `openbank-libs-testing` without inverting the module graph. Shipping the primitive for the next new property suite to adopt, same reasoning as the Clock kit (#788).

## Test plan
- [x] `MoneyTestDataTest` — 6/6 passing (boundary values, balanced-pair sums to zero, scale validity across all common currencies).
- [x] `ktlintCheck` + `detekt` — clean.

Refs #467 (leaving open — remaining: outbox dispatch conformance kit, and the fleet sweeps for the already-shipped kits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)