### PR TITLE
chore(governance): resync OPA policy bundles with rules.yaml source

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "a89cb7daf0a3ee06"
+    openbank.tech/policy-checksum: "9966b567a3ebada5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -973,6 +973,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1102,9 +1127,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1164,6 +1190,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1201,14 +1228,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a89cb7daf0a3ee06"
+        openbank.tech/policy-checksum: "9966b567a3ebada5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "94e78c23dccd8d9c"
+    openbank.tech/policy-checksum: "649015f2590013a3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1017,6 +1017,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1146,9 +1171,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1208,6 +1234,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1245,14 +1272,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "94e78c23dccd8d9c"
+        openbank.tech/policy-checksum: "649015f2590013a3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "c25f754c13617733"
+    openbank.tech/policy-checksum: "e4acb7570fa3d4b3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -922,6 +922,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1051,9 +1076,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1113,6 +1139,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1150,14 +1177,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c25f754c13617733"
+        openbank.tech/policy-checksum: "e4acb7570fa3d4b3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "6b27c3206846579f"
+    openbank.tech/policy-checksum: "1b75a2fd778ad900"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -940,6 +940,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1069,9 +1094,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1131,6 +1157,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1168,14 +1195,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6b27c3206846579f"
+        openbank.tech/policy-checksum: "1b75a2fd778ad900"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "78e69b979075036f"
+    openbank.tech/policy-checksum: "87d04e15342c06f4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1260,14 +1260,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "78e69b979075036f"
+        openbank.tech/policy-checksum: "87d04e15342c06f4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "5d3318c2352d152d"
+    openbank.tech/policy-checksum: "c6595ba0beffb780"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -825,14 +825,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5d3318c2352d152d"
+        openbank.tech/policy-checksum: "c6595ba0beffb780"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "22c326cc4317e94d"
+    openbank.tech/policy-checksum: "5fdb458cf4901218"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -933,6 +933,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1062,9 +1087,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1124,6 +1150,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1161,14 +1188,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "22c326cc4317e94d"
+        openbank.tech/policy-checksum: "5fdb458cf4901218"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "552f329e4d4dd51b"
+    openbank.tech/policy-checksum: "32aa1c734eb20800"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -970,6 +970,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1099,9 +1124,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1161,6 +1187,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1198,14 +1225,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "552f329e4d4dd51b"
+        openbank.tech/policy-checksum: "32aa1c734eb20800"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "0bea2ab27af620d5"
+    openbank.tech/policy-checksum: "eda80599ab7c83be"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1029,6 +1029,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1158,9 +1183,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1220,6 +1246,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1257,14 +1284,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0bea2ab27af620d5"
+        openbank.tech/policy-checksum: "eda80599ab7c83be"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "4d12c45d9013cf50"
+    openbank.tech/policy-checksum: "9a701761e8bae8ad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1140,8 +1140,8 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
       - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
@@ -1241,14 +1241,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d12c45d9013cf50"
+        openbank.tech/policy-checksum: "9a701761e8bae8ad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "5d3318c2352d152d"
+    openbank.tech/policy-checksum: "c6595ba0beffb780"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -825,14 +825,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "5d3318c2352d152d"
+        openbank.tech/policy-checksum: "c6595ba0beffb780"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3b5769d9519408af"
+    openbank.tech/policy-checksum: "7a6f39e65a177d9a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -976,6 +976,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1105,9 +1130,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1167,6 +1193,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1204,14 +1231,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "db82bb667556f78e"
+    openbank.tech/policy-checksum: "2cb10ba1e7fa3ca9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -961,6 +961,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1090,9 +1115,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1152,6 +1178,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1189,14 +1216,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "264828289580f396" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "7a046a1eca4aa600" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -369,7 +369,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "eaf8783527fd6f5e"
+        openbank.tech/policy-checksum: "cc374fc12b7728c1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -722,7 +722,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "db82bb667556f78e" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "2cb10ba1e7fa3ca9" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1045,7 +1045,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c509503ab090a5b4"
+        openbank.tech/policy-checksum: "e9af05ac6c3126bc"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1360,7 +1360,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3b5769d9519408af" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "7a6f39e65a177d9a" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1943,7 +1943,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d4439240554429e8" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "ac68f22e41856296" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2333,7 +2333,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "74cc69d620a1e368"
+        openbank.tech/policy-checksum: "51ab79f6d6cf7123"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c509503ab090a5b4"
+    openbank.tech/policy-checksum: "e9af05ac6c3126bc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -934,6 +934,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1063,9 +1088,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1125,6 +1151,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1162,14 +1189,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "eaf8783527fd6f5e"
+    openbank.tech/policy-checksum: "cc374fc12b7728c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -955,6 +955,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1084,9 +1109,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1146,6 +1172,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1183,14 +1210,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d4439240554429e8"
+    openbank.tech/policy-checksum: "ac68f22e41856296"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -935,6 +935,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1064,9 +1089,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1126,6 +1152,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1163,14 +1190,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "74cc69d620a1e368"
+    openbank.tech/policy-checksum: "51ab79f6d6cf7123"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -938,6 +938,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1067,9 +1092,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1129,6 +1155,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1166,14 +1193,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "264828289580f396"
+    openbank.tech/policy-checksum: "7a046a1eca4aa600"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -991,6 +991,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1120,9 +1145,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1182,6 +1208,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1219,14 +1246,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "e0c94d0cdac6084f"
+    openbank.tech/policy-checksum: "53c93d6e3120bd61"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1199,14 +1199,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e0c94d0cdac6084f"
+        openbank.tech/policy-checksum: "53c93d6e3120bd61"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "dc1987a94206271b"
+    openbank.tech/policy-checksum: "9b559425dc9b799f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -958,6 +958,31 @@ data:
         enforced: advisory
         target_enforce_date: "2026-10-01"   # ADR-0144
         blocked_on: "the version-bump half is effectively covered by release-please + check-app-version-override.sh; 'test added for new behavior' has no automated diff-aware detector (not yet written) — may get redefined to lean on the coverage ratchet gate instead of a literal test-added check"
+      release_scope_mismatch:
+        # The inverse failure mode of service_code_change above: release-please attributes a
+        # commit to a component by the FILES IT TOUCHES under that component's directory,
+        # regardless of the typed scope (RELEASE.md) — so a feat/fix/perf/security (or
+        # breaking-marked) commit that only touches <service>/src/test/**, a root file like
+        # <service>/openapi.yaml, or gitops/docs outside the service dir entirely still makes
+        # release-please propose a release, even though only <service>/src/main/** should
+        # (rule 2). Observed live: PR #547 (feat(finrep): register ArgoCD Application — touched
+        # only a src/test boot-smoke test + gitops/docs outside the package dir) -> PR #551
+        # (finrep-service 0.4.0 proposed for an unchanged artifact). Harmless SemVer inflation,
+        # not a broken invariant — but the same mechanism misfires for any test-only or
+        # openapi.yaml-only PR typed feat/fix, so it is worth catching at PR time rather than
+        # correcting release-please output by hand (which rule 3 forbids anyway).
+        detect: ["<service>/** changed", "PR title type in {feat,fix,perf,security} or a breaking marker/footer", "no changed file under <service>/src/main/** (or openbank-admin-ui/src/**)"]
+        require:
+          - "use a non-releasing type (test/docs/chore/refactor/build/ci) when the PR doesn't touch the release-worthy subtree"
+          - "or split the src/main change and the non-src/main change into separate commits/PRs when both a release and a non-releasing change are intended"
+        gate: release-scope-mismatch
+        enforced: advisory
+        target_enforce_date: "2026-10-01"   # ADR-0144, same timeline as service_code_change (same root-cause class)
+        # CI producer is LIVE (advisory): openbank-infra/scripts/check-release-scope-mismatch.py runs
+        # in the "Validate manifests" job on every PR, right after release-registration consistency.
+        # Classifies from the PR title (the default squash-commit subject). Findings are ::warning
+        # annotations. Flip to enforced = pass --enforce to the script in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-release-scope-mismatch.py"
       service_config_change:
         # SmallRye Config / SnakeYAML do NOT merge duplicate mapping keys — the LAST
         # occurrence wins and earlier ones are SILENTLY dropped to library defaults, so
@@ -1087,9 +1112,10 @@ data:
       - openbank-lending-service
       - openbank-sca-service
       - openbank-consent-service
-      - openbank-fraud-service                # ADR-0084: first executable landed (Phase 1 skeleton)
-      - openbank-billing-service              # ADR-0143: fee posting to the ledger (Phase 2b skeleton)
+      - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+      - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
       - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
+      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1149,6 +1175,7 @@ data:
         - send                              # swift: send an outbound wire message (issue #395)
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
+        - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1186,14 +1213,17 @@ data:
         enforced: advisory                  # weekly advisory runs are live; blocking flip pending sustained >=70%
         target_enforce_date: "2026-09-30"   # ADR-0144
         ci_producer: .github/workflows/pitest.yml
-        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-07, issue #265 D3):
-        # 9/15 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
-        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06).
-        # The remaining 6 (sca, consent, billing, clearing, swift, lending) stay excluded: each has
-        # only 1-2 domain files, and those files are plain data models (no branching money-movement
-        # logic), so mutation testing there is noise, not signal — re-confirmed by file count on
-        # 2026-07-07, unchanged since the 2026-07-06 rollout. Revisit if any of these services grows
-        # real decision logic in its domain layer.
+        # Fleet rollout re-verified complete per the ADR-0063 criterion (2026-07-11, issue #265 D3):
+        # 10/17 money-path services wired (pitest.yml weekly) — ledger, balance, account, transaction,
+        # fx + sepa-payment, sepa-instant, domestic-payment, fraud (SSDLC-audit rollout 2026-07-06) +
+        # sanctions (2026-07-11: 3 domain files — screening/matching decision logic — matches the
+        # "substantive domain math" criterion, not the thin-domain one; 67% local baseline).
+        # The remaining 7 (sca, consent, billing, clearing, swift, lending, settlement) stay excluded:
+        # each has only 1-2 domain files, and those files are plain data models (no branching
+        # money-movement logic), so mutation testing there is noise, not signal — re-confirmed by
+        # file count on 2026-07-11 (settlement and sanctions were both added to money_path_services
+        # after the 2026-07-07 note above; settlement re-confirmed thin, sanctions was the one that
+        # wasn't). Revisit if any of the remaining 7 grows real decision logic in its domain layer.
         # True baselines at rollout (after fixing the KILLED-quote parsing bug): account 49%,
         # transaction 46%, balance 55%, ledger 65%, fx 73%.
         blocked_on: "blocking flip requires each service to sustain >=70% mutation kill score on the weekly run; account/transaction/balance/ledger are below it today (see baselines above)"

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dc1987a94206271b"
+        openbank.tech/policy-checksum: "9b559425dc9b799f"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Summary

Regenerate every OPA policy bundle ConfigMap and its pod-roll checksum annotation from the current policy source, so the committed artifacts stop drifting behind `rules.yaml`. This clears the red (non-required) `opa-policy.yml` check that was firing on every PR touching `rules.yaml` / gitops, and re-aligns the deployed OPA bundles with their source.

## Type of change

- [x] chore (build / tooling)

## Linked issues

N/A — derived-artifact hygiene; no open issue tracks the bundle drift (no ADR decision or backlog item involved, just a regenerate-and-commit sync).

## Changes

- Ran all 21 bundle generators (`openbank-infra/gitops/**/gen-*-opa-bundle*.sh` + `agent/gen-opa-bundle-configmap.sh`) and committed their output: 20 per-service `*-opa-bundle.yaml` ConfigMaps + `agent-opa-bundle.yaml`, plus the matching `openbank.tech/policy-checksum` pod-roll annotations in the `*-service*.yaml` / `customer-edge.yaml` / `payments-services.yaml` manifests (34 files total).
- **Why they were stale:** each generator hashes the whole `rules.yaml` (comments included) into every bundle. Recent `rules.yaml` edits — the `release_scope_mismatch` rule, `money_path_services` / `four_eyes` / pitest comment refreshes, the #753 D3 sanctions note — merged without regenerating the bundles.

## Reviewer notes

- **Derived-artifact sync only — no policy logic changed.** The embedded Rego blocks (`rest.rego`, `agents.rego`, per-service `*_rest_ext.rego`) are byte-identical old vs new across all 21 bundles; the only diffs are the embedded `rules.yaml` / `agents.yaml` **data** and the checksum annotations. The `*-service*.yaml` manifest changes are exclusively `policy-checksum` bumps.
- Verified locally: `openbank-infra/opa/build-bundle.sh` → `opa test` 111/111, `opa check --strict`, all decision assertions green; and generator idempotency (a second run produces no further diff). The `opa-policy.yml` CI check should go green here.
- Fleet-wide (34 gitops files) but mechanical — regenerated, not hand-edited (rule #6 / derived data).

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: GitOps (ArgoCD applies the regenerated ConfigMaps; the checksum annotation rolls each pod so the new bundle is actually served — subPath mounts do not hot-reload).
- Rollback plan: revert this commit; ArgoCD re-applies the prior bundles.
- Data migration reversible: N/A