### PR TITLE
feat(ledger): wire four-eyes enforcement mechanism (ADR-0155)

### DIFF
--- a/docs/threat-models/openbank-ledger-service.md
+++ b/docs/threat-models/openbank-ledger-service.md
@@ -174,3 +174,59 @@ Added in Phase B to make the scheduler's daily invariant queryable by auditors a
 | T6 | **Enumeration** — caller probes UUIDs for non-existent control accounts | Empty list returned for unknown `controlAccountId`; no 404 distinguishable from zero-activity account — timing-safe. |
 | T7 | **Denial of service via large `asOf` range** — `asOf` is a single date; the query is bounded to `entry_date <= :asOf` over a single control account | Query always scans a single account; index on `(account_id, entry_date)` (V7 migration) keeps cost proportional to account volume, not total ledger size. |
 | T8 | **TieOutScheduler silent failure** — exception in one currency skips remaining currencies | Per-currency `try/catch` logs `ERROR` and continues; `openbank.subledger.tieout.break` is a counter (non-zero = alert), not suppressed by exceptions. |
+
+## 7. Four-eyes approval (ADR-0155) — STRIDE supplement
+
+`POST /{journalId}/reverse` (`ledger.reverse`) is a money-path action OPA (`rest.rego`) can flag
+`four_eyes_required`. New endpoint `PATCH /api/v1/journals/approvals/{id}` lets a DIFFERENT
+operator decide the resulting `PendingApproval`; the maker retries `POST /{journalId}/reverse`
+with an `X-Approval-Id` header. **`authz.four-eyes.enforce` stays `false` in this PR** — the
+`ApprovalStore`/endpoint are wired (rollout tracked in issue #413, mirroring the sepa-payment
+pilot), but blocking is a deliberate follow-up flip, not bundled here (see ADR-0155).
+
+This is a NEW Redis dependency for ledger-service — previously ledger had no Redis surface at all
+(see §1/namespace note, now superseded). The `ApprovalStore` (`RedisApprovalStore`) is the only
+consumer; no Idempotency-Key dedup is added by this change.
+
+Note: ledger already has an independent, in-service four-eyes control on year-close attestation
+(`ledger.approve`, §4 Key invariants above — the attestor must differ from the draft author,
+enforced fail-closed in both the use case and the domain). The ADR-0155 mechanism here is a
+second, separate control specifically on **journal reversal** — a different action, gated through
+the shared `ApprovalStore`/`AuthorizeInterceptor` path (currently advisory, `enforce=false`).
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **S**poofing | A caller other than an operator decides an approval | `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` + OPA `@Authorize(action="ledger.approval.decide")` on the decide endpoint |
+| **E**oP | The maker approves their own reversal request (self-approval defeats maker-checker) | `ApprovalStore.decide` throws `SelfApprovalNotAllowedException` (mapped to 403) when `decidedBy == makerId` — enforced in the domain port itself, not just the REST layer, and `makerId`/`decidedBy` both resolve via the same `.principal.name` extraction (interceptor vs. `SecurityIdentity`) so the comparison can't silently mismatch for the same real person |
+| **T**ampering | A stale, mismatched, or already-consumed `X-Approval-Id` is replayed to unlock a different reversal | `AuthorizeInterceptor` requires the approval's `action` + `resourceId` + `makerId` to match the CURRENT request exactly, `status == APPROVED`, and marks it `EXECUTED` (one-time use) on success; any mismatch re-issues a fresh pending approval instead of proceeding |
+| **R**epudiation | No record of who approved a gated reversal | `PendingApproval.decidedBy` + `decidedAt` recorded in the approval record itself (Redis, TTL-bounded — see Residual risk below: not yet a permanent audit trail) |
+| **I**nfo disclosure | Approval id enumeration reveals journal/action metadata to an unauthorized caller | `find`/`decide` require the caller to already hold a valid, role-gated session; the id itself is a random id (`RedisApprovalStore`, not sequential) |
+| **D**oS | Flooding `POST /{journalId}/reverse` to exhaust Redis with pending approvals | Bounded by the same rate-limit/idempotency controls as the gated endpoint itself; each `PendingApproval` is TTL-bounded (86400s) so abandoned records expire |
+
+**DFD update:** adds `Operator (checker) → PATCH /api/v1/journals/approvals/{id} → Redis
+(approval:*)` alongside the existing `POST /{journalId}/reverse` edge; the maker's retry reuses
+the existing DFD edge.
+**Risk class:** integrity (segregation of duties, reversal) + confidentiality (approval record scope).
+**Rollback:** `authz.four-eyes.enforce=false` (default) — the endpoint and store exist but do not
+change any existing request's outcome until explicitly flipped.
+
+**Residual risk:** four-eyes `PendingApproval` records are TTL-bounded (Redis), not a permanent
+audit trail (ADR-0155) — a durable-audit requirement for "who approved what, forever" would need
+an additional store; not implemented in this PR. Also open (unchanged by this PR): S1 above (the
+`openbank-services` shared-credential blast radius) and E1 (RBAC + OPA both key off the same role
+set) apply equally to the new `ledger.approval.decide` action.
+
+## 8. Change log
+
+- **2026-07-12** — Wired the four-eyes (maker-checker) enforcement *mechanism* (ADR-0155) onto
+  `ledger.reverse`, mirroring the account/sepa-payment/lending rollouts (issue #413). This is
+  ledger-service's first-ever Redis dependency: new in-namespace `redis` Deployment/Service
+  (`openbank-infra/gitops/components/ledger/redis.yaml`) plus a `redis-ingress-allow-list`
+  NetworkPolicy, `QUARKUS_REDIS_HOSTS` wired on the Rollout, and `quarkus-redis-client` added to
+  the build. New `ApprovalConfig` (`RedisApprovalStore` producer) and `PATCH
+  /api/v1/journals/approvals/{id}` checker-decide endpoint (`@RolesAllowed(Roles.OPERATOR,
+  Roles.ADMIN)`, `@Authorize(action = "ledger.approval.decide")`); two new exception mappers
+  (`SelfApprovalNotAllowedMapper` → 403, `InvalidApprovalStateMapper` → 409) appended to the
+  existing `ExceptionMappers.kt`. STRIDE supplement added in §7 above. **`authz.four-eyes.enforce`
+  stays `false`** — no behavior change to any existing request; this PR only wires the mechanism.
+  Rollback: revert the commit (no DB/schema change; `ApprovalStore` records live in Redis with a TTL).

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -4,9 +4,9 @@
 # bus when journal entries are posted. OIDC bearer-token validation points at
 # Keycloak over the in-cluster http leg (discovery returns the public issuer, so
 # browser-minted user tokens validate without touching the self-signed edge
-# cert). No Redis (no Idempotency-Key surface) and no Ingress — internal only.
-# Stays in CrashLoop until the DB and the realm client are reachable; ArgoCD
-# converges as each dependency comes up.
+# cert). Redis backs the ADR-0155 four-eyes ApprovalStore (no Idempotency-Key
+# surface). No Ingress — internal only. Stays in CrashLoop until the DB and the
+# realm client are reachable; ArgoCD converges as each dependency comes up.
 #
 # Progressive delivery: Deployment→Rollout (ADR-0098 Phase 2). Canary strategy
 # — 10% 5 min → 30% 5 min → 100%. ClusterAnalysisTemplate openbank-money-path-canary
@@ -69,6 +69,9 @@ spec:
                 secretKeyRef:
                   name: ledger-db-app
                   key: password
+            # Redis for the four-eyes ApprovalStore (ADR-0155).
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://redis.ledger.svc:6379
             # Flyway checksum mismatch on V7/V9/V11 (2026-07-11 bootstrap redeploy, #880):
             # ledger-service hadn't been redeployed since 2026-07-06, so a repo-wide
             # migration-file touch-up landed while it sat un-deployed. Repair-at-start

--- a/openbank-infra/gitops/components/ledger/namespace.yaml
+++ b/openbank-infra/gitops/components/ledger/namespace.yaml
@@ -1,7 +1,8 @@
 # Ledger banking domain (ADR-0037: domain = namespace). App plane. Holds
-# ledger-service plus its single-owner CNPG Postgres, co-located (R4). Money-path
-# domain: the double-entry sub-ledger. No Redis (no Idempotency-Key surface) and
-# no public Ingress — ledger is an internal ClusterIP service driven by other
+# ledger-service plus its single-owner CNPG Postgres, co-located (R4), and an
+# in-namespace Redis backing the ADR-0155 four-eyes ApprovalStore (no
+# Idempotency-Key surface). Money-path domain: the double-entry sub-ledger. No
+# public Ingress — ledger is an internal ClusterIP service driven by other
 # domains over Kafka and in-cluster REST.
 apiVersion: v1
 kind: Namespace

--- a/openbank-infra/gitops/components/ledger/network-policies.yaml
+++ b/openbank-infra/gitops/components/ledger/network-policies.yaml
@@ -76,3 +76,21 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-allow-list
+  namespace: ledger
+  labels:
+    app.kubernetes.io/part-of: ledger
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/openbank-infra/gitops/components/ledger/redis.yaml
+++ b/openbank-infra/gitops/components/ledger/redis.yaml
@@ -1,0 +1,82 @@
+# Redis-backed ApprovalStore for the ADR-0155 four-eyes mechanism (ledger-service has no other
+# Idempotency-Key/Redis surface). Ephemeral on purpose — persistence is disabled
+# (--save "" --appendonly no), so a restart just clears in-flight PendingApproval records, which
+# is acceptable for the sandbox (TTL-bounded anyway, RedisApprovalStore). Prod should use an
+# operator-managed HA Redis. Pinned to the alpine image's redis uid 999/gid 1000 to satisfy PSS
+# restricted; /data is a writable emptyDir so the root fs can stay read-only.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: ledger
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: ledger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 192Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: ledger
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/openbank-ledger-service/build.gradle.kts
+++ b/openbank-ledger-service/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation(libs.quarkus.oidc.client.reactive.filter)
     implementation(libs.quarkus.rest.client.reactive)
     implementation(libs.quarkus.rest.client.reactive.jackson)
+    // Redis-backed ApprovalStore for the ADR-0155 four-eyes mechanism (ledger has no other
+    // Idempotency-Key/Redis surface today — this is the first Redis dependency in this service).
+    implementation(libs.quarkus.redis.client)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
 

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/approval/ApprovalConfig.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/approval/ApprovalConfig.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.approval
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+/**
+ * Per-service producer for [ApprovalStore] (ADR-0155). Mirrors the standard per-service
+ * ApprovalStore producer pattern used by the other ADR-0155 rollouts (account-service et al.) —
+ * see [RedisApprovalStore]'s KDoc for why this is a per-service `@Produces` rather than a
+ * libs-side bean. Ledger-service has no other Redis surface today (no Idempotency-Key
+ * dedup/`IdempotencyConfig`), so this is also the first thing in this service to wire
+ * `ReactiveRedisDataSource`.
+ */
+@ApplicationScoped
+class ApprovalConfig {
+    @Produces
+    @ApplicationScoped
+    fun approvalStore(redis: ReactiveRedisDataSource, clock: Clock): ApprovalStore = RedisApprovalStore(redis, clock)
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ApprovalResource.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.security.Roles
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+/**
+ * Checker-facing endpoint for the four-eyes gate (ADR-0155). A maker's
+ * `POST /{journalId}/reverse` call on a `four_eyes_required` action is paused by
+ * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a
+ * `PendingApproval` id; a DIFFERENT operator decides it here, then the maker
+ * retries the original call with an `X-Approval-Id` header.
+ */
+@Path("/api/v1/journals/approvals")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Ledger Approvals", description = "Four-eyes decisions for gated ledger actions")
+class ApprovalResource(private val approvalStore: ApprovalStore) {
+
+    @Inject
+    lateinit var identity: SecurityIdentity
+
+    @PATCH
+    @Path("/{id}")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "ledger.approval.decide", resource = "#id")
+    @Operation(summary = "Approve or reject a pending four-eyes approval")
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+        val decided = approvalStore.decide(id, checkerId(), request.approve)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        return Response.ok(decided.toResponse()).build()
+    }
+
+    // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id
+    // (sc.userPrincipal?.name), or approval.makerId and this checker's id would be
+    // formatted differently for the same real person and the self-approval guard
+    // in ApprovalStore.decide could silently fail to catch a maker approving their
+    // own request. SecurityIdentity (not @Context SecurityContext) because this is
+    // a `suspend fun` — see YearCloseResource for the same workaround (in a Kotlin
+    // `suspend` resource method @Context does not reliably resolve, SecurityIdentity does).
+    private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+}
+
+data class DecideApprovalRequest(val approve: Boolean)
+
+data class ApprovalResponse(
+    val id: String,
+    val action: String,
+    val resourceId: String?,
+    val status: String,
+    val decidedBy: String?,
+)
+
+fun PendingApproval.toResponse() = ApprovalResponse(
+    id = id,
+    action = action,
+    resourceId = resourceId,
+    status = status.name,
+    decidedBy = decidedBy,
+)

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/rest/ExceptionMappers.kt
@@ -12,6 +12,10 @@ import com.openbank.ledger.application.usecase.YearCloseConflictException
 import com.openbank.ledger.application.usecase.YearCloseNotFoundException
 import com.openbank.ledger.domain.model.LedgerConflictException
 import com.openbank.ledger.domain.model.LedgerValidationException
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.approval.InvalidApprovalStateException
+import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import com.openbank.libs.domain.identifiers.Ids
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.core.Response.Status.CONFLICT
@@ -103,6 +107,43 @@ class ClosedFiscalPeriodExceptionMapper : ExceptionMapper<ClosedFiscalPeriodExce
         .entity(mapOf("error" to (exception.message ?: "Fiscal period is closed")))
         .type(MediaType.APPLICATION_JSON)
         .build()
+}
+
+// ADR-0155: a checker can never decide their own PendingApproval — ApprovalStore.decide
+// enforces this itself (defense-in-depth), surfaced here as a plain 403.
+@Provider
+class SelfApprovalNotAllowedMapper : ExceptionMapper<SelfApprovalNotAllowedException> {
+    override fun toResponse(exception: SelfApprovalNotAllowedException): Response =
+        Response.status(Response.Status.FORBIDDEN)
+            .entity(
+                ApiError(
+                    // ADR-0106: a per-response correlation id, not a durable/indexed identifier — Ids.randomId().
+                    traceId = Ids.randomId().toString(),
+                    status = 403,
+                    code = "FORBIDDEN",
+                    message = exception.message ?: "Forbidden",
+                ),
+            )
+            .build()
+}
+
+// decide()/markExecuted() reject re-deciding or re-consuming an approval that isn't in the
+// expected status (guards against an EXECUTED approval being flipped back to APPROVED and
+// replayed). Surfaced as a 409, matching the existing conflict-mapper convention above for
+// state-machine violations.
+@Provider
+class InvalidApprovalStateMapper : ExceptionMapper<InvalidApprovalStateException> {
+    override fun toResponse(exception: InvalidApprovalStateException): Response =
+        Response.status(Response.Status.CONFLICT)
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = 409,
+                    code = "CONFLICT",
+                    message = exception.message ?: "Conflict",
+                ),
+            )
+            .build()
 }
 
 // ExceptionMapper<Exception> (GlobalExceptionMapper) is intentionally NOT declared here.

--- a/openbank-ledger-service/src/main/resources/application.yaml
+++ b/openbank-ledger-service/src/main/resources/application.yaml
@@ -47,6 +47,9 @@ quarkus:
     tls:
       verification: none
 
+  redis:
+    hosts: redis://localhost:6379
+
   rest-client:
     fx-service:
       url: ${FX_SERVICE_URL:http://localhost:8119}
@@ -107,6 +110,13 @@ opa:
   timeout-ms: "${OPA_TIMEOUT_MS:500}"
 authz:
   enforce: "${AUTHZ_ENFORCE:false}"
+  # ADR-0155: four-eyes ENFORCEMENT (blocking a maker's request pending a second
+  # approver), independent of the base allow/deny enforce toggle above. Stays false
+  # here — this PR only wires the ApprovalStore/endpoint (mirrors the sepa-payment
+  # pilot); flipping this is a deliberate, separate follow-up once the maker/checker
+  # runbook is reviewed, not bundled with the wiring itself.
+  four-eyes:
+    enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"
 
 openbank:
   rate-limit:

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/it/PostgresRedpandaTestResource.kt
@@ -5,16 +5,21 @@
 package com.openbank.ledger.it
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.redpanda.RedpandaContainer
 import org.testcontainers.utility.DockerImageName
 
-/** CI infra sweep (#578). Isolated PostgreSQL + Redpanda (Kafka API) per test JVM.
- *  For ITs that boot the app's @Channel("ledger-events-out") emitter without an
- *  in-memory switch, so a real broker is needed (else they'd use the shared stack). */
+/** CI infra sweep (#578). Isolated PostgreSQL + Redpanda (Kafka API) + Valkey (Redis) per test
+ *  JVM. For ITs that boot the app's @Channel("ledger-events-out") emitter without an in-memory
+ *  switch, so a real broker is needed (else they'd use the shared stack). Redis was added for
+ *  ADR-0155's four-eyes ApprovalStore (issue #413) — quarkus-redis-client registers a readiness
+ *  health check, so ANY test booting the full app via this resource now needs a reachable Redis
+ *  or `/q/health/ready` reports DOWN (this bit LedgerApiIT's health-check assertion). */
 class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     private var postgres: PostgreSQLContainer<*>? = null
     private var redpanda: RedpandaContainer? = null
+    private var redis: GenericContainer<*>? = null
     override fun start(): Map<String, String> {
         val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
             .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_ledger_it")
@@ -26,6 +31,9 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
         )
         rp.start()
         redpanda = rp
+        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        rd.start()
+        redis = rd
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         val bootstrap = rp.bootstrapServers
@@ -36,10 +44,12 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
             "quarkus.datasource.password" to "openbank_secret",
             "kafka.bootstrap.servers" to bootstrap,
             "mp.messaging.connector.smallrye-kafka.bootstrap.servers" to bootstrap,
+            "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
             "quarkus.devservices.enabled" to "false",
         )
     }
     override fun stop() {
+        redis?.stop()
         redpanda?.stop()
         postgres?.stop()
     }


### PR DESCRIPTION
## Summary
Rolls out the ADR-0155 maker-checker mechanism to `openbank-ledger-service` (issue #413
batch 2), gating `ledger.reverse`. Mirrors the account-service/sepa-payment pilot exactly.

**This is ledger-service's first Redis dependency** (it had no prior Idempotency-Key/Redis
surface) — this PR adds the Redis infra alongside the mechanism: new in-namespace
`redis` Deployment+Service, `redis-ingress-allow-list` NetworkPolicy, `quarkus-redis-client`,
`QUARKUS_REDIS_HOSTS` on the Rollout.

- `ApprovalConfig`: per-service `@Produces ApprovalStore` via `RedisApprovalStore`.
- `ApprovalResource`: checker-facing `PATCH /api/v1/journals/approvals/{id}`,
  `@RolesAllowed(OPERATOR, ADMIN)` + `@Authorize(action="ledger.approval.decide")`.
- `ExceptionMappers`: `SelfApprovalNotAllowedMapper` (403), `InvalidApprovalStateMapper` (409).
- `application.yaml`: `authz.four-eyes.enforce` (default `false`) — mechanism only, no
  behavior change. Flipping it on is a deliberate, separate follow-up.
- Threat model: new STRIDE supplement + change log. Notes ledger already has an
  independent four-eyes-style control on year-close attestation (`ledger.approve`) —
  this is a second, separate control specifically on journal reversal.

## Money-path
`ledger-service` is money-path — 2-approval + threat-model review per ADR-0030 (threat
model updated in this PR).

## Test plan
- [x] `ktlintCheck` pass
- [x] `quarkusBuild` pass (CDI wiring for the new `ApprovalConfig`/`ReactiveRedisDataSource`
      producer resolves cleanly)
- [x] All touched YAML validated + checked for duplicate keys
- [ ] Post-merge: confirm Redis pod comes up healthy, decide endpoint reachable

Refs #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)