### PR TITLE
docs: capture the no-swap memory-livelock node-hang footgun (CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,21 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   `.github/scripts/check-no-service-principal-type.sh` (`rules.yaml: authz_policy`).
 
 ### GitOps / Kubernetes
+- **A no-swap node under memory pressure can hang whole-guest instead of OOM-killing.** Kernel
+  reclaim livelocks; kubelet and the SSM agent starve together while EC2 status checks stay `ok`,
+  so the node lingers NotReady and singleton pods (e.g. the ArgoCD application-controller) strand
+  (issue #809). Diagnosis shortcut: CloudWatch `CPUUtilization` pinned at a constant high plateau
+  for hours = livelock — terminate the instance, don't debug the guest. The defenses are layered
+  and ALL needed: honest memory *requests* (Karpenter bin-packs by requests — an undeclared
+  ~200Mi-per-node DaemonSet is what actually kills 4Gi nodes), kubelet eviction headroom in the
+  EC2NodeClass (the AMI default `memory.available<100Mi` reacts too late), memory *limits* on
+  singletons (a container OOM-kill self-heals; a dead node doesn't), and Karpenter `NodeRepair`
+  as the backstop (EKS node auto repair covers only managed node groups, and consolidation cannot
+  touch a node holding a `do-not-disrupt` pod).
+- **Right-sizing requests can pin a NodePool at its `limits` cap.** The cap was calibrated to the
+  old, understated requests; after raising them Karpenter may refuse to provision
+  ("all available instance types exceed limits for nodepool"), leaving pods Pending and stalling
+  drift rolls. Whenever you raise requests or eviction headroom, re-check the pool's `limits`.
 - **`strategy.type: Recreate` + Server-Side Apply = HTTP 403.** Use `RollingUpdate` with
   `maxSurge: 0 / maxUnavailable: 1` for identical zero-concurrency behaviour.
 - **Use explicit registry prefixes for container images** (`docker.io/library/<image>` for official


### PR DESCRIPTION
## Summary

Routes the #809 lesson into the repo per the knowledge-capture rule (`rules.yaml: knowledge_capture`): two new bullets in the GitOps/Kubernetes pitfalls section of `CLAUDE.md` —

1. A no-swap node under memory pressure hangs whole-guest (kernel reclaim livelock; kubelet + SSM starve while EC2 status checks stay `ok`) instead of OOM-killing — with the CloudWatch CPU-plateau diagnosis shortcut and the layered defense (honest requests, EC2NodeClass eviction headroom, limits on singletons, Karpenter `NodeRepair` backstop).
2. Right-sizing requests can pin a NodePool at its `limits` cap and block all provisioning — re-check the cap whenever requests rise.

## Type of change

- [x] Docs

## Linked issues

Refs #809

## Security / compliance impact

None. Documentation only; generalized (no account/instance specifics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)