### PR TITLE
feat(gitops): balances-db CNPG cluster to instances:2 (HA) — ADR-0159 sweep 4/17

### DIFF
--- a/openbank-infra/gitops/components/balances/postgres.yaml
+++ b/openbank-infra/gitops/components/balances/postgres.yaml
@@ -16,7 +16,27 @@ spec:
   # deadlocks, xid age, WAL archiving) with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # HA (ADR-0159): primary + hot standby with async streaming replication and
+  # CNPG-managed automated failover. `enablePodAntiAffinity` + required
+  # `kubernetes.io/hostname` keeps the two pods on DIFFERENT NODES — that is both
+  # the HA guarantee and the fix for the single-instance un-drainable-PDB node-roll
+  # block (issue #809): with a standby present the PDB permits one disruption, so
+  # Karpenter drains/rolls a DB-hosting node without the manual delete-primary dance.
+  # The topologySpreadConstraint softly spreads the pair across AZs when capacity
+  # allows. Async replication (no minSyncReplicas) keeps the write path independent
+  # of standby health; synchronous is deferred to a production decision (ADR-0159).
+  instances: 2
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: balances-db
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3


### PR DESCRIPTION
## Summary
Sweep 4/17 of issue #850 (ADR-0159): `balances-db` instances:1 -> instances:2, same
pattern as `ledger-db` (#854), `transaction-db` (#910), `accounts-db` — required
hostname anti-affinity, soft cross-AZ topologySpreadConstraint, async replication.

## Money-path
`balance-service` is money-path — flagging for 2-approval per ADR-0030.
Topology-only change, no new trust boundary.

## Test plan
- [x] YAML parses
- [ ] Post-merge: standby streaming healthy
- [ ] Post-merge: test switchover succeeds before ticking the box in #850

Refs #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)