### PR TITLE
fix(balance): create missing balance_reconciliation_seq (daily EoD tie-out never persisted)

### DIFF
--- a/openbank-balance-service/src/main/resources/db/migration/V9__balance_reconciliation_seq.sql
+++ b/openbank-balance-service/src/main/resources/db/migration/V9__balance_reconciliation_seq.sql
@@ -1,0 +1,22 @@
+-- Create the missing Hibernate id sequence for balance_reconciliation.
+--
+-- BalanceReconciliationEntity (ADR-0039 Phase A, added in V4) is a Panache entity that
+-- allocates ids from a sequence named "balance_reconciliation_seq" (allocationSize 50).
+-- V4 created the table with BIGSERIAL (so only "balance_reconciliation_id_seq" exists) and
+-- the schema is generation:none, so every INSERT runs `nextval('balance_reconciliation_seq')`
+-- and fails with: relation "balance_reconciliation_seq" does not exist (42P01).
+--
+-- V5__hibernate_sequences.sql backfilled balances_seq / balance_holds_seq / balance_outbox_seq
+-- but MISSED this one. The reconciliation line was later added to V5 in source — but V5 had
+-- already been applied to live databases, and Flyway never re-runs an applied migration, so
+-- the fix never reached them: the daily control-account tie-out (BalanceReconciliationScheduler,
+-- 23:30) has therefore persisted ZERO rows since day one — the reconcile use-case 500s on the
+-- missing sequence on every run and the scheduler swallows it. This is a forward migration
+-- (never edit an applied migration) that finally creates the sequence on existing databases.
+--
+-- IF NOT EXISTS makes it idempotent: a no-op on any database provisioned after the V5 edit
+-- (where V5 already created it). Matches the repo convention: unquoted, lowercase, INCREMENT BY 50.
+--
+-- Rollback: DROP SEQUENCE IF EXISTS balance_reconciliation_seq;
+
+CREATE SEQUENCE IF NOT EXISTS balance_reconciliation_seq INCREMENT BY 50;


### PR DESCRIPTION
## Why (audit-critical)

The daily control-account ⇄ sub-ledger reconciliation (ADR-0039 Phase A, `BalanceReconciliationScheduler` @ 23:30) has persisted **zero** rows since inception — the **daily EoD tie-out has never run to completion**. `balance_reconciliation` allocates ids from `balance_reconciliation_seq`, which **doesn't exist** on live DBs, so `reconcile()` fails every run with `relation "balance_reconciliation_seq" does not exist (42P01)` and the scheduler swallows it.

Root cause is the classic **"never edit an applied migration"**: `V5__hibernate_sequences` missed the reconciliation sequence; the line was later added to V5 in source, but V5 was already applied and Flyway never re-runs an applied migration (`REPAIR_AT_START` only reconciles the checksum, it doesn't re-execute), so it never reached existing DBs.

## What

Forward migration `V9__balance_reconciliation_seq.sql`:
```sql
CREATE SEQUENCE IF NOT EXISTS balance_reconciliation_seq INCREMENT BY 50;
```
`IF NOT EXISTS` is idempotent (no-op on DBs provisioned after the V5 edit). A **new** migration, never an edit of V5.

## Verification
- Confirmed live: `SELECT count(*) FROM balance_reconciliation` → **0**; manual `POST /reconciliation` → HTTP 500 with the 42P01 error; `balance_reconciliation_seq` absent from `pg_sequences` while the other three exist.
- Dry-ran V9 against the live balances DB: `BEGIN; CREATE SEQUENCE IF NOT EXISTS …; SELECT nextval(…); ROLLBACK;` → succeeds, no drift.
- `REPAIR_AT_START=true` reconciles the pre-existing V5 checksum mismatch on boot, so the redeploy applies V9 cleanly.

## Rollback
`DROP SEQUENCE IF EXISTS balance_reconciliation_seq;`

## Follow-ups (separate)
- **Backfill** recent business days once deployed (issue #855, step 3).
- Harden the `suspend fun` `@Scheduled` + add a "last successful tie-out" heartbeat/alert (step 2).
- day-end UI: distinguish "never ran / failed / stale" from "no data yet" (step 4).

## Governance
Money-path service → **2 approvals + threat model required**. Threat model unchanged (`docs/threat-models/openbank-balance-service.md`) — this restores an existing control, adds no new surface.

## Linked issues
Closes #855