### PR TITLE
fix(admin-ui): remove unused Link import in iaops page

### DIFF
--- a/openbank-admin-ui/src/app/iaops/page.tsx
+++ b/openbank-admin-ui/src/app/iaops/page.tsx
@@ -5,7 +5,6 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
   Bot, RefreshCw, ScrollText, GitBranch, Scale,


### PR DESCRIPTION
## What
Removes the unused `Link` import from `next/link` in `src/app/iaops/page.tsx` — nothing in the file references it.

## Linked issues
Refs #865

## Test plan
- [x] Verified no other usage of `Link`/`<Link` in the file
- [ ] CI: lint + build