### PR TITLE
fix(account): propagate a service token to product-catalog (#401 rollout)

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogClient.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/client/ProductCatalogClient.kt
@@ -5,17 +5,24 @@
 package com.openbank.account.infrastructure.client
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
-// product-catalog's product-read endpoints are unauthenticated (public reference data), so no
-// OidcClientRequestReactiveFilter provider here, unlike SanctionsServiceClient.
+// product-catalog now authenticates its callers (issue #401, #743): reads require a valid
+// token (@Authenticated). This comment previously said "unauthenticated, public reference
+// data" — true when this file was written, stale since #743 merged 2026-07-11. Propagate an
+// openbank-services bearer like SanctionsServiceClient, or every account-open product lookup
+// gets a 401 -> ProductLookupResult.Unavailable -> validation silently skipped (fail-open by
+// design, so this was never a crash, just a silent bypass of ADR-0158's whole point).
 @RegisterRestClient(configKey = "product-catalog-api")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
 @Path("/api/v1/products")
 @Produces(MediaType.APPLICATION_JSON)
 interface ProductCatalogClient {


### PR DESCRIPTION
## Summary

Found while checking the status of other open PRs: **#727** added a new product-catalog caller (`ProductCatalogClient`, account-open validation, ADR-0158) that merged at 11:51 UTC — **before** #743 (12:20 UTC) made product-catalog `@Authenticated`. Its own code comment ("product-catalog's product-read endpoints are unauthenticated") was true when written and is now stale.

## Impact (silent, not a crash)

`ProductCatalogAdapter` deliberately fails open on any non-404 error (by design — see its class doc). So a 401 from product-catalog doesn't break account opening; it maps to `ProductLookupResult.Unavailable` and **silently skips** the product validation ADR-0158 exists for. Could not observe a live 401 directly — product-catalog is currently KEDA-scaled to zero replicas (ADR-0083 pilot, no traffic), so any raw connection attempt (mine included, via a scratch debug pod) gets "connection refused" regardless of auth. Confirmed the fix is needed by comparing against billing-service's already-working client (#744), which hits the identical `http://product-catalog.accounts.svc:8104` URL and required the same fix.

## Type of change

- [x] fix

## Linked issues

Refs #401 (product-catalog authentication rollout)

## Changes

- `ProductCatalogClient.kt`: `@RegisterProvider(OidcClientRequestReactiveFilter::class)`, matching `SanctionsServiceClient`'s existing pattern in the same service. The `quarkus-oidc-client-reactive-filter` dependency was already present in `build.gradle.kts` (used by the sanctions client) — no build file change needed.

## Definition of Done

- [x] `:openbank-account-service:compileKotlin ktlintCheck` pass locally.
- No DB/API/event change.

## Security checklist

- [x] No secrets/PII. Money-path service (account-service) → 2 approvals + threat model per ADR-0030 (threat model already exists, unaffected by this change).
