### PR TITLE
feat(gitops): clearing-db CNPG cluster to instances:2 (HA) — ADR-0159 sweep 8/17

### DIFF
--- a/openbank-infra/gitops/components/payments/postgres.yaml
+++ b/openbank-infra/gitops/components/payments/postgres.yaml
@@ -220,7 +220,27 @@ spec:
   # deadlocks, xid age, WAL archiving) with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # HA (ADR-0159): primary + hot standby with async streaming replication and
+  # CNPG-managed automated failover. `enablePodAntiAffinity` + required
+  # `kubernetes.io/hostname` keeps the two pods on DIFFERENT NODES — that is both
+  # the HA guarantee and the fix for the single-instance un-drainable-PDB node-roll
+  # block (issue #809): with a standby present the PDB permits one disruption, so
+  # Karpenter drains/rolls a DB-hosting node without the manual delete-primary dance.
+  # The topologySpreadConstraint softly spreads the pair across AZs when capacity
+  # allows. Async replication (no minSyncReplicas) keeps the write path independent
+  # of standby health; synchronous is deferred to a production decision (ADR-0159).
+  instances: 2
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: clearing-db
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3


### PR DESCRIPTION
Sweep 8/17 of #850 (ADR-0159). Same pattern as prior sweeps: instances:1 -> instances:2, required hostname anti-affinity, soft cross-AZ topologySpreadConstraint.

`clearing-service` is money-path — 2-approval per ADR-0030. Topology-only.

- [x] YAML parses
- [ ] Post-merge: standby healthy, switchover verified before ticking box in #850

Refs #850