### PR TITLE
fix(kyverno): writable ECR cred cache for admission controller (unblocks new-image deploys)

### DIFF
--- a/openbank-infra/gitops/apps/kyverno.yaml
+++ b/openbank-infra/gitops/apps/kyverno.yaml
@@ -32,6 +32,23 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+          container:
+            # The amazon-ecr-credential-helper (registryCredentialHelpers=…,amazon)
+            # caches its ECR auth token under $HOME/.ecr. HOME defaults to
+            # /home/nonroot, which is on the readOnlyRootFilesystem, so the write
+            # fails ("open /home/nonroot/.ecr/…: no such file or directory") and the
+            # helper re-authenticates (ECR GetAuthorizationToken) on EVERY image
+            # verification. Under load that intermittently times out, so cosign
+            # signature/attestation fetches fail and validly-signed images get
+            # rejected as "unverified" — which the image-verify cache then pins for
+            # its whole TTL, silently wedging all NEW-image deploys fleet-wide
+            # (admin-ui + agent-service seen; incident 2026-07-11). Point HOME at the
+            # already-writable sigstore emptyDir (TUF_ROOT=/.sigstore) so the token
+            # caches and ECR auth stays reliable. No new volume — the chart exposes
+            # no extra-volume hook for the admission controller, only extraEnvVars.
+            extraEnvVars:
+              - name: HOME
+                value: /.sigstore
         backgroundController:
           replicas: 1
           resources:


### PR DESCRIPTION
## Incident

New-image deploys were silently wedging fleet-wide: ArgoCD couldn't roll **admin-ui** `sandbox-e845172a` (nor **agent-service** `sandbox-b69a7362`, earliest 2026-07-08) because Kyverno's `verify-openbank-image-signatures` (**Enforce**) rejected them as *"unverified image"*.

**The images are validly signed** — `cosign verify --key awskms:///alias/openbank-cosign-signing` and `cosign verify-attestation --type cyclonedx` both pass, and the policy's embedded `publicKeys` == that KMS key. The failure was entirely on the admission controller's side.

## Root cause

The `amazon-ecr-credential-helper` caches its ECR token under `$HOME/.ecr`. `HOME` defaults to `/home/nonroot`, which is on the admission controller's `readOnlyRootFilesystem` → the write fails (`open /home/nonroot/.ecr/.config.json.tmp: no such file or directory`, seen ~59×/40s). So the helper re-runs ECR `GetAuthorizationToken` on **every** verification; under load those intermittently **time out**, cosign signature/attestation fetches fail, and the **image-verify cache pins the failure** for its TTL — permanently blocking that image.

## Fix

Point `HOME` at the already-writable sigstore emptyDir (`TUF_ROOT=/.sigstore`) via `admissionController.container.extraEnvVars`, so the credential helper can cache its token and ECR auth stays reliable. The kyverno chart exposes no extra-volume hook for the admission controller — only `extraEnvVars` — so reusing the sigstore volume is the chart-native fix.

## Verified live (selfHeal temporarily off on the kyverno app)

- `HOME=/.sigstore` → the `no such file` / re-auth errors **stop** (0 in 35s, was 59).
- admin-ui + other new images **verify and roll immediately**, with the image-verify cache **left enabled** (default).
- admin-ui is now serving `sandbox-e845172a` (1/1). After this merges + syncs, I'll re-enable `selfHeal` on the kyverno app.

## Follow-ups (not in this PR)
- `verify-openbank-image-sbom-attestation` (Audit) has a JMESPath bug: `{{ data.bomFormat }}` → `Unknown key "data"` (should be `{{ bomFormat }}` for a CycloneDX predicate). Audit-only, non-blocking.
- The auto-deploy GitOps PRs are still authored with an unsigned user-PAT commit (peter-evans `sign-commits` only signs with `GITHUB_TOKEN`/GitHub App); needs a GitHub App token.

## Linked issues
Refs #759