### PR TITLE
ci(security): skip CodeQL on gitops/docs-only PRs (FinOps + unblock deploy PRs)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_sbom: ${{ steps.f.outputs.run_sbom }}
+      run_codeql: ${{ steps.f.outputs.run_codeql }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -42,25 +43,46 @@ jobs:
           EVENT: ${{ github.event_name }}
           BEFORE: ${{ github.event.before }}
           SHA: ${{ github.sha }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
+          # Code paths that warrant CodeQL semantic analysis. A gitops/docs/*.md-only PR
+          # (e.g. an auto-generated deploy image-bump) changes none of these, so the
+          # ~14 min java-kotlin autobuild is pure waste there. CodeQL is NOT a required
+          # check, so skipping it on such PRs is safe — the weekly + main-push full scan
+          # (and Trivy on every PR) still cover them.
+          CODE_RE='(\.(java|kt|kts)$|(^|/)(build|settings)\.gradle|gradle/|\.(js|jsx|ts|tsx|mjs|cjs)$|(^|/)package(-lock)?\.json$|(^|/)Dockerfile|\.github/workflows/)'
           # schedule / manual: always run the full audit.
           if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          # PRs never run the SBOM jobs (too heavy for the PR gate).
+          # PRs never run the SBOM jobs (too heavy for the PR gate). CodeQL runs only
+          # when code actually changed — diff against the merge-base with the target
+          # branch (not the frozen base.sha, which drifts once a competing PR merges).
           if [ "$EVENT" = "pull_request" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_REF" >/dev/null 2>&1 || true
+            BASE="$(git merge-base "origin/$BASE_REF" HEAD 2>/dev/null || true)"
+            if [ -n "$BASE" ] && ! git diff --name-only "$BASE" HEAD | grep -qE "$CODE_RE"; then
+              echo "run_codeql=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "run_codeql=true" >> "$GITHUB_OUTPUT"   # default to running when unsure
+            fi
             echo "run_sbom=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           # First push of a branch has an all-zero "before" → cannot diff, run to be safe.
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "run_sbom=true" >> "$GITHUB_OUTPUT"; echo "run_codeql=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
+          CHANGED="$(git diff --name-only "$BEFORE" "$SHA")"
           # Dependency-affecting paths: Gradle build/version files, lockfiles, Dockerfiles.
-          if git diff --name-only "$BEFORE" "$SHA" \
-               | grep -qE '(\.gradle\.kts$|gradle/libs\.versions\.toml$|gradle\.lockfile$|gradle/wrapper/|Dockerfile|package-lock\.json$|pnpm-lock\.yaml$|yarn\.lock$)'; then
+          if echo "$CHANGED" | grep -qE '(\.gradle\.kts$|gradle/libs\.versions\.toml$|gradle\.lockfile$|gradle/wrapper/|Dockerfile|package-lock\.json$|pnpm-lock\.yaml$|yarn\.lock$)'; then
             echo "run_sbom=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_sbom=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$CHANGED" | grep -qE "$CODE_RE"; then
+            echo "run_codeql=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_codeql=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ---------------------------------------------------------------------------
@@ -68,6 +90,7 @@ jobs:
   # ---------------------------------------------------------------------------
   codeql:
     name: CodeQL
+    needs: detect-deps
     # CodeQL uploads results to GitHub code scanning, which on a PRIVATE repo is a
     # paid GHAS add-on (not bundled with Free/Pro) — the init step errors with
     # "Code scanning is not enabled for this repository". So this job auto-skips
@@ -75,7 +98,9 @@ jobs:
     # mirroring the dependency-review job in ci.yml. Until then Trivy fs + Dependabot
     # cover vulnerable-dependency detection. (Aside: the CodeQL CLI also does not
     # support linux/arm64, so it could not run on the arm64 sandbox runner anyway.)
-    if: github.event.repository.private == false
+    # Skip on gitops/docs-only PRs (run_codeql=false) — CodeQL isn't a required check
+    # there, and the java-kotlin autobuild is the ~14 min tax that strands deploy PRs.
+    if: github.event.repository.private == false && needs.detect-deps.outputs.run_codeql != 'false'
     # Standard github/codeql-action usage targets ubuntu-latest; no self-hosted-specific
     # dependency here (setup-java/setup-node are already used to work around the Hetzner
     # pool lacking those toolchains). Public repo = free GitHub-hosted minutes.


### PR DESCRIPTION
## Summary

The `java-kotlin` CodeQL leg runs `./gradlew testClasses` (whole-fleet dependency resolution, **~14 min**) on **every** pull request — including ones that change no code, like the **auto-generated gitops image-bump deploy PRs**. That's wasted Free-tier CI time, and combined with strict-up-to-date branch protection on a busy `main`, it's a big part of why those deploy PRs strand (they go BEHIND before the long run finishes — the "admin UI hasn't updated in days" symptom).

## Type of change

- [x] CI / FinOps

## Linked issues

Refs #759

## Changes

CodeQL is **not a required check** (only `all-green`, `Validate manifests`, `Gitleaks`, `issue-hygiene` are — verified via `gh pr checks --required`), so it's safe to skip when a PR touches no code:
- Extend the existing `detect-deps` job to emit **`run_codeql`** (mirrors `run_sbom`), computed from a **merge-base** diff against the target branch — not the frozen `base.sha` (the ADR-0048 / #538 drift gotcha).
- Gate the `codeql` job on `needs.detect-deps.outputs.run_codeql != 'false'`.
- Code paths that still trigger CodeQL: `*.java/kt/kts`, `build/settings.gradle`, `gradle/`, `*.js/ts/tsx…`, `package(-lock).json`, `Dockerfile`, `.github/workflows/`.

**Trivy (IaC scan) still runs on every PR**, and the weekly + main-push full scans are unchanged — so security coverage of gitops/docs PRs is preserved. Defaults to running CodeQL when the diff base can't be resolved (fail-safe).

## Verification

- `security.yml` parses; `codeql` now `needs: detect-deps`; `detect-deps` outputs `run_sbom` + `run_codeql`.
- On a gitops-only PR (this repo's deploy PRs) `run_codeql=false` → the 14 min leg is skipped; a Java PR keeps full CodeQL.

## Security / compliance impact

CodeQL results for no-code PRs are covered by the scheduled + push scans; no reduction in coverage of actual code changes. Not a required check, so skipping never leaves a required gate pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)