### PR TITLE
fix(settlement): missing createdBy bug + add ledger pact coverage (#468)

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -62,6 +62,7 @@ jobs:
             :openbank-lending-service:test --tests "com.openbank.lending.contract.*PactConsumerTest" \
             :openbank-notification-service:test --tests "com.openbank.notification.contract.*PactConsumerTest" \
             :openbank-sepa-payment:test --tests "com.openbank.sepa.contract.*PactConsumerTest" \
+            :openbank-settlement-service:test --tests "com.openbank.settlement.contract.*PactConsumerTest" \
             :openbank-transaction-service:test --tests "com.openbank.transaction.contract.*PactConsumerTest"
 
       - name: Fail on drift between regenerated and committed pacts

--- a/openbank-settlement-service/build.gradle.kts
+++ b/openbank-settlement-service/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+    // Consumer-driven contract for the ledger-service postJournal call (ADR-0063, issue #468).
+    testImplementation(libs.pact.consumer)
 }
 
 kover {
@@ -62,4 +64,21 @@ kover {
             }
         }
     }
+}
+
+// Pact: write the generated consumer contract to pacts/ and forward broker config, matching
+// transaction-service/fx-service/lending-service's tasks.withType<Test> block (ADR-0063 P1/P2).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapter.kt
@@ -31,6 +31,14 @@ class LedgerBookAdapter(
 
     private val log = Logger.getLogger(LedgerBookAdapter::class.java)
 
+    companion object {
+        // Settlement booking is a system-initiated posting (Temporal workflow / legacy async
+        // path, ADR-0108), not a human/security-context action — mirrors ledger-service's own
+        // FxRevaluationService.SYSTEM_USER sentinel pattern, with a distinct UUID so audit trails
+        // can tell settlement-service's system postings apart from ledger's internal ones.
+        val SYSTEM_USER: UUID = UUID.fromString("00000000-0000-0000-0000-000000005e77")
+    }
+
     override suspend fun book(settlementId: UUID) {
         val settlement = requireNotNull(settlementRepository.findById(settlementId)) {
             "Settlement $settlementId not found"
@@ -44,6 +52,7 @@ class LedgerBookAdapter(
                 entryDate = today,
                 valueDate = today,
                 description = "Settlement booking $settlementId",
+                createdBy = SYSTEM_USER,
                 lines = listOf(
                     JournalLineRequest(
                         glAccountId = glDebitAccountId,

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/client/LedgerRestClient.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/client/LedgerRestClient.kt
@@ -32,6 +32,7 @@ data class PostJournalRequest(
     val entryDate: String,
     val valueDate: String,
     val description: String,
+    val createdBy: UUID,
     val lines: List<JournalLineRequest>,
 )
 

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Consumer-driven contract for the journal posting settlement-service makes when booking a
+ * settlement ([com.openbank.settlement.infrastructure.adapter.LedgerBookAdapter.book], ADR-0108,
+ * issue #468 edge 2). Same endpoint and response shape as lending-service's/transaction-service's
+ * postJournal contracts. The ledger-service provider verification
+ * (LedgerPactProviderVerificationTest) already handles this via the "the standard chart of
+ * accounts is seeded" state shared with them — no changes needed there.
+ *
+ * Unlike lending's contract, settlement's real request populates `subAccountId` on BOTH lines
+ * (the payer/payee sub-account each leg is posted against) plus a `createdBy` sentinel
+ * ([com.openbank.settlement.infrastructure.adapter.LedgerBookAdapter.SYSTEM_USER] — settlement
+ * booking is a system-initiated posting, not a human/security-context action).
+ *
+ * Both lines target the SAME GL account (a0000000-...-002, 2100 Customer Deposit Control) rather
+ * than debiting cash-clearing (...-001) like lending's/transaction's contracts do: ledger-service
+ * rejects `subAccountId` on any leg that isn't a deposit-control leg (ADR-0039 Phase B,
+ * `LedgerService.kt` "subAccountId is only allowed on deposit-control legs") — a real 422 this
+ * test caught on first write, using ...-001 for the debit leg like the other services' contracts.
+ * A settlement moves money between two of the bank's own customer sub-accounts, so neither leg
+ * should touch cash-clearing anyway (no money enters/leaves the bank).
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
+class SettlementLedgerPostJournalPactConsumerTest {
+
+    private val transactionId = "55555555-5555-5555-5555-555555555555"
+    private val payerAccountId = "66666666-6666-6666-6666-666666666666"
+    private val payeeAccountId = "77777777-7777-7777-7777-777777777777"
+
+    private val requestBody = """
+        {
+          "idempotencyKey": "settlement-book-$transactionId",
+          "transactionId": "$transactionId",
+          "entryDate": "2026-01-15",
+          "valueDate": "2026-01-15",
+          "description": "Settlement booking $transactionId",
+          "createdBy": "00000000-0000-0000-0000-000000005e77",
+          "lines": [
+            {
+              "glAccountId": "a0000000-0000-0000-0000-000000000002",
+              "side": "DEBIT",
+              "amount": 750.00,
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "baseAmount": 750.00,
+              "baseCurrencyCode": "CZK",
+              "subAccountId": "$payerAccountId"
+            },
+            {
+              "glAccountId": "a0000000-0000-0000-0000-000000000002",
+              "side": "CREDIT",
+              "amount": 750.00,
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "baseAmount": 750.00,
+              "baseCurrencyCode": "CZK",
+              "subAccountId": "$payeeAccountId"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Pact(consumer = "openbank-settlement-service", provider = "openbank-ledger-service")
+    fun postSettlementJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the standard chart of accounts is seeded")
+        .uponReceiving("POST a balanced two-line CZK settlement journal")
+        .path("/api/v1/journals")
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(requestBody)
+        .willRespondWith()
+        .status(201)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.uuid("id")
+                o.uuid("transactionId")
+                o.stringType("status", "POSTED")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "postSettlementJournalPact")
+    fun `postJournal returns the created journal with id, transactionId and status`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType("application/json")
+            .body(requestBody)
+            .post("/api/v1/journals")
+            .then()
+            .statusCode(201)
+            .extract().jsonPath()
+
+        assertThat(body.getString("id")).isNotBlank()
+        assertThat(body.getString("transactionId")).isNotBlank()
+        assertThat(body.getString("status")).isNotBlank()
+    }
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapterTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapterTest.kt
@@ -59,6 +59,7 @@ class LedgerBookAdapterTest {
         assertThat(request.captured.transactionId).isEqualTo(settlement.id)
         assertThat(request.captured.entryDate).isEqualTo("2026-07-06")
         assertThat(request.captured.valueDate).isEqualTo("2026-07-06")
+        assertThat(request.captured.createdBy).isEqualTo(LedgerBookAdapter.SYSTEM_USER)
         assertThat(request.captured.lines).hasSize(2)
 
         val debitLine = request.captured.lines.single { it.side == "DEBIT" }

--- a/pacts/openbank-settlement-service-openbank-ledger-service.json
+++ b/pacts/openbank-settlement-service-openbank-ledger-service.json
@@ -1,0 +1,114 @@
+{
+  "consumer": {
+    "name": "openbank-settlement-service"
+  },
+  "interactions": [
+    {
+      "description": "POST a balanced two-line CZK settlement journal",
+      "providerStates": [
+        {
+          "name": "the standard chart of accounts is seeded"
+        }
+      ],
+      "request": {
+        "body": {
+          "createdBy": "00000000-0000-0000-0000-000000005e77",
+          "description": "Settlement booking 55555555-5555-5555-5555-555555555555",
+          "entryDate": "2026-01-15",
+          "idempotencyKey": "settlement-book-55555555-5555-5555-5555-555555555555",
+          "lines": [
+            {
+              "amount": 750.00,
+              "baseAmount": 750.00,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000000002",
+              "side": "DEBIT",
+              "subAccountId": "66666666-6666-6666-6666-666666666666"
+            },
+            {
+              "amount": 750.00,
+              "baseAmount": 750.00,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000000002",
+              "side": "CREDIT",
+              "subAccountId": "77777777-7777-7777-7777-777777777777"
+            }
+          ],
+          "transactionId": "55555555-5555-5555-5555-555555555555",
+          "valueDate": "2026-01-15"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/journals"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "POSTED",
+          "transactionId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            },
+            "$.transactionId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transactionId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-ledger-service"
+  }
+}


### PR DESCRIPTION
## Summary

Coverage-expansion sweep for #468, edge 2 (money-path priority order): **settlement → ledger**. Settlement calls `openbank-ledger-service`'s `POST /api/v1/journals` directly (not through transaction-service).

## ⚠️ Real bug found and fixed along the way

`ledger-service`'s `PostJournalRequest.createdBy` is a required, non-nullable `UUID`, but settlement's client-side `PostJournalRequest` never had the field at all — every real `LedgerBookAdapter.book()` call has been omitting it. Jackson treats a missing required Kotlin constructor param as a hard deserialization failure, so **settlement has never been able to actually book a journal against a real ledger-service**. `LedgerBookAdapterTest` mocked `LedgerRestClient` entirely, so no real JSON serialization ever ran against the requirement — same blind-spot pattern as the sepa-instant `valueDate` bug from edge 1.

Fixed with a dedicated `SYSTEM_USER` sentinel (settlement booking is system-initiated, not a human/security-context action) — mirrors `FxRevaluationService.SYSTEM_USER`'s existing pattern in ledger-service, with a distinct UUID.

## A finding that turned out NOT to be a bug

While investigating, I initially flagged `debit-account-id == credit-account-id` in settlement's config as a misconfiguration. It isn't: **ledger-service rejects `subAccountId` on any leg that isn't a deposit-control leg** (ADR-0039 Phase B) — confirmed by a real 422 my first draft of this pact triggered, using the cash-clearing account for the debit leg like lending's/transaction's contracts do. Since settlement sets `subAccountId` on both legs, both legs must target the deposit-control account. A settlement moves money between two of the bank's own customers, so neither leg should touch cash-clearing anyway. Settlement's existing config is the intentionally-correct shape.

## Coverage work (second commit, no version bump — test/CI only)

- New `SettlementLedgerPostJournalPactConsumerTest`, docstring explains the GL-account/subAccountId constraint above.
- Wired `openbank-settlement-service/build.gradle.kts` with `libs.pact.consumer` + the `pact.rootDir`/`pactbroker.*` forwarding block.
- `LedgerPactProviderVerificationTest` needed **zero changes** — its existing "the standard chart of accounts is seeded" state, already shared by transaction-service and lending-service, covers this too.
- Added the module to `pact-drift-check.yml`'s regenerate step.

## Real end-to-end verification (not just a mocked green light)

Unlike transaction-service's `@PactBroker`-gated provider test (which only runs in a broker-connected CI lane), ledger-service's provider test uses `@PactFolder` (git-pact) and **always runs, no broker required**. I ran it directly against the new pact and confirmed all 5 interactions across all 4 consumers (account, balance ×2, transaction, lending, settlement) verify successfully — this is a genuine, not just simulated, contract verification.

## Test plan
- [x] `SettlementLedgerPostJournalPactConsumerTest` (new) — 1/1 passing, pact JSON committed
- [x] `LedgerBookAdapterTest` (existing, +1 assertion for `createdBy`) — 3/3 passing
- [x] `:openbank-ledger-service:test --tests LedgerPactProviderVerificationTest` — **real** provider verification, 5/5 interactions passing (including my new one)
- [x] `ktlintCheck` + `detekt` on settlement-service — clean
- [x] `:openbank-settlement-service:quarkusBuild` — CDI wiring intact

Refs #468 (leaving open — priority order has billing→ledger and clearing inbound next, then the platform edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)