### PR TITLE
ci(services-ci): stop cancelling in-flight main-push builds

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -31,8 +31,18 @@ permissions:
 concurrency:
   # Don't let the nightly run cancel an in-flight PR/main run (or vice-versa): give the
   # scheduled/manual fleet build its own concurrency lane.
-  group: services-ci-${{ github.ref }}-${{ github.event_name == 'schedule' && 'nightly' || 'ci' }}
-  cancel-in-progress: true
+  #
+  # For push-to-main, github.ref is always refs/heads/main regardless of commit — so
+  # without a per-SHA key, any push landing while a prior main push is still building
+  # (bot commits from release-please/auto-deploy land every few minutes) cancels that
+  # run outright. A cancelled run never reaches the Pact publish step, so the broker's
+  # "latest main tag" consumer pact freezes at the last commit that happened to finish
+  # uninterrupted, and can-i-deploy keeps citing that stale/failed verification forever
+  # (issue #846). Key push-to-main by SHA so every commit gets its own lane and is never
+  # cancelled; PR pushes keep the superseding behavior (a new push to the same branch
+  # should cancel the old run).
+  group: services-ci-${{ github.ref }}-${{ github.event_name == 'schedule' && 'nightly' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci') }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary
- `services-ci.yml`'s concurrency group only keyed on `github.ref`, which is always
  `refs/heads/main` for every push to `main` — so a bot commit (release-please,
  auto-deploy) landing while a prior push's build was still running cancelled that run
  outright, before it reached the Pact publish step.
- This left the broker's "latest main tag" consumer pact frozen at whichever commit last
  finished uninterrupted, so `can-i-deploy` kept citing a stale/failed verification on every
  later deploy attempt for `openbank-account-service`, regardless of what was actually being
  deployed — confirmed on two separate runs today (`workflow_dispatch` run 29162819832 and a
  genuine push-triggered run 29164508317 for PR #835), both citing the identical stale
  `verification-results/389`.
- Fix: key push-to-main by commit SHA so every main commit gets its own concurrency lane and
  is never cancelled by a later push. PR-branch pushes keep the existing cancel-on-supersede
  behavior (a new push to the same branch still cancels the old run, as intended).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses
- [x] `actionlint .github/workflows/services-ci.yml` — no new findings (pre-existing
      shellcheck notes elsewhere in the file, unrelated to this change)
- [ ] Observe the next few pushes to `main` land close together and confirm each
      `services-ci.yml` run completes instead of being cancelled

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)