### PR TITLE
fix(customer-edge): use Admin.listGroups instead of deprecated listConsumerGroups

### DIFF
--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/PartyEventsConsumerGroupIdBootIT.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/integration/PartyEventsConsumerGroupIdBootIT.kt
@@ -9,7 +9,7 @@ import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
-import org.apache.kafka.clients.admin.ListConsumerGroupsOptions
+import org.apache.kafka.clients.admin.ListGroupsOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.Properties
@@ -46,7 +46,7 @@ class PartyEventsConsumerGroupIdBootIT {
             val deadline = System.currentTimeMillis() + DEADLINE_MS
             var groupIds: Set<String> = emptySet()
             while (System.currentTimeMillis() < deadline) {
-                groupIds = admin.listConsumerGroups(ListConsumerGroupsOptions())
+                groupIds = admin.listGroups(ListGroupsOptions.forConsumerGroups())
                     .all().get().map { it.groupId() }.toSet()
                 if (groupIds.isNotEmpty()) break
                 Thread.sleep(POLL_INTERVAL_MS)


### PR DESCRIPTION
## What
`Admin.listConsumerGroups()` is deprecated in kafka-clients 4.x; replaced with the unified `Admin.listGroups(ListGroupsOptions.forConsumerGroups())`.

## Linked issues
Refs #865

## Test plan
- [x] Test-only change, mechanical API replacement (same semantics)
- [ ] CI: compile + boot IT