### PR TITLE
fix(sepa-payment): send valueDate in the format transaction-service actually parses

### DIFF
--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/SettlementAdapter.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/client/SettlementAdapter.kt
@@ -49,7 +49,7 @@ class SettlementAdapter(
     @Timeout(8_000)
     open suspend fun settleWithResilience(payment: SepaPayment): SettlementOutcome {
         val token = oidcClient.get().tokens.awaitSuspending().accessToken
-        val valueDate = LocalDate.now(clock).format(DateTimeFormatter.BASIC_ISO_DATE)
+        val valueDate = LocalDate.now(clock).format(DateTimeFormatter.ISO_LOCAL_DATE)
 
         val request = InitiateSettlementRequest(
             idempotencyKey = "sepa-settlement-${payment.id}",


### PR DESCRIPTION
## Summary

`SettlementAdapter` formats `valueDate` with `DateTimeFormatter.BASIC_ISO_DATE` (e.g. `20260120`), but `TransactionResource.initiateTransaction` parses it via `LocalDate.parse(request.valueDate)` with no formatter argument (defaults to `ISO_LOCAL_DATE`, e.g. `2026-01-20`). Every real settlement call from sepa-payment to transaction-service throws `DateTimeParseException`, caught and surfaced as `SettlementUnavailableException` — sepa-payment has never actually been able to settle a payment against a real transaction-service.

This is the identical bug found and fixed for sepa-instant in #840, which flagged sepa-payment as carrying the same defect ("tracked as a separate follow-up"). `openbank-domestic-payment`'s `SettlementAdapter` already uses `ISO_LOCAL_DATE` correctly.

## Type of change

- [x] fix (bug fix)

## Linked issues

N/A — direct bug fix mirroring the fix already applied for sepa-instant in #840; not part of a tracked issue.

## Changes

- `SettlementAdapter.kt`: `DateTimeFormatter.BASIC_ISO_DATE` → `DateTimeFormatter.ISO_LOCAL_DATE` for the `valueDate` sent to transaction-service.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — infra-only change.
- [x] Unit tests added/updated — existing `SettlementAdapterTest` (6/6) covers the adapter; none pinned the old (wrong) date format, so no test needed to change.
- [ ] Integration tests added/updated (if service boundary involved) — not added; same scope decision as #840 (contract coverage tracked separately under #468).
- [ ] Contract tests updated (if public API changed) — no API change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes (ran `detekt`, `ktlintCheck`, `test`, `quarkusBuild` for `:openbank-sepa-payment` locally).
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated — no REST API changed.
- [ ] Flyway migration added — no DB change.
- [ ] Avro schema versioned — no event change.
- [ ] Docs updated — no architectural change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`, `as Any`, `@Suppress("...")`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code changed → this is a money-path service (`rules.yaml: money_path_services`), needs 2 approvals.
- [ ] PII path changed.
- [ ] Cardholder data path changed.

## Compliance impact

- [ ] None — internal date-formatting bug fix, no compliance-relevant behavior change.

## Rollout / Rollback

- Deployment strategy: rolling (standard service release via release-please patch bump).
- Rollback plan: revert this commit; the prior (broken) format never worked in production, so a rollback returns to a known-broken no-op state, not a regression.
- Data migration reversible: N/A.

## Reviewer notes

Money-path service — needs 2 approvals per `rules.yaml`. Version bump is automatic via release-please from this `fix:` commit; `version.txt` was not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)