### PR TITLE
fix(kyverno): except arc-runners from SBOM-attestation Enforce (ARC deadlock)

### DIFF
--- a/openbank-infra/gitops/components/kyverno/arc-runner-image-exception.yaml
+++ b/openbank-infra/gitops/components/kyverno/arc-runner-image-exception.yaml
@@ -1,0 +1,39 @@
+# TEMPORARY exception — remove once openbank-ci-runner carries a valid CycloneDX SBOM
+# attestation and `kubectl get polr -A` reports 0 fail for verify-openbank-image-sbom-attestation
+# against arc-runners pods.
+#
+# Incident (2026-07-12): verify-openbank-image-sbom-attestation graduated Audit -> Enforce
+# (PR #887) while openbank-ci-runner's own attestation step in runner-image.yml is
+# continue-on-error and had been silently failing. Once Enforce landed, every ARC runner pod
+# using that image (openbank-build AND openbank-deploy pools) was rejected at admission —
+# a hard deadlock, since the only workflow that can rebuild+attest a fixed runner image
+# (runner-image.yml) itself needs an ARC runner (ambient IRSA for the ECR/KMS push, see that
+# workflow's own comment) that is blocked by the same policy it would fix. No workflow
+# re-trigger can break this cycle from inside the cluster.
+#
+# This PolicyException mirrors the existing (previously gitops-untracked, applied out-of-band
+# on 2026-06-17) arc-runner-image-exception scope — same namespace, same object name, adding
+# only the SBOM-attestation rule the original exception predates. Scoped to Pod resources in
+# arc-runners only; does not touch any openbank-* application namespace or the signature policy.
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: arc-runner-image-exception
+  namespace: arc-runners
+spec:
+  match:
+    any:
+      - resources:
+          kinds:
+            - Pod
+          namespaces:
+            - arc-runners
+  exceptions:
+    - policyName: verify-openbank-image-signatures
+      ruleNames:
+        - verify-cosign-signature
+        - autogen-verify-cosign-signature
+    - policyName: verify-openbank-image-sbom-attestation
+      ruleNames:
+        - verify-cyclonedx-sbom-attestation
+        - autogen-verify-cyclonedx-sbom-attestation


### PR DESCRIPTION
## Summary — URGENT, live incident

`verify-openbank-image-sbom-attestation` graduated Audit → Enforce in #887. `openbank-ci-runner`'s
own SBOM attestation step in `runner-image.yml` is `continue-on-error` and had been silently
failing, so every ARC runner pod using that image is now rejected at admission.

**This is a hard deadlock**, confirmed live via ARC controller logs (repeated admission-webhook
denials for both `openbank-build-ddttt-runner-*` and `openbank-deploy-spz2n-runner-*`): the only
workflow that can rebuild+attest a fixed runner image (`runner-image.yml`) itself needs an ARC
runner (ambient IRSA for the ECR/KMS push — ADR-0053) that is blocked by the same policy it would
fix. No workflow re-trigger can break this from inside the cluster. Both `openbank-build` (6/6
runners) and `openbank-deploy` have been stuck for hours.

Downstream impact: `sepa-payment` (money-path) and `party-service` currently have **zero running
pods** — their Rollouts can't progress because `can-i-deploy` (which needs `openbank-build`) can
never get a runner.

## Fix

Adds the SBOM-attestation rule to the existing `arc-runner-image-exception` `PolicyException`
(previously gitops-untracked, applied out-of-band on 2026-06-17 for the signature policy only —
this also fixes that drift by bringing it under gitops management). Same namespace/object, scoped
strictly to `Pod` resources in `arc-runners`. Does not touch any `openbank-*` application
namespace and does not loosen the signature policy.

**TEMPORARY** — remove once `openbank-ci-runner` has a real attestation and
`kubectl get polr -A` reports 0 fail for this policy against `arc-runners`. Tracked as a
fast-follow (fixing `runner-image.yml`'s silent `continue-on-error` attestation failure),
not resolved by this PR.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; ..."`)
- [x] Matches the Kyverno `v2` `PolicyException` schema of the existing live (untracked) object
- [ ] Post-merge: ArgoCD `kyverno-policies` app auto-syncs (automated + selfHeal) — verify
      `kubectl get ephemeralrunner -n arc-runners` starts reaching `Running`, then re-check
      `sepa-payment`/`party-service` Rollout health.

Refs #887, #846. N/A tracking issue for this specific deadlock — found live during incident response.