### PR TITLE
fix(infra): enable Karpenter NodeRepair to auto-replace hung NotReady nodes

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -269,6 +269,26 @@ resource "helm_release" "argocd" {
       name  = "controller.priorityClassName"
       value = "system-cluster-critical"
     },
+    # The chart ships the controller with no resources at all (BestEffort). On the
+    # bin-packed 4Gi spot nodes the controller (~1-2Gi for this fleet's app count)
+    # repeatedly exhausted node memory into a full guest hang: kubelet + SSM died
+    # while EC2 status checks stayed ok, stranding the singleton pod (issue #809,
+    # 2026-07-11 — two such nodes within an hour, each dying minutes after this
+    # pod landed on it). The request steers scheduling onto a node with real
+    # headroom; the limit turns a runaway into a container OOM-kill (self-healing)
+    # instead of a node-killing kernel thrash.
+    {
+      name  = "controller.resources.requests.cpu"
+      value = "250m"
+    },
+    {
+      name  = "controller.resources.requests.memory"
+      value = "1536Mi"
+    },
+    {
+      name  = "controller.resources.limits.memory"
+      value = "2560Mi"
+    },
   ]
 }
 

--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -270,24 +270,26 @@ resource "helm_release" "argocd" {
       value = "system-cluster-critical"
     },
     # The chart ships the controller with no resources at all (BestEffort). On the
-    # bin-packed 4Gi spot nodes the controller (~1-2Gi for this fleet's app count)
-    # repeatedly exhausted node memory into a full guest hang: kubelet + SSM died
-    # while EC2 status checks stayed ok, stranding the singleton pod (issue #809,
-    # 2026-07-11 — two such nodes within an hour, each dying minutes after this
-    # pod landed on it). The request steers scheduling onto a node with real
-    # headroom; the limit turns a runaway into a container OOM-kill (self-healing)
-    # instead of a node-killing kernel thrash.
+    # bin-packed 4Gi spot nodes the controller repeatedly exhausted node memory
+    # into a full guest hang: kubelet + SSM died while EC2 status checks stayed
+    # ok, stranding the singleton pod (issue #809, 2026-07-11 — several such
+    # nodes in one day, each dying minutes after this pod landed on it). Measured
+    # live: the startup reconciliation of this fleet's apps blows through 2.5Gi
+    # within a minute (an earlier 2560Mi limit OOM-killed it at 61s of age). The
+    # request keeps it off the 4Gi shapes entirely; the limit turns a runaway
+    # into a container OOM-kill (self-healing) instead of a node-killing kernel
+    # reclaim livelock.
     {
       name  = "controller.resources.requests.cpu"
       value = "250m"
     },
     {
       name  = "controller.resources.requests.memory"
-      value = "1536Mi"
+      value = "2560Mi"
     },
     {
       name  = "controller.resources.limits.memory"
-      value = "2560Mi"
+      value = "3584Mi"
     },
   ]
 }

--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -85,6 +85,12 @@ resource "helm_release" "karpenter" {
       name  = "settings.interruptionQueue"
       value = local.karpenter_queue_name
     },
+    # Auto-replace nodes stuck NotReady (guest-level hang passes EC2 status checks;
+    # EKS node auto repair covers only the bootstrap managed node group). Issue #809.
+    {
+      name  = "settings.featureGates.nodeRepair"
+      value = "true"
+    },
     # Controller must run on the bootstrap managed nodes, never on nodes it owns.
     {
       name  = "controller.resources.requests.cpu"


### PR DESCRIPTION
## Summary

Durable fix for the recurring node-churn that stranded the ArgoCD application-controller **again** today (2026-07-11) — this time via **involuntary node failure**, which the `karpenter.sh/do-not-disrupt` protection from #790 cannot cover. Two protections, same file:

1. **Enable Karpenter `NodeRepair`.** Karpenter-provisioned nodes hit guest-level hangs (memory-reclaim livelock: CPU pinned ~85–88 % for hours, kubelet + SSM agent starve, EC2 status checks stay `ok`) and then linger `NotReady` indefinitely: EKS Node Auto Repair (#217) covers only the bootstrap managed node group, and Karpenter's own repair controller defaults off (`NodeRepair=false` confirmed live). Five+ hung nodes on 2026-07-11 alone; one sat NotReady ~13 h.
2. **Give the application-controller real resources.** The chart default is *no* resources (BestEffort). Karpenter bin-packs by requests, so the controller repeatedly landed on 4Gi shapes already carrying JVM boot-storms and exhausted node memory into exactly that livelock — several nodes died minutes after this pod scheduled onto them. Measured live: startup reconciliation with a full OutOfSync backlog blows through 2.5Gi within a minute (a first-cut 2560Mi limit OOM-killed it at 61 s). Final sizing: request `2560Mi` (reserves most of a 4Gi shape or forces a roomier node) + limit `3584Mi` (a runaway becomes a container OOM-kill, not a dead node). Root-cause follow-ups (eviction headroom, fleet request audit) tracked in #809.

## Type of change

- [x] Fix (platform infra hardening)

## Linked issues

Refs #809

## Changes

In `aws/envs/sandbox-platform/main.tf`:
- `karpenter` Helm release: `settings.featureGates.nodeRepair=true`.
- `argocd` Helm release: `controller.resources` requests (`cpu=250m`, `memory=2560Mi`) + memory limit (`3584Mi`).

## Verification

- `tofu fmt -check` clean; targeted `tofu plan` showed only the two in-place Helm release updates.
- **Both changes are already applied out-of-band** (this env has no CI apply pipeline; per repo convention this PR is the mandatory bookkeeping): live Karpenter runs `FEATURE_GATES=...,NodeRepair=true,...` (rolled out), ArgoCD release carries the controller requests/limits, and the controller is Running and syncing the fleet (735Mi steady-state after the startup spike; one startup OOM-kill with a full backlog is survivable — the retry converges).

## Security / compliance impact

None. Node-lifecycle feature gate + scheduling resources on platform controllers; no data, RBAC, or network changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)