### PR TITLE
chore(gitops): auto-deploy services @ 7eb136746ddf560548167743bd6b585079ac4be8

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -69,7 +69,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-a407c3ae
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-7eb13674
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 7eb136746ddf560548167743bd6b585079ac4be8.

**Changed services:** ["openbank-product-catalog"]

Each image tag was updated to `sandbox-7eb136746ddf560548167743bd6b585079ac4be8` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.