### PR TITLE
security(kyverno): graduate SBOM-attestation policy from Audit to Enforce

### DIFF
--- a/openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
+++ b/openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
@@ -11,18 +11,24 @@
 # first signature-Enforce attempt broke the fleet (#770 revert).
 #
 # Rollout (mirrors the signature policy's staging; rules.yaml provenance.enforce_criteria):
-#   1. (this file) Audit — surface images without the SBOM attestation as
-#      PolicyReport violations, break nothing. Expected to report violations for
-#      every pod whose image predates auto-deploy attestation — that is the point:
-#      the report is the redeploy worklist.
-#   2. (pending) Redeploy the running fleet so every live image carries the
-#      attestation (rules.yaml provenance.enforce_criteria #2). Verify:
-#      `kubectl get polr -A` reports 0 fail for this policy.
-#   3. (pending) Flip validationFailureAction to Enforce — only after criterion #2
-#      holds and the Audit report has run clean for an observation window
-#      (provenance.enforce_criteria #4). Same caveat as the signature policy:
-#      a `kubectl rollout undo` to a pre-attestation revision would be rejected
-#      under Enforce — rebuild or attest that digest first.
+#   1. (done) Audit — surface images without the SBOM attestation as PolicyReport
+#      violations, break nothing. Violations reported for every pod whose image
+#      predated auto-deploy attestation — that was the point: the report was the
+#      redeploy worklist.
+#   2. (done, 2026-07-12) Redeploy the running fleet so every live image carries the
+#      attestation. Surfaced a much larger latent problem along the way: almost the
+#      entire 17-service money-path fleet had never been redeployed via GitOps since
+#      initial setup, so a fleet-wide bootstrap was needed first (issue #846, PRs
+#      #847/#880/#882/#883/#884/#885) before this criterion could genuinely hold.
+#      Verified: `kubectl get polr -A` reports 0 fail for this policy against any
+#      openbank-* application pod (the small residual fail count is transient
+#      arc-runners CI-runner churn, unrelated to this policy's own scope).
+#   3. (done, 2026-07-12) Flip validationFailureAction to Enforce, per explicit
+#      maintainer authorization rather than a multi-day soak (provenance.enforce_criteria
+#      #4's "observation window" — judged satisfied given the depth of verification
+#      #2 required to actually reach a clean report). Same caveat as the signature
+#      policy: a `kubectl rollout undo` to a pre-attestation revision would be
+#      REJECTED under Enforce — rebuild or attest that digest first.
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
@@ -32,13 +38,13 @@ metadata:
     policies.kyverno.io/category: Supply Chain Security
     policies.kyverno.io/severity: high
     policies.kyverno.io/description: >-
-      Audits that every openbank-* container image carries a cosign-signed
+      Enforces that every openbank-* container image carries a cosign-signed
       CycloneDX SBOM attestation (predicateType https://cyclonedx.org/bom,
-      KMS public key). Audit mode until the running fleet is fully redeployed
-      with attested images; then staged to Enforce per rules.yaml
-      provenance.enforce_criteria (ADR-0144 graduation).
+      KMS public key). Graduated from Audit to Enforce 2026-07-12 (ADR-0144
+      graduation, rules.yaml provenance.enforce_criteria) after the running
+      fleet was fully redeployed with attested images.
 spec:
-  validationFailureAction: Audit
+  validationFailureAction: Enforce
   background: false
   webhookTimeoutSeconds: 30
   failurePolicy: Ignore


### PR DESCRIPTION
## Summary
- ADR-0030 D4 step 4 / ADR-0121 Axis 2 / `rules.yaml` `provenance.enforce_criteria` #3:
  flips `verify-openbank-image-sbom-attestation`'s `validationFailureAction` from `Audit`
  to `Enforce`. Every `openbank-*` pod admitted from now on must carry a valid
  cosign-signed CycloneDX SBOM attestation, or admission is rejected.
- Criterion #2 (fleet redeployed so every live image carries the attestation) now
  genuinely holds: `kubectl get polr -A` reports 0 fail for this policy against any
  `openbank-*` application pod. Getting there required a much larger fleet-wide bootstrap
  than originally scoped (issue #846 → PRs #847/#880/#882/#883/#884/#885) — almost the
  entire money-path fleet had never been redeployed via GitOps since initial setup, which
  this session's investigation uncovered and fixed end to end.
- Criterion #4's "observation window" is satisfied by explicit maintainer authorization
  rather than a further multi-day soak, given how much verification criterion #2 already
  required to reach a genuinely clean report.

## Scope note
This PR only flips the Kyverno rule itself (criterion #3). `rules.yaml`'s broader
`provenance.enforced: advisory` is intentionally left as-is — criterion #1 (every
deployable service's release-evidence bundle) was not verified in this pass, so flipping
that top-level status would overstate what was actually checked here.

## Test plan
- [x] `kubectl get polr -A` — 0 fail for this policy against any application pod
      (verified live before this PR was opened)
- [x] `python3 -c "import yaml; list(yaml.safe_load_all(...))"` — YAML parses
- [ ] Post-merge: confirm no pod admission regressions (fail-open webhook, `failurePolicy:
      Ignore`, means a Kyverno outage never blocks the cluster either way)

Refs #310, #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)