### PR TITLE
fix(infra): add kubelet memory-eviction headroom to Karpenter node classes

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -397,6 +397,17 @@ resource "kubectl_manifest" "ec2nodeclass_runners" {
         ManagedBy                = "karpenter"
         Role                     = "arc-runner"
       }
+      # Eviction headroom against the no-swap memory-reclaim livelock (issue
+      # #809) — two of the four hung nodes on 2026-07-11 were runner nodes
+      # under Gradle build memory pressure. Evicting the runner pod (the job
+      # retries) beats a dead node that strands work for hours. Same block as
+      # the default EC2NodeClass; a change here drift-rolls the runner nodes.
+      kubelet = {
+        evictionHard              = { "memory.available" = "400Mi" }
+        evictionSoft              = { "memory.available" = "600Mi" }
+        evictionSoftGracePeriod   = { "memory.available" = "60s" }
+        evictionMaxPodGracePeriod = 60
+      }
       # CI/CD SPEED: put kubelet/containerd ephemeral storage (dind image layers,
       # Gradle build dir, Testcontainers volumes) on the instance's local NVMe via
       # RAID0 instead of the gp3 root EBS. NVMe random-IO is ~an order of magnitude

--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -128,6 +128,20 @@ resource "kubectl_manifest" "ec2nodeclass_default" {
       amiSelectorTerms = [
         { alias = "al2023@latest" }
       ]
+      # Eviction headroom against the no-swap memory-reclaim livelock (issue
+      # #809): with the AMI default (evictionHard memory.available<100Mi, 10s
+      # cadence) a memory spike outruns kubelet eviction and the kernel
+      # livelocks — kubelet + SSM starve while EC2 status checks stay ok, the
+      # node lingers NotReady, singleton pods strand. Evict pods well before
+      # that point instead; Karpenter also subtracts this from allocatable, so
+      # bin-packing gets honest. NOTE: any change here drifts every node of
+      # this class → Karpenter rolls them per the NodePool disruption budgets.
+      kubelet = {
+        evictionHard              = { "memory.available" = "300Mi" }
+        evictionSoft              = { "memory.available" = "500Mi" }
+        evictionSoftGracePeriod   = { "memory.available" = "60s" }
+        evictionMaxPodGracePeriod = 60
+      }
       role = local.karpenter_node_role_name
       subnetSelectorTerms = [
         { tags = { "karpenter.sh/discovery" = local.cluster_name } }


### PR DESCRIPTION
## Summary

Second follow-up from #809 (recurring node hangs via no-swap memory-reclaim livelock; companion to #819). The AMI-default kubelet eviction threshold (`memory.available<100Mi`, 10 s monitor cadence) is too little, too late: a memory spike outruns eviction and the kernel livelocks — kubelet and the SSM agent starve while EC2 status checks stay `ok`, the node lingers NotReady, singleton pods strand.

Give kubelet room to act first:

- **default** EC2NodeClass: `evictionHard memory.available<300Mi`, soft band at 500Mi (60 s grace, max pod grace 60 s).
- **runners** EC2NodeClass: hard 400Mi / soft 600Mi — two of the four 2026-07-11 hangs were runner nodes under Gradle build pressure; evicting the runner pod (the job retries) beats a dead node.

Karpenter subtracts these thresholds from node allocatable, so bin-packing tightens by the same amount — this and #819 together make the scheduler stop building nodes that are over real capacity at boot.

## Type of change

- [x] Fix (platform infra hardening)

## Linked issues

Refs #809

## Deploy note

`aws/envs/sandbox-platform` has no CI apply pipeline — applied out-of-band with a targeted plan/apply; this PR is the bookkeeping. **The kubelet-config change drifts every node of both classes**; Karpenter rolls them gradually per the NodePool disruption budgets (default pool max 50 %, overnight freeze 20:00–07:00 UTC; runner nodes roll as jobs drain).

## Security / compliance impact

None. Kubelet eviction thresholds only; no data, RBAC, or network changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)