### PR TITLE
fix(fx): grant the real M2M caller role in the Pact provider test, not a phantom one

### DIFF
--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
@@ -32,12 +32,21 @@ import java.util.UUID
 /**
  * Provider-side verification for the FX rate contract published by transaction-service
  * (ADR-0063 P2 Batch B). Seeds an EUR/CZK SPOT rate so that GET /api/v1/fx/rates/EUR/CZK
- * returns 200 with the expected shape. The `@TestSecurity` satisfies the OIDC check on the
- * rates endpoint (service role required per ADR-0018).
+ * returns 200 with the expected shape. `@TestSecurity` must grant a role the endpoint's
+ * `@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")` actually
+ * accepts — `ROLE_SERVICE` is not in that list and, per the Keycloak realm config
+ * (`openbank-realm.json` / `realm-template.json`), isn't even a realm role any real client
+ * is ever granted. The real M2M caller (transaction-service, via the shared
+ * `openbank-services` client) authenticates as `service-account-openbank-services`, whose
+ * realmRoles is `["ROLE_OPERATOR"]` — that's the role this test must present too, or every
+ * verification 403s before reaching the resource method (confirmed live: verification result
+ * #2247, 2026-07-11, and broken since this test was added on 2026-07-02 without ever being
+ * noticed locally, since it's `@EnabledIfSystemProperty(pactbroker.url)`-skipped without a
+ * broker).
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.fx.it.PostgresRedisTestResource::class)
-@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE"])
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_OPERATOR"])
 @Provider("openbank-fx-service")
 @PactBroker
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")


### PR DESCRIPTION
## Summary
- `FxPactProviderVerificationTest`'s `@TestSecurity` granted `ROLE_SERVICE`, which `FxResource`'s `@RolesAllowed("ROLE_VIEWER", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_PAYMENTS")` never accepted — every verification 403s before the request reaches the resource method.
- Confirmed live via the Pact Broker's read-only API: verification result #2247 (2026-07-11) shows `expected status of 200 but was 403` with an empty body / missing `Content-Type` — the signature of a security-interceptor rejection, not an application-level error. Broken since this test was added on 2026-07-02, never noticed locally because it's `@EnabledIfSystemProperty(pactbroker.url)`-skipped without a broker.
- `ROLE_SERVICE` isn't even a real Keycloak realm role — checked both `openbank-infra/docker/keycloak/realm/openbank-realm.json` and the sandbox `realm-template.json`; neither defines it. The actual M2M caller (transaction-service, via the shared `openbank-services` client) authenticates as `service-account-openbank-services`, whose `realmRoles` is `["ROLE_OPERATOR"]`.
- Fix: `@TestSecurity(roles = ["ROLE_SERVICE"])` → `@TestSecurity(roles = ["ROLE_OPERATOR"])`, matching what production actually sends. `AUTHZ_ENFORCE` defaults `false` in fx-service's `application.yaml`, so the OPA `@Authorize` layer is advisory-only in this test profile and doesn't need a matching change.

## Test plan
- [x] `:openbank-fx-service:compileTestKotlin` — BUILD SUCCESSFUL
- [x] `:openbank-fx-service:ktlintCheck` — BUILD SUCCESSFUL
- [x] `:openbank-fx-service:detekt` — BUILD SUCCESSFUL
- [ ] CI: `pactbroker.url`-gated `FxPactProviderVerificationTest` will run for real against the broker and publish a fresh verification result — the actual validation channel for this fix.

Linked issues: N/A — found while investigating a separate pact-verification gap flagged during the balance-service Vert.x-context fix (#858); no tracking issue was open for it.