### PR TITLE
docs(gitops): correct finrep placeholder-tag comment's predicted failure mode

### DIFF
--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -3,8 +3,8 @@
 # following the same first-registration pattern as developer-portal's `sandbox-sec1` — it
 # does NOT point at a real pushed image yet. Run `build-push-service.sh finrep --bump` (or the
 # CI auto-deploy pipeline) to build+push the real `sandbox-<git-sha>` image and rewrite this
-# tag before relying on this Deployment actually coming up (ArgoCD will otherwise report
-# ImagePullBackOff — see PR #547 reviewer notes).
+# tag before relying on this Deployment actually coming up (Kyverno blocks even ArgoCD's dry-run
+# diff for a nonexistent tag, so the app sticks at sync status Unknown, not ImagePullBackOff — see PR #547 reviewer notes).
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
## Summary
- One-line correction to the finrep-service manifest's placeholder-tag comment.
- It predicted ArgoCD would report `ImagePullBackOff` for the `sandbox-init` placeholder tag. Observed instead (checked live via `status.conditions` on the `finrep` Application, unchanged since 2026-07-08): Kyverno's `verify-openbank-image-signatures` blocks even ArgoCD's server-side dry-run diff for the nonexistent tag, so the app sticks at sync status `Unknown` — not `OutOfSync`, not `ImagePullBackOff` — and never actually applies the update.
- No behavior change; comment-only.

## Test plan
- N/A — documentation-only change to a YAML comment.

Linked issues: N/A — found while investigating a Kyverno false-rejection question flagged earlier this session; this is a distinct, self-contained doc correction, not a code fix.