### PR TITLE
fix(anacredit): use Admin.listGroups instead of deprecated listConsumerGroups

### DIFF
--- a/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/integration/LendingEventsConsumerGroupIdBootIT.kt
+++ b/openbank-anacredit-service/src/test/kotlin/com/openbank/anacredit/integration/LendingEventsConsumerGroupIdBootIT.kt
@@ -9,7 +9,7 @@ import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
-import org.apache.kafka.clients.admin.ListConsumerGroupsOptions
+import org.apache.kafka.clients.admin.ListGroupsOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.Properties
@@ -47,7 +47,7 @@ class LendingEventsConsumerGroupIdBootIT {
             val deadline = System.currentTimeMillis() + DEADLINE_MS
             var groupIds: Set<String> = emptySet()
             while (System.currentTimeMillis() < deadline) {
-                groupIds = admin.listConsumerGroups(ListConsumerGroupsOptions())
+                groupIds = admin.listGroups(ListGroupsOptions.forConsumerGroups())
                     .all().get().map { it.groupId() }.toSet()
                 if (groupIds.isNotEmpty()) break
                 Thread.sleep(POLL_INTERVAL_MS)


### PR DESCRIPTION
## What
`Admin.listConsumerGroups()` is deprecated in kafka-clients 4.x; replaced with the unified `Admin.listGroups(ListGroupsOptions.forConsumerGroups())`.

## Linked issues
Refs #865

## Test plan
- [x] Test-only change, mechanical API replacement (same semantics, `GroupListing.groupId()` == old `ConsumerGroupListing.groupId()`)
- [ ] CI: compile + boot IT