### PR TITLE
fix(gitops): repair Flyway checksum mismatch on ledger/settlement redeploy

### DIFF
--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -69,6 +69,16 @@ spec:
                 secretKeyRef:
                   name: ledger-db-app
                   key: password
+            # Flyway checksum mismatch on V7/V9/V11 (2026-07-11 bootstrap redeploy, #880):
+            # ledger-service hadn't been redeployed since 2026-07-06, so a repo-wide
+            # migration-file touch-up landed while it sat un-deployed. Repair-at-start
+            # re-baselines the recorded checksums to the current files — safe, matching the
+            # onboarding-service precedent (#730): git history shows these migration files
+            # have had no real content edit since their original authoring commit. Remove
+            # once the live schema_history rows are confirmed repaired (one clean boot is
+            # enough; safe to leave briefly, repair is a no-op once checksums already match).
+            - name: QUARKUS_FLYWAY_REPAIR_AT_START
+              value: "true"
             # Kafka producer → Strimzi tls:9093 (mTLS, ADR-0137 #2665 Tier 1).
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: openbank-cluster-kafka-bootstrap.messaging.svc:9093

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1976,6 +1976,16 @@ spec:
                 secretKeyRef:
                   name: settlement-service-db-app
                   key: password
+            # Flyway checksum mismatch on V1 (2026-07-11 bootstrap redeploy, #880):
+            # settlement-service hadn't been redeployed since 2026-07-02, so a repo-wide
+            # migration-file touch-up landed while it sat un-deployed. Repair-at-start
+            # re-baselines the recorded checksum to the current file — safe, matching the
+            # onboarding-service precedent (#730): git history shows this migration file
+            # has had no real content edit since its original authoring commit. Remove
+            # once the live schema_history row is confirmed repaired (one clean boot is
+            # enough; safe to leave briefly, repair is a no-op once checksums already match).
+            - name: QUARKUS_FLYWAY_REPAIR_AT_START
+              value: "true"
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
             - name: QUARKUS_OIDC_AUTH_SERVER_URL


### PR DESCRIPTION
## Summary
- Both `ledger-service` and `settlement-service` crash-looped after PR #880's bootstrap
  redeploy: `FlywayValidateException: checksum mismatch` (ledger V7/V9/V11, settlement V1).
- Root-caused with a real-spec debug pod (copied the actual Rollout's pod template, ran it
  standalone to capture live boot logs — a bare `kubectl run` with just the image lacks the
  env/secret wiring and gives misleading errors).
- Same class of issue as the onboarding-service precedent (#730): neither service had been
  redeployed since well before a repo-wide migration-file touch-up landed, so the checksum
  drift stayed latent until this rollout finally exercised it.

## Fix
`QUARKUS_FLYWAY_REPAIR_AT_START=true` on both services, matching #730's exact pattern —
re-baselines the recorded schema_history checksums to the current files.

**Why this is safe:** `git log` on both migration files shows no content edit since their
original authoring commit — only a one-time repo-wide pass changed bytes outside each file's
own per-file history (same relicense-class mechanism as #730), not a real schema-affecting
change to either file.

## Test plan
- [x] Reproduced the crash via a debug pod built from the live Rollout's actual pod template
- [ ] Redeploy ledger-service/settlement-service with this env var and confirm `1/1 Running`
      with 0 restarts
- [ ] Remove `QUARKUS_FLYWAY_REPAIR_AT_START` in a follow-up once confirmed durable (safe to
      leave briefly — repair is a no-op once checksums already match)

Refs #310, #880

🤖 Generated with [Claude Code](https://claude.com/claude-code)