### PR TITLE
fix(gitops): right-size memory requests for observability and Kafka pods

### DIFF
--- a/openbank-infra/gitops/apps/alloy.yaml
+++ b/openbank-infra/gitops/apps/alloy.yaml
@@ -63,10 +63,15 @@ spec:
           # 256Mi OOMKilled (exit 137, crashloop) the DaemonSet pod on the CI
           # runner nodes — arc-runners with dind emit a huge log volume Alloy must
           # buffer. 512Mi holds those nodes; service nodes stay well under it.
+          # Request raised 128Mi → 320Mi (issue #809): measured steady-state is
+          # 256-310Mi on EVERY node, so the 128Mi request understated real per-node
+          # DaemonSet overhead by ~180Mi — a key ingredient of the 4Gi-node memory
+          # exhaustion / reclaim-livelock hangs. The request must reflect reality
+          # for Karpenter's bin-packing to be honest.
           resources:
             requests:
               cpu: 50m
-              memory: 128Mi
+              memory: 320Mi
             limits:
               cpu: 300m
               memory: 512Mi

--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -162,10 +162,12 @@ spec:
             resources:
               requests:
                 cpu: 200m
-                # 512Mi → 1Gi: steady-state head + WAL replay sits above 512Mi with the
-                # current fleet of ServiceMonitors/PodMonitors; reserve it so the pod lands
-                # on a node that can actually hold it.
-                memory: 1Gi
+                # 512Mi → 1Gi → 2560Mi (issue #809): measured steady-state is ~2.4Gi
+                # with the current scrape fleet, so a 1Gi request under-declared
+                # ~1.4Gi of real usage to the scheduler — the single biggest
+                # request-vs-RSS gap in the cluster and a direct contributor to
+                # node memory exhaustion. Reserve what it actually uses.
+                memory: 2560Mi
               limits:
                 cpu: "1"
                 # 1536Mi → 3Gi: the server was OOMKilled (exit 137) during startup TSDB
@@ -248,10 +250,12 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              # 128Mi → 384Mi (issue #809): measured steady-state ~340Mi sat just
+              # under the old 384Mi limit while the request declared a third of it.
+              memory: 384Mi
             limits:
               cpu: 500m
-              memory: 384Mi
+              memory: 512Mi
           # We define Prometheus + Tempo ourselves (below) to wire the full
           # correlation web, so disable the chart's auto-provisioned default.
           sidecar:

--- a/openbank-infra/gitops/apps/tempo.yaml
+++ b/openbank-infra/gitops/apps/tempo.yaml
@@ -96,7 +96,9 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 320Mi
+              # 320Mi → 640Mi (issue #809): measured steady-state ~615Mi — the
+              # request must cover it so bin-packing stays honest.
+              memory: 640Mi
             limits:
               cpu: 500m
               # bumped 640Mi → 1Gi → 2Gi: local-blocks in-memory span buffer kept

--- a/openbank-infra/gitops/components/kafka/kafka.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka.yaml
@@ -38,7 +38,9 @@ spec:
   resources:
     requests:
       cpu: 250m
-      memory: 768Mi
+      # 768Mi → 1152Mi (issue #809): measured steady-state ~1Gi — the request
+      # must cover it so Karpenter's bin-packing stays honest.
+      memory: 1152Mi
     limits:
       cpu: "1"
       memory: 1536Mi
@@ -121,9 +123,26 @@ spec:
   kafkaExporter:
     topicRegex: ".*"
     groupRegex: ".*"
+  # Strimzi ships the entity operator with NO resources (BestEffort) — the pod
+  # measures ~470Mi (topic ~210Mi + user ~260Mi) that the scheduler never saw,
+  # eroding node headroom on whatever node it lands on (issue #809).
   entityOperator:
-    topicOperator: {}
-    userOperator: {}
+    topicOperator:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 256Mi
+        limits:
+          cpu: 250m
+          memory: 384Mi
+    userOperator:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 288Mi
+        limits:
+          cpu: 250m
+          memory: 448Mi
 ---
 # Domain event topic for account-service. Declared explicitly (the broker does
 # not auto-create topics) so the topic operator manages it and the producer's


### PR DESCRIPTION
## Summary

First of two follow-ups from #809 (recurring node hangs via no-swap memory-reclaim livelock). A live fleet audit showed the cluster is over-requested in aggregate (usage/request = 0.68) — the JVM service fleet is fine — but a handful of platform pods run far above what they request, and Karpenter bin-packs by requests:

| Pod | Measured | Old request | New request |
|---|---|---|---|
| alloy (DaemonSet, **every node**) | ~256–310Mi | 128Mi | 320Mi |
| prometheus | ~2.4Gi | 1Gi | 2560Mi |
| tempo | ~615Mi | 320Mi | 640Mi |
| grafana | ~340Mi | 128Mi | 384Mi (limit 384→512Mi) |
| Kafka broker (dual) | ~1Gi | 768Mi | 1152Mi |
| Strimzi entity operator | ~470Mi | **none (BestEffort)** | 256+288Mi (+limits) |

The alloy line is the load-bearing one: ~180Mi of undeclared overhead on every node, including the 4Gi shapes where the death-packs happened. Requests now reflect measured steady-state, so the scheduler stops creating nodes that are already over capacity the moment they boot.

Second follow-up (kubelet eviction headroom in the EC2NodeClasses) comes as a separate PR — it drift-rolls the fleet and deserves its own review.

## Type of change

- [x] Fix (platform capacity correctness)

## Linked issues

Refs #809

## Verification

- Numbers taken from `kubectl top --containers` snapshots vs. pod spec requests across the whole cluster (audit table in #809).
- ArgoCD applies this automatically after merge; alloy DaemonSet and the Kafka/entity-operator pods roll with the new requests. Expect Karpenter to provision slightly more capacity — that capacity was always being consumed, just never declared.

## Security / compliance impact

None. Scheduling resource declarations only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)