### PR TITLE
fix(fraud): use Admin.listGroups instead of deprecated listConsumerGroups

### DIFF
--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/integration/TransactionSignalConsumerBootIT.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/integration/TransactionSignalConsumerBootIT.kt
@@ -12,7 +12,7 @@ import io.restassured.module.kotlin.extensions.Then
 import io.restassured.module.kotlin.extensions.When
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
-import org.apache.kafka.clients.admin.ListConsumerGroupsOptions
+import org.apache.kafka.clients.admin.ListGroupsOptions
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -68,7 +68,7 @@ class TransactionSignalConsumerBootIT {
             val deadline = System.currentTimeMillis() + DEADLINE_MS
             var groupIds: Set<String> = emptySet()
             while (System.currentTimeMillis() < deadline) {
-                groupIds = admin.listConsumerGroups(ListConsumerGroupsOptions())
+                groupIds = admin.listGroups(ListGroupsOptions.forConsumerGroups())
                     .all().get().map { it.groupId() }.toSet()
                 if (groupIds.isNotEmpty()) break
                 Thread.sleep(POLL_INTERVAL_MS)


### PR DESCRIPTION
## What
`Admin.listConsumerGroups()` is deprecated in kafka-clients 4.x; replaced with the unified `Admin.listGroups(ListGroupsOptions.forConsumerGroups())`.

## Linked issues
Refs #865

## Test plan
- [x] Test-only change, mechanical API replacement (same semantics)
- [ ] CI: compile + boot IT