### PR TITLE
fix(ledger): unbreak main — InMemoryJournalRepository missing appendOutbox

### DIFF
--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceIdempotencyPropertyTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/application/usecase/LedgerServiceIdempotencyPropertyTest.kt
@@ -97,6 +97,8 @@ class LedgerServiceIdempotencyPropertyTest {
             outbox: List<OutboxMessage>,
         ): JournalEntry = error("not exercised by postJournal")
 
+        override suspend fun appendOutbox(messages: List<OutboxMessage>): Int = error("not exercised by postJournal")
+
         override suspend fun trialBalance(asOf: LocalDate): List<TrialBalanceLine> = error("not exercised")
 
         override suspend fun trialBalanceForPeriod(from: LocalDate, to: LocalDate): List<TrialBalanceLine> =


### PR DESCRIPTION
## Summary

`main` is currently broken: `:openbank-ledger-service:compileTestKotlin` fails, blocking any test
run for the whole module.

Root cause is a semantic merge conflict between two PRs that each passed CI independently but
never saw each other's change:
- PR #888 (`feat(ledger): add operator replay endpoint...`), merged 08:11:49, added
  `appendOutbox(messages: List<OutboxMessage>): Int` to the `JournalRepository` interface
  (`LedgerPorts.kt`).
- PR #836 (`test(fx,ledger,balance): property tests for FX margin, idempotency, projection
  order`), merged 08:16:35 — five minutes later — added
  `LedgerServiceIdempotencyPropertyTest.kt` with a hand-written `InMemoryJournalRepository` fake
  that predates #888's interface addition.

Neither PR's own CI run ever saw the other's diff. Together on `main`, the fake no longer
satisfies the interface it implements.

## Fix

`appendOutbox` is only called by `ReplayBookedChangesService`, never by
`LedgerService.postJournal` (the path this property test exercises) — so the fix follows this
same fake's existing pattern for its other not-exercised members (`saveReversal`,
`trialBalance`, `subLedgerBalances`, `controlAccountTieOut`):

```kotlin
override suspend fun appendOutbox(messages: List<OutboxMessage>): Int = error("not exercised by postJournal")
```

## Verification

Reproduced and fixed against a clean **detached checkout of `origin/main`** (not a stale local
branch — per this repo's own documented "stale checkout" pitfall):
- Before the fix: `compileTestKotlin` fails with `Class 'InMemoryJournalRepository' is not
  abstract and does not implement abstract member: suspend fun appendOutbox(...)`.
- After the fix: `BUILD SUCCESSFUL`.
- Full `:openbank-ledger-service:test`: 198/198, 0 failures/errors.
- `ktlintCheck` + `detekt`: clean.
- Also re-ran the other 5 property-test files added by the same PR #836
  (`JournalEntryPropertyTest`, `MoneyPropertyTest`, `BalancePropertyTest`,
  `BalanceProjectionOrderPropertyTest`, `FxConversionMathPropertyTest`) — all pass, confirming
  issue #469's full scope (ledger double-entry, Money arithmetic, FX conversion, balance
  projection, idempotency) is genuinely covered end-to-end once this fix lands.

Test-only change — no `src/main/**` touched, no version bump needed.

Refs #469 — the failure this fixes is in #469's own coverage work; not closing here since this PR
only unbreaks the build, it doesn't change the scope of #469 itself.