### PR TITLE
fix(openbao): correct db-rotation service→namespace/dbname mapping (runbook 0006 §3)

### DIFF
--- a/openbank-infra/gitops/components/openbao/db-rotation-job.yaml
+++ b/openbank-infra/gitops/components/openbao/db-rotation-job.yaml
@@ -95,12 +95,6 @@ spec:
                     secretKeyRef:
                       name: openbao-db-admin-passwords
                       key: notifications
-                - name: VAULT_ADMIN_PASS_PUSH_NOTIFICATIONS
-                  valueFrom:
-                    secretKeyRef:
-                      name: openbao-db-admin-passwords
-                      key: push-notifications
-                      optional: true
                 - name: VAULT_ADMIN_PASS_AUDIT
                   valueFrom:
                     secretKeyRef:
@@ -116,7 +110,6 @@ spec:
                     secretKeyRef:
                       name: openbao-db-admin-passwords
                       key: fx
-                      optional: true
                 - name: VAULT_ADMIN_PASS_ACCOUNT
                   valueFrom:
                     secretKeyRef:

--- a/openbank-infra/gitops/components/openbao/dynamic-db-credentials.yaml
+++ b/openbank-infra/gitops/components/openbao/dynamic-db-credentials.yaml
@@ -22,7 +22,7 @@
 # without a cluster restart — no application downtime expected.
 #
 # Services covered (Phase 1 scope — lowest-risk-first ordering, ADR-0099 §Phase 1 ¶4):
-#   notifications, push-notifications, audit, balance, fx, account, transaction, ledger
+#   notifications, audit, balance, fx, account, transaction, ledger
 # Pilot service (validate first): notifications
 #
 # vault_admin passwords are injected as env vars (VAULT_ADMIN_PASS_<SERVICE>) by the
@@ -121,13 +121,12 @@ data:
     # CNPG cluster names verified from postgres.yaml manifests (2026-06-30).
     # vault_admin passwords read from env vars set by the CronJob Secret ref
     # (see db-rotation-job.yaml and runbook 0006 step 3).
-    configure_service notifications      notifications-db      notifications  openbank_notifications "${VAULT_ADMIN_PASS_NOTIFICATIONS}"
-    configure_service push-notifications push-notifications-db notifications  openbank_push_notifications "${VAULT_ADMIN_PASS_PUSH_NOTIFICATIONS}"
-    configure_service audit              audit-db              audit          openbank_audit         "${VAULT_ADMIN_PASS_AUDIT}"
-    configure_service balance            balances-db           balances       openbank_balances      "${VAULT_ADMIN_PASS_BALANCE}"
-    configure_service fx                 fx-db                 fx-service     openbank_fx            "${VAULT_ADMIN_PASS_FX}"
-    configure_service account            accounts-db           accounts       openbank_accounts      "${VAULT_ADMIN_PASS_ACCOUNT}"
-    configure_service transaction        transaction-db        transaction    openbank_transaction   "${VAULT_ADMIN_PASS_TRANSACTION}"
-    configure_service ledger             ledger-db             ledger         openbank_ledger        "${VAULT_ADMIN_PASS_LEDGER}"
+    configure_service notifications      notifications-db      notifications  openbank_notifications  "${VAULT_ADMIN_PASS_NOTIFICATIONS}"
+    configure_service audit              audit-db              audit          openbank_audit          "${VAULT_ADMIN_PASS_AUDIT}"
+    configure_service balance            balances-db           balances       openbank_balances       "${VAULT_ADMIN_PASS_BALANCE}"
+    configure_service fx                 fx-db                 fx             openbank_fx             "${VAULT_ADMIN_PASS_FX}"
+    configure_service account            accounts-db           accounts       openbank_accounts       "${VAULT_ADMIN_PASS_ACCOUNT}"
+    configure_service transaction        transaction-db        payments       openbank_transactions   "${VAULT_ADMIN_PASS_TRANSACTION}"
+    configure_service ledger             ledger-db             ledger         openbank_ledger         "${VAULT_ADMIN_PASS_LEDGER}"
 
     echo "[openbao-db] all services configured."


### PR DESCRIPTION
## Summary

Fixes the OpenBao dynamic-DB rotation script (`openbao-db-rotation-sync` CronJob, ADR-0099/runbook 0006) so it can actually complete once the out-of-band §3 (`vault_admin` role bootstrap) is done. Found while diagnosing a live incident: `ledger-service`, `aml-service`, `audit-service`, `dispute-service` and others crash-looping/failing to schedule because their dynamic DB credentials (`database/creds/<service>-db-vault-role`) were never issued — the rotation job that configures the OpenBao database secrets engine has been silently failing every Sunday since 2026-07-05 (`error: timed out waiting for the condition`), and long-running pods only surfaced the symptom once node rotation forced them to reconnect.

Verified this PR's fixes against the **live cluster** (not just the repo), independently of the changes themselves:

## Bugs fixed

1. **`fx`: namespace `fx-service` → `fx`.** `fx-service` namespace does not exist in the cluster; the real one is `fx` (confirmed: `kubectl get ns fx-service` 404s, `fx` is Active with `fx-db-1` running).
2. **`transaction`: namespace `transaction` → `payments`, AND dbname `openbank_transaction` → `openbank_transactions` (plural).** Neither `transaction` namespace nor a database literally named `openbank_transaction` (singular) exist — confirmed against `openbank-infra/gitops/components/payments/postgres.yaml`'s initdb block (`database: openbank_transactions`).
3. **`push-notifications`: removed entirely.** Its CNPG cluster (`push-notifications-db`) and service module exist nowhere in the cluster or this repo. The script's `set -eu` means an unset `VAULT_ADMIN_PASS_PUSH_NOTIFICATIONS` (the Secret key is `optional: true`, so the env var is simply absent) aborts the **entire script on the 2nd service** — meaning `audit/balance/fx/account/transaction/ledger` never ran, even before considering bugs #1/#2. This is very likely the proximate reason every run has failed since this ConfigMap was introduced.
4. **`fx` Secret key: dropped `optional: true`.** fx-service is a real Phase 1 service; marking its credential optional was inconsistent with audit/balance/account/transaction/ledger.

## Type of change

- [x] fix

## Linked issues

Refs runbook 0006 §3/§4. N/A — no tracked issue yet for the wider incident; opening one is a reasonable follow-up but out of scope for this narrow script fix.

## Changes

- `dynamic-db-credentials.yaml`: corrected `configure_service` args for fx/transaction, removed the push-notifications line + its mention in the services-covered comment.
- `db-rotation-job.yaml`: removed the `VAULT_ADMIN_PASS_PUSH_NOTIFICATIONS` env block, dropped `optional: true` on the `fx` key.

## Definition of Done

- [x] YAML valid (both files, `yaml.safe_load_all`).
- [x] Embedded `configure.sh` shell syntax valid (`sh -n`).
- [x] No merge conflicts against current `main`.
- [x] No generator/regen step needed — this ConfigMap is plain kustomize-referenced, not derived.
- **Scope note:** the separate `secret-rotator-cronjob.yaml` (Tier 2, its own service list including a `push-notifications-service` reference) is a different mechanism and intentionally untouched here — worth checking separately.

## What this PR does NOT fix (needs an operator, out-of-band, root-token-gated — runbook 0006 §3/§4)

This is necessary but not sufficient. The `vault_admin` Postgres role + `openbao-db-admin-passwords` K8s Secret referenced by runbook 0006 §3 were **never created** (verified: `kubectl get secret openbao-db-admin-passwords -n vault` → NotFound; `vault_admin` role absent from `pg_roles` on ledger-db). And the `eso` OpenBao policy needs the `database/creds/*` read capability added (§4) before ExternalSecrets will sync. Both require the break-glass root token (`openbank/openbao/break-glass`) and are intentionally NOT part of this PR.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] Governance/CI config change → deferred to human review by the agent-review workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
