### PR TITLE
feat(gitops): ledger-db CNPG cluster to instances:2 (HA) — ADR-0159 sweep 1/17

### DIFF
--- a/openbank-infra/gitops/components/ledger/postgres.yaml
+++ b/openbank-infra/gitops/components/ledger/postgres.yaml
@@ -16,7 +16,27 @@ spec:
   # deadlocks, xid age, WAL archiving) with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # HA (ADR-0159): primary + hot standby with async streaming replication and
+  # CNPG-managed automated failover. `enablePodAntiAffinity` + required
+  # `kubernetes.io/hostname` keeps the two pods on DIFFERENT NODES — that is both
+  # the HA guarantee and the fix for the single-instance un-drainable-PDB node-roll
+  # block (issue #809): with a standby present the PDB permits one disruption, so
+  # Karpenter drains/rolls a DB-hosting node without the manual delete-primary dance.
+  # The topologySpreadConstraint softly spreads the pair across AZs when capacity
+  # allows. Async replication (no minSyncReplicas) keeps the write path independent
+  # of standby health; synchronous is deferred to a production decision (ADR-0159).
+  instances: 2
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: ledger-db
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3


### PR DESCRIPTION
## Summary

First cluster in the **ADR-0159 money-path HA sweep** (#850). Converts `ledger/ledger-db` from `instances: 1` to `instances: 2`: a hot standby with async streaming replication + CNPG automated failover, **required** per-hostname anti-affinity (the two pods never share a node), and a soft cross-AZ `topologySpreadConstraint`.

## Why

Single-instance ledger-db has (1) **no failover** — a node loss = the ledger money path is down for minutes until the pod reschedules + crash-recovers; and (2) an **un-drainable PDB** (`allowedDisruptions=0`) that was one of the 15 nodes stalling the #809 drift roll and forcing the manual `delete pod <primary>` dance. `instances: 2` fixes both: automatic switchover on node loss, and the standby is evictable so Karpenter drains/rolls the node cleanly.

## Type of change

- [x] Feature (platform availability — gitops manifest only)

## Linked issues

Refs #850 (sweep tracker — one PR per cluster, stays open). Decision: ADR-0159.

## Money-path review notes (ADR-0030)

- **2 approvals + threat-model review required** (`money-path` label). Security/availability analysis is in ADR-0159 §Consequences/§Compliance.
- **No new attack surface**: the standby is a second Postgres pod in the *same* namespace; replication is intra-cluster over the pod network (already covered by ledger's NetworkPolicies + the CNPG operator wiring). No change to data handling, RBAC, secrets, or external interfaces. It *reduces* risk by removing the DB single-point-of-failure — the `openbank-ledger-service` threat model's DoS/availability posture improves; no new STRIDE entry is introduced.
- **Async, not synchronous** (no `minSyncReplicas`) — deliberate per ADR-0159; synchronous (zero-RPO, write-unavailable if standby down) is deferred to a production decision.

## Apply / verification (post-merge, GitOps)

- This is ArgoCD-managed; it applies on merge, **not** out-of-band. Applying `instances:1→2` is **online** — CNPG adds the replica via `pg_basebackup` while the primary keeps serving (non-disruptive).
- After apply, before ticking the #850 box: confirm the standby is streaming healthy (`cnpg_*` replication-lag metrics, already exported via the PodMonitor) and perform a **test switchover**.
- Capacity: the standby needs a second same-AZ-or-other node slot; the default NodePool cpu-limit is 48 (#825) — watch it doesn't re-pin.

## Security / compliance impact

DORA: positive (money-path operational resilience). PCI/GDPR/PSD2/CNB: not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)