### PR TITLE
feat(ledger): operator replay endpoint for historical booked-change events (#860)

### DIFF
--- a/openbank-infra/gitops/components/ledger/gen-ledger-opa-bundle.sh
+++ b/openbank-infra/gitops/components/ledger/gen-ledger-opa-bundle.sh
@@ -31,6 +31,8 @@ LEDGER_REST_EXT=$(cat << 'REGO'
 #   ledger.approve  — attest a DRAFT year-close (#fiscalYear) — a statutory close,
 #                      not a routine posting; kept operator-only, no M2M path.
 #   ledger.trigger  — run the daily FX revaluation (ops/backfill only)
+#   ledger.replay   — re-emit historical AccountBookedChanged for a window (ops recovery,
+#                      #860); posts no journal, re-drives the book of record's own events.
 #
 # Base rest.rego's operator-read-any / compliance-read-any only cover HUMAN
 # ROLE_OPERATOR/ROLE_ADMIN/ROLE_COMPLIANCE on *.read + *.list — but every ledger read
@@ -95,7 +97,7 @@ allowed_reasons contains "operator-ledger-write" if {
 	input.principal.type == "HUMAN"
 	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
 	role in input.principal.roles
-	input.action in {"ledger.create", "ledger.reverse", "ledger.trigger"}
+	input.action in {"ledger.create", "ledger.reverse", "ledger.trigger", "ledger.replay"}
 }
 
 # Year-close attestation (ledger.approve) is deliberately its OWN rule, not folded into

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6075207ce346047b"
+    openbank.tech/policy-checksum: "75ddda455fdbab69"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -302,6 +302,8 @@ data:
     #   ledger.approve  — attest a DRAFT year-close (#fiscalYear) — a statutory close,
     #                      not a routine posting; kept operator-only, no M2M path.
     #   ledger.trigger  — run the daily FX revaluation (ops/backfill only)
+    #   ledger.replay   — re-emit historical AccountBookedChanged for a window (ops recovery,
+    #                      #860); posts no journal, re-drives the book of record's own events.
     #
     # Base rest.rego's operator-read-any / compliance-read-any only cover HUMAN
     # ROLE_OPERATOR/ROLE_ADMIN/ROLE_COMPLIANCE on *.read + *.list — but every ledger read
@@ -366,7 +368,7 @@ data:
     	input.principal.type == "HUMAN"
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
-    	input.action in {"ledger.create", "ledger.reverse", "ledger.trigger"}
+    	input.action in {"ledger.create", "ledger.reverse", "ledger.trigger", "ledger.replay"}
     }
 
     # Year-close attestation (ledger.approve) is deliberately its OWN rule, not folded into

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6075207ce346047b"
+        openbank.tech/policy-checksum: "75ddda455fdbab69"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-ledger-service/ktlint-baseline.xml
+++ b/openbank-ledger-service/ktlint-baseline.xml
@@ -23,6 +23,9 @@
         <error line="43" column="25" source="standard:trailing-comma-on-declaration-site" />
         <error line="52" column="36" source="standard:trailing-comma-on-declaration-site" />
     </file>
+    <file name="src/main/kotlin/com/openbank/ledger/application/port/in/ReplayBookedChangesPorts.kt">
+        <error line="5" column="9" source="standard:package-name" />
+    </file>
     <file name="src/main/kotlin/com/openbank/ledger/application/port/in/YearClosePorts.kt">
         <error line="5" column="9" source="standard:package-name" />
     </file>

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/in/ReplayBookedChangesPorts.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/in/ReplayBookedChangesPorts.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.application.port.`in`
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/**
+ * Ops recovery: re-emit historical `AccountBookedChanged` events for a date window so a downstream
+ * projection that missed them (e.g. balance-service's sub-ledger, issue #860) can catch up.
+ *
+ * The ledger is the authoritative source; this replays its own already-posted booked movements — it
+ * posts NO new journal and mutates NO ledger state. The re-emitted events are reconstructed exactly as
+ * the original post emitted them (`JournalEntry.bookedDeltas()`), so a consumer that dedups on the
+ * business key `(journalEntryId, accountId, currency)` applies only the genuinely-missing deltas.
+ *
+ * `dryRun` (default true) previews the counts + net delta per currency WITHOUT emitting anything.
+ */
+data class ReplayBookedChangesCommand(val from: LocalDate, val to: LocalDate, val dryRun: Boolean = true)
+
+data class ReplayBookedChangesResult(
+    val dryRun: Boolean,
+    val from: LocalDate,
+    val to: LocalDate,
+    /** POSTED journal entries scanned in the window. */
+    val journalEntriesScanned: Int,
+    /** AccountBookedChanged events that were (or, in a dry run, would be) re-emitted. */
+    val bookedChangeEvents: Int,
+    /** Distinct customer accounts touched. */
+    val accountsTouched: Int,
+    /** Net booked delta per currency across the window — a sanity preview of what the replay carries. */
+    val netDeltaByCurrency: Map<String, BigDecimal>,
+)
+
+interface ReplayBookedChangesUseCase {
+    suspend fun replay(command: ReplayBookedChangesCommand): ReplayBookedChangesResult
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/LedgerPorts.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/LedgerPorts.kt
@@ -49,6 +49,13 @@ interface JournalRepository {
      */
     suspend fun save(entry: JournalEntry, idempotencyKey: String?, outbox: List<OutboxMessage>): JournalEntry
 
+    /**
+     * Append standalone outbox messages (no journal entry) in one transaction — used by the
+     * booked-change replay (ops recovery, issue #860) to re-emit historical events for a downstream
+     * projection catch-up. Returns the number of messages enqueued.
+     */
+    suspend fun appendOutbox(messages: List<OutboxMessage>): Int
+
     /** Persist a reversal entry, flag the original as reversed, and enqueue its outbox messages, atomically. */
     suspend fun saveReversal(
         reversal: JournalEntry,

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/ReplayBookedChangesService.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/usecase/ReplayBookedChangesService.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesCommand
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesResult
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesUseCase
+import com.openbank.ledger.application.port.out.JournalRepository
+import com.openbank.ledger.domain.event.AccountBookedChangedEvent
+import com.openbank.ledger.domain.model.AccountBookedDelta
+import com.openbank.ledger.domain.model.JournalEntry
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.math.BigDecimal
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * Re-emits historical `AccountBookedChanged` events for a date window (issue #860). It reconstructs
+ * each event exactly as the original journal post did — via [JournalEntry.bookedDeltas], the same
+ * credit-minus-base-amount logic — and enqueues it on the transactional outbox, so the existing
+ * dispatcher relays it to `openbank.ledger.journal.posted` under the `ce-type` header the downstream
+ * projection filters on. Posts NO journal and mutates NO ledger state.
+ *
+ * Idempotency is the consumer's: it dedups on `(journalEntryId, accountId, currency)`, so a replay
+ * lands only the deltas it never applied — re-running is safe.
+ */
+@ApplicationScoped
+class ReplayBookedChangesService(
+    private val journalRepository: JournalRepository,
+    private val objectMapper: ObjectMapper,
+    private val clock: Clock,
+) : ReplayBookedChangesUseCase {
+    private val log = Logger.getLogger(ReplayBookedChangesService::class.java)
+
+    override suspend fun replay(command: ReplayBookedChangesCommand): ReplayBookedChangesResult {
+        require(!command.from.isAfter(command.to)) {
+            "from (${command.from}) must not be after to (${command.to})"
+        }
+        val tally = Tally()
+        var afterId: UUID? = null
+        while (true) {
+            val page = journalRepository.findByDateRange(command.from, command.to, PAGE_SIZE, afterId)
+            page.forEach { tally.accumulate(it, command.dryRun) }
+            if (page.size < PAGE_SIZE) break
+            afterId = page.last().id
+        }
+
+        if (!command.dryRun && tally.messages.isNotEmpty()) {
+            journalRepository.appendOutbox(tally.messages)
+            log.warnf(
+                "Booked-change replay ENQUEUED %d AccountBookedChanged events " +
+                    "(%d journal entries, %d accounts, window %s..%s) for downstream re-projection (#860).",
+                tally.events,
+                tally.scanned,
+                tally.accounts.size,
+                command.from,
+                command.to,
+            )
+        } else {
+            log.infof(
+                "Booked-change replay DRY-RUN: %d events / %d entries / %d accounts in %s..%s; nothing emitted.",
+                tally.events,
+                tally.scanned,
+                tally.accounts.size,
+                command.from,
+                command.to,
+            )
+        }
+        return tally.toResult(command)
+    }
+
+    /** Builds the outbox message for one booked delta, identical to the original post's emission. */
+    private fun replayMessage(entry: JournalEntry, delta: AccountBookedDelta): OutboxMessage {
+        val event = AccountBookedChangedEvent(
+            aggregateId = delta.accountId,
+            version = entry.version,
+            currency = delta.currency,
+            delta = delta.delta,
+            journalEntryId = entry.id,
+            transactionId = entry.transactionId,
+            entryDate = entry.entryDate,
+            occurredAt = clock.instant(),
+        )
+        return OutboxMessage(
+            aggregateId = delta.accountId,
+            eventType = event.eventType,
+            payload = objectMapper.writeValueAsString(event),
+        )
+    }
+
+    /** Running totals for a replay pass; keeps the paging loop flat. */
+    private inner class Tally {
+        var scanned = 0
+        var events = 0
+        val accounts = mutableSetOf<UUID>()
+        val netByCurrency = mutableMapOf<String, BigDecimal>()
+        val messages = mutableListOf<OutboxMessage>()
+
+        fun accumulate(entry: JournalEntry, dryRun: Boolean) {
+            scanned++
+            entry.bookedDeltas().forEach { delta ->
+                events++
+                accounts += delta.accountId
+                netByCurrency.merge(delta.currency, delta.delta, BigDecimal::add)
+                if (!dryRun) messages += replayMessage(entry, delta)
+            }
+        }
+
+        fun toResult(command: ReplayBookedChangesCommand) = ReplayBookedChangesResult(
+            dryRun = command.dryRun,
+            from = command.from,
+            to = command.to,
+            journalEntriesScanned = scanned,
+            bookedChangeEvents = events,
+            accountsTouched = accounts.size,
+            netDeltaByCurrency = netByCurrency,
+        )
+    }
+
+    private companion object {
+        // Cursor page size for scanning posted entries in the window; bounds memory on a wide replay.
+        const val PAGE_SIZE = 500
+    }
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
@@ -132,6 +132,14 @@ class PanacheJournalRepository(
                 .replaceWith(entry)
         }.awaitSuspending()
 
+    override suspend fun appendOutbox(messages: List<OutboxMessage>): Int = if (messages.isEmpty()) {
+        0
+    } else {
+        Panache.withTransaction {
+            persistOutbox(messages).replaceWith(messages.size)
+        }.awaitSuspending()
+    }
+
     override suspend fun saveReversal(
         reversal: JournalEntry,
         originalId: UUID,

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/LedgerResource.kt
@@ -12,6 +12,9 @@ import com.openbank.ledger.application.port.`in`.JournalLineRequest
 import com.openbank.ledger.application.port.`in`.LedgerUseCase
 import com.openbank.ledger.application.port.`in`.ListJournalsQuery
 import com.openbank.ledger.application.port.`in`.PostJournalCommand
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesCommand
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesResult
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesUseCase
 import com.openbank.ledger.application.port.`in`.ReverseJournalCommand
 import com.openbank.ledger.domain.model.JournalEntry
 import com.openbank.ledger.domain.model.JournalLine
@@ -52,7 +55,11 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Ledger", description = "General ledger journal entries")
-class LedgerResource(private val clock: Clock, private val ledgerUseCase: LedgerUseCase) {
+class LedgerResource(
+    private val clock: Clock,
+    private val ledgerUseCase: LedgerUseCase,
+    private val replayUseCase: ReplayBookedChangesUseCase,
+) {
 
     @GET
     @RolesAllowed(Roles.SERVICE, Roles.AUDITOR, Roles.VIEWER, Roles.OPERATOR, Roles.ADMIN)
@@ -149,6 +156,27 @@ class LedgerResource(private val clock: Clock, private val ledgerUseCase: Ledger
         val cmd = ReverseJournalCommand(journalId = journalId, reason = request.reason, reversedBy = request.reversedBy)
         val entry = ledgerUseCase.reverseJournal(cmd)
         return Response.ok(entry.toResponse()).build()
+    }
+
+    @POST
+    @Path("/replay-booked-changes")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "ledger.replay", resource = "")
+    @Operation(
+        summary = "Re-emit historical AccountBookedChanged events for a date window (ops recovery, #860)",
+        description = "Reconstructs and re-enqueues the ledger's own already-posted booked movements so a " +
+            "downstream projection that missed them can catch up idempotently. Posts no journal and mutates " +
+            "no ledger state. dryRun (default true) previews the counts + net delta per currency without emitting.",
+    )
+    suspend fun replayBookedChanges(request: ReplayBookedChangesRequest): Response {
+        val result = replayUseCase.replay(
+            ReplayBookedChangesCommand(
+                from = LocalDate.parse(request.from),
+                to = LocalDate.parse(request.to),
+                dryRun = request.dryRun,
+            ),
+        )
+        return Response.ok(result.toResponse()).build()
     }
 }
 
@@ -291,4 +319,26 @@ private fun TrialBalance.toResponse() = TrialBalanceResponse(
             net = it.net,
         )
     },
+)
+
+data class ReplayBookedChangesRequest(val from: String, val to: String, val dryRun: Boolean = true)
+
+data class ReplayBookedChangesResponse(
+    val dryRun: Boolean,
+    val from: String,
+    val to: String,
+    val journalEntriesScanned: Int,
+    val bookedChangeEvents: Int,
+    val accountsTouched: Int,
+    val netDeltaByCurrency: Map<String, BigDecimal>,
+)
+
+private fun ReplayBookedChangesResult.toResponse() = ReplayBookedChangesResponse(
+    dryRun = dryRun,
+    from = from.toString(),
+    to = to.toString(),
+    journalEntriesScanned = journalEntriesScanned,
+    bookedChangeEvents = bookedChangeEvents,
+    accountsTouched = accountsTouched,
+    netDeltaByCurrency = netDeltaByCurrency,
 )

--- a/openbank-ledger-service/src/main/resources/openapi.yaml
+++ b/openbank-ledger-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Ledger Service API
-  version: 1.7.0
+  version: 1.8.0
   description: Double-entry journal ledger — query journal entries and transaction postings.
   license:
     name: Apache-2.0
@@ -171,6 +171,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiError'
+
+  /api/v1/journals/replay-booked-changes:
+    post:
+      tags: [Ledger]
+      summary: Re-emit historical AccountBookedChanged events for a date window (ops recovery, #860)
+      description: >
+        Operations-recovery action. Reconstructs and re-enqueues the ledger's own already-posted
+        booked movements for a date window so a downstream projection that missed them (e.g.
+        balance-service's deposit-control sub-ledger, ADR-0039) can catch up idempotently — the
+        consumer dedups on `(journalEntryId, accountId, currency)`, so only genuinely-missing
+        deltas land. Posts NO journal and mutates NO ledger state. `dryRun` (default true) previews
+        the counts and net delta per currency without emitting anything.
+      operationId: replayBookedChanges
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReplayBookedChangesRequest'
+      responses:
+        '200':
+          description: Replay summary — counts and net booked delta per currency for the window
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReplayBookedChangesResponse'
+        '400':
+          description: Invalid window (`from` after `to`) or unparseable date
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/journals/trial-balance:
     get:
@@ -624,6 +660,53 @@ components:
           type: string
           format: uuid
           description: Operator posting the reversal.
+
+    ReplayBookedChangesRequest:
+      type: object
+      required: [from, to]
+      properties:
+        from:
+          type: string
+          format: date
+          description: Inclusive start of the entry-date window to replay.
+        to:
+          type: string
+          format: date
+          description: Inclusive end of the entry-date window to replay.
+        dryRun:
+          type: boolean
+          default: true
+          description: >
+            When true (default) only previews the counts and net delta per currency without
+            emitting any event. Set false to actually re-enqueue the booked-change events.
+
+    ReplayBookedChangesResponse:
+      type: object
+      required: [dryRun, from, to, journalEntriesScanned, bookedChangeEvents, accountsTouched, netDeltaByCurrency]
+      properties:
+        dryRun:
+          type: boolean
+          description: Whether this run only previewed (true) or actually emitted (false) the events.
+        from:
+          type: string
+          format: date
+        to:
+          type: string
+          format: date
+        journalEntriesScanned:
+          type: integer
+          description: POSTED journal entries scanned in the window.
+        bookedChangeEvents:
+          type: integer
+          description: AccountBookedChanged events that were (or, in a dry run, would be) re-emitted.
+        accountsTouched:
+          type: integer
+          description: Distinct customer accounts touched by the replay.
+        netDeltaByCurrency:
+          type: object
+          additionalProperties:
+            type: number
+          description: Net booked delta per currency across the window — a sanity preview of what the replay carries.
 
     PostJournalLineRequest:
       type: object

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/ReplayBookedChangesServiceTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/ReplayBookedChangesServiceTest.kt
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.ledger.application.port.`in`.ReplayBookedChangesCommand
+import com.openbank.ledger.application.port.out.JournalRepository
+import com.openbank.ledger.domain.model.JournalEntry
+import com.openbank.ledger.domain.model.JournalLine
+import com.openbank.ledger.domain.model.JournalSide
+import com.openbank.ledger.domain.model.JournalStatus
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+class ReplayBookedChangesServiceTest {
+
+    private val from = LocalDate.of(2026, 6, 1)
+    private val to = LocalDate.of(2026, 6, 30)
+    private val clock = Clock.fixed(Instant.parse("2026-07-12T00:00:00Z"), ZoneOffset.UTC)
+
+    private val journalRepository = mockk<JournalRepository>()
+    private val objectMapper = mockk<ObjectMapper> { every { writeValueAsString(any()) } returns "{}" }
+
+    private val service = ReplayBookedChangesService(journalRepository, objectMapper, clock)
+
+    private val accountA = UUID.randomUUID()
+    private val accountB = UUID.randomUUID()
+    private val depositControlGl = UUID.randomUUID()
+    private val cashClearingGl = UUID.randomUUID()
+
+    /** A balanced entry that books +[amount] [currency] onto customer [account] (a deposit-control credit). */
+    private fun bookingEntry(account: UUID, amount: String, currency: String = "CZK"): JournalEntry {
+        val id = UUID.randomUUID()
+        val money = Money.of(amount, currency)
+        val cash = JournalLine(
+            id = UUID.randomUUID(),
+            journalId = id,
+            glAccountId = cashClearingGl,
+            side = JournalSide.DEBIT,
+            amount = money,
+            fxRate = null,
+            baseAmount = money,
+            sequence = 1,
+        )
+        val deposit = JournalLine(
+            id = UUID.randomUUID(),
+            journalId = id,
+            glAccountId = depositControlGl,
+            side = JournalSide.CREDIT,
+            amount = money,
+            fxRate = null,
+            baseAmount = money,
+            sequence = 2,
+            subAccountId = account,
+        )
+        return JournalEntry(
+            id = id,
+            entryNumber = 1L,
+            transactionId = UUID.randomUUID(),
+            entryDate = from,
+            valueDate = from,
+            description = "booking",
+            status = JournalStatus.POSTED,
+            lines = listOf(cash, deposit),
+            createdAt = Instant.now(clock),
+            createdBy = UUID.randomUUID(),
+            version = 3L,
+        )
+    }
+
+    @Test
+    fun `dry-run tallies events and net delta but emits nothing`() = runBlocking<Unit> {
+        coEvery { journalRepository.findByDateRange(from, to, any(), null) } returns
+            listOf(bookingEntry(accountA, "100.00"), bookingEntry(accountB, "40.00"))
+
+        val result = service.replay(ReplayBookedChangesCommand(from, to, dryRun = true))
+
+        assertThat(result.dryRun).isTrue()
+        assertThat(result.journalEntriesScanned).isEqualTo(2)
+        assertThat(result.bookedChangeEvents).isEqualTo(2)
+        assertThat(result.accountsTouched).isEqualTo(2)
+        assertThat(result.netDeltaByCurrency).containsEntry("CZK", BigDecimal("140.00"))
+        coVerify(exactly = 0) { journalRepository.appendOutbox(any()) }
+    }
+
+    @Test
+    fun `real run enqueues one outbox message per booked delta with the routing metadata`() = runBlocking<Unit> {
+        coEvery { journalRepository.findByDateRange(from, to, any(), null) } returns
+            listOf(bookingEntry(accountA, "100.00"))
+        val enqueued = slot<List<OutboxMessage>>()
+        coEvery { journalRepository.appendOutbox(capture(enqueued)) } returns 1
+
+        val result = service.replay(ReplayBookedChangesCommand(from, to, dryRun = false))
+
+        assertThat(result.dryRun).isFalse()
+        assertThat(result.bookedChangeEvents).isEqualTo(1)
+        assertThat(enqueued.captured).singleElement().satisfies({
+            assertThat(it.aggregateId).isEqualTo(accountA)
+            assertThat(it.eventType).isEqualTo("AccountBookedChanged")
+        })
+    }
+
+    @Test
+    fun `pages through the repository until a short page ends the scan`() = runBlocking<Unit> {
+        val fullPage = (1..500).map { bookingEntry(accountA, "1.00") }
+        val lastId = fullPage.last().id
+        coEvery { journalRepository.findByDateRange(from, to, any(), null) } returns fullPage
+        coEvery { journalRepository.findByDateRange(from, to, any(), lastId) } returns
+            listOf(bookingEntry(accountB, "2.00"))
+
+        val result = service.replay(ReplayBookedChangesCommand(from, to, dryRun = true))
+
+        assertThat(result.journalEntriesScanned).isEqualTo(501)
+        assertThat(result.netDeltaByCurrency).containsEntry("CZK", BigDecimal("502.00"))
+        coVerify(exactly = 1) { journalRepository.findByDateRange(from, to, any(), lastId) }
+    }
+
+    @Test
+    fun `rejects an inverted window`() = runBlocking<Unit> {
+        assertThatThrownBy {
+            runBlocking { service.replay(ReplayBookedChangesCommand(to, from, dryRun = true)) }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerSecurityContractTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/rest/LedgerSecurityContractTest.kt
@@ -44,4 +44,13 @@ class LedgerSecurityContractTest {
                 .containsExactlyInAnyOrder("ROLE_OPERATOR")
         }
     }
+
+    @Test
+    fun `booked-change replay is an ops recovery action restricted to operator and admin`() {
+        // #860: re-emits historical book-of-record events for a downstream projection catch-up.
+        // Ops-only (operator + admin, like other ops triggers) — never service/viewer/auditor.
+        assertThat(rolesOf("replayBookedChanges"))
+            .describedAs("replayBookedChanges roles (ops recovery — re-emits book-of-record events)")
+            .containsExactlyInAnyOrder("ROLE_OPERATOR", "ROLE_ADMIN")
+    }
 }


### PR DESCRIPTION
## What

Adds `POST /api/v1/journals/replay-booked-changes` — an **ops-recovery** action that reconstructs and re-enqueues the ledger's own already-posted `AccountBookedChanged` events for a date window, so a downstream projection that missed them can catch up.

Direct enabler for **#860**: the balance-service deposit-control sub-ledger (ADR-0039) drifted from the GL because a run of booked-change events never projected, and the Kafka topic's 7-day retention can't cover the ~41-day gap. The authoritative ledger re-drives its own events instead.

## How

- Reconstructs each event exactly as the original post did (`JournalEntry.bookedDeltas()` — same credit-positive base-amount logic) and enqueues it on the **transactional outbox**; the existing dispatcher relays it to `openbank.ledger.journal.posted` under the same `ce-type` the consumer filters on.
- Idempotency is the consumer's: it dedups on `(journalEntryId, accountId, currency)`, so a replay lands **only genuinely-missing deltas** — re-running is safe.
- **Posts no journal and mutates no ledger state.** The book of record is untouched; only its own past events are re-emitted.
- `dryRun` **defaults to `true`** — previews counts + net delta per currency without emitting. Real emission requires an explicit `dryRun=false`.
- Pages posted entries (`findByDateRange`, page size 500) to bound memory on a wide window.

## Authorization (money-path)

- New `ledger.replay` action, added to the ledger OPA bundle's `operator-ledger-write` rule (operator/admin only). Bundle regenerated via `gen-ledger-opa-bundle.sh` (checksum + Rollout annotation synced).
- **Not** reachable by any service/viewer/auditor principal — consistent with `ledger.trigger` (FX revaluation), which is also operator-only with no M2M path.
- Locked by `LedgerSecurityContractTest` (`replayBookedChanges` ⇒ `ROLE_OPERATOR` + `ROLE_ADMIN`).
- Not a four-eyes verb: it neither posts nor reverses a journal and moves no value, so it stays out of `rules.yaml: four_eyes.verbs` (same rationale as `trigger`).

## API contract (ADR-0048)

- `openapi.yaml` gains the new path + `ReplayBookedChangesRequest`/`ReplayBookedChangesResponse` schemas.
- `info.version` `1.7.0` → `1.8.0` (additive endpoint, non-breaking; major stays `1` = `/api/v1`).

## Tests

- `ReplayBookedChangesServiceTest` (new): dry-run tallies-but-emits-nothing, real-run enqueues one outbox message per delta with the routing metadata, pagination through a short-page terminator, inverted-window guard. **4/4 green.**
- `LedgerSecurityContractTest`: new role assertion. **3/3 green.**
- Local gate green: `compileKotlin`/`compileTestKotlin` + `detekt` + `ktlintMainSourceSetCheck`/`ktlintTestSourceSetCheck`.

## Notes

- `ktlint-baseline.xml` gains **one** entry (`ReplayBookedChangesPorts.kt` — the unavoidable `package-name` finding on the `port.\`in\`` keyword directory, identical to its three sibling port files). Added surgically, not via full regeneration (local ktlint differs from CI's and would have dropped 44 unrelated frozen entries).
- Threat model `docs/threat-models/openbank-ledger-service.md` already exists (money-path). This endpoint adds no new state-mutation surface (re-emits already-posted events, operator-gated, dry-run default); no new threat class introduced.
- **This PR only adds the mechanism. The actual replay execution to fix the #860 drift is a separate, signed-off operational step** (dry-run first, then `dryRun=false`).

## Linked issues

Refs #860