### PR TITLE
feat(admin-ui): calm scale-to-zero states + last-7-days spend view

### DIFF
--- a/openbank-admin-ui/src/app/fees/page.tsx
+++ b/openbank-admin-ui/src/app/fees/page.tsx
@@ -8,7 +8,7 @@ import { useState, useMemo, useEffect, useCallback } from 'react'
 import { Receipt, Search, RefreshCw } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-import { classifyBffFailure } from '@/lib/services/bff'
+import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 
 // Shape served by openbank-product-catalog GET /api/v1/fees — the bank-wide fee
@@ -54,7 +54,11 @@ export default function FeesPage() {
     setLoading(true)
     setUnavailable(null)
     try {
-      const res = await fetch('/api/product-catalog/fees', { cache: 'no-store' })
+      // Via the BFF proxy (not the dedicated /api/product-catalog route): the proxy
+      // detects KEDA scale-to-zero (ADR-0057) → a calm "idle" state instead of a
+      // scary "unreachable", and relays the operator token (product-catalog is now
+      // auth-gated). product-catalog is the KEDA-scaled fees system of record.
+      const res = await fetch(svcUrl('product-catalog', '/api/v1/fees'), { cache: 'no-store' })
       if (!res.ok) {
         setFees([])
         setUnavailable({ kind: await classifyBffFailure(res) })

--- a/openbank-admin-ui/src/app/finops/page.tsx
+++ b/openbank-admin-ui/src/app/finops/page.tsx
@@ -591,6 +591,41 @@ function FinOpsContent() {
                     </div>
                   </div>
 
+                  {/* LAST 7 DAYS — the window operators watch day-to-day, with a
+                      week-over-week delta. Higher spend is red (bad), lower green. */}
+                  {costs.daily.length >= 1 && (() => {
+                    const sum = (a: DailyCost[]) => a.reduce((s, d) => s + d.amount, 0)
+                    const last7 = costs.daily.slice(-7)
+                    const prev7 = costs.daily.slice(-14, -7)
+                    const l7 = sum(last7)
+                    const avg = last7.length ? l7 / last7.length : 0
+                    const delta = prev7.length > 0 && sum(prev7) > 0 ? ((l7 - sum(prev7)) / sum(prev7)) * 100 : null
+                    const up = (delta ?? 0) >= 0
+                    return (
+                      <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '18px', marginBottom: '18px',
+                        padding: '14px 18px', borderRadius: '10px', background: 'var(--surface-2)', border: '1px solid var(--border)' }}>
+                        <div>
+                          <div style={{ fontSize: '11px', fontWeight: 700, color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                            {t('Posledních 7 dní', 'Last 7 days')}
+                          </div>
+                          <div style={{ fontSize: '26px', fontWeight: 800, color: 'var(--text-primary)', lineHeight: 1.15 }}>
+                            ${l7.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                          </div>
+                        </div>
+                        <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>
+                          {t('⌀ / den', 'avg / day')}: <strong>${avg.toFixed(2)}</strong>
+                        </div>
+                        {delta !== null && (
+                          <span style={{ display: 'inline-flex', alignItems: 'center', gap: '4px', fontSize: '12px', fontWeight: 700,
+                            color: up ? '#dc2626' : '#16a34a' }}>
+                            {up ? <TrendingUp size={13} /> : <TrendingDown size={13} />}
+                            {up ? '+' : ''}{delta.toFixed(1)}% {t('vs. předchozích 7 dní', 'vs. prior 7 days')}
+                          </span>
+                        )}
+                      </div>
+                    )
+                  })()}
+
                   {/* DAILY SPEND TREND — the per-day series we otherwise only read in the console */}
                   <DailySpendTrend daily={costs.daily} currency={costs.currency} />
 

--- a/openbank-admin-ui/src/app/product-catalog/page.tsx
+++ b/openbank-admin-ui/src/app/product-catalog/page.tsx
@@ -6,15 +6,15 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import {
-  Package, Search, RefreshCw, AlertCircle, Edit, Play, Square, Plus, X,
+  Package, Search, RefreshCw, Edit, Play, Square, Plus, X,
   Eye, EyeOff, CreditCard, Globe, TrendingDown,
   Clock, FileText, Tag, Users, ExternalLink, History, CheckCircle2,
   Layers, Banknote, Shield,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
-
-const PROXY = '/api/product-catalog'
+import { svcUrl, classifyBffFailure, type BffFailure } from '@/lib/services/bff'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
 
 const STATUS_COLOR: Record<string, { bg: string; text: string; border: string }> = {
   ACTIVE:     { bg: 'var(--success-bg)',  text: 'var(--success-text)',  border: 'var(--success-border)' },
@@ -63,13 +63,27 @@ interface Product {
   createdAt?: string; updatedAt?: string
 }
 
+// Go through the BFF proxy (not a dedicated /api/product-catalog route): the proxy
+// detects KEDA scale-to-zero (ADR-0057) → a calm "idle" state instead of an
+// uncaught 500, and relays the operator token (product-catalog is now auth-gated).
+class ApiError extends Error {
+  kind: BffFailure
+  constructor(kind: BffFailure, message: string) {
+    super(message)
+    this.kind = kind
+  }
+}
+
 async function apiFetch(path: string, opts?: RequestInit) {
-  const res = await fetch(`${PROXY}${path}`, { cache: 'no-store', signal: AbortSignal.timeout(8000), ...opts })
+  const res = await fetch(svcUrl('product-catalog', `/api/v1/products${path}`), {
+    cache: 'no-store', signal: AbortSignal.timeout(8000), ...opts,
+  })
   if (!res.ok) {
+    const kind = await classifyBffFailure(res.clone())
     const text = await res.text().catch(() => '')
     let msg: string
     try { const parsed = JSON.parse(text); msg = parsed?.message ?? parsed?.error ?? text } catch { msg = text || res.statusText }
-    throw new Error(`${res.status} ${msg}`)
+    throw new ApiError(kind, msg || res.statusText)
   }
   return res.json()
 }
@@ -416,12 +430,13 @@ function ProductDetailPanel({ product, onClose, onEdit, onToggleStatus }: { prod
 }
 
 export default function ProductCatalogPage() {
-  const { t } = useLanguage()
+  const { t, language } = useLanguage()
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  // Typed unavailable reason → renders the calm <DataUnavailable> panel (idle /
+  // waking / unreachable) instead of a red "service is down" banner.
+  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
-  const [healthStatus, setHealthStatus] = useState<boolean | null>(null)
 
   const [search, setSearch] = useState('')
   const [typeFilter, setTypeFilter] = useState('ALL')
@@ -436,11 +451,10 @@ export default function ProductCatalogPage() {
 
   const load = useCallback(async () => {
     setLoading(true)
-    setError(null)
+    setUnavailable(null)
     setActionError(null)
     try {
       const data = await apiFetch('')
-      setHealthStatus(true)
       let items: Product[] = Array.isArray(data) ? data : (data.items ?? data.content ?? data.products ?? [])
       items = items.sort((a, b) => {
         if (a.updatedAt && b.updatedAt) return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
@@ -451,9 +465,9 @@ export default function ProductCatalogPage() {
         const refreshed = items.find(p => p.id === selectedProduct.id)
         if (refreshed) setSelectedProduct(refreshed)
       }
-    } catch (e: any) {
-      setHealthStatus(false)
-      setError(e.message ?? 'Failed to load product catalog')
+    } catch (e) {
+      setProducts([])
+      setUnavailable({ kind: e instanceof ApiError ? e.kind : 'unreachable' })
     } finally {
       setLoading(false)
     }
@@ -549,10 +563,15 @@ export default function ProductCatalogPage() {
             </div>
           </div>
 
-          {healthStatus === false && (
-            <div className="card" style={{ padding: '12px 16px', color: 'var(--danger-text)', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '8px', background: 'var(--danger-bg)', border: '1px solid var(--danger-border)' }}>
-              <AlertCircle size={15} />
-              <span style={{ fontSize: '13px' }}>{t('Služba katalogu produktů je nedostupná.', 'Product Catalog Service is unreachable.')}</span>
+          {unavailable && (
+            <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
+              <DataUnavailable
+                kind={unavailable.kind}
+                service={t('Katalog produktů', 'Product Catalog')}
+                feature={t('Produkty', 'Products')}
+                lang={language}
+                dense
+              />
             </div>
           )}
 
@@ -595,7 +614,6 @@ export default function ProductCatalogPage() {
             ))}
           </div>
 
-          {error && <div className="card" style={{ padding: '12px 16px', color: 'var(--danger-text)', marginBottom: '16px', fontSize: '13px' }}>{error}</div>}
 
           <div className="card" style={{ overflow: 'hidden' }}>
             <table className="data-table">

--- a/openbank-infra/gitops/components/admin-ui/cost-collector.yaml
+++ b/openbank-infra/gitops/components/admin-ui/cost-collector.yaml
@@ -124,34 +124,40 @@ spec:
                   END=$(date -u +%Y-%m-%d)
                   START=$(date -u -d "@$(( $(date -u +%s) - 2592000 ))" +%Y-%m-%d)
                   NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                  # FIX: aggregate ALL ResultsByTime periods. ResultsByTime[0]
-                  # only picks the first MONTHLY bucket; a window spanning two
-                  # months (e.g. May+June) would give just the few-day June total
-                  # ($0.17). Write the aggregator to a temp file so the Python code
-                  # stays outside the YAML block scalar (no indentation conflict).
+                  # A single DAILY, group-by-SERVICE query feeds BOTH aggregates:
+                  # summing a service's amount across every day gives services[]
+                  # (the domain breakdown), summing all services within a day gives
+                  # daily[] (the per-day spend trend the FinOps page charts). We
+                  # aggregate ALL ResultsByTime periods — never ResultsByTime[0]
+                  # alone, which would drop every day but the first. Write the
+                  # aggregator to a temp file so the Python stays outside the YAML
+                  # block scalar (no indentation conflict).
                   printf '%s\n' \
                     'import json,os' \
                     'd=json.load(open("/tmp/_ce_raw.json"))' \
                     'T={}' \
+                    'D={}' \
                     'for p in d.get("ResultsByTime",[]):' \
+                    '  day=p.get("TimePeriod",{}).get("Start","")' \
                     '  for g in p.get("Groups",[]):' \
                     '    n=g["Keys"][0];a=float(g["Metrics"]["UnblendedCost"]["Amount"])' \
                     '    T[n]=T.get(n,0.0)+a' \
+                    '    if day:D[day]=D.get(day,0.0)+a' \
                     'S=sorted([{"name":k,"amount":round(v,2)} for k,v in T.items() if v>0.001],key=lambda x:-x["amount"])' \
-                    'import sys' \
-                    'out={"available":bool(S),"currency":"USD","periodStart":os.environ["CE_START"],"periodEnd":os.environ["CE_END"],"services":S,"collectedAt":os.environ["CE_NOW"],"source":"aws-cost-explorer-cronjob"}' \
+                    'DA=[{"date":k,"amount":round(v,2)} for k,v in sorted(D.items())]' \
+                    'out={"available":bool(S),"currency":"USD","periodStart":os.environ["CE_START"],"periodEnd":os.environ["CE_END"],"total":round(sum(s["amount"] for s in S),2),"services":S,"daily":DA,"collectedAt":os.environ["CE_NOW"],"source":"aws-cost-explorer-cronjob"}' \
                     'json.dump(out,open("/tmp/cost-report.json","w"))' \
-                    'print("ok",len(S),round(sum(s["amount"] for s in S),2))' \
+                    'print("ok",len(S),"services",len(DA),"days",round(sum(s["amount"] for s in S),2))' \
                     > /tmp/agg.py
                   if aws ce get-cost-and-usage \
                        --time-period Start=$START,End=$END \
-                       --granularity MONTHLY --metrics UnblendedCost \
+                       --granularity DAILY --metrics UnblendedCost \
                        --group-by Type=DIMENSION,Key=SERVICE \
                        --region us-east-1 --output json > /tmp/_ce_raw.json 2>/dev/null; then
                     CE_START="$START" CE_END="$END" CE_NOW="$NOW" \
                     python3 /tmp/agg.py
                   else
-                    printf '{"available":false,"reason":"cost explorer query failed","currency":"USD","periodStart":"%s","periodEnd":"%s","total":0,"services":[],"collectedAt":"%s","source":"aws-cost-explorer-cronjob"}\n' \
+                    printf '{"available":false,"reason":"cost explorer query failed","currency":"USD","periodStart":"%s","periodEnd":"%s","total":0,"services":[],"daily":[],"collectedAt":"%s","source":"aws-cost-explorer-cronjob"}\n' \
                       "$START" "$END" "$NOW" > /tmp/cost-report.json
                   fi
                   echo "collected:"; cat /tmp/cost-report.json


### PR DESCRIPTION
## What & why

Operators logged in and saw four pages rendering **intentionally idle** (KEDA scale-to-zero, ADR-0057) or auth-gated services as hard **errors**, plus the FinOps **spend trend never appearing** and no last-7-days view.

### Fixes
- **Fees** — was fetching the dedicated `/api/product-catalog/fees` route (hits the backend directly, no scale-to-zero detection, no operator token). Now goes through the **BFF proxy** (`svcUrl`): an idle backend classifies as `scaled_to_zero` → calm `DataUnavailable` panel, and the operator's Keycloak token is relayed (product-catalog auth cutover).
- **Product Catalog** — the dedicated `proxy()` never caught the fetch failure, so an idle backend surfaced as an **uncaught 500** + a red "služba je nedostupná" banner. Migrated to the **BFF proxy + graceful `DataUnavailable`** (removes the red banner and the raw 500/401 leak).
- **FinOps daily trend** — was gated on a `daily[]` series, but the in-cluster cost-collector CronJob queried Cost Explorer at **MONTHLY** granularity → `daily[]` always empty → trend never showed. Switched to a single **DAILY, group-by-SERVICE** query that emits `daily[]` (per-day totals) alongside `services[]` — the durable LIVE source.
- **FinOps 7-day view** — new **"Posledních 7 dní"** summary (7-day total, avg/day, week-over-week delta) above the daily trend chart.

### Verification
- `tsc --noEmit` clean · `eslint` clean (warnings only, pre-existing) · `next build` ✓
- `graceful-states.guard.test.ts` — 77/77 pass (no raw `HTTP ${...}` / alert-error leaks)
- (4 pre-existing `finops-allocation`/`taxonomy` failures are governance-manifest drift on `main`, unrelated to this PR)

## Linked issues
Refs #759