### PR TITLE
chore(gitops): auto-deploy services @ 147b7a68df826edd219925e5012f92b6e6d31cbc

### DIFF
--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -22,7 +22,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: dispute-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-dispute-service:sandbox-307c919f
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-dispute-service:sandbox-147b7a68
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8135}


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 147b7a68df826edd219925e5012f92b6e6d31cbc.

**Changed services:** ["openbank-dispute-service"]

Each image tag was updated to `sandbox-147b7a68df826edd219925e5012f92b6e6d31cbc` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.