### PR TITLE
fix(ci): correct dependency-submission.yml path filter for libs.versions.toml

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -24,7 +24,7 @@ on:
     branches: [main]
     paths:
       - "**/build.gradle.kts"
-      - "gradle/libs.versions.toml"
+      - "openbank-libs/gradle/libs.versions.toml"
       - "settings.gradle.kts"
       - "gradle/wrapper/**"
   schedule:


### PR DESCRIPTION
## What
The `dependency-submission.yml` push-path filter watched `gradle/libs.versions.toml`, but the actual version catalog lives at `openbank-libs/gradle/libs.versions.toml` (see `settings.gradle.kts`'s `from(files("openbank-libs/gradle/libs.versions.toml"))`).

## Impact
A BOM/dependency bump to the real file never triggers this workflow, so GitHub's dependency graph (and therefore Dependabot alerts) goes stale silently. Confirmed live: PR #873 (Quarkus BOM 3.33.2 -> 3.37.2) merged to `main` without firing `dependency-submission.yml` — had to `gh workflow run dependency-submission.yml` manually to get the graph to recalculate.

## Linked issues
N/A — operational CI gap found while verifying #873's Dependabot impact.

## Test plan
- [x] Path filter now matches the real file location
- [ ] Next `openbank-libs/gradle/libs.versions.toml` change on `main` should auto-trigger this workflow