### PR TITLE
ci(deploy): sign auto-deploy GitOps commits so required_signatures stops stranding them

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -407,6 +407,12 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # Create the commit through the GitHub API so it is signed/verified. The
+          # main ruleset enforces required_signatures; a plain git commit here is
+          # unsigned → the deploy PR is blocked forever and the admin UI silently
+          # stops updating (had to be re-signed by hand every time). sign-commits
+          # makes the bot commit verified so auto-merge actually lands it.
+          sign-commits: true
           branch: chore/admin-ui-deploy-${{ github.sha }}
           delete-branch: true
           commit-message: "chore(admin-ui): deploy ${{ steps.build.outputs.tag }}"

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -706,6 +706,10 @@ jobs:
           # the PR can never auto-merge. Falls back to GITHUB_TOKEN so the pipeline still opens
           # a (manually-mergeable) PR if the secret is not set.
           token: ${{ secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # Create the commit through the GitHub API so it is signed/verified — the main
+          # ruleset enforces required_signatures, and an unsigned bot commit blocks the
+          # deploy PR forever (services silently stop updating until a human re-signs it).
+          sign-commits: true
           branch: chore/gitops-auto-deploy-${{ github.sha }}
           delete-branch: true
           commit-message: "chore(gitops): auto-deploy sandbox-${{ github.sha && github.sha || '' }}"


### PR DESCRIPTION
## Summary

**The real durable fix for "the admin UI / services silently stop updating for days."** The `main` ruleset enforces **`required_signatures`**, but `peter-evans/create-pull-request` creates a plain **unsigned** git commit by default — so every auto-generated admin-ui / gitops deploy PR was unverified → **blocked forever** by the signature rule, and had to be re-signed by hand each time (or never merged). It was **not** strict-up-to-date (that's off) nor CodeQL (not required) — those were red herrings until I dumped the full ruleset.

## Type of change

- [x] CI fix (deploy pipeline)

## Linked issues

Refs #759

## Changes

Set **`sign-commits: true`** on both deploy-PR creators:
- `admin-ui-deploy.yml` (the admin-UI GitOps bump)
- `auto-deploy.yml` (the per-service GitOps bump)

`sign-commits: true` makes the action create the commit through the GitHub API, so it comes out **verified** — satisfying `required_signatures` and letting the existing auto-merge actually land it. The `GITOPS_PR_TOKEN` (fine-grained PAT/App token with contents+PR write) already has the API permission this needs.

## Verification

- Both workflow files parse.
- Reproduced live today: the auto-generated deploy PR #789 was `verified=false / reason=unsigned` and stuck; a hand-signed equivalent (#805) merged instantly.

## Notes

Complements #803 (skip CodeQL on gitops/docs PRs — a FinOps win that also trims those PRs' CI time). This PR is the one that removes the actual merge blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)