### PR TITLE
feat(gitops): sanctions-db CNPG cluster to instances:2 (HA) — ADR-0159 sweep 17/17 (final)

### DIFF
--- a/openbank-infra/gitops/components/sanctions-service/postgres.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/postgres.yaml
@@ -14,7 +14,27 @@ spec:
   # deadlocks, xid age, WAL archiving) with zero app changes.
   monitoring:
     enablePodMonitor: true
-  instances: 1
+  # HA (ADR-0159): primary + hot standby with async streaming replication and
+  # CNPG-managed automated failover. `enablePodAntiAffinity` + required
+  # `kubernetes.io/hostname` keeps the two pods on DIFFERENT NODES — that is both
+  # the HA guarantee and the fix for the single-instance un-drainable-PDB node-roll
+  # block (issue #809): with a standby present the PDB permits one disruption, so
+  # Karpenter drains/rolls a DB-hosting node without the manual delete-primary dance.
+  # The topologySpreadConstraint softly spreads the pair across AZs when capacity
+  # allows. Async replication (no minSyncReplicas) keeps the write path independent
+  # of standby health; synchronous is deferred to a production decision (ADR-0159).
+  instances: 2
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cnpg.io/cluster: sanctions-db
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3


### PR DESCRIPTION
Sweep 17/17 of #850 — the LAST cluster in the fleet sweep. Same pattern as prior sweeps. sanctions-service is money-path — 2-approval per ADR-0030.

Once this merges and its switchover is verified, all 17 money-path CNPG clusters run instances:2.

- [x] YAML parses
- [ ] Post-merge: standby healthy, switchover verified

Refs #850