### PR TITLE
fix(admin-ui): show fx-service scale-to-zero state on the FX page

### DIFF
--- a/openbank-admin-ui/src/app/api/fx/rates/route.ts
+++ b/openbank-admin-ui/src/app/api/fx/rates/route.ts
@@ -4,10 +4,41 @@
 
 import { NextResponse } from 'next/server'
 import { CURRENCY_META } from '@/lib/currency-meta'
+import { inCluster, discoverServices, resolveInClusterBaseUrl } from '@/lib/discovery'
 
-const FX_SERVICE_URL = process.env.FX_SERVICE_URL ?? 'http://openbank-fx-service:8119'
+// Off-cluster (local dev / docker-compose) fallback only. In-cluster we resolve
+// fx-service through discovery, never this literal — the real Service is
+// `fx-service.fx.svc:8119`, not `openbank-fx-service`.
+const FX_SERVICE_URL = process.env.FX_SERVICE_URL ?? 'http://localhost:8119'
 
 export const dynamic = 'force-dynamic'
+
+// fx-service is on the FinOps off-hours scaledown allowlist (fx/rollout/fx-service),
+// so it legitimately sits at zero replicas overnight/weekends. Resolve its state via
+// discovery so the FX page can show a calm "idle (scale-to-zero)" badge instead of a
+// misleading red "down" — and so a genuinely-up service isn't mislabelled red just
+// because the old hardcoded `openbank-fx-service` host never resolved.
+type FxStatus = 'up' | 'scaled_to_zero' | 'down' | 'not_deployed'
+
+async function resolveFxService(): Promise<{ status: FxStatus; baseUrl: string | null }> {
+  if (!inCluster()) {
+    // Local dev: probe the direct URL; can't distinguish scale-to-zero here.
+    try {
+      const res = await fetch(`${FX_SERVICE_URL}/q/health/ready`, { signal: AbortSignal.timeout(3000) })
+      return { status: res.ok ? 'up' : 'down', baseUrl: FX_SERVICE_URL }
+    } catch {
+      return { status: 'down', baseUrl: FX_SERVICE_URL }
+    }
+  }
+  const discovered = await discoverServices()
+  const fx = discovered?.find((d) => d.name === 'fx-service')
+  if (!fx) return { status: 'not_deployed', baseUrl: null }
+  if (fx.scaledToZero) return { status: 'scaled_to_zero', baseUrl: null }
+  // readyReplicas IS the kubelet's /q/health/ready verdict re-published by the control
+  // plane, so we trust discovery's readiness rather than a second in-band health probe.
+  const baseUrl = await resolveInClusterBaseUrl('fx-service')
+  return { status: fx.ready ? 'up' : 'down', baseUrl }
+}
 
 async function fetchCnbRates() {
   const res = await fetch('https://api.cnb.cz/cnbapi/exrates/daily?lang=EN', {
@@ -60,18 +91,9 @@ async function fetchEcbRates() {
   return result
 }
 
-async function fetchFxServiceHealth(): Promise<boolean> {
+async function fetchFxServiceRates(baseUrl: string) {
   try {
-    const res = await fetch(`${FX_SERVICE_URL}/q/health/ready`, { signal: AbortSignal.timeout(3000) })
-    return res.ok
-  } catch {
-    return false
-  }
-}
-
-async function fetchFxServiceRates() {
-  try {
-    const res = await fetch(`${FX_SERVICE_URL}/api/v1/fx/rates`, { signal: AbortSignal.timeout(5000) })
+    const res = await fetch(`${baseUrl}/api/v1/fx/rates`, { signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return Array.isArray(data) ? data : (data?.rates ?? [])
@@ -80,9 +102,9 @@ async function fetchFxServiceRates() {
   }
 }
 
-async function fetchFxConversions() {
+async function fetchFxConversions(baseUrl: string) {
   try {
-    const res = await fetch(`${FX_SERVICE_URL}/api/v1/fx/conversions`, { signal: AbortSignal.timeout(5000) })
+    const res = await fetch(`${baseUrl}/api/v1/fx/conversions`, { signal: AbortSignal.timeout(5000) })
     if (!res.ok) return []
     const data = await res.json()
     return Array.isArray(data) ? data : (data?.conversions ?? [])
@@ -92,12 +114,15 @@ async function fetchFxConversions() {
 }
 
 export async function GET() {
-  const [cnbRates, ecbRates, serviceUp, fxRates, conversions] = await Promise.allSettled([
+  const fx = await resolveFxService()
+  // Only reach out to fx-service when it's actually serving; a scaled-to-zero or
+  // undeployed service has no reachable pod, so skip the fetch (and its timeout).
+  const canFetch = fx.status === 'up' && fx.baseUrl !== null
+  const [cnbRates, ecbRates, fxRates, conversions] = await Promise.allSettled([
     fetchCnbRates(),
     fetchEcbRates(),
-    fetchFxServiceHealth(),
-    fetchFxServiceRates(),
-    fetchFxConversions(),
+    canFetch ? fetchFxServiceRates(fx.baseUrl!) : Promise.resolve([]),
+    canFetch ? fetchFxConversions(fx.baseUrl!) : Promise.resolve([]),
   ])
 
   return NextResponse.json({
@@ -112,7 +137,9 @@ export async function GET() {
       error: ecbRates.status === 'rejected' ? String(ecbRates.reason) : null,
     },
     fxService: {
-      up: serviceUp.status === 'fulfilled' ? serviceUp.value : false,
+      status: fx.status,
+      // `up` kept for backward-compat with any older client; `status` is authoritative.
+      up: fx.status === 'up',
       rates: fxRates.status === 'fulfilled' ? fxRates.value : [],
       conversions: conversions.status === 'fulfilled' ? conversions.value : [],
     },

--- a/openbank-admin-ui/src/app/fx/page.tsx
+++ b/openbank-admin-ui/src/app/fx/page.tsx
@@ -9,7 +9,7 @@ import {
   Globe, TrendingUp, RefreshCw, CheckCircle2, XCircle, Clock,
   ArrowLeftRight, Save, History, Edit3, Banknote, Download,
   Calendar, Play, AlertCircle, Settings, Eye, EyeOff, Percent,
-  ChevronDown, ChevronUp, Lock, Unlock,
+  ChevronDown, ChevronUp, Lock, Unlock, Moon,
 } from 'lucide-react'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { CURRENCY_META } from '@/lib/currency-meta'
@@ -87,6 +87,25 @@ const INITIAL_SCHEDULES: ScheduleEntry[] = [
 const ECB_CURRENCIES = ['USD', 'GBP', 'JPY', 'CHF', 'PLN', 'HUF', 'RON', 'SEK', 'NOK', 'DKK', 'AUD', 'CAD', 'CNY']
 const DEFAULT_PUBLISHED = ['USD', 'EUR', 'GBP', 'CHF', 'JPY', 'PLN', 'HUF', 'SEK', 'NOK', 'DKK']
 
+// fx-service is on the FinOps scaledown allowlist, so "not reachable" usually means
+// "intentionally idle", not "broken". Map the /api/fx/rates status to a calm badge:
+// scale-to-zero is amber "asleep", never a red "down". null = still checking.
+type FxStatus = 'up' | 'scaled_to_zero' | 'down' | 'not_deployed'
+function fxBadge(status: FxStatus | null, t: (cs: string, en: string) => string) {
+  switch (status) {
+    case 'up':
+      return { icon: CheckCircle2, bg: 'var(--success-bg)', fg: 'var(--success-text)', border: 'var(--success-border)', label: t('fx-service :8119', 'fx-service :8119') }
+    case 'scaled_to_zero':
+      return { icon: Moon, bg: 'var(--warning-bg)', fg: 'var(--warning-text)', border: 'var(--warning-border)', label: t('fx-service spí (scale-to-zero)', 'fx-service idle (scaled to zero)') }
+    case 'down':
+      return { icon: XCircle, bg: 'var(--danger-bg)', fg: 'var(--danger-text)', border: 'var(--danger-border)', label: t('fx-service neodpovídá', 'fx-service is not responding') }
+    case 'not_deployed':
+      return { icon: XCircle, bg: 'var(--surface-3)', fg: 'var(--text-tertiary)', border: 'var(--border)', label: t('fx-service není nasazen', 'fx-service not deployed') }
+    default:
+      return { icon: Clock, bg: 'var(--surface-3)', fg: 'var(--text-tertiary)', border: 'var(--border)', label: t('fx-service — zjišťuji…', 'fx-service — checking…') }
+  }
+}
+
 function applyMargin(mid: number, pct: number, direction: 'buy' | 'sell'): number {
   return direction === 'buy' ? mid * (1 - pct / 100) : mid * (1 + pct / 100)
 }
@@ -128,7 +147,7 @@ export default function FxPage() {
   const [ecbSyncedAt, setEcbSyncedAt] = useState<string | null>(null)
   const [ecbError, setEcbError] = useState<string | null>(null)
 
-  const [serviceUp, setServiceUp] = useState<boolean | null>(null)
+  const [fxStatus, setFxStatus] = useState<FxStatus | null>(null)
   const [conversions, setConversions] = useState<FxConversion[]>([])
 
   const [margin, setMargin] = useState<MarginConfig>({ buyPct: 1.5, sellPct: 1.5 })
@@ -170,7 +189,7 @@ export default function FxPage() {
       setEcbSyncedAt(data.ecb?.syncedAt ?? null)
       setEcbError(data.ecb?.error ?? null)
 
-      setServiceUp(data.fxService?.up ?? false)
+      setFxStatus((data.fxService?.status as FxStatus | undefined) ?? (data.fxService?.up ? 'up' : 'down'))
       setConversions(data.fxService?.conversions ?? [])
 
       const nowStr = new Date().toISOString()
@@ -297,13 +316,17 @@ export default function FxPage() {
               <Download size={13} style={{ animation: refreshing === 'all' ? 'spin 1s linear infinite' : 'none' }} />
               {t('Stáhnout vše', 'Fetch All')}
             </button>
-            <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600, padding: '4px 10px', borderRadius: '20px',
-              background: serviceUp === true ? 'var(--success-bg)' : serviceUp === false ? 'var(--danger-bg)' : 'var(--surface-3)',
-              color: serviceUp === true ? 'var(--success-text)' : serviceUp === false ? 'var(--danger-text)' : 'var(--text-tertiary)',
-              border: `1px solid ${serviceUp === true ? 'var(--success-border)' : serviceUp === false ? 'var(--danger-border)' : 'var(--border)'}` }}>
-              {serviceUp === true ? <CheckCircle2 size={10} /> : serviceUp === false ? <XCircle size={10} /> : <Clock size={10} />}
-              fx-service :8119
-            </span>
+            {(() => {
+              const b = fxBadge(fxStatus, t)
+              const Icon = b.icon
+              return (
+                <span style={{ display: 'flex', alignItems: 'center', gap: '5px', fontSize: '11px', fontWeight: 600, padding: '4px 10px', borderRadius: '20px',
+                  background: b.bg, color: b.fg, border: `1px solid ${b.border}` }}>
+                  <Icon size={10} />
+                  {b.label}
+                </span>
+              )
+            })()}
           </div>
         </div>
 
@@ -335,9 +358,11 @@ export default function FxPage() {
             {t('externí referenční kurzy (data-api.ecb.europa.eu)', 'external reference rates (data-api.ecb.europa.eu)')}
           </span>
           <span style={{ display: 'flex', alignItems: 'center', gap: '5px', color: 'var(--text-tertiary)' }}>
-            {serviceUp === true ? <CheckCircle2 size={11} style={{ color: 'var(--success-text)' }} /> : serviceUp === false ? <XCircle size={11} style={{ color: 'var(--danger-text)' }} /> : <Clock size={11} />}
+            {(() => { const b = fxBadge(fxStatus, t); const Icon = b.icon; return <Icon size={11} style={{ color: b.fg }} /> })()}
             <strong style={{ color: 'var(--text-secondary)' }}>fx-service</strong>
-            {t('interní FX engine + konverze (DB)', 'internal FX engine + conversions (DB)')}
+            {fxStatus === 'scaled_to_zero'
+              ? t('interní FX engine + konverze (DB) — spí (scale-to-zero)', 'internal FX engine + conversions (DB) — idle (scaled to zero)')
+              : t('interní FX engine + konverze (DB)', 'internal FX engine + conversions (DB)')}
           </span>
           <span style={{ marginLeft: 'auto', color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
             <AlertCircle size={11} style={{ verticalAlign: '-1px', marginRight: '4px' }} />


### PR DESCRIPTION
## Problem

The FX (Devizové operace) page badge showed **red `fx-service :8119`** even though `fx-service` is **1/1 up**. Root cause: `/api/fx/rates` probed a hardcoded `http://openbank-fx-service:8119` — a host that **doesn't resolve** (the real Service is `fx-service.fx.svc:8119`). And there was no way to tell an intentional **FinOps scaledown** (fx-service is on the allowlist → 0 replicas overnight/weekends) from a genuine outage — both looked red.

## Fix

- **Route** resolves fx-service through cluster **discovery**: `scaledToZero` → `scaled_to_zero`, ready → `up`, deployed-but-not-ready → `down`, absent → `not_deployed`. It reaches the rates/conversions endpoints at the correct discovered DNS, and only when the service is actually up (a sleeping pod is skipped — no wasted 5s timeout). Off-cluster it keeps the direct-URL probe.
- **Page** maps that status to a four-state badge: 🟢 up · 🟡 **"spí (scale-to-zero)"** idle · 🔴 down · ⚪ not-deployed. So a scaled-to-zero engine reads as **calmly idle, not broken**, and a genuinely-up one is finally green. (`up` kept in the response for backward-compat; `status` authoritative.)

The FX page already works without fx-service (CNB/ECB external rates + browser-computed bank sheet), so this is purely the honesty of the status indicator.

## Verification
- `tsc` clean · `eslint` clean (2 pre-existing warnings elsewhere) · `next build` ✓ · guards 154/154
- admin-ui, not money-path — no fx-service change.

## Linked issues
Refs #759