### PR TITLE
feat(balance): wire four-eyes enforcement mechanism (ADR-0155)

### DIFF
--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -66,6 +66,8 @@ Domain layer has zero framework imports (ADR-0002); overdraft + reconciliation m
   verified callers collectively need (no blanket allow across every balance action), but not to the
   specific caller. Tightening this needs per-caller identity (mTLS SPIFFE, ADR-0017, or a dedicated
   OIDC client per caller) — tracked as a follow-up, not solved here.
+- Four-eyes approval-decide endpoint: same role set as the gated actions (`OPERATOR`/`ADMIN`),
+  plus a domain-level segregation-of-duties check (checker id != maker id) — see §4a.
 
 ## 4. STRIDE analysis
 
@@ -80,6 +82,42 @@ Domain layer has zero framework imports (ADR-0002); overdraft + reconciliation m
 | D1 | Reconciliation / writes | **DoS** — hold exhaustion / write storm / expensive tie-out scans | Rate limits; idempotency drops retries; per-currency aggregation; scheduled reconciliation cadence; reactive non-blocking stack | Gateway rate-limit — infra scope |
 | E1 | Roles | **Elevation** — read role triggers a debit / raises own overdraft | Deny-by-default; explicit role for money movement; cover check cannot mutate; OPA now enforced (a viewer/read-only reason never grants `balance.credit`/`balance.debit`) | Low |
 | T3 | Ledger client | **Tampering / spoofing of source** — projection trusts a forged ledger response | Authenticated ledger-service inside trust mesh; reconciliation compares against ledger as golden source, flags mismatch | mTLS/service-identity hardening — infra scope |
+
+## 4a. Four-eyes approval (ADR-0155) — STRIDE supplement
+
+Both `POST /{accountId}/credit` (`balance.credit`) and `POST /{accountId}/debit`
+(`balance.debit`) are money-path actions OPA (`rest.rego`) can flag `four_eyes_required`. New
+endpoint `PATCH /api/v1/balances/approvals/{id}` lets a DIFFERENT operator decide the resulting
+`PendingApproval`; the maker retries the original credit/debit call with an `X-Approval-Id`
+header. A single decide endpoint handles approvals for BOTH gated actions — `ApprovalStore.decide`
+resolves by approval id regardless of which action created the pending record. Note both actions
+also admit `ROLE_SERVICE` (M2M) callers, same as today — this mechanism does not change that;
+**`authz.four-eyes.enforce` stays `false` in this PR** — the `ApprovalStore`/endpoint are wired
+(mirroring the account-service rollout, issue #413), but blocking is a deliberate follow-up flip,
+not bundled here (see ADR-0155).
+
+This is also balance-service's **first** Redis dependency: a new namespace-local `redis`
+Deployment/Service (`openbank-infra/gitops/components/balances/redis.yaml`) backs the
+`RedisApprovalStore` producer — the service's existing money-movement idempotency (V8
+`balance_movement` dedup ledger) stays DB-based and is untouched by this change.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **S**poofing | A caller other than an operator decides an approval | `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` + OPA `@Authorize(action="balance.approval.decide")` on the decide endpoint |
+| **E**oP | The maker approves their own credit/debit request (self-approval defeats maker-checker) | `ApprovalStore.decide` throws `SelfApprovalNotAllowedException` (mapped to 403) when `decidedBy == makerId` — enforced in the domain port itself, not just the REST layer, and `makerId`/`decidedBy` both resolve via the same `.principal.name` extraction (interceptor vs. `SecurityIdentity`) so the comparison can't silently mismatch for the same real person |
+| **T**ampering | A stale, mismatched, or already-consumed `X-Approval-Id` is replayed to unlock a different request | `AuthorizeInterceptor` requires the approval's `action` + `resourceId` + `makerId` to match the CURRENT request exactly, `status == APPROVED`, and marks it `EXECUTED` (one-time use) on success; any mismatch re-issues a fresh pending approval instead of proceeding |
+| **R**epudiation | No record of who approved a gated credit/debit | `PendingApproval.decidedBy` + `decidedAt` recorded in the approval record itself (Redis, TTL-bounded — see ADR-0155 Negative consequences: not yet a permanent audit trail) |
+| **I**nfo disclosure | Approval id enumeration reveals account/action metadata to an unauthorized caller | `find`/`decide` require the caller to already hold a valid, role-gated session; the id itself is a random id (`RedisApprovalStore`, not sequential) |
+| **D**oS | Flooding `POST /{accountId}/credit`\|`/debit` to exhaust Redis with pending approvals | Bounded by the same rate-limit/idempotency controls as the gated endpoints themselves; each `PendingApproval` is TTL-bounded (86400s) so abandoned records expire |
+
+**DFD update:** adds `Operator (checker) → PATCH /api/v1/balances/approvals/{id} → Redis
+(approval:*)` alongside the existing `POST /{accountId}/credit`|`/debit` edges; the maker's retry
+reuses the existing DFD edges. New same-namespace-only trust boundary: `balance-service pod →
+redis.balances.svc:6379` (NetworkPolicy `redis-ingress-allow-list`, in-namespace callers only).
+**Risk class:** integrity (segregation of duties) + confidentiality (approval record scope).
+**Rollback:** `authz.four-eyes.enforce=false` (default) — the endpoint and store exist but do not
+change any existing request's outcome until explicitly flipped; the Redis deployment itself can
+also be deleted (nothing else in balance-service depends on it).
 
 ## 5. Key invariants (must never regress)
 
@@ -106,9 +144,25 @@ Domain layer has zero framework imports (ADR-0002); overdraft + reconciliation m
   retiring any independent balance write path.~~ **Done 2026-06-17** (Phase D-2): projection enabled
   as the sole booked-mover; the transaction saga's direct debit/credit is removed (see change log).
 - Mutation testing (pitest) on overdraft + reconciliation math (ADR-0030 D3).
+- Four-eyes now has the *mechanism* wired (§4a) but not enforced (`authz.four-eyes.enforce=false`)
+  on `balance.credit`/`balance.debit` — flipping it is a deliberate follow-up once the
+  maker/checker runbook is reviewed, tracked under issue #413.
 
 ## 7. Change log
 
+- **2026-07-12** — Wired the four-eyes (maker-checker) enforcement *mechanism* (ADR-0155) onto
+  `balance.credit`/`balance.debit`, mirroring the account-service rollout (issue #413). New
+  `ApprovalConfig` (`RedisApprovalStore` producer) and `PATCH /api/v1/balances/approvals/{id}`
+  checker-decide endpoint (`@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)`, `@Authorize(action =
+  "balance.approval.decide")`); two new exception mappers (`SelfApprovalNotAllowedMapper` → 403,
+  `InvalidApprovalStateMapper` → 409). Also adds balance-service's **first** Redis dependency (a
+  new namespace-local `redis` Deployment/Service under `openbank-infra/gitops/components/balances/`
+  plus a `redis-ingress-allow-list` NetworkPolicy, same-namespace-only) — the pre-existing DB-based
+  movement idempotency (V8 `balance_movement` ledger) is untouched. STRIDE supplement added in §4a
+  above. **`authz.four-eyes.enforce` stays `false`** — no behavior change to any existing request;
+  this PR only wires the mechanism. Rollback: revert the commit (no DB/schema change on the balance
+  schema; `ApprovalStore` records live in the new Redis with a TTL; the Redis deployment can also be
+  deleted, nothing else depends on it).
 - **2026-06-19** — A1 defense-in-depth (issue #628): added per-account ownership check on `getBalances` /
   `getBalance` via new `AccountServiceClient` (M2M REST call to account-service). When the caller
   supplies `X-Customer-Party-Id` the returned balance is scoped to the requesting party — mismatch

--- a/openbank-balance-service/build.gradle.kts
+++ b/openbank-balance-service/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     // DomainMetrics (incl. the outbox-backlog gauge) was a silent no-op. Adding this wires the
     // /q/metrics surface so the gauge actually emits (ADR-0077 / ADR-0079).
     implementation(libs.quarkus.micrometer.registry.prometheus)
+    // Redis-backed ApprovalStore for the four-eyes maker-checker mechanism (ADR-0155).
+    // First Redis usage in balance-service — see ApprovalConfig KDoc.
+    implementation(libs.quarkus.redis.client)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactive)

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/approval/ApprovalConfig.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/approval/ApprovalConfig.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.infrastructure.approval
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+/**
+ * Per-service producer for [ApprovalStore] (ADR-0155). Mirrors the sepa-payment pilot's
+ * `ApprovalConfig` — see [RedisApprovalStore]'s KDoc for why this is a per-service `@Produces`
+ * rather than a libs-side bean. balance-service has no pre-existing `IdempotencyConfig` peer
+ * (its money-movement idempotency is DB-based — see the `balance_movement` dedup ledger, V8
+ * migration) — this is the FIRST Redis wiring in this service, added solely for the
+ * [ReactiveRedisDataSource] this producer consumes.
+ */
+@ApplicationScoped
+class ApprovalConfig {
+    @Produces
+    @ApplicationScoped
+    fun approvalStore(redis: ReactiveRedisDataSource, clock: Clock): ApprovalStore = RedisApprovalStore(redis, clock)
+}

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResource.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.security.Roles
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+/**
+ * Checker-facing endpoint for the four-eyes gate (ADR-0155). Both `POST /{accountId}/credit`
+ * (`balance.credit`) and `POST /{accountId}/debit` (`balance.debit`) are money-moving actions
+ * OPA (`rest.rego`) can flag `four_eyes_required`; either one is paused by
+ * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a `PendingApproval` id, and
+ * a DIFFERENT operator decides it here — this single endpoint handles approvals for BOTH gated
+ * actions, since [ApprovalStore.decide] resolves by approval id regardless of which action
+ * created the pending approval. The maker then retries the original credit/debit call with an
+ * `X-Approval-Id` header.
+ */
+@Path("/api/v1/balances/approvals")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Balance Approvals", description = "Four-eyes decisions for gated balance credit/debit actions")
+class ApprovalResource(private val approvalStore: ApprovalStore) {
+
+    @Inject
+    lateinit var identity: SecurityIdentity
+
+    @PATCH
+    @Path("/{id}")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "balance.approval.decide", resource = "#id")
+    @Operation(summary = "Approve or reject a pending four-eyes approval")
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+        val decided = approvalStore.decide(id, checkerId(), request.approve)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        return Response.ok(decided.toResponse()).build()
+    }
+
+    // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id
+    // (sc.userPrincipal?.name), or approval.makerId and this checker's id would be
+    // formatted differently for the same real person and the self-approval guard
+    // in ApprovalStore.decide could silently fail to catch a maker approving their
+    // own request. SecurityIdentity (not @Context SecurityContext) because this is
+    // a `suspend fun` — see AccountResource.operatorId() for the same workaround.
+    private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+}
+
+data class DecideApprovalRequest(val approve: Boolean)
+
+data class ApprovalResponse(
+    val id: String,
+    val action: String,
+    val resourceId: String?,
+    val status: String,
+    val decidedBy: String?,
+)
+
+fun PendingApproval.toResponse() = ApprovalResponse(
+    id = id,
+    action = action,
+    resourceId = resourceId,
+    status = status.name,
+    decidedBy = decidedBy,
+)

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/rest/ExceptionMappers.kt
@@ -4,7 +4,13 @@
 
 package com.openbank.balance.infrastructure.rest
 
-import com.openbank.balance.application.usecase.*
+import com.openbank.balance.application.usecase.BalanceNotFoundException
+import com.openbank.balance.application.usecase.HoldNotFoundException
+import com.openbank.balance.application.usecase.InsufficientFundsException
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.approval.InvalidApprovalStateException
+import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import com.openbank.libs.domain.identifiers.Ids
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.ext.ExceptionMapper
 import jakarta.ws.rs.ext.Provider
@@ -25,4 +31,41 @@ class InsufficientFundsMapper : ExceptionMapper<InsufficientFundsException> {
 class HoldNotFoundMapper : ExceptionMapper<HoldNotFoundException> {
     override fun toResponse(e: HoldNotFoundException): Response =
         Response.status(404).entity(mapOf("error" to "NOT_FOUND", "message" to e.message)).build()
+}
+
+// ADR-0155: a checker can never decide their own PendingApproval — ApprovalStore.decide
+// enforces this itself (defense-in-depth), surfaced here as a plain 403.
+@Provider
+class SelfApprovalNotAllowedMapper : ExceptionMapper<SelfApprovalNotAllowedException> {
+    override fun toResponse(exception: SelfApprovalNotAllowedException): Response =
+        Response.status(Response.Status.FORBIDDEN)
+            .entity(
+                ApiError(
+                    // ADR-0106: a per-response correlation id, not a durable/indexed identifier — Ids.randomId().
+                    traceId = Ids.randomId().toString(),
+                    status = 403,
+                    code = "FORBIDDEN",
+                    message = exception.message ?: "Forbidden",
+                ),
+            )
+            .build()
+}
+
+// Code review finding: decide()/markExecuted() now reject re-deciding or re-consuming an
+// approval that isn't in the expected status (was previously unguarded, allowing an EXECUTED
+// approval to be flipped back to APPROVED and replayed). Surfaced as a 409, matching the
+// existing BalanceNotFoundMapper-style convention for domain-exception mapping.
+@Provider
+class InvalidApprovalStateMapper : ExceptionMapper<InvalidApprovalStateException> {
+    override fun toResponse(exception: InvalidApprovalStateException): Response =
+        Response.status(Response.Status.CONFLICT)
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = 409,
+                    code = "CONFLICT",
+                    message = exception.message ?: "Conflict",
+                ),
+            )
+            .build()
 }

--- a/openbank-balance-service/src/main/resources/application.yaml
+++ b/openbank-balance-service/src/main/resources/application.yaml
@@ -57,6 +57,9 @@ quarkus:
     credentials:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
 
+  redis:
+    hosts: redis://localhost:6379
+
   rest-client:
     ledger-service:
       url: ${LEDGER_SERVICE_URL:http://localhost:8101}
@@ -205,3 +208,10 @@ opa:
 # logged at WARN, the request still proceeds. Flip to enforce is Phase 5.
 authz:
   enforce: "${AUTHZ_ENFORCE:false}"
+  # ADR-0155: four-eyes ENFORCEMENT (blocking a maker's request pending a second
+  # approver), independent of the base allow/deny enforce toggle above. Stays false
+  # here — this PR only wires the ApprovalStore/endpoint (mirrors the sepa-payment
+  # pilot); flipping this is a deliberate, separate follow-up once the maker/checker
+  # runbook is reviewed, not bundled with the wiring itself.
+  four-eyes:
+    enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/approval/ApprovalConfigTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/approval/ApprovalConfigTest.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.infrastructure.approval
+
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.mockk.mockk
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+/** Unit coverage for the trivial [ApprovalStore][com.openbank.libs.approval.ApprovalStore] producer (ADR-0155). */
+class ApprovalConfigTest {
+
+    @Test
+    fun `approvalStore produces a RedisApprovalStore wired with the given redis and clock`() {
+        val redis = mockk<ReactiveRedisDataSource>()
+        val clock = Clock.systemUTC()
+
+        val store = ApprovalConfig().approvalStore(redis, clock)
+
+        assertThat(store).isInstanceOf(RedisApprovalStore::class.java)
+    }
+}

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.balance.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.PendingApproval
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+/** Unit coverage for the [PendingApproval] -> `ApprovalResponse` mapping (ADR-0155). */
+class ApprovalResourceMappingTest {
+
+    @Test
+    fun `toResponse maps every field including a decided approval`() {
+        val decidedAt = OffsetDateTime.parse("2026-07-12T00:00:00Z")
+        val approval = PendingApproval(
+            id = "appr-1",
+            action = "balance.credit",
+            resourceId = "acc-1",
+            makerId = "maker",
+            status = ApprovalStatus.APPROVED,
+            createdAt = decidedAt.minusHours(1),
+            decidedBy = "checker",
+            decidedAt = decidedAt,
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.id).isEqualTo("appr-1")
+        assertThat(response.action).isEqualTo("balance.credit")
+        assertThat(response.resourceId).isEqualTo("acc-1")
+        assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.decidedBy).isEqualTo("checker")
+    }
+
+    @Test
+    fun `toResponse maps a still-pending approval with a null decidedBy`() {
+        val approval = PendingApproval(
+            id = "appr-2",
+            action = "balance.debit",
+            resourceId = null,
+            makerId = "maker",
+            status = ApprovalStatus.PENDING,
+            createdAt = OffsetDateTime.parse("2026-07-12T00:00:00Z"),
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.resourceId).isNull()
+        assertThat(response.status).isEqualTo("PENDING")
+        assertThat(response.decidedBy).isNull()
+    }
+}

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/it/PostgresRedpandaTestResource.kt
@@ -5,17 +5,22 @@
 package com.openbank.balance.it
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.redpanda.RedpandaContainer
 import org.testcontainers.utility.DockerImageName
 
-/** CI infra sweep (#578) idiom: isolated PostgreSQL + Redpanda (Kafka API) per test JVM.
- *  balance-service boots the @Channel("balance-outbox-out") emitter and two @Incoming
+/** CI infra sweep (#578) idiom: isolated PostgreSQL + Redpanda (Kafka API) + Valkey (Redis) per
+ *  test JVM. balance-service boots the @Channel("balance-outbox-out") emitter and two @Incoming
  *  consumers (ledger-events-in, balance-init-in) without an in-memory switch, so a real
- *  broker is needed at boot. Flyway runs against the container DB (V1..V8). */
+ *  broker is needed at boot. Flyway runs against the container DB (V1..V8). Redis was added for
+ *  ADR-0155's four-eyes ApprovalStore (issue #413) — quarkus-redis-client registers a readiness
+ *  health check, so ANY test booting the full app via this resource now needs a reachable Redis
+ *  or `/q/health/ready` reports DOWN (this bit BalanceApiIT/BalanceBootSmokeIT). */
 class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
     private var postgres: PostgreSQLContainer<*>? = null
     private var redpanda: RedpandaContainer? = null
+    private var redis: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
         val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
@@ -28,6 +33,9 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
         )
         rp.start()
         redpanda = rp
+        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        rd.start()
+        redis = rd
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         val bootstrap = rp.bootstrapServers
@@ -38,11 +46,13 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
             "quarkus.datasource.password" to "openbank_secret",
             "kafka.bootstrap.servers" to bootstrap,
             "mp.messaging.connector.smallrye-kafka.bootstrap.servers" to bootstrap,
+            "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
             "quarkus.devservices.enabled" to "false",
         )
     }
 
     override fun stop() {
+        redis?.stop()
         redpanda?.stop()
         postgres?.stop()
     }

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -70,6 +70,9 @@ spec:
                 secretKeyRef:
                   name: balances-db-app
                   key: password
+            # Redis for the four-eyes ApprovalStore (ADR-0155).
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://redis.balances.svc:6379
             # Kafka → Strimzi tls:9093 (mTLS, ADR-0137 #2665 Tier 1).
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: openbank-cluster-kafka-bootstrap.messaging.svc:9093

--- a/openbank-infra/gitops/components/balances/network-policies.yaml
+++ b/openbank-infra/gitops/components/balances/network-policies.yaml
@@ -79,3 +79,21 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-allow-list
+  namespace: balances
+  labels:
+    app.kubernetes.io/part-of: balances
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/openbank-infra/gitops/components/balances/redis.yaml
+++ b/openbank-infra/gitops/components/balances/redis.yaml
@@ -1,0 +1,83 @@
+# Redis for the four-eyes ApprovalStore (ADR-0155) — balance-service has no other Redis
+# usage (its money-movement idempotency is DB-based, the balance_movement dedup ledger,
+# V8 migration). Ephemeral on purpose — persistence is disabled (--save "" --appendonly
+# no), so a restart just clears in-flight pending approvals, which is acceptable for the
+# sandbox. Prod should use an operator-managed HA Redis. Pinned to the alpine image's
+# redis uid 999/gid 1000 to satisfy PSS restricted; /data is a writable emptyDir so the
+# root fs can stay read-only.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: balances
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: balances
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 192Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: balances
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis


### PR DESCRIPTION
## Summary
Rolls out the ADR-0155 maker-checker mechanism to `openbank-balance-service` (issue #413
batch 2), gating both `balance.credit` and `balance.debit` through a single decide
endpoint. Mirrors the account-service/sepa-payment pilot.

**This is balance-service's first Redis dependency** (its idempotency is DB-based, V8
`balance_movement` table) — this PR adds the Redis infra alongside the mechanism.

- `ApprovalConfig`: per-service `@Produces ApprovalStore` via `RedisApprovalStore`.
- `ApprovalResource`: checker-facing `PATCH /api/v1/balances/approvals/{id}`,
  `@RolesAllowed(OPERATOR, ADMIN)` + `@Authorize(action="balance.approval.decide")`.
  A single endpoint handles both credit and debit approvals — `ApprovalStore.decide`
  resolves by approval id, not by which action created it.
- `ExceptionMappers`: `SelfApprovalNotAllowedMapper` (403), `InvalidApprovalStateMapper` (409).
- `application.yaml`: `authz.four-eyes.enforce` (default `false`) — mechanism only.
- Threat model: STRIDE supplement covering both gated actions.

## Money-path
`balance-service` is money-path — 2-approval + threat-model review per ADR-0030 (threat
model updated in this PR).

## Test plan
- [x] `compileKotlin` + `ktlintCheck` both pass
- [x] All touched YAML validated
- [ ] Post-merge: confirm Redis pod comes up healthy, decide endpoint reachable

Refs #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)