### PR TITLE
chore(gitops): auto-deploy services @ c3aac7231bb73826b28c3c668dbdd6b945e34367

### DIFF
--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: aml-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-aml-service:sandbox-7d2ecdf7
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-aml-service:sandbox-c3aac723
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit c3aac7231bb73826b28c3c668dbdd6b945e34367.

**Changed services:** ["openbank-aml-service"]

Each image tag was updated to `sandbox-c3aac7231bb73826b28c3c668dbdd6b945e34367` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.