### PR TITLE
fix(analytics-sink): use Admin.listGroups instead of deprecated listConsumerGroups

### DIFF
--- a/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/integration/AnalyticsEventsConsumerGroupIdBootIT.kt
+++ b/openbank-analytics-sink/src/test/kotlin/com/openbank/analytics/integration/AnalyticsEventsConsumerGroupIdBootIT.kt
@@ -9,7 +9,7 @@ import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
-import org.apache.kafka.clients.admin.ListConsumerGroupsOptions
+import org.apache.kafka.clients.admin.ListGroupsOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -55,7 +55,7 @@ class AnalyticsEventsConsumerGroupIdBootIT {
             val deadline = System.currentTimeMillis() + DEADLINE_MS
             var groupIds: Set<String> = emptySet()
             while (System.currentTimeMillis() < deadline) {
-                groupIds = admin.listConsumerGroups(ListConsumerGroupsOptions())
+                groupIds = admin.listGroups(ListGroupsOptions.forConsumerGroups())
                     .all().get().map { it.groupId() }.toSet()
                 if (groupIds.isNotEmpty()) break
                 Thread.sleep(POLL_INTERVAL_MS)


### PR DESCRIPTION
## What
`Admin.listConsumerGroups()` is deprecated in kafka-clients 4.x; replaced with the unified `Admin.listGroups(ListGroupsOptions.forConsumerGroups())`.

## Linked issues
Refs #865

## Test plan
- [x] Test-only change, mechanical API replacement (same semantics)
- [ ] CI: compile + boot IT