### PR TITLE
fix(openbao): dedicated vault-db ClusterSecretStore for the database secrets engine

### DIFF
--- a/openbank-infra/gitops/components/accounts/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/accounts/db-dynamic-externalsecret.yaml
@@ -5,6 +5,9 @@
 # refreshInterval: 1h keeps the Secret ahead of the 24h lease TTL (max 72h).
 # CNPG cluster: accounts-db, namespace: accounts, DB: openbank_accounts
 # Prerequisite: runbook 0006 §3 (vault_admin role + configure.sh run for account).
+# Uses the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+# not `vault-kv` (KV v2, openbank/ mount) — the database secrets engine is not
+# KV-versioned; see clustersecretstore-db.yaml for why reusing vault-kv 404s.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,7 +20,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-kv
+    name: vault-db
   target:
     name: accounts-db-dynamic
     creationPolicy: Owner
@@ -32,9 +35,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: database/creds/account-db-vault-role
+        key: creds/account-db-vault-role
         property: username
     - secretKey: password
       remoteRef:
-        key: database/creds/account-db-vault-role
+        key: creds/account-db-vault-role
         property: password

--- a/openbank-infra/gitops/components/audit/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/audit/db-dynamic-externalsecret.yaml
@@ -4,6 +4,9 @@
 # at database/creds/audit-db-vault-role and projects them into `audit-db-dynamic`.
 # refreshInterval: 1h keeps the Secret ahead of the 24h lease TTL (max 72h).
 # Prerequisite: runbook 0006 §3 (vault_admin role + configure.sh run for audit).
+# Uses the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+# not `vault-kv` (KV v2, openbank/ mount) — the database secrets engine is not
+# KV-versioned; see clustersecretstore-db.yaml for why reusing vault-kv 404s.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -16,7 +19,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-kv
+    name: vault-db
   target:
     name: audit-db-dynamic
     creationPolicy: Owner
@@ -31,9 +34,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: database/creds/audit-db-vault-role
+        key: creds/audit-db-vault-role
         property: username
     - secretKey: password
       remoteRef:
-        key: database/creds/audit-db-vault-role
+        key: creds/audit-db-vault-role
         property: password

--- a/openbank-infra/gitops/components/balances/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/balances/db-dynamic-externalsecret.yaml
@@ -4,6 +4,9 @@
 # at database/creds/balance-db-vault-role and projects them into `balances-db-dynamic`.
 # refreshInterval: 1h keeps the Secret ahead of the 24h lease TTL (max 72h).
 # Prerequisite: runbook 0006 §3 (vault_admin role + configure.sh run for balance).
+# Uses the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+# not `vault-kv` (KV v2, openbank/ mount) --- the database secrets engine is not
+# KV-versioned; see clustersecretstore-db.yaml for why reusing vault-kv 404s.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -16,7 +19,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-kv
+    name: vault-db
   target:
     name: balances-db-dynamic
     creationPolicy: Owner
@@ -31,9 +34,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: database/creds/balance-db-vault-role
+        key: creds/balance-db-vault-role
         property: username
     - secretKey: password
       remoteRef:
-        key: database/creds/balance-db-vault-role
+        key: creds/balance-db-vault-role
         property: password

--- a/openbank-infra/gitops/components/external-secrets/clustersecretstore-db.yaml
+++ b/openbank-infra/gitops/components/external-secrets/clustersecretstore-db.yaml
@@ -1,0 +1,39 @@
+# ClusterSecretStore — dedicated handle for OpenBao's Database Secrets Engine
+# (ADR-0099 Tier 1). The database engine issues dynamic, non-versioned credentials
+# at database/creds/<role> — a different API shape than the KV v2 `openbank`
+# mount `vault-kv` is configured for. Reusing `vault-kv` (path: openbank,
+# version: v2) here silently mis-routes every read: ESO's KV v2 client always
+# constructs <path>/data/<key>, so a key of `database/creds/<role>` resolves to
+# the nonsense path `openbank/data/database/creds/<role>` — which 404s ("Secret
+# does not exist") regardless of policy. Found live 2026-07-11 diagnosing a
+# ledger-service outage: the `eso-read` policy already granted `database/creds/*`
+# and a root-token read succeeded, but ESO's own reads through `vault-kv` kept
+# failing until this dedicated store existed — confirmed by a scratch
+# ClusterSecretStore + ExternalSecret test against the live cluster before this
+# file was written (SecretSynced: True).
+#
+# path: database, version: v1 => ESO does a literal GET at <path>/<key>, with no
+# data/metadata KV v2 wrapping — the correct shape for a non-KV engine like the
+# database secrets engine.
+#
+# Same auth as vault-kv: Kubernetes auth method, role `eso` (bound to policy
+# `eso-read` — NOT `eso`, a naming trap runbook 0006 §4 originally got wrong;
+# `eso-read` now grants `database/creds/*` in addition to its existing
+# `openbank/data|metadata/*`).
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: vault-db
+spec:
+  provider:
+    vault:
+      server: http://openbao.vault.svc:8200
+      path: database
+      version: v1
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: eso
+          serviceAccountRef:
+            name: external-secrets
+            namespace: external-secrets

--- a/openbank-infra/gitops/components/fx-service/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/fx-service/db-dynamic-externalsecret.yaml
@@ -5,6 +5,9 @@
 # refreshInterval: 1h keeps the Secret ahead of the 24h lease TTL (max 72h).
 # CNPG cluster: fx-db, namespace: fx, DB: openbank_fx
 # Prerequisite: runbook 0006 §3 (vault_admin role + configure.sh run for fx).
+# Uses the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+# not `vault-kv` (KV v2, openbank/ mount) --- the database secrets engine is not
+# KV-versioned; see clustersecretstore-db.yaml for why reusing vault-kv 404s.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,7 +20,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-kv
+    name: vault-db
   target:
     name: fx-db-dynamic
     creationPolicy: Owner
@@ -32,9 +35,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: database/creds/fx-db-vault-role
+        key: creds/fx-db-vault-role
         property: username
     - secretKey: password
       remoteRef:
-        key: database/creds/fx-db-vault-role
+        key: creds/fx-db-vault-role
         property: password

--- a/openbank-infra/gitops/components/ledger/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/ledger/db-dynamic-externalsecret.yaml
@@ -5,6 +5,9 @@
 # refreshInterval: 1h keeps the Secret ahead of the 24h lease TTL (max 72h).
 # CNPG cluster: ledger-db, namespace: ledger, DB: openbank_ledger
 # Prerequisite: runbook 0006 §3 (vault_admin role + configure.sh run for ledger).
+# Uses the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+# not `vault-kv` (KV v2, openbank/ mount) --- the database secrets engine is not
+# KV-versioned; see clustersecretstore-db.yaml for why reusing vault-kv 404s.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -17,7 +20,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-kv
+    name: vault-db
   target:
     name: ledger-db-dynamic
     creationPolicy: Owner
@@ -32,9 +35,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: database/creds/ledger-db-vault-role
+        key: creds/ledger-db-vault-role
         property: username
     - secretKey: password
       remoteRef:
-        key: database/creds/ledger-db-vault-role
+        key: creds/ledger-db-vault-role
         property: password

--- a/openbank-infra/gitops/components/notifications/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/notifications/db-dynamic-externalsecret.yaml
@@ -14,12 +14,18 @@
 # balance, fx, account, transaction, ledger). Rollout order: lowest-risk-first.
 #
 # Prerequisites (runbook 0006 §3):
-#   1. vault_admin role created in notifications-db with CREATEROLE.
+#   1. vault_admin role created in notifications-db with CREATEROLE, AND granted
+#      GRANT SELECT/INSERT/UPDATE/DELETE ON ALL TABLES IN SCHEMA public WITH GRANT
+#      OPTION (CREATEROLE alone cannot re-grant table privileges it doesn't hold —
+#      the dynamic role's creation_statements does exactly that GRANT).
 #   2. bao write database/config/notifications-db ... (configure.sh does this).
 #   3. bao write database/roles/notifications-db-vault-role ... (configure.sh).
-#   4. ESO ClusterSecretStore `vault-kv` must be granted read on database/creds/*.
-#      The `eso` policy covers `openbank/*` (KV); extend it to `database/creds/*`
-#      per runbook 0006 §2 before this ExternalSecret can sync.
+#   4. `eso-read` (NOT `eso` — that policy name is unrelated to this k8s-auth role)
+#      must be granted read on database/creds/*, AND this ExternalSecret must use
+#      the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+#      never `vault-kv` (KV v2) — the database secrets engine is not KV-versioned;
+#      routing through vault-kv 404s regardless of policy. See
+#      clustersecretstore-db.yaml.
 #
 # NOTE: the notification-service Deployment currently reads POSTGRES_PASSWORD from
 # the CNPG-generated Secret `notifications-db-app`. Once this ExternalSecret is
@@ -37,7 +43,7 @@ spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
-    name: vault-kv
+    name: vault-db
   target:
     name: notifications-db-dynamic
     creationPolicy: Owner
@@ -53,9 +59,9 @@ spec:
   data:
     - secretKey: username
       remoteRef:
-        key: database/creds/notifications-db-vault-role
+        key: creds/notifications-db-vault-role
         property: username
     - secretKey: password
       remoteRef:
-        key: database/creds/notifications-db-vault-role
+        key: creds/notifications-db-vault-role
         property: password

--- a/openbank-infra/gitops/components/payments/db-dynamic-externalsecret.yaml
+++ b/openbank-infra/gitops/components/payments/db-dynamic-externalsecret.yaml
@@ -1,0 +1,53 @@
+# ADR-0099 Tier 1 — dynamic DB credentials for transaction-service (Phase 1)
+#
+# ESO fetches short-lived Postgres credentials from OpenBao database secrets engine
+# at database/creds/transaction-db-vault-role and projects them into
+# `transaction-db-dynamic`. refreshInterval: 1h keeps the Secret ahead of the 24h
+# lease TTL (max 72h).
+# CNPG cluster: transaction-db, namespace: payments, DB: openbank_transactions
+# Prerequisite: runbook 0006 §3 (vault_admin role + configure.sh run for
+# transaction) — vault_admin also needs GRANT ... WITH GRANT OPTION on the
+# existing tables (CREATEROLE alone cannot re-grant privileges it doesn't hold).
+# Uses the dedicated `vault-db` ClusterSecretStore (path: database, version: v1),
+# not `vault-kv` (KV v2, openbank/ mount) — the database secrets engine is not
+# KV-versioned; see external-secrets/clustersecretstore-db.yaml for why reusing
+# vault-kv 404s.
+#
+# This manifest did not previously exist — transaction-service was in the Phase 1
+# rollout list (dynamic-db-credentials.yaml, ADR-0099 §Phase 1 ¶4) but had no
+# ExternalSecret projecting its dynamic credential into the namespace (found live
+# 2026-07-11 diagnosing a rotation-scope outage: `kubectl get externalsecret
+# transaction-db-dynamic -n payments` was NotFound).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: transaction-db-dynamic
+  namespace: payments
+  annotations:
+    openbank.io/adr: "0099"
+    openbank.io/rotation-tier: "1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-db
+  target:
+    name: transaction-db-dynamic
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+          secret.reloader.stakater.com/match: "true"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: creds/transaction-db-vault-role
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: creds/transaction-db-vault-role
+        property: password


### PR DESCRIPTION
## Summary

Fixes the third and final root cause in the OpenBao dynamic-DB rotation outage chain. `ledger-service` and 5 other services were down/degraded because their dynamic DB credentials could never sync — even after fixing the rotation script (#826) and completing the out-of-band `vault_admin` bootstrap (runbook 0006 §3 + a `WITH GRANT OPTION` grant this exposed as also missing).

## Root cause

ESO's `ClusterSecretStore` `vault-kv` is hardcoded for the KV v2 mount `openbank` (`path: openbank`, `version: v2`). OpenBao's **database secrets engine** (`database/creds/<role>`) is a completely different, non-KV-versioned API. Reusing `vault-kv` for it makes ESO construct `<path>/data/<key>` for every read — so `database/creds/ledger-db-vault-role` gets mis-routed to the nonsense path `openbank/data/database/creds/ledger-db-vault-role`, which 404s ("Secret does not exist") **regardless of policy grants**.

This masqueraded as a policy problem for a while: a root-token `bao read database/creds/ledger-db-vault-role` succeeded (root bypasses all policy, so it never goes through this store/routing at all), but ESO's own reads through `vault-kv` kept failing identically even after granting `eso-read` (the *actual* policy the `eso` k8s-auth role uses — `eso` itself, which runbook 0006 §4 says to update, is a different, unattached policy — another naming trap) the `database/creds/*` capability.

**Verified empirically against the live cluster before writing this fix**: created a scratch `ClusterSecretStore` (`path: database`, `version: v1`) + a scratch `ExternalSecret`, confirmed `SecretSynced: True`, then removed both scratch resources.

## Changes

- **New** `external-secrets/clustersecretstore-db.yaml`: `vault-db` store — `path: database`, `version: v1` (plain `<path>/<key>` GET, no KV v2 `data/`/`metadata/` wrapping). Same `kubernetes` auth, role `eso`, as `vault-kv`.
- **6 existing** `db-dynamic-externalsecret.yaml` files (accounts, audit, balances, fx-service, ledger, notifications): `secretStoreRef.name` → `vault-db`, `remoteRef.key` `database/creds/X` → `creds/X` (the store's `path` now supplies that prefix). Also corrected `notifications`' own comment block, which documented the exact same wrong `vault-kv`/`eso` assumption baked into runbook 0006 §4 — this is very likely *why* nobody caught it: the design's own docs never anticipated this failure mode, so it looked "done" once the policy-write step was written down.
- **New** `payments/db-dynamic-externalsecret.yaml` for transaction-service: this manifest **never existed at all**. `transaction-db-dynamic` was in the Phase 1 service list (`dynamic-db-credentials.yaml`) but had no `ExternalSecret` projecting anything into the `payments` namespace — found live via `kubectl get externalsecret transaction-db-dynamic -n payments` → NotFound.

## Type of change

- [x] fix

## Linked issues

Refs runbook 0006 §4. Third of three fixes in this incident chain: #826 (rotation script namespace/dbname mapping) + the out-of-band `vault_admin` `WITH GRANT OPTION` grant (root-token-gated, already applied directly — not a git change) + this PR (ClusterSecretStore routing).

## Definition of Done

- [x] YAML valid on all 8 files (`yaml.safe_load`).
- [x] No merge conflicts against current `main`.
- [x] **Empirically verified the fix mechanism against the live cluster** (scratch store + scratch ExternalSecret, `SecretSynced: True`, cleaned up) before writing the permanent manifests.
- No app code change; no Deployment env-var wiring change (matches the existing pattern — `notifications`' own comment documents that Deployment wiring to consume `*-db-dynamic` is separate, future work, not yet done for any of these services).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] Governance/infra change → deferred to human review by the agent-review workflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
