### PR TITLE
fix(admin-ui): re-authenticate on refresh failure instead of dead 401 panels

### DIFF
--- a/openbank-admin-ui/src/components/auth/ReauthOnExpiry.tsx
+++ b/openbank-admin-ui/src/components/auth/ReauthOnExpiry.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+"use client"
+import { useEffect, useRef } from "react"
+import { useSession, signIn } from "next-auth/react"
+
+/**
+ * Re-authenticate instead of showing dead panels when the token refresh fails.
+ *
+ * When the Keycloak refresh-token grant fails (SSO session gone / refresh token
+ * expired), `authOptions`' jwt callback marks the session `error:
+ * "RefreshAccessTokenError"` but keeps the now-stale access token. The BFF proxy
+ * then keeps forwarding that dead bearer, so every service answers 401 and the
+ * operator sees "Vypršela relace" panels across the console rather than being asked
+ * to sign in again.
+ *
+ * This watches for that terminal session state and kicks off a fresh Keycloak
+ * sign-in — silent if the SSO session is still alive, the login page otherwise — so
+ * the console self-heals. Mounted once under SessionProvider; NextAuth's
+ * refetch-on-window-focus is what surfaces the error when an operator returns to an
+ * idle tab (we deliberately do NOT add a refetch interval — proactive polling would
+ * keep refreshing the token and defeat the 1h idle-session cap, ADR-0080 F-AUTH-03).
+ */
+export function ReauthOnExpiry() {
+  const { data: session } = useSession()
+  // signIn() triggers a full-page redirect, but guard against a double-fire (React
+  // strict mode / a re-render landing before navigation) so we never stack sign-ins.
+  const triggered = useRef(false)
+
+  useEffect(() => {
+    if (session?.user?.error === "RefreshAccessTokenError" && !triggered.current) {
+      triggered.current = true
+      void signIn("keycloak")
+    }
+  }, [session?.user?.error])
+
+  return null
+}

--- a/openbank-admin-ui/src/components/auth/SessionProvider.tsx
+++ b/openbank-admin-ui/src/components/auth/SessionProvider.tsx
@@ -4,7 +4,13 @@
 
 "use client"
 import { SessionProvider as NextAuthSessionProvider } from "next-auth/react"
+import { ReauthOnExpiry } from "./ReauthOnExpiry"
 
 export function SessionProvider({ children }: { children: React.ReactNode }) {
-  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>
+  return (
+    <NextAuthSessionProvider>
+      <ReauthOnExpiry />
+      {children}
+    </NextAuthSessionProvider>
+  )
 }


### PR DESCRIPTION
## Problem

When Keycloak's refresh-token grant fails (SSO session gone / refresh token expired), `authOptions`' jwt callback marks the session `error: "RefreshAccessTokenError"` **but keeps the now-stale access token**. The BFF proxy keeps forwarding that dead bearer, so every service answers **401** and the operator sees **"Vypršela relace"** panels across the whole console instead of being asked to sign in again.

(This is the actual cause of the clearing/standing-orders 401s reported earlier — a **global** session expiry, not a per-service auth gap. Verified live: `clearing-service` returns 200 with a valid token, 401 without.)

## Fix

A small client component `ReauthOnExpiry`, mounted once under `SessionProvider`, watches for that terminal session state and kicks off a fresh Keycloak sign-in — **silent if the SSO session is still alive, the login page otherwise** — so the console self-heals. A `ref` guards against a double-fire before the redirect lands.

**Deliberately no `refetchInterval`:** proactive session polling would keep refreshing the token and defeat the 1h idle-session cap (ADR-0080 F-AUTH-03). NextAuth's default refetch-on-window-focus surfaces the error when an operator returns to an idle tab — exactly the scenario that produced the stale-token 401s.

## Verification
- `tsc --noEmit` clean (only pre-existing e2e type errors) · `eslint` clean · `next build` ✓ · guards 77/77
- No production auth/middleware code changed; purely additive client-side self-heal.

## Linked issues
Refs #759