### PR TITLE
fix(swift): fail-closed crash bug + add clearing-simulator pact coverage (#468)

### DIFF
--- a/openbank-clearing-simulator/build.gradle.kts
+++ b/openbank-clearing-simulator/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    // Provider-side verification of the pacs.008/pacs.002 contract rail services publish
+    // (ADR-0063, issue #468). Git-pact (@PactFolder), matching ledger-service — no broker needed.
+    testImplementation(libs.pact.provider)
 }
 
 kover {

--- a/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/contract/ClearingSimulatorPactProviderVerificationTest.kt
+++ b/openbank-clearing-simulator/src/test/kotlin/com/openbank/clearingsimulator/contract/ClearingSimulatorPactProviderVerificationTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.clearingsimulator.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Provider-side Pact verification for `openbank-clearing-simulator`'s inbound `pacs.008` endpoint
+ * (issue #468 edge 4 — "clearing inbound"). First pact wiring in this module: every payment rail
+ * (sepa-instant, sepa-payment, swift-service, domestic-payment) submits here via
+ * `ClearingSimulatorClient.submitCreditTransfer`; swift-service is the first consumer with a
+ * committed contract ([com.openbank.swift.contract.ClearingSimulatorPactConsumerTest]).
+ *
+ * Git-pact (`@PactFolder`, resolved relative to this module's working directory at `../pacts` =
+ * the monorepo-root `pacts/` dir), matching `LedgerPactProviderVerificationTest`'s pattern — always
+ * runs, no broker, no CI secret required. `@TestSecurity` matches the endpoint's
+ * `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN")`, mirroring how every real rail
+ * authenticates (`ClearingSimulatorApiIT`'s own `@TestSecurity(user = "rail", roles =
+ * ["ROLE_SERVICE"])`).
+ */
+@QuarkusTest
+@TestSecurity(user = "rail", roles = ["ROLE_SERVICE"])
+@Provider("openbank-clearing-simulator")
+@PactFolder("../pacts")
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+class ClearingSimulatorPactProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    @State("the clearing simulator is available")
+    fun stateSimulatorAvailable() {
+        // Stateless, deterministic counterparty (no DB) — no setup needed. A well-formed transfer
+        // always settles (ACSC) unless its amount triggers a deterministic reject.
+    }
+}

--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -95,6 +95,9 @@ tasks.withType<Test> {
         // stalling the JVM for 30+ min. Exclude in CI; pact publishing runs as a dedicated step.
         // Re-enable once the pact-publish CI step is wired per #2404.
         exclude("**/SwiftEventPactConsumerTest*")
+        // ClearingSimulatorPactConsumerTest (issue #468 edge 4): same PactConsumerTestExt
+        // auto-publish hang as SwiftEventPactConsumerTest above — it runs fine locally.
+        exclude("**/ClearingSimulatorPactConsumerTest*")
 
         // CI hang #4 (#2404) background: test JVM used to hang 43+ min AFTER all tests
         // completed, in TestWorker$3.run() → LauncherSession.close() → CustomLauncherInterceptor

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/client/SchemeGatewayAdapter.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/client/SchemeGatewayAdapter.kt
@@ -52,11 +52,15 @@ class SchemeGatewayAdapter(@RestClient private val client: ClearingSimulatorClie
     @Suppress("TooGenericExceptionCaught")
     override suspend fun submit(message: SwiftMessage): SchemeSubmissionOutcome {
         val pacs008 = builder.build(instruction(message))
-        check(validator.validate(pacs008) is Iso20022ValidationResult.Valid) {
-            "rail built a non-conforming pacs.008 for SWIFT message ${message.id}"
-        }
 
+        // The validity check must be inside this try/catch, not before it: a SwiftMessage with a
+        // legitimately-nullable debtor field (orderingCustomerAccount/Name — see instruction())
+        // builds a pacs.008 the XSD rejects (empty IBAN/name), and the class's own fail-closed
+        // contract promises that surfaces as SchemeGatewayUnavailableException, not a raw crash.
         val pacs002 = try {
+            check(validator.validate(pacs008) is Iso20022ValidationResult.Valid) {
+                "rail built a non-conforming pacs.008 for SWIFT message ${message.id}"
+            }
             self.submitWithResilience(pacs008)
         } catch (ex: Exception) {
             log.warnf(ex, "Scheme gateway unavailable for SWIFT message %s; holding", message.id)

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/ClearingSimulatorPactConsumerTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/ClearingSimulatorPactConsumerTest.kt
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.swift.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.Matchers
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.consumer.xml.PactXmlBuilder
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.openbank.libs.iso20022.ChargeBearer
+import com.openbank.libs.iso20022.CreditTransferInstruction
+import com.openbank.libs.iso20022.Pacs008Builder
+import com.openbank.libs.iso20022.SettlementMethod
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * Consumer-driven contract for swift-service's inbound-to-clearing submission
+ * ([com.openbank.swift.infrastructure.client.SchemeGatewayAdapter.submit], ADR-0104 D2/D4,
+ * issue #468 edge 4 — "clearing inbound"). Unlike edges 1-3, this is an HTTP contract with an XML
+ * body, not JSON, and unlike the issue's own "message pact" framing, the transport is synchronous
+ * REST, not Kafka: `ClearingSimulatorClient.submitCreditTransfer` is a plain `@RegisterRestClient`
+ * `POST`. swift-service is the CONSUMER (it depends on the simulator's request/response shape);
+ * `openbank-clearing-simulator` is the PROVIDER — a real internal service (a non-production
+ * counterparty simulator, not the actual SWIFT/EBA network), so provider verification is exactly
+ * as meaningful here as it was for ledger-service in edges 2-3.
+ *
+ * The request is built via the real [Pacs008Builder] (same production code
+ * [com.openbank.swift.infrastructure.client.SchemeGatewayAdapter] uses) with fixed/deterministic
+ * field values — faithful to production shape without hand-crafting XML that could silently drift
+ * from what the builder actually emits. The response can't be exact-matched: the simulator stamps
+ * `CreDtTm` with the live clock (`ClearingSimulatorService.clear`'s `now` parameter), so
+ * `CreDtTm` uses a timestamp matcher via [PactXmlBuilder] — this is the first XML/matcher pact in
+ * the repo (every prior contract is JSON).
+ *
+ * Found and fixed alongside this contract: [SchemeGatewayAdapter]'s `instruction()` mapping
+ * defaulted `debtorName`/`debtorIban` to `""` when a SWIFT message's `orderingCustomerName`/
+ * `orderingCustomerAccount` were null (both legitimately nullable) — an empty IBAN/name violates
+ * the pacs.008 XSD, and the resulting `check()` failure threw a raw `IllegalStateException` before
+ * the class's own fail-closed `try`/`catch`, not the documented `SchemeGatewayUnavailableException`.
+ * That's a domain-mapping bug a wire-contract test wouldn't itself exercise (this contract uses a
+ * normal, fully-populated instruction); it's regression-guarded separately in
+ * `SchemeGatewayAdapterTest`.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-clearing-simulator", pactVersion = PactSpecVersion.V3)
+class ClearingSimulatorPactConsumerTest {
+
+    private val requestXml = Pacs008Builder().build(
+        CreditTransferInstruction(
+            messageId = "SWIFT-TRX-PACT-001",
+            creationDateTime = OffsetDateTime.of(2026, 1, 20, 10, 15, 30, 0, ZoneOffset.UTC),
+            interbankSettlementDate = OffsetDateTime.of(2026, 1, 20, 10, 15, 30, 0, ZoneOffset.UTC),
+            endToEndId = "TRX-PACT-001",
+            transactionId = null,
+            amount = BigDecimal("12.34"),
+            currency = "EUR",
+            chargeBearer = ChargeBearer.SHAR,
+            settlementMethod = SettlementMethod.COVE,
+            debtorName = "Alice Debtor",
+            debtorIban = "DE89370400440532013000",
+            debtorAgentBic = "GIBACZPX",
+            creditorAgentBic = "DEUTDEFF",
+            creditorName = "Bob Creditor",
+            creditorIban = "GB33BUKB20201555555555",
+            remittanceInfo = "Invoice 1",
+        ),
+    )
+
+    @Pact(consumer = "openbank-swift-service", provider = "openbank-clearing-simulator")
+    fun submitCreditTransferPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the clearing simulator is available")
+        .uponReceiving("POST a pacs.008 credit transfer converted from an MT103")
+        .path("/api/v1/clearing/credit-transfers")
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/xml"))
+        .body(requestXml, "application/xml")
+        .willRespondWith()
+        .status(200)
+        .headers(mapOf("Content-Type" to "application/xml"))
+        .body(
+            PactXmlBuilder("Document").build { root ->
+                root.setAttributes(mapOf("xmlns" to "urn:iso:std:iso:20022:tech:xsd:pacs.002.001.10"))
+                root.appendElement("FIToFIPmtStsRpt", emptyMap<String, Any?>()) { rpt ->
+                    rpt.appendElement("GrpHdr", emptyMap<String, Any?>()) { grpHdr ->
+                        // Both are simulator-derived, not literal echoes of the request: MsgId is
+                        // "SIM-STS-" + the submitted endToEndId (ClearingSimulatorService.clear),
+                        // and CreDtTm is Instant.now(clock).toString() — variable fractional-second
+                        // digit count, not a fixed-width offset — so both need a matcher, not an
+                        // exact value; a stricter fixed-format timestamp matcher failed real
+                        // provider verification on this (Instant.toString() isn't ISO_OFFSET_DATE_TIME).
+                        grpHdr.appendElement(
+                            "MsgId",
+                            emptyMap<String, Any?>(),
+                            Matchers.regexp("SIM-STS-.+", "SIM-STS-TRX-PACT-001"),
+                        )
+                        grpHdr.appendElement(
+                            "CreDtTm",
+                            emptyMap<String, Any?>(),
+                            Matchers.regexp(
+                                "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z",
+                                "2026-01-20T10:15:30.123456Z",
+                            ),
+                        )
+                    }
+                    rpt.appendElement("TxInfAndSts", emptyMap<String, Any?>()) { tx ->
+                        tx.appendElement("OrgnlEndToEndId", emptyMap<String, Any?>(), "TRX-PACT-001")
+                        tx.appendElement("TxSts", emptyMap<String, Any?>(), "ACSC")
+                    }
+                }
+            },
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "submitCreditTransferPact")
+    fun `submitCreditTransfer returns an ACSC pacs_002 for a well-formed pacs_008`(mockServer: MockServer) {
+        val body = given()
+            .baseUri(mockServer.getUrl())
+            .contentType("application/xml")
+            .body(requestXml)
+            .post("/api/v1/clearing/credit-transfers")
+            .then()
+            .statusCode(200)
+            .extract().body().asString()
+
+        assertThat(body).contains("urn:iso:std:iso:20022:tech:xsd:pacs.002.001.10")
+        assertThat(body).contains("<TxSts>ACSC</TxSts>")
+        assertThat(body).contains("<OrgnlEndToEndId>TRX-PACT-001</OrgnlEndToEndId>")
+    }
+}

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/infrastructure/client/SchemeGatewayAdapterTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/infrastructure/client/SchemeGatewayAdapterTest.kt
@@ -58,6 +58,16 @@ class SchemeGatewayAdapterTest {
     }
 
     @Test
+    fun `a missing orderingCustomer account or name fails closed instead of crashing`() {
+        // Both are legitimately nullable on SwiftMessage (no validate() requirement), but an
+        // empty IBAN/name violates the pacs.008 XSD — must hold the message, not raise a raw
+        // IllegalStateException past the caller's fail-closed contract.
+        assertThatThrownBy {
+            runBlocking { adapter.submit(message(orderingCustomerAccount = null, orderingCustomerName = null)) }
+        }.isInstanceOf(SchemeGatewayUnavailableException::class.java)
+    }
+
+    @Test
     fun `OUR charge code maps to pacs008 with DEBT ChargeBearer`(): Unit = runBlocking {
         every { client.submitCreditTransfer(any()) } answers { call ->
             val xml = call.invocation.args[0] as String
@@ -79,14 +89,18 @@ class SchemeGatewayAdapterTest {
         adapter.submit(message(chargeCode = "SHA"))
     }
 
-    private fun message(chargeCode: String = "SHA") = SwiftMessage(
+    private fun message(
+        chargeCode: String = "SHA",
+        orderingCustomerAccount: String? = "DE89370400440532013000",
+        orderingCustomerName: String? = "Alice",
+    ) = SwiftMessage(
         id = UUID.fromString("55555555-5555-5555-5555-555555555555"),
         idempotencyKey = "test", messageType = SwiftMessageType.MT103,
         senderBic = "ABCDEFGH", receiverBic = "IJKLMNOP",
         transactionReference = "TRX-001", relatedReference = null,
         valueDate = "20260622", currency = "EUR", amountMinorUnits = 100_00L,
-        orderingCustomerAccount = "DE89370400440532013000", orderingCustomerAccountId = null,
-        orderingCustomerName = "Alice",
+        orderingCustomerAccount = orderingCustomerAccount, orderingCustomerAccountId = null,
+        orderingCustomerName = orderingCustomerName,
         beneficiaryAccount = "GB33BUKB20201555555555", beneficiaryName = "Bob",
         remittanceInfo = "Invoice 1", chargeCode = chargeCode,
         priority = SwiftPriority.NORMAL, status = SwiftStatus.VALIDATED,

--- a/pacts/openbank-swift-service-openbank-clearing-simulator.json
+++ b/pacts/openbank-swift-service-openbank-clearing-simulator.json
@@ -1,0 +1,63 @@
+{
+  "consumer": {
+    "name": "openbank-swift-service"
+  },
+  "interactions": [
+    {
+      "description": "POST a pacs.008 credit transfer converted from an MT103",
+      "providerStates": [
+        {
+          "name": "the clearing simulator is available"
+        }
+      ],
+      "request": {
+        "body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:pacs.008.001.08\">\n    <FIToFICstmrCdtTrf>\n        <GrpHdr>\n            <MsgId>SWIFT-TRX-PACT-001</MsgId>\n            <CreDtTm>2026-01-20T10:15:30Z</CreDtTm>\n            <NbOfTxs>1</NbOfTxs>\n            <SttlmInf>\n                <SttlmMtd>COVE</SttlmMtd>\n            </SttlmInf>\n        </GrpHdr>\n        <CdtTrfTxInf>\n            <PmtId>\n                <EndToEndId>TRX-PACT-001</EndToEndId>\n            </PmtId>\n            <IntrBkSttlmAmt Ccy=\"EUR\">12.34</IntrBkSttlmAmt>\n            <IntrBkSttlmDt>2026-01-20</IntrBkSttlmDt>\n            <ChrgBr>SHAR</ChrgBr>\n            <Dbtr>\n                <Nm>Alice Debtor</Nm>\n            </Dbtr>\n            <DbtrAcct>\n                <Id>\n                    <IBAN>DE89370400440532013000</IBAN>\n                </Id>\n            </DbtrAcct>\n            <DbtrAgt>\n                <FinInstnId>\n                    <BICFI>GIBACZPX</BICFI>\n                </FinInstnId>\n            </DbtrAgt>\n            <CdtrAgt>\n                <FinInstnId>\n                    <BICFI>DEUTDEFF</BICFI>\n                </FinInstnId>\n            </CdtrAgt>\n            <Cdtr>\n                <Nm>Bob Creditor</Nm>\n            </Cdtr>\n            <CdtrAcct>\n                <Id>\n                    <IBAN>GB33BUKB20201555555555</IBAN>\n                </Id>\n            </CdtrAcct>\n            <RmtInf>\n                <Ustrd>Invoice 1</Ustrd>\n            </RmtInf>\n        </CdtTrfTxInf>\n    </FIToFICstmrCdtTrf>\n</Document>\n",
+        "headers": {
+          "Content-Type": "application/xml"
+        },
+        "method": "POST",
+        "path": "/api/v1/clearing/credit-transfers"
+      },
+      "response": {
+        "body": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<Document xmlns=\"urn:iso:std:iso:20022:tech:xsd:pacs.002.001.10\">\n    <FIToFIPmtStsRpt>\n        <GrpHdr>\n            <MsgId>SIM-STS-TRX-PACT-001</MsgId>\n            <CreDtTm>2026-01-20T10:15:30.123456Z</CreDtTm>\n        </GrpHdr>\n        <TxInfAndSts>\n            <OrgnlEndToEndId>TRX-PACT-001</OrgnlEndToEndId>\n            <TxSts>ACSC</TxSts>\n        </TxInfAndSts>\n    </FIToFIPmtStsRpt>\n</Document>\n",
+        "headers": {
+          "Content-Type": "application/xml"
+        },
+        "matchingRules": {
+          "body": {
+            "$.Document.FIToFIPmtStsRpt.GrpHdr.CreDtTm.#text": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"
+                }
+              ]
+            },
+            "$.Document.FIToFIPmtStsRpt.GrpHdr.MsgId.#text": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "SIM-STS-.+"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-clearing-simulator"
+  }
+}


### PR DESCRIPTION
## Summary

Coverage-expansion sweep for #468, edge 4 (**clearing inbound**). The issue's own framing guessed "pacs.008 as message pact" — wrong on investigation: `ClearingSimulatorClient.submitCreditTransfer` is a plain synchronous `@RegisterRestClient POST` with a real response body the caller inspects, not an async Kafka message. Every payment rail (sepa-instant, sepa-payment, swift-service, domestic-payment) calls it the same way. **swift-service is the consumer, `openbank-clearing-simulator` is the provider** — a real internal non-production counterparty simulator, so provider verification is exactly as meaningful here as it was for ledger-service in edges 2-3.

## ⚠️ Real bug found and fixed — a legitimate incoming SWIFT MT103 crashes instead of holding gracefully

`SchemeGatewayAdapter.instruction()` defaults `debtorName`/`debtorIban` to `""` when a SWIFT message's `orderingCustomerName`/`orderingCustomerAccount` are null (both legitimately nullable — not required by `SwiftMessage.validate()`). An empty IBAN/name violates the pacs.008 XSD, and the resulting `check()` call sat **before** the class's own fail-closed `try`/`catch`, so it threw a raw `IllegalStateException` instead of the documented `SchemeGatewayUnavailableException` ("the caller holds the message in VALIDATED rather than releasing it without confirmation"). `SchemeGatewayAdapterTest`'s fixture hardcoded non-null debtor fields in every case, despite null being a known, deliberately-supported state elsewhere in the same module (`SwiftMapperTest`, `SwiftDtosTest`, and even the *provider* pact test all construct `SwiftMessage` with these fields null). Fixed by moving `check()` inside the try/catch.

## First XML/matcher pact in the repo (every prior contract is JSON)

- **Request**: built via the real `Pacs008Builder` (the same production code the adapter uses) with fixed field values — faithful to production shape without hand-crafting XML that could drift from what the builder emits.
- **Response**: needed `PactXmlBuilder` + matchers, not exact-match — discovered via two real provider-verification failures before landing on the right shape:
  1. The simulator's `CreDtTm` uses `Instant.now(clock).toString()` — variable fractional-second digit count, not the fixed-width offset format I initially assumed. A strict `Matchers.timestamp(...)` format failed real verification; switched to a tolerant regex matcher.
  2. `MsgId` is derived (`"SIM-STS-" + the submitted endToEndId`), not a literal echo — switched to a regex matcher instead of an exact value.
  3. `PactXmlBuilder`'s 2-arg `(rootName, namespace)` constructor auto-assigns an `ns:` prefix; the real shared XML builder (`XmlDoc`, used by both `Pacs008Builder`/`Pacs002Builder`) emits an **unprefixed** default `xmlns`. That mismatch made the comparator unable to descend past the root — fixed with a plain `xmlns` attribute via `setAttributes()` instead.

## First-ever pact wiring in `openbank-clearing-simulator`

Provider-side, `@PactFolder` git-pact matching ledger-service's pattern (not `@PactBroker`) — always runs, no broker needed.

## CI note

swift-service's new consumer test is excluded from CI the same way `SwiftEventPactConsumerTest` already is (#2404 — `PactConsumerTestExt`'s broker auto-publish hangs the JVM when `pactbroker.url` is forwarded but the broker 404s/401s). It runs fine locally and is **genuinely verified here**, just not drift-checked in CI until #2404 lands — same caveat edge 1 called out for transaction-service's `@PactBroker`-gated verification.

## Real end-to-end verification

Ran `ClearingSimulatorPactProviderVerificationTest` directly against the live endpoint — **1/1 interaction passing**.

## Test plan
- [x] `ClearingSimulatorPactConsumerTest` (new) — 1/1 passing, pact JSON committed
- [x] `SchemeGatewayAdapterTest` (existing + 1 new regression case) — 6/6 passing
- [x] `ClearingSimulatorPactProviderVerificationTest` — **real** provider verification, 1/1 passing
- [x] `ktlintCheck` + `detekt` on swift-service and clearing-simulator — clean
- [x] `:openbank-swift-service:quarkusBuild` + `:openbank-clearing-simulator:quarkusBuild` — CDI wiring intact

Refs #468 (leaving open — remaining priority: the platform edges — kyc→party, onboarding→party/kyc/sca, dispute→transaction, interest→balance, standing-order→payment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)