### PR TITLE
test(fx,ledger,balance): property tests for FX margin, idempotency, projection order

### DIFF
--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/domain/model/BalanceProjectionOrderPropertyTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/domain/model/BalanceProjectionOrderPropertyTest.kt
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.domain.model
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Permutation-order-independence property (ADR-0011, issue #469 item 5). [BalancePropertyTest]'s
+ * "booked-delta projection is unguarded and moves booked and available in lock-step" proves
+ * order-independence for a SINGLE delta; this proves the stronger claim across a whole SEQUENCE:
+ * folding a batch of ledger-projected booked deltas into a [Balance] is commutative — the final
+ * projected balance does not depend on the order the events are replayed in.
+ *
+ * Scoped deliberately to [Balance.applyBookedDelta]: it is the one balance mutation with no
+ * overdraft-floor guard (ADR-0039 Phase D — the read-model catching up to an already-posted ledger
+ * fact, not a new spend decision), so it is unconditionally commutative/associative (plain signed
+ * `BigDecimal` addition). [Balance.applyDebit]/[Balance.withReservation] carry a `require(...)`
+ * overdraft-floor guard that can throw for one ordering of a permutation and not another even
+ * though the final sum would match — reordering those is not a safe general property.
+ */
+class BalanceProjectionOrderPropertyTest {
+
+    private val signedArb = Arb.long(-10_000_000L, 10_000_000L).map { BigDecimal(it).movePointLeft(2) }
+    private val nonNegArb = Arb.long(0L, 10_000_000L).map { BigDecimal(it).movePointLeft(2) }
+
+    private val balanceArb: Arb<Balance> =
+        Arb.bind(signedArb, signedArb, nonNegArb, nonNegArb) { booked, available, reserved, limit ->
+            Balance(
+                id = UUID.randomUUID(),
+                accountId = UUID.randomUUID(),
+                currency = "EUR",
+                bookedAmount = booked,
+                availableAmount = available,
+                reservedAmount = reserved,
+                pendingAmount = BigDecimal.ZERO,
+                updatedAt = OffsetDateTime.now(),
+                version = 7L,
+                arrangedOverdraftLimit = limit,
+            )
+        }
+
+    private fun fold(bal: Balance, deltas: List<BigDecimal>): Balance =
+        deltas.fold(bal) { b, d -> b.applyBookedDelta(d) }
+
+    @Test
+    fun `folding a sequence of booked deltas is independent of application order`(): Unit = runBlocking {
+        checkAll(200, balanceArb, Arb.list(signedArb, 1..8)) { bal, deltas ->
+            val inOrder = fold(bal, deltas)
+
+            repeat(3) {
+                val reordered = fold(bal, deltas.shuffled())
+                assertThat(reordered.bookedAmount).isEqualByComparingTo(inOrder.bookedAmount)
+                assertThat(reordered.availableAmount).isEqualByComparingTo(inOrder.availableAmount)
+                assertThat(reordered.version).isEqualTo(inOrder.version)
+            }
+        }
+    }
+
+    @Test
+    fun `folding a sequence of booked deltas equals applying their sum in one step`(): Unit = runBlocking {
+        checkAll(200, balanceArb, Arb.list(signedArb, 0..8)) { bal, deltas ->
+            val folded = fold(bal, deltas)
+            val sum = deltas.fold(BigDecimal.ZERO) { acc, d -> acc + d }
+            val oneStep = bal.applyBookedDelta(sum)
+
+            assertThat(folded.bookedAmount).isEqualByComparingTo(oneStep.bookedAmount)
+            assertThat(folded.availableAmount).isEqualByComparingTo(oneStep.availableAmount)
+        }
+    }
+}

--- a/openbank-fx-service/build.gradle.kts
+++ b/openbank-fx-service/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     testImplementation(libs.quarkus.test.security)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
+    // Property-based testing of FX conversion margin invariants (ADR-0011, issue #469).
+    testImplementation("io.kotest:kotest-property:5.9.1")
     testImplementation(libs.rest.assured.kotlin)
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
     testImplementation(libs.testcontainers)

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/application/usecase/FxService.kt
@@ -17,7 +17,6 @@ import com.openbank.libs.observability.DomainMetrics
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -65,15 +64,14 @@ class FxService(
             ?: error("No FX rate available for ${cmd.fromCurrency}/${cmd.toCurrency}")
         require(rate.isValid(Instant.now(clock))) { "FX rate expired for ${cmd.fromCurrency}/${cmd.toCurrency}" }
 
-        val fromAmount = BigDecimal(cmd.fromAmountMinorUnits)
-        val toAmount = fromAmount.multiply(rate.askRate).setScale(0, RoundingMode.HALF_UP)
-        val fee = fromAmount.multiply(BigDecimal("0.005")).setScale(0, RoundingMode.HALF_UP) // 0.5% fee
+        val toAmount = FxConversionMath.convertedAmountMinorUnits(cmd.fromAmountMinorUnits, rate.askRate)
+        val fee = FxConversionMath.feeMinorUnits(cmd.fromAmountMinorUnits)
 
         // ADR-0032: screen the converting party synchronously *before* the conversion is allowed to
         // settle. CLEAR settles, BLOCK fails with a CRITICAL AML case, REVIEW / screening-unavailable
         // hold the conversion in PENDING (fail-closed — never settled un-screened).
         metrics.paymentSubmitted("fx", "${cmd.fromCurrency}_${cmd.toCurrency}")
-        val result = applyScreening(cmd, rate, toAmount.toLong(), fee.toLong())
+        val result = applyScreening(cmd, rate, toAmount, fee)
         scoreFraudShadow(cmd)
         return result
     }

--- a/openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt
+++ b/openbank-fx-service/src/main/kotlin/com/openbank/fx/domain/model/FxRate.kt
@@ -5,6 +5,7 @@
 package com.openbank.fx.domain.model
 
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.Instant
 import java.util.UUID
 
@@ -21,7 +22,7 @@ data class FxRate(
     val source: RateSource,
     val validFrom: Instant,
     val validTo: Instant,
-    val createdAt: Instant
+    val createdAt: Instant,
 ) {
     val pair: String get() = "$baseCurrency/$quoteCurrency"
     val midRate: BigDecimal get() = (bidRate + askRate).divide(BigDecimal.TWO)
@@ -43,7 +44,24 @@ data class FxConversion(
     val rateId: UUID,
     val status: FxConversionStatus,
     val createdAt: Instant,
-    val settledAt: Instant?
+    val settledAt: Instant?,
 )
 
 enum class FxConversionStatus { PENDING, SETTLED, FAILED, REVERSED }
+
+/**
+ * Pure conversion arithmetic (issue #469 item 3 — ADR-0011 property testing). Extracted out of
+ * [FxService][com.openbank.fx.application.usecase.FxService].convert() so the margin math is
+ * callable from a property test without instantiating the use case and its 8 mocked ports.
+ */
+object FxConversionMath {
+    private val FEE_RATE = BigDecimal("0.005")
+
+    /** `fromAmount * appliedRate`, rounded HALF_UP to whole minor units. */
+    fun convertedAmountMinorUnits(fromAmountMinorUnits: Long, appliedRate: BigDecimal): Long =
+        BigDecimal(fromAmountMinorUnits).multiply(appliedRate).setScale(0, RoundingMode.HALF_UP).toLong()
+
+    /** The bank's 0.5% margin on the source amount, rounded HALF_UP to whole minor units. */
+    fun feeMinorUnits(fromAmountMinorUnits: Long): Long =
+        BigDecimal(fromAmountMinorUnits).multiply(FEE_RATE).setScale(0, RoundingMode.HALF_UP).toLong()
+}

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/domain/model/FxConversionMathPropertyTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/domain/model/FxConversionMathPropertyTest.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.fx.domain.model
+
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/**
+ * Margin-preservation property tests (ADR-0011, issue #469 item 3). [FxServiceTest] pins specific
+ * hand-picked amounts/rates for [FxConversionMath]; this suite asserts the margin can't be
+ * arithmetically eliminated, inverted, or made to shrink with scale across a wide input space —
+ * the "for all" guarantee example tests can't give.
+ */
+class FxConversionMathPropertyTest {
+
+    // Non-negative source amounts up to ~10 billion major units — comfortably past any real
+    // transfer while staying inside Long/BigDecimal.multiply headroom for a 4-decimal-place rate.
+    private val amountArb = Arb.long(0L, 999_999_999_999L)
+
+    // 1 tick = 0.0001, matching the 4-decimal-place rates used fleet-wide (e.g. bid=24.90, ask=25.10).
+    private val rateTickArb = Arb.long(1L, 1_000_000L)
+    private val rateArb = rateTickArb.map { BigDecimal(it).movePointLeft(4) }
+
+    private fun orderedPairArb(arb: Arb<Long>): Arb<Pair<Long, Long>> =
+        Arb.bind(arb, arb) { a, b -> minOf(a, b) to maxOf(a, b) }
+
+    private fun bidAskArb(): Arb<Pair<BigDecimal, BigDecimal>> = Arb.bind(rateTickArb, rateTickArb) { a, b ->
+        BigDecimal(minOf(a, b)).movePointLeft(4) to BigDecimal(maxOf(a, b)).movePointLeft(4)
+    }
+
+    @Test
+    fun `fee is never negative and never exceeds the source amount`(): Unit = runBlocking {
+        checkAll(amountArb) { fromAmount ->
+            val fee = FxConversionMath.feeMinorUnits(fromAmount)
+            assertThat(fee).isGreaterThanOrEqualTo(0L)
+            assertThat(fee).isLessThanOrEqualTo(fromAmount)
+        }
+    }
+
+    @Test
+    fun `fee is always within half a minor unit of the exact 0_5 percent value`(): Unit = runBlocking {
+        checkAll(amountArb) { fromAmount ->
+            val fee = FxConversionMath.feeMinorUnits(fromAmount)
+            val exact = BigDecimal(fromAmount).multiply(BigDecimal("0.005"))
+            assertThat(BigDecimal(fee).subtract(exact).abs()).isLessThanOrEqualTo(BigDecimal("0.5"))
+        }
+    }
+
+    @Test
+    fun `fee never shrinks as the source amount grows`(): Unit = runBlocking {
+        checkAll(orderedPairArb(amountArb)) { (smaller, larger) ->
+            val feeSmaller = FxConversionMath.feeMinorUnits(smaller)
+            val feeLarger = FxConversionMath.feeMinorUnits(larger)
+            assertThat(feeLarger).isGreaterThanOrEqualTo(feeSmaller)
+        }
+    }
+
+    @Test
+    fun `converted amount never shrinks as the source amount grows, for a fixed rate`(): Unit = runBlocking {
+        checkAll(orderedPairArb(amountArb), rateArb) { (smaller, larger), rate ->
+            val convertedSmaller = FxConversionMath.convertedAmountMinorUnits(smaller, rate)
+            val convertedLarger = FxConversionMath.convertedAmountMinorUnits(larger, rate)
+            assertThat(convertedLarger).isGreaterThanOrEqualTo(convertedSmaller)
+        }
+    }
+
+    @Test
+    fun `converted amount is never negative for a non-negative source amount and rate`(): Unit = runBlocking {
+        checkAll(amountArb, rateArb) { fromAmount, rate ->
+            assertThat(FxConversionMath.convertedAmountMinorUnits(fromAmount, rate)).isGreaterThanOrEqualTo(0L)
+        }
+    }
+
+    @Test
+    fun `converting at the ask rate is never smaller than converting the same amount at the bid rate`(): Unit =
+        runBlocking {
+            checkAll(amountArb, bidAskArb()) { fromAmount, (bid, ask) ->
+                val atBid = FxConversionMath.convertedAmountMinorUnits(fromAmount, bid)
+                val atAsk = FxConversionMath.convertedAmountMinorUnits(fromAmount, ask)
+                assertThat(atAsk).isGreaterThanOrEqualTo(atBid)
+            }
+        }
+
+    @Test
+    fun `FxRate mid rate always sits between bid and ask, and spread is never negative`(): Unit = runBlocking {
+        checkAll(bidAskArb()) { (bid, ask) ->
+            val rate = fxRate(bid, ask)
+            assertThat(rate.spread).isGreaterThanOrEqualTo(BigDecimal.ZERO)
+            assertThat(rate.midRate).isGreaterThanOrEqualTo(bid)
+            assertThat(rate.midRate).isLessThanOrEqualTo(ask)
+        }
+    }
+
+    private fun fxRate(bid: BigDecimal, ask: BigDecimal) = FxRate(
+        id = java.util.UUID.randomUUID(),
+        baseCurrency = "EUR",
+        quoteCurrency = "CZK",
+        bidRate = bid,
+        askRate = ask,
+        rateType = RateType.SPOT,
+        source = RateSource.ECB,
+        validFrom = java.time.Instant.parse("2026-01-01T00:00:00Z"),
+        validTo = java.time.Instant.parse("2026-12-31T23:59:59Z"),
+        createdAt = java.time.Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceIdempotencyPropertyTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceIdempotencyPropertyTest.kt
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.openbank.ledger.application.port.`in`.JournalLineRequest
+import com.openbank.ledger.application.port.`in`.PostJournalCommand
+import com.openbank.ledger.application.port.out.GlAccountRepository
+import com.openbank.ledger.application.port.out.JournalRepository
+import com.openbank.ledger.application.port.out.YearCloseRepository
+import com.openbank.ledger.domain.model.ControlAccountTieOut
+import com.openbank.ledger.domain.model.GlAccount
+import com.openbank.ledger.domain.model.GlAccountType
+import com.openbank.ledger.domain.model.JournalEntry
+import com.openbank.ledger.domain.model.JournalSide
+import com.openbank.ledger.domain.model.SubLedgerBalance
+import com.openbank.ledger.domain.model.TrialBalanceLine
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Idempotency property test (ADR-0011, issue #469 item 5): applying the same command N times
+ * must be observably equivalent to applying it once. [LedgerServiceTest]'s "replays original
+ * entry on idempotency hit" pins one hand-picked case with a canned mock return; this suite
+ * exercises the REAL sequential replay path ([LedgerService.postJournal]'s
+ * `findByIdempotencyKey` fast-path) end-to-end against a stateful in-memory fake, across many
+ * random amounts and repeat counts.
+ *
+ * Honest scope: this is the sequential ("apply, then replay") guarantee only. The concurrent-race
+ * path — two submissions racing before either commits, recovered in production via the
+ * `ledger_idempotency` unique-constraint catch in [LedgerService.recoverConcurrentReplay] — is
+ * infrastructure-layer (Postgres) behavior and isn't reachable from a pure/fake-backed test; it's
+ * covered by the service's Testcontainers-backed integration tests instead.
+ */
+class LedgerServiceIdempotencyPropertyTest {
+
+    private val debitAccountId = UUID.fromString("a0000000-0000-0000-0000-000000000001")
+    private val creditAccountId = UUID.fromString("a0000000-0000-0000-0000-000000000002")
+
+    private val amountArb = Arb.long(1L, 999_999_999L).map { BigDecimal(it).movePointLeft(2) }
+    private val repeatCountArb = Arb.int(2, 5)
+
+    private class InMemoryJournalRepository : JournalRepository {
+        private val byIdempotencyKey = mutableMapOf<String, JournalEntry>()
+        private var counter = 0L
+        var saveCount: Int = 0
+            private set
+
+        override suspend fun findById(id: UUID): JournalEntry? = null
+        override suspend fun findByTransactionId(transactionId: UUID): List<JournalEntry> = emptyList()
+
+        override suspend fun findByDateRange(
+            from: LocalDate,
+            to: LocalDate,
+            limit: Int,
+            afterId: UUID?,
+        ): List<JournalEntry> = emptyList()
+
+        override suspend fun findByIdempotencyKey(idempotencyKey: String): JournalEntry? =
+            byIdempotencyKey[idempotencyKey]
+
+        override suspend fun nextEntryNumber(): Long = ++counter
+
+        override suspend fun save(
+            entry: JournalEntry,
+            idempotencyKey: String?,
+            outbox: List<OutboxMessage>,
+        ): JournalEntry {
+            saveCount++
+            if (idempotencyKey != null) byIdempotencyKey[idempotencyKey] = entry
+            return entry
+        }
+
+        override suspend fun saveReversal(
+            reversal: JournalEntry,
+            originalId: UUID,
+            originalEntryDate: LocalDate,
+            outbox: List<OutboxMessage>,
+        ): JournalEntry = error("not exercised by postJournal")
+
+        override suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLine> = error("not exercised")
+
+        override suspend fun trialBalanceForPeriod(from: LocalDate, to: LocalDate): List<TrialBalanceLine> =
+            error("not exercised")
+
+        override suspend fun subLedgerBalances(asOf: LocalDate, subAccountId: UUID?): List<SubLedgerBalance> =
+            error("not exercised")
+
+        override suspend fun controlAccountTieOut(controlAccountId: UUID, asOf: LocalDate): List<ControlAccountTieOut> =
+            error("not exercised")
+    }
+
+    private fun glAccount(id: UUID, code: String, type: GlAccountType, currency: String) = GlAccount(
+        id = id,
+        code = code,
+        name = "Account $code",
+        type = type,
+        currency = CurrencyCode.of(currency),
+        parentId = null,
+        isLeaf = true,
+        isEnabled = true,
+        createdAt = Instant.now(),
+    )
+
+    private fun postCommand(idempotencyKey: String, amount: BigDecimal) = PostJournalCommand(
+        idempotencyKey = idempotencyKey,
+        transactionId = UUID.randomUUID(),
+        entryDate = LocalDate.of(2026, 1, 15),
+        valueDate = LocalDate.of(2026, 1, 15),
+        description = "Property test posting",
+        lines = listOf(
+            JournalLineRequest(
+                glAccountId = debitAccountId,
+                side = JournalSide.DEBIT,
+                amount = amount,
+                currencyCode = "CZK",
+                fxRate = null,
+                baseAmount = amount,
+                baseCurrencyCode = "CZK",
+            ),
+            JournalLineRequest(
+                glAccountId = creditAccountId,
+                side = JournalSide.CREDIT,
+                amount = amount,
+                currencyCode = "CZK",
+                fxRate = null,
+                baseAmount = amount,
+                baseCurrencyCode = "CZK",
+            ),
+        ),
+        postedBy = UUID.randomUUID(),
+    )
+
+    @Test
+    fun `posting the same idempotency key N times is equivalent to posting it once`(): Unit = runBlocking {
+        checkAll(amountArb, repeatCountArb) { amount, repeats ->
+            val journalRepository = InMemoryJournalRepository()
+            val glAccountRepository = mockk<GlAccountRepository>()
+            coEvery { glAccountRepository.findById(debitAccountId) } returns
+                glAccount(debitAccountId, "1100", GlAccountType.ASSET, "CZK")
+            coEvery { glAccountRepository.findById(creditAccountId) } returns
+                glAccount(creditAccountId, "2100", GlAccountType.LIABILITY, "CZK")
+            val yearCloseRepository = mockk<YearCloseRepository>()
+            coEvery { yearCloseRepository.isFiscalYearAttested(any()) } returns false
+            val metrics = mockk<DomainMetrics>(relaxed = true)
+            val jsonMapper = ObjectMapper()
+                .registerModule(JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            val service = LedgerService(
+                journalRepository,
+                glAccountRepository,
+                jsonMapper,
+                metrics,
+                yearCloseRepository,
+            )
+
+            val idempotencyKey = UUID.randomUUID().toString()
+            val command = postCommand(idempotencyKey, amount)
+
+            val results = (1..repeats).map { service.postJournal(command) }
+
+            // Every replay returns the exact same entry — same identity, same content.
+            assertThat(results.map { it.id }.distinct()).hasSize(1)
+            results.forEach { assertThat(it).isEqualTo(results.first()) }
+
+            // N applications have the identical observable persistence effect as one.
+            assertThat(journalRepository.saveCount).isEqualTo(1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the three remaining property-test items on #469 (after #755 shipped Money arithmetic property tests): FX conversion margin-preservation, idempotency, and balance-projection order-independence.

### 1. FX conversion margin-preservation (`openbank-fx-service`)

`FxService.convert()`'s rate/fee math was two `BigDecimal` lines inlined in an `@ApplicationScoped` use case with 8 injected ports — not callable from a property test without mocking all of them. Extracted into a pure `FxConversionMath` object (`FxRate.kt`) and updated `convert()` to call it — **same formula, same rounding, observable behavior unchanged** (existing `FxServiceTest`/`FxRateTest` pass unmodified, 19/19).

New `FxConversionMathPropertyTest` (7 properties, `checkAll` over random amounts/rates):
- fee is never negative and never exceeds the source amount
- fee is always within half a minor unit of the exact 0.5% value (rounding tolerance)
- fee never shrinks as the source amount grows
- converted amount never shrinks as the source amount grows, for a fixed rate
- converted amount is never negative for non-negative inputs
- converting at the ask rate is never smaller than converting the same amount at the bid rate — the spread the bank applies is never inverted by extreme inputs
- `FxRate.midRate` always sits between bid and ask; spread is never negative

### 2. Idempotency: N applications == 1 (`openbank-ledger-service`)

`LedgerServiceTest`'s existing idempotency test pins one hand-picked case via a canned mock return. `LedgerServiceIdempotencyPropertyTest` exercises the **real** `findByIdempotencyKey` fast-path end-to-end through a small stateful in-memory `JournalRepository` fake, across random amounts and repeat counts (2-5): every replay returns the identical entry, and `save` is invoked exactly once regardless of how many times `postJournal` is called with the same key.

**Honest scope** (documented in the test docstring): this proves the *sequential* replay guarantee only. The concurrent-race path — two submissions racing before either commits, recovered via the `ledger_idempotency` unique-constraint catch in `recoverConcurrentReplay` — is Postgres-constraint-backed infrastructure behavior, not reachable from a fake-backed test. That's what the service's Testcontainers ITs already cover.

### 3. Balance projection permutation-order-independence (`openbank-balance-service`)

`BalanceProjectionOrderPropertyTest` proves folding a *sequence* of ledger-projected booked deltas into a `Balance` is commutative — order doesn't affect the final projected balance. Scoped deliberately to `applyBookedDelta`: it's the one mutation with no overdraft-floor guard (ADR-0039 Phase D — the read-model catching up to an already-posted ledger fact), so it's unconditionally order-independent. `applyDebit`/`withReservation` carry a `require(...)` guard that can throw for one permutation and not another even when the final sum matches — reordering those isn't a safe general property. Stronger than `BalancePropertyTest`'s existing single-delta order test, which doesn't cover commutativity across a whole sequence.

## Test plan
- [x] `FxConversionMathPropertyTest` (7 new) + `FxServiceTest` (16) + `FxRateTest` (3) — 26/26 passing
- [x] `LedgerServiceIdempotencyPropertyTest` (1 new) + `LedgerServiceTest` (33 across nested classes) — 34/34 passing
- [x] `BalanceProjectionOrderPropertyTest` (2 new) + `BalancePropertyTest` (8) — 10/10 passing
- [x] `ktlintCheck` + `detekt` on all three modules — clean
- [x] `:openbank-fx-service:quarkusBuild` — CDI wiring intact after the `FxService.convert()` refactor

Refs #469 (leaving open — issue lists further items beyond these three if wanted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)