### PR TITLE
feat(balance): watchdog alerts when the daily EoD tie-out goes stale/absent (step 2 of #855)

### DIFF
--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.infrastructure.schedule
+
+import com.openbank.balance.application.port.out.ReconciliationRecordRepository
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Freshness watchdog for the daily control-account ⇄ sub-ledger reconciliation (ADR-0039 Phase A).
+ *
+ * The daily tie-out ([BalanceReconciliationScheduler] @ 23:30) is an audit-critical control, and it
+ * can fail SILENTLY: [com.openbank.balance.application.usecase.BalanceReconciliationService] persists
+ * only on success and the scheduler swallows exceptions after logging, so a broken run leaves no
+ * record and no alarm. That is exactly how a missing id sequence let the tie-out persist ZERO rows
+ * for 41 days unnoticed (issue #855).
+ *
+ * This watchdog runs hourly and escalates the ABSENCE of a fresh tie-out to ERROR, so the log-based
+ * alerting stack (Alloy → Loki) pages instead of the gap sitting silent — a missed daily control is
+ * now loud. It is read-only and never touches a balance.
+ */
+@ApplicationScoped
+class ReconciliationFreshnessWatchdog(
+    private val recordRepo: ReconciliationRecordRepository,
+    private val clock: Clock,
+) {
+    private val log = Logger.getLogger(ReconciliationFreshnessWatchdog::class.java)
+
+    // The daily run fires at 23:30, so a healthy tie-out is at most ~24h old; allow a 1h grace (25h)
+    // for run duration or a delayed scheduler before we call it a missed control.
+    private val staleAfter = Duration.ofHours(25)
+
+    @Scheduled(
+        cron = "{openbank.reconciliation.freshness-cron:0 20 * * * ?}",
+        timeZone = "Europe/Prague",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun checkFreshness() {
+        val latest = recordRepo.findLatest()
+        if (latest == null) {
+            log.error(
+                "Balance reconciliation freshness: NO tie-out has ever succeeded — the daily " +
+                    "control-account ⇄ sub-ledger reconciliation (ADR-0039) is absent. Investigate.",
+            )
+            return
+        }
+        val ageHours = Duration.between(latest.generatedAt.toInstant(), Instant.now(clock)).toHours()
+        if (ageHours > staleAfter.toHours()) {
+            log.errorf(
+                "Balance reconciliation freshness: STALE — last successful tie-out was %dh ago " +
+                    "(as-of %s), past the %dh daily SLA; a scheduled run was likely missed.",
+                ageHours, latest.asOf, staleAfter.toHours(),
+            )
+        } else {
+            log.debugf("Balance reconciliation freshness OK: last tie-out %dh ago (as-of %s).", ageHours, latest.asOf)
+        }
+    }
+}

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
@@ -55,7 +55,9 @@ class ReconciliationFreshnessWatchdog(
             log.errorf(
                 "Balance reconciliation freshness: STALE — last successful tie-out was %dh ago " +
                     "(as-of %s), past the %dh daily SLA; a scheduled run was likely missed.",
-                ageHours, latest.asOf, staleAfter.toHours(),
+                ageHours,
+                latest.asOf,
+                staleAfter.toHours(),
             )
         } else {
             log.debugf("Balance reconciliation freshness OK: last tie-out %dh ago (as-of %s).", ageHours, latest.asOf)

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
@@ -32,9 +32,9 @@ class ReconciliationFreshnessWatchdog(
 ) {
     private val log = Logger.getLogger(ReconciliationFreshnessWatchdog::class.java)
 
-    // The daily run fires at 23:30, so a healthy tie-out is at most ~24h old; allow a 1h grace (25h)
+    // The daily run fires at 23:30, so a healthy tie-out is at most ~24h old; allow a 1h grace
     // for run duration or a delayed scheduler before we call it a missed control.
-    private val staleAfter = Duration.ofHours(25)
+    private val staleAfter = Duration.ofHours(DAILY_SLA_HOURS)
 
     @Scheduled(
         cron = "{openbank.reconciliation.freshness-cron:0 20 * * * ?}",
@@ -60,5 +60,10 @@ class ReconciliationFreshnessWatchdog(
         } else {
             log.debugf("Balance reconciliation freshness OK: last tie-out %dh ago (as-of %s).", ageHours, latest.asOf)
         }
+    }
+
+    private companion object {
+        // 24h daily cadence + 1h grace for run duration / a delayed scheduler.
+        const val DAILY_SLA_HOURS = 25L
     }
 }


### PR DESCRIPTION
## Why (step 2 of #855)
The daily control-account ⇄ sub-ledger reconciliation (ADR-0039, @ 23:30) fails **silently** — the use-case persists only on success and the scheduler swallows exceptions, so a broken run leaves no record and no alarm. That's exactly how the missing `balance_reconciliation_seq` let the tie-out persist **zero rows for 41 days** unnoticed.

## What
`ReconciliationFreshnessWatchdog` — an hourly, read-only `@Scheduled` bean that reads the latest reconciliation and escalates its **absence** to `ERROR` (never run, or last success older than the 25h daily SLA), so the log-based alerting stack (Alloy → Loki) **pages instead of the gap sitting silent**. A missed daily control is now loud.

## Notes
- The scheduler mechanism is sound: `BalanceOutboxDispatcher` already runs a `suspend @Scheduled` in this service, so Quarkus 3.33 fires suspend schedules — the 41-day gap was the sequence (fixed in #856), not the scheduler. This guards the failure **mode** (silent).
- `DomainMetrics` is a no-op path here for custom gauges, so a **log-based** watchdog is the reliable signal (Loki alerting), not a Prometheus gauge.
- Read-only; never touches a balance.

## Verification
`:openbank-balance-service:compileKotlin` clean.

## Governance
Money-path → **2 approvals + threat model**. Threat model unchanged (read-only observability, no new surface). **Needs the same four-eyes waiver as #856 to merge** — I did not enable auto-merge.

## Linked issues
Refs #855