### PR TITLE
fix(sepa-instant): valueDate format bug + add transaction-service pact coverage (#468)

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -61,6 +61,7 @@ jobs:
             :openbank-fraud-service:test --tests "com.openbank.fraud.contract.*PactConsumerTest" \
             :openbank-lending-service:test --tests "com.openbank.lending.contract.*PactConsumerTest" \
             :openbank-notification-service:test --tests "com.openbank.notification.contract.*PactConsumerTest" \
+            :openbank-sepa-instant:test --tests "com.openbank.sepainstant.contract.*PactConsumerTest" \
             :openbank-sepa-payment:test --tests "com.openbank.sepa.contract.*PactConsumerTest" \
             :openbank-transaction-service:test --tests "com.openbank.transaction.contract.*PactConsumerTest"
 

--- a/openbank-sepa-instant/build.gradle.kts
+++ b/openbank-sepa-instant/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     // In-memory reactive-messaging connector: SctInstBootSmokeIT swaps the Kafka outgoing
     // channel to InMemoryConnector so the boot smoke-test needs no broker (ADR-0104 D4 / #578).
     testImplementation(libs.smallrye.reactive.messaging.inmemory)
+    // Consumer-driven contract for the transaction-service settlement call (ADR-0063, issue #468).
+    testImplementation(libs.pact.consumer)
 }
 
 kover {
@@ -91,4 +93,21 @@ pitest {
     timestampedReports = false
     threads = 4
     excludedClasses = setOf("com.openbank.sepainstant.domain.*Kt")
+}
+
+// Pact: write the generated consumer contract to pacts/ and forward broker config, matching
+// transaction-service/fx-service/domestic-payment's tasks.withType<Test> block (ADR-0063 P1/P2).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }

--- a/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/client/SettlementAdapter.kt
+++ b/openbank-sepa-instant/src/main/kotlin/com/openbank/sepainstant/infrastructure/client/SettlementAdapter.kt
@@ -54,7 +54,7 @@ class SettlementAdapter(@RestClient private val client: TransactionServiceClient
             amount = payment.amount,
             currencyCode = payment.currency,
             description = "SCT Inst settlement ${payment.endToEndId}",
-            valueDate = LocalDate.now(clock).format(DateTimeFormatter.BASIC_ISO_DATE),
+            valueDate = LocalDate.now(clock).format(DateTimeFormatter.ISO_LOCAL_DATE),
             rail = "SEPA_INST",
             instructionType = "ONE_OFF",
         )

--- a/openbank-sepa-instant/src/test/kotlin/com/openbank/sepainstant/contract/SepaInstantTransactionServicePactConsumerTest.kt
+++ b/openbank-sepa-instant/src/test/kotlin/com/openbank/sepainstant/contract/SepaInstantTransactionServicePactConsumerTest.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sepainstant.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the settlement call sepa-instant makes once the scheme returns
+ * ACSC ([com.openbank.sepainstant.infrastructure.client.SettlementAdapter.settleWithResilience],
+ * ADR-0108, issue #468 edge 1). The consumer posts POST /api/v1/transactions and expects
+ * {id, status}. The provider verification lives in TransactionPactProviderVerificationTest
+ * (transaction-service) — same provider as domestic-payment and sepa-payment's contracts, hence
+ * the shared "a valid source account exists" state.
+ *
+ * The request body's `valueDate` uses ISO_LOCAL_DATE ("2026-01-20"), matching what
+ * TransactionResource actually parses (`LocalDate.parse(request.valueDate)`, no formatter
+ * argument = ISO_LOCAL_DATE). SettlementAdapter previously formatted with BASIC_ISO_DATE
+ * ("20260120"), which would have thrown DateTimeParseException on every real settlement call —
+ * fixed alongside this contract, since a body-shape test that pinned the pre-existing bug
+ * wouldn't be testing the real contract.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-transaction-service", pactVersion = PactSpecVersion.V3)
+class SepaInstantTransactionServicePactConsumerTest {
+
+    private val requestBody = """
+        {
+          "idempotencyKey": "sct-inst-settlement-pact-001",
+          "type": "DEBIT",
+          "sourceAccountId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "amount": 500.00,
+          "currencyCode": "EUR",
+          "description": "SCT Inst settlement pact-e2e-001",
+          "valueDate": "2026-01-20",
+          "rail": "SEPA_INST",
+          "instructionType": "ONE_OFF"
+        }
+    """.trimIndent()
+
+    @Pact(consumer = "openbank-sepa-instant", provider = "openbank-transaction-service")
+    fun initiateSctInstSettlementPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("a valid source account exists")
+        .uponReceiving("POST initiate SCT Inst settlement transaction")
+        .path("/api/v1/transactions")
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(requestBody)
+        .willRespondWith()
+        .status(201)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.uuid("id")
+                o.stringType("status", "PROCESSING")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "initiateSctInstSettlementPact")
+    fun `initiateTransaction returns the created transaction with id and status`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType("application/json")
+            .body(requestBody)
+            .post("/api/v1/transactions")
+            .then()
+            .statusCode(201)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isNotBlank()
+        assertThat(body.getString("status")).isNotBlank()
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactProviderVerificationTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/TransactionPactProviderVerificationTest.kt
@@ -90,6 +90,14 @@ class TransactionPactProviderVerificationTest {
         // registered to return COMPLETED — no per-interaction setup needed here.
     }
 
+    @State("a valid source account exists")
+    fun stateValidSourceAccountExists() {
+        // Shared by domestic-payment, sepa-payment, and sepa-instant's consumer pacts (issue
+        // #468) — previously unhandled (pact-jvm silently skips a missing state, so this was a
+        // live gap, not a failure). No setup needed: initiateTransaction doesn't require the
+        // account to pre-exist in this test's Postgres, only that sourceAccountId parses as a UUID.
+    }
+
     @State("transaction-service has initiated a payment transaction")
     fun stateTransactionInitiated() {
         // No setup needed: the message producer below returns a deterministic payload.

--- a/pacts/openbank-sepa-instant-openbank-transaction-service.json
+++ b/pacts/openbank-sepa-instant-openbank-transaction-service.json
@@ -1,0 +1,82 @@
+{
+  "consumer": {
+    "name": "openbank-sepa-instant"
+  },
+  "interactions": [
+    {
+      "description": "POST initiate SCT Inst settlement transaction",
+      "providerStates": [
+        {
+          "name": "a valid source account exists"
+        }
+      ],
+      "request": {
+        "body": {
+          "amount": 500.00,
+          "currencyCode": "EUR",
+          "description": "SCT Inst settlement pact-e2e-001",
+          "idempotencyKey": "sct-inst-settlement-pact-001",
+          "instructionType": "ONE_OFF",
+          "rail": "SEPA_INST",
+          "sourceAccountId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+          "type": "DEBIT",
+          "valueDate": "2026-01-20"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/transactions"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "PROCESSING"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-transaction-service"
+  }
+}


### PR DESCRIPTION
## Summary

Coverage-expansion sweep for #468, edge 1 (money-path priority order): **sepa-instant → transaction-service**. sepa-instant calls only transaction-service directly (`POST /api/v1/transactions` on ACSC) — ledger is booked internally by transaction-service, not called by sepa-instant, so this edge closes out the "transaction/ledger" pairing from the issue's priority list.

## ⚠️ Real bug found and fixed along the way

While building the contract, `SettlementAdapter` turned out to format `valueDate` with `DateTimeFormatter.BASIC_ISO_DATE` ("20260120"), but `TransactionResource.initiateTransaction` parses it via `LocalDate.parse(request.valueDate)` with no formatter argument (= `ISO_LOCAL_DATE`, "2026-01-20"). **Every real settlement call from sepa-instant to transaction-service has been throwing `DateTimeParseException`** (caught and surfaced as `SettlementUnavailableException`) — sepa-instant has never actually been able to settle a payment against a real transaction-service. No existing test caught this since nothing asserted the serialized date format, only mocked the client.

`openbank-domestic-payment`'s `SettlementAdapter` already does this correctly. **`openbank-sepa-payment` has the identical bug** — tracked as a separate follow-up (different release scope/service, needs its own PR + 2 approvals as a money-path service).

Fixed in the first commit (`fix(sepa-instant): ...`, patch bump).

## Coverage work (second commit, no version bump — test/CI only)

- New `SepaInstantTransactionServicePactConsumerTest`, mirroring the existing `domestic-payment`/`sepa-payment` consumer tests against the same provider.
- Wired `openbank-sepa-instant/build.gradle.kts` with `libs.pact.consumer` + the `pact.rootDir`/`pactbroker.*` forwarding block (copied from transaction-service/fx-service/domestic-payment).
- `TransactionPactProviderVerificationTest` was missing a `@State("a valid source account exists")` handler even though domestic-payment's and sepa-payment's *existing* consumer pacts already declare that state — pact-jvm silently skips a missing state rather than failing, so this was a live, undetected gap for all three consumers, not something new from this PR. Added it once, shared by all three now.
- Added the module to `pact-drift-check.yml`'s regenerate step so this contract can't silently drift after the next `SettlementAdapter` change.

## Test plan
- [x] `SepaInstantTransactionServicePactConsumerTest` (new) — 1/1 passing, pact JSON committed
- [x] `SettlementAdapterTest` (existing) — 6/6 passing, unaffected by the date-format fix (no test pinned the old format)
- [x] `ktlintCheck` + `detekt` on sepa-instant and transaction-service — clean
- [x] `:openbank-sepa-instant:quarkusBuild` — CDI wiring intact

Refs #468 (leaving open — priority order has settlement→ledger, billing→ledger, and clearing inbound next, then the platform edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)