### PR TITLE
test(pact): add kyc-service consumer contract for party-domain events (#468)

### DIFF
--- a/.github/workflows/pact-drift-check.yml
+++ b/.github/workflows/pact-drift-check.yml
@@ -59,6 +59,7 @@ jobs:
             :openbank-consent-service:test --tests "com.openbank.consent.contract.*PactConsumerTest" \
             :openbank-domestic-payment:test --tests "com.openbank.domestic.contract.*PactConsumerTest" \
             :openbank-fraud-service:test --tests "com.openbank.fraud.contract.*PactConsumerTest" \
+            :openbank-kyc-service:test --tests "com.openbank.kyc.contract.*PactConsumerTest" \
             :openbank-lending-service:test --tests "com.openbank.lending.contract.*PactConsumerTest" \
             :openbank-notification-service:test --tests "com.openbank.notification.contract.*PactConsumerTest" \
             :openbank-sepa-payment:test --tests "com.openbank.sepa.contract.*PactConsumerTest" \

--- a/openbank-kyc-service/build.gradle.kts
+++ b/openbank-kyc-service/build.gradle.kts
@@ -42,6 +42,25 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+    // Consumer-driven contract for the party-events Kafka messages (ADR-0063, issue #468).
+    testImplementation(libs.pact.consumer)
+}
+
+// Pact: write the generated consumer contract to pacts/ and forward broker config, matching
+// account-service/ledger-service's tasks.withType<Test> block (ADR-0063 P1/P2).
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }
 
 kover {

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/PartyEventMessagePactConsumerTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/PartyEventMessagePactConsumerTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.kyc.contract
+
+import au.com.dius.pact.consumer.MessagePactBuilder
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.consumer.junit5.ProviderType
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.annotations.Pact
+import au.com.dius.pact.core.model.messaging.Message
+import au.com.dius.pact.core.model.messaging.MessagePact
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.UUID
+
+/**
+ * Consumer-driven MESSAGE contracts for party-domain events kyc-service consumes
+ * ([com.openbank.kyc.infrastructure.kafka.PartyEventConsumer], ADR-0068, issue #468 platform
+ * edge — kyc -> party). Not a REST edge: kyc-service makes no `@RegisterRestClient` call to
+ * party-service at all — the real integration is party-service publishing to
+ * `openbank.party.events`, consumed here.
+ *
+ * Narrower than account-service's sibling contract
+ * ([com.openbank.account.contract.PartyCreatedMessagePactConsumerTest]) on purpose: this only
+ * asserts the fields [PartyEventConsumer] actually reads (`eventType`, `partyId`, and
+ * `legalName` for PARTY_CREATED only) — not every field the real envelope happens to carry.
+ * Asserting more than the consumer depends on would fail this contract if party-service ever
+ * legitimately dropped a field kyc-service never needed.
+ *
+ * party-service verifies both via `PartyEventPactProviderVerificationTest`
+ * (`@PactFolder("../pacts")` — always runs, no Pact Broker involved). PARTY_CREATED reuses that
+ * class's existing `"a party has been created"` state; PARTY_ERASED needed a new one, added
+ * alongside this contract.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(
+    providerName = "openbank-party-service",
+    providerType = ProviderType.ASYNCH,
+    pactVersion = PactSpecVersion.V3,
+)
+class PartyEventMessagePactConsumerTest {
+
+    @Pact(consumer = "openbank-kyc-service", provider = "openbank-party-service")
+    fun partyCreatedPact(builder: MessagePactBuilder): MessagePact = builder
+        .given("a party has been created")
+        .expectsToReceive("a PARTY_CREATED event")
+        .withContent(
+            newJsonBody { o ->
+                o.stringValue("eventType", "PARTY_CREATED")
+                o.uuid("partyId")
+                o.stringType("legalName", "Jane Smith")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "partyCreatedPact")
+    fun `the PARTY_CREATED event carries the fields PartyEventConsumer needs`(messages: List<Message>) {
+        val node = ObjectMapper().readTree(messages.first().contentsAsBytes())
+
+        assertThat(node.path("eventType").asText()).isEqualTo("PARTY_CREATED")
+        assertThat(UUID.fromString(node.path("partyId").asText())).isNotNull()
+        assertThat(node.path("legalName").asText()).isNotBlank()
+    }
+
+    @Pact(consumer = "openbank-kyc-service", provider = "openbank-party-service")
+    fun partyErasedPact(builder: MessagePactBuilder): MessagePact = builder
+        .given("a party has been erased")
+        .expectsToReceive("a PARTY_ERASED event")
+        .withContent(
+            newJsonBody { o ->
+                o.stringValue("eventType", "PARTY_ERASED")
+                o.uuid("partyId")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "partyErasedPact")
+    fun `the PARTY_ERASED event carries the fields PartyEventConsumer needs`(messages: List<Message>) {
+        val node = ObjectMapper().readTree(messages.first().contentsAsBytes())
+
+        assertThat(node.path("eventType").asText()).isEqualTo("PARTY_ERASED")
+        assertThat(UUID.fromString(node.path("partyId").asText())).isNotNull()
+    }
+}

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumerTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/infrastructure/kafka/PartyEventConsumerTest.kt
@@ -137,6 +137,13 @@ class PartyEventConsumerTest {
     }
 
     @Test
+    fun `PARTY_ERASED without a valid partyId is acked without anonymising or throwing`(): Unit = runBlocking {
+        consumer.consume("""{"eventType":"PARTY_ERASED"}""") // no partyId
+
+        coVerify(exactly = 0) { kycCaseRepository.anonymizeByPartyId(any(), any()) }
+    }
+
+    @Test
     fun `a domain failure is swallowed so the consumer group is not wedged`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
         coEvery { kycService.openCaseForParty(partyId) } throws RuntimeException("db down")

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
@@ -127,4 +127,22 @@ class PartyEventPactProviderVerificationTest {
         )
         return objectMapper.writeValueAsString(event)
     }
+
+    @State("a party has been erased")
+    fun partyHasBeenErased() {
+        // No setup: produced deterministically by the @PactVerifyProvider method below.
+    }
+
+    @PactVerifyProvider("a PARTY_ERASED event")
+    fun producePartyErasedEvent(): String {
+        // Mirrors KafkaPartyEventPublisher.publishPartyErased: the separate, narrower envelope
+        // (no partyType/status/kycStatus/legalName/email — those are gone by the time GDPR
+        // Art. 17 erasure runs).
+        val event = linkedMapOf(
+            "eventType" to "PARTY_ERASED",
+            "partyId" to UUID.randomUUID(),
+            "erasedAt" to Instant.now(),
+        )
+        return objectMapper.writeValueAsString(event)
+    }
 }

--- a/pacts/openbank-kyc-service-openbank-party-service.json
+++ b/pacts/openbank-kyc-service-openbank-party-service.json
@@ -1,0 +1,97 @@
+{
+  "consumer": {
+    "name": "openbank-kyc-service"
+  },
+  "messages": [
+    {
+      "contents": {
+        "eventType": "PARTY_CREATED",
+        "legalName": "Jane Smith",
+        "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+      },
+      "description": "a PARTY_CREATED event",
+      "generators": {
+        "body": {
+          "$.partyId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.legalName": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "type"
+              }
+            ]
+          },
+          "$.partyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "a party has been created"
+        }
+      ]
+    },
+    {
+      "contents": {
+        "eventType": "PARTY_ERASED",
+        "partyId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+      },
+      "description": "a PARTY_ERASED event",
+      "generators": {
+        "body": {
+          "$.partyId": {
+            "type": "Uuid"
+          }
+        }
+      },
+      "matchingRules": {
+        "body": {
+          "$.partyId": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "regex",
+                "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              }
+            ]
+          }
+        }
+      },
+      "metaData": {
+        "contentType": "application/json"
+      },
+      "providerStates": [
+        {
+          "name": "a party has been erased"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-party-service"
+  }
+}


### PR DESCRIPTION
## Summary

Coverage-expansion sweep for #468, first platform edge: **kyc → party**. The issue's own framing is misleading here (unlike clearing-inbound's explicit "message pact" callout, this one reads like the mostly-REST edges before it): **kyc-service makes no `@RegisterRestClient` call to party-service at all.** The real integration is party-service publishing `PARTY_CREATED`/`PARTY_UPDATED`/`KYC_STATUS_CHANGED`/`PARTY_ERASED` to `openbank.party.events`, consumed by kyc-service's `PartyEventConsumer` (ADR-0068) to auto-open KYC cases and anonymise erased parties' PII (GDPR Art. 17).

## Coverage work (single commit, no version bump — test/CI only)

- New `PartyEventMessagePactConsumerTest` covers the two events kyc-service actually reads (`PARTY_CREATED`, `PARTY_ERASED`) — **deliberately narrower** than account-service's sibling contract for the same topic, which asserts `partyType`/`status` fields kyc-service never reads. Asserting fields a consumer doesn't depend on would fail the contract if party-service ever legitimately dropped one kyc-service never needed.
- `PartyEventPactProviderVerificationTest` already had a `"a party has been created"` state (reused as-is); added `"a party has been erased"` + its `@PactVerifyProvider`, mirroring `KafkaPartyEventPublisher.publishPartyErased`'s narrower envelope (no `partyType`/`status`/`kycStatus`/`legalName`/`email` — gone by GDPR erasure time).
- Added a `PARTY_ERASED`-without-`partyId` regression test to the existing `PartyEventConsumerTest` — `PARTY_CREATED` already had one, `PARTY_ERASED`'s identical null-guard path (`handleErased`) didn't.
- Wired `openbank-kyc-service/build.gradle.kts` with `libs.pact.consumer` + the forwarding block, and added the module to `pact-drift-check.yml`'s regenerate step.

## No real production bug this edge

Unlike edges 1-4, nothing was broken here: kyc's consumer never parses a date/timestamp from the payload (edge 1's bug class structurally can't occur), and its one required field (`partyId`) was already correctly null-guarded on both event types.

## Real end-to-end verification

Ran `PartyEventPactProviderVerificationTest` directly — **5/5 interactions passing** across both consumers (kyc-service's 2 new ones + account-service's existing 3).

## Test plan
- [x] `PartyEventMessagePactConsumerTest` (new) — 2/2 passing, pact JSON committed
- [x] `PartyEventConsumerTest` (existing + 1 new regression case) — 10/10 passing
- [x] `PartyEventPactProviderVerificationTest` — **real** provider verification, 5/5 passing
- [x] `ktlintCheck` + `detekt` on kyc-service and party-service — clean
- [x] `:openbank-kyc-service:quarkusBuild` — CDI wiring intact

Refs #468 (leaving open — remaining platform edges: onboarding→party/kyc/sca, dispute→transaction, interest→balance, standing-order→payment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)