### PR TITLE
fix(infra): raise default NodePool cpu limit for right-sized requests

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -219,11 +219,19 @@ resource "kubectl_manifest" "nodepool_default" {
           { nodes = "50%" },
         ]
       }
-      # Hard cap: at 4xlarge max, 32 vCPU = 2× c7g.4xlarge which comfortably
-      # fits all ~28 services + DaemonSets. Without this Karpenter happily
+      # Hard cap against runaway provisioning: without it Karpenter once
       # provisioned 14× c6g.12xlarge (~$235/day) with no warning.
+      # 32 → 48 vCPU (issue #809): the 32 cap was calibrated to the fleet's
+      # OLD, understated memory requests. Right-sizing them (#819) plus the
+      # kubelet eviction headroom (#820, subtracted from allocatable) raised
+      # declared demand, and the pool pinned at exactly 32/32 CPU — Karpenter
+      # then could NOT provision a node for the (2560Mi-request) ArgoCD
+      # application-controller ("all available instance types exceed limits"),
+      # leaving the deploy backbone Pending and stalling the drift roll. 48
+      # gives the roll surge + honest requests room while still capping
+      # runaway cost.
       limits = {
-        cpu    = "32"
+        cpu    = "48"
         memory = "128Gi"
       }
     }


### PR DESCRIPTION
## Summary

Completes the #809 capacity-correctness pair (#819 + #820). The default NodePool's 32-vCPU hard cap was calibrated to the fleet's old, **understated** memory requests. Once requests were right-sized (#819) and kubelet eviction headroom started being subtracted from allocatable (#820), the pool pinned at exactly 32/32 CPU and Karpenter refused to provision (`all available instance types exceed limits for nodepool`) — the ArgoCD application-controller (2560Mi request) sat Pending with `18 Insufficient memory` across the fleet, and the drift roll stalled behind the same wall. Raise the cap to 48 vCPU (memory limit unchanged at 128Gi, which was never binding: 59.5Gi used). The cap still exists to stop runaway provisioning (the 14× c6g.12xlarge incident).

## Type of change

- [x] Fix (platform capacity correctness)

## Linked issues

Refs #809

## Verification

- Applied out-of-band (env has no CI apply; this PR is the bookkeeping). Post-apply: Karpenter immediately provisioned, the controller is Running on a fresh node, pool at 30/48 CPU, drift roll resumed.

## Security / compliance impact

None. Autoscaler capacity limit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)