### PR TITLE
feat(transaction): wire four-eyes enforcement mechanism (ADR-0155)

### DIFF
--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -60,6 +60,39 @@ reference/counterparty/amount/date). Holds customer financial movement data.
 | **D**oS | Search flooding (expensive multi-criteria query) | `limit` coerced to ≤200; `offset` ≥0; pagination |
 | **E**oP | Viewer initiates a transaction | Reads exclude write role; initiate = `OPERATOR` only, deny-by-default |
 
+## 4a. Four-eyes approval (ADR-0155) — STRIDE supplement
+
+`POST /{transactionId}/reverse` (`transaction.reverse`) is a money-path action OPA (`rest.rego`) can
+flag `four_eyes_required`. New endpoint `PATCH /api/v1/transactions/approvals/{id}` lets a DIFFERENT
+operator decide the resulting `PendingApproval`; the maker retries `POST /{transactionId}/reverse`
+with an `X-Approval-Id` header. Unlike `account.freeze` (human-only maker), `transaction.reverse`
+also permits `Roles.SERVICE` (M2M) makers — the checker role set below is unaffected by that, since
+**`authz.four-eyes.enforce` stays `false` in this PR** — the `ApprovalStore`/endpoint are wired
+(mirroring the account-service rollout, issue #413), but blocking is a deliberate follow-up flip,
+not bundled here (see ADR-0155).
+
+This service had **no Redis client wired before this change**. The `ApprovalStore` (Redis-backed)
+is wired onto the payments namespace's existing shared Redis instance (`redis.payments.svc:6379`,
+already used by sepa-payment/domestic-payment/sepa-instant for idempotency) rather than a new
+dedicated instance — no new trust boundary or NetworkPolicy edge is introduced; the existing
+`redis-ingress-allow-list` (same-namespace-only) already covers transaction-service as a caller.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **S**poofing | A caller other than an operator decides an approval | `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` + OPA `@Authorize(action="transaction.approval.decide")` on the decide endpoint |
+| **E**oP | The maker approves their own reversal request (self-approval defeats maker-checker) — including an M2M (`Roles.SERVICE`) maker, since `transaction.reverse` permits SERVICE callers | `ApprovalStore.decide` throws `SelfApprovalNotAllowedException` (mapped to 403) when `decidedBy == makerId` — enforced in the domain port itself, not just the REST layer; `makerId`/`decidedBy` both resolve via the same `.principal.name` extraction (interceptor vs. `SecurityIdentity`) so the comparison can't silently mismatch for the same real caller |
+| **T**ampering | A stale, mismatched, or already-consumed `X-Approval-Id` is replayed to unlock a different request | `AuthorizeInterceptor` requires the approval's `action` + `resourceId` + `makerId` to match the CURRENT request exactly, `status == APPROVED`, and marks it `EXECUTED` (one-time use) on success; any mismatch re-issues a fresh pending approval instead of proceeding |
+| **R**epudiation | No record of who approved a gated reversal | `PendingApproval.decidedBy` + `decidedAt` recorded in the approval record itself (Redis, TTL-bounded — see ADR-0155 Negative consequences: not yet a permanent audit trail) |
+| **I**nfo disclosure | Approval id enumeration reveals transaction/action metadata to an unauthorized caller | `find`/`decide` require the caller to already hold a valid, role-gated session; the id itself is a random id (`RedisApprovalStore`, not sequential) |
+| **D**oS | Flooding `POST /{transactionId}/reverse` to exhaust the shared payments Redis with pending approvals | Bounded by the same rate-limit/idempotency controls as the gated endpoint itself; each `PendingApproval` is TTL-bounded (86400s) so abandoned records expire; the Redis instance is already shared/sized for three other services' idempotency traffic |
+
+**DFD update:** adds `Operator (checker) → PATCH /api/v1/transactions/approvals/{id} → Redis
+(approval:*, redis.payments.svc)` alongside the existing `POST /{transactionId}/reverse` edge; the
+maker's retry reuses the existing DFD edge.
+**Risk class:** integrity (segregation of duties) + confidentiality (approval record scope).
+**Rollback:** `authz.four-eyes.enforce=false` (default) — the endpoint and store exist but do not
+change any existing request's outcome until explicitly flipped.
+
 ## 5. Residual risks / assumptions
 
 - **Booked balance is now a ledger projection (ADR-0039 Phase D-2).** The saga no longer debits/credits
@@ -79,6 +112,8 @@ reference/counterparty/amount/date). Holds customer financial movement data.
 - Search authorization is role-coarse — per-account/per-party scoping is OPA's job (ADR-0034 follow-up).
 - A null security principal on initiate falls back to a zero-UUID actor — acceptable only while OIDC
   is mandatory at the gateway; revisit if the gateway becomes optional.
+- Reversal now has the four-eyes *mechanism* wired (§4a) but not enforced
+  (`authz.four-eyes.enforce=false`) — a candidate for a follow-up rollout under issue #413.
 - **Temporal orchestration path (ADR-0120 Phase 1, flag-gated OFF).** When
   `openbank.transaction.orchestration.temporal.enabled=true`, `initiateTransaction` drives the payment
   through a durable `PaymentWorkflow` instead of `PaymentSagaOrchestrator`; activities wrap the **same**
@@ -96,6 +131,16 @@ reference/counterparty/amount/date). Holds customer financial movement data.
 
 ## 6. Change log
 
+- **2026-07-12** — Wired the four-eyes (maker-checker) enforcement *mechanism* (ADR-0155) onto
+  `transaction.reverse`, mirroring the account-service rollout (issue #413). New `ApprovalConfig`
+  (`RedisApprovalStore` producer, wired onto this service's first-ever Redis client — reuses the
+  payments namespace's existing shared Redis instance rather than a new dedicated one) and
+  `PATCH /api/v1/transactions/approvals/{id}` checker-decide endpoint (`@RolesAllowed(Roles.OPERATOR,
+  Roles.ADMIN)`, `@Authorize(action = "transaction.approval.decide")`); two new exception mappers
+  (`SelfApprovalNotAllowedMapper` → 403, `InvalidApprovalStateMapper` → 409). STRIDE supplement added
+  in §4a above. **`authz.four-eyes.enforce` stays `false`** — no behavior change to any existing
+  request; this PR only wires the mechanism. Rollback: revert the commit (no DB/schema change;
+  `ApprovalStore` records live in Redis with a TTL).
 - **2026-07-11** — #747: `PaymentJournalFactory`'s cash-clearing leg (the bank-side leg of a
   one-sided inbound/outbound payment) was hardcoded to the CZK-only GL account regardless of the
   transaction's actual currency, so ledger-service rejected any non-CZK one-sided payment (422,

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -104,6 +104,11 @@ spec:
                 secretKeyRef:
                   name: transaction-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # Redis for the four-eyes ApprovalStore (ADR-0155). Reuses the payments
+            # namespace's existing shared Redis instance (redis.yaml), already used by
+            # sepa-payment/domestic-payment/sepa-instant for idempotency.
+            - name: QUARKUS_REDIS_HOSTS
+              value: redis://redis.payments.svc:6379
             # ADR-0137 image-independent convergence: load the scheme-accepted
             # group.id / DLQ-topic override (transaction-service-msg-override
             # ConfigMap, mounted below) as an external Quarkus config source so

--- a/openbank-transaction-service/build.gradle.kts
+++ b/openbank-transaction-service/build.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.oidc)
     implementation(libs.quarkus.oidc.client.reactive.filter)
+    // Four-eyes ApprovalStore backing store (ADR-0155) — this service had no Redis client
+    // before; wired onto the existing shared payments-namespace Redis instance (gitops).
+    implementation(libs.quarkus.redis.client)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
 

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/approval/ApprovalConfig.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/approval/ApprovalConfig.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.approval
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+/**
+ * Per-service producer for [ApprovalStore] (ADR-0155). Mirrors the account-service
+ * rollout — see [RedisApprovalStore]'s KDoc for why this is a per-service `@Produces`
+ * rather than a libs-side bean.
+ */
+@ApplicationScoped
+class ApprovalConfig {
+    @Produces
+    @ApplicationScoped
+    fun approvalStore(redis: ReactiveRedisDataSource, clock: Clock): ApprovalStore = RedisApprovalStore(redis, clock)
+}

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResource.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.security.Roles
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+/**
+ * Checker-facing endpoint for the four-eyes gate (ADR-0155). A maker's
+ * `POST /{transactionId}/reverse` call on a `four_eyes_required` action is paused by
+ * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a
+ * `PendingApproval` id; a DIFFERENT operator decides it here, then the maker
+ * retries the original call with an `X-Approval-Id` header. Note `transaction.reverse`
+ * also permits `Roles.SERVICE` (M2M) makers, unlike account.freeze's human-only maker
+ * set — this endpoint's checker role set is unaffected either way, since
+ * `authz.four-eyes.enforce` stays false and no blocking behavior is introduced here.
+ */
+@Path("/api/v1/transactions/approvals")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Transaction Approvals", description = "Four-eyes decisions for gated transaction actions")
+class ApprovalResource(private val approvalStore: ApprovalStore) {
+
+    @Inject
+    lateinit var identity: SecurityIdentity
+
+    @PATCH
+    @Path("/{id}")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "transaction.approval.decide", resource = "#id")
+    @Operation(summary = "Approve or reject a pending four-eyes approval")
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+        val decided = approvalStore.decide(id, checkerId(), request.approve)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        return Response.ok(decided.toResponse()).build()
+    }
+
+    // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id
+    // (sc.userPrincipal?.name), or approval.makerId and this checker's id would be
+    // formatted differently for the same real person and the self-approval guard
+    // in ApprovalStore.decide could silently fail to catch a maker approving their
+    // own request. SecurityIdentity (not @Context SecurityContext) because this is
+    // a `suspend fun`.
+    private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+}
+
+data class DecideApprovalRequest(val approve: Boolean)
+
+data class ApprovalResponse(
+    val id: String,
+    val action: String,
+    val resourceId: String?,
+    val status: String,
+    val decidedBy: String?,
+)
+
+fun PendingApproval.toResponse() = ApprovalResponse(
+    id = id,
+    action = action,
+    resourceId = resourceId,
+    status = status.name,
+    decidedBy = decidedBy,
+)

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/ExceptionMappers.kt
@@ -4,6 +4,10 @@
 
 package com.openbank.transaction.infrastructure.rest
 
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.approval.InvalidApprovalStateException
+import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.transaction.application.usecase.TransactionNotFoundException
 import com.openbank.transaction.application.usecase.TransactionUpdateConflictException
 import jakarta.ws.rs.core.MediaType
@@ -42,5 +46,42 @@ class TransactionUpdateConflictExceptionMapper : ExceptionMapper<TransactionUpda
         Response.status(Response.Status.CONFLICT)
             .entity(mapOf("error" to (exception.message ?: "Transaction was modified concurrently")))
             .type(MediaType.APPLICATION_JSON)
+            .build()
+}
+
+// ADR-0155: a checker can never decide their own PendingApproval — ApprovalStore.decide
+// enforces this itself (defense-in-depth), surfaced here as a plain 403.
+@Provider
+class SelfApprovalNotAllowedMapper : ExceptionMapper<SelfApprovalNotAllowedException> {
+    override fun toResponse(exception: SelfApprovalNotAllowedException): Response =
+        Response.status(Response.Status.FORBIDDEN)
+            .entity(
+                ApiError(
+                    // ADR-0106: a per-response correlation id, not a durable/indexed identifier — Ids.randomId().
+                    traceId = Ids.randomId().toString(),
+                    status = 403,
+                    code = "FORBIDDEN",
+                    message = exception.message ?: "Forbidden",
+                ),
+            )
+            .build()
+}
+
+// Code review finding: decide()/markExecuted() now reject re-deciding or re-consuming an
+// approval that isn't in the expected status (was previously unguarded, allowing an EXECUTED
+// approval to be flipped back to APPROVED and replayed). Surfaced as a 409, matching the
+// existing TransactionUpdateConflictExceptionMapper convention for state-machine violations.
+@Provider
+class InvalidApprovalStateMapper : ExceptionMapper<InvalidApprovalStateException> {
+    override fun toResponse(exception: InvalidApprovalStateException): Response =
+        Response.status(Response.Status.CONFLICT)
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = 409,
+                    code = "CONFLICT",
+                    message = exception.message ?: "Conflict",
+                ),
+            )
             .build()
 }

--- a/openbank-transaction-service/src/main/resources/application.yaml
+++ b/openbank-transaction-service/src/main/resources/application.yaml
@@ -58,6 +58,12 @@ quarkus:
     tls:
       verification: none
 
+  # Four-eyes ApprovalStore backing store (ADR-0155). This service had no Redis client
+  # before; in gitops it points at the payments namespace's existing shared Redis instance
+  # (already used by sepa-payment/domestic-payment/sepa-instant idempotency).
+  redis:
+    hosts: redis://localhost:6379
+
   otel:
     exporter:
       otlp:
@@ -196,3 +202,10 @@ opa:
   timeout-ms: "${OPA_TIMEOUT_MS:500}"
 authz:
   enforce: "${AUTHZ_ENFORCE:false}"
+  # ADR-0155: four-eyes ENFORCEMENT (blocking a maker's request pending a second
+  # approver), independent of the base allow/deny enforce toggle above. Stays false
+  # here — this PR only wires the ApprovalStore/endpoint (mirrors the account-service
+  # rollout); flipping this is a deliberate, separate follow-up once the maker/checker
+  # runbook is reviewed, not bundled with the wiring itself.
+  four-eyes:
+    enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/approval/ApprovalConfigTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/approval/ApprovalConfigTest.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.approval
+
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.mockk.mockk
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+/** Unit coverage for the trivial [ApprovalStore][com.openbank.libs.approval.ApprovalStore] producer (ADR-0155). */
+class ApprovalConfigTest {
+
+    @Test
+    fun `approvalStore produces a RedisApprovalStore wired with the given redis and clock`() {
+        val redis = mockk<ReactiveRedisDataSource>()
+        val clock = Clock.systemUTC()
+
+        val store = ApprovalConfig().approvalStore(redis, clock)
+
+        assertThat(store).isInstanceOf(RedisApprovalStore::class.java)
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalExceptionMappersTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalExceptionMappersTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.InvalidApprovalStateException
+import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/** Unit coverage for the ADR-0155 exception mappers (403/409 on the four-eyes decide endpoint). */
+class ApprovalExceptionMappersTest {
+
+    @Test
+    fun `SelfApprovalNotAllowedMapper maps to 403 with the exception message`() {
+        val response = SelfApprovalNotAllowedMapper().toResponse(SelfApprovalNotAllowedException("maker-1"))
+
+        assertThat(response.status).isEqualTo(403)
+        val body = response.entity as ApiError
+        assertThat(body.status).isEqualTo(403)
+        assertThat(body.code).isEqualTo("FORBIDDEN")
+        assertThat(body.message).contains("maker-1")
+    }
+
+    @Test
+    fun `InvalidApprovalStateMapper maps to 409 with the exception message`() {
+        val exception = InvalidApprovalStateException("appr-1", ApprovalStatus.PENDING, ApprovalStatus.EXECUTED)
+
+        val response = InvalidApprovalStateMapper().toResponse(exception)
+
+        assertThat(response.status).isEqualTo(409)
+        val body = response.entity as ApiError
+        assertThat(body.status).isEqualTo(409)
+        assertThat(body.code).isEqualTo("CONFLICT")
+        assertThat(body.message).contains("appr-1")
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceMappingTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceMappingTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.PendingApproval
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+
+/** Unit coverage for the [PendingApproval] -> `ApprovalResponse` mapping (ADR-0155). */
+class ApprovalResourceMappingTest {
+
+    @Test
+    fun `toResponse maps every field including a decided approval`() {
+        val decidedAt = OffsetDateTime.parse("2026-07-12T00:00:00Z")
+        val approval = PendingApproval(
+            id = "appr-1",
+            action = "transaction.reverse",
+            resourceId = "txn-1",
+            makerId = "maker",
+            status = ApprovalStatus.APPROVED,
+            createdAt = decidedAt.minusHours(1),
+            decidedBy = "checker",
+            decidedAt = decidedAt,
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.id).isEqualTo("appr-1")
+        assertThat(response.action).isEqualTo("transaction.reverse")
+        assertThat(response.resourceId).isEqualTo("txn-1")
+        assertThat(response.status).isEqualTo("APPROVED")
+        assertThat(response.decidedBy).isEqualTo("checker")
+    }
+
+    @Test
+    fun `toResponse maps a still-pending approval with a null decidedBy`() {
+        val approval = PendingApproval(
+            id = "appr-2",
+            action = "transaction.reverse",
+            resourceId = null,
+            makerId = "maker",
+            status = ApprovalStatus.PENDING,
+            createdAt = OffsetDateTime.parse("2026-07-12T00:00:00Z"),
+        )
+
+        val response = approval.toResponse()
+
+        assertThat(response.resourceId).isNull()
+        assertThat(response.status).isEqualTo("PENDING")
+        assertThat(response.decidedBy).isNull()
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceTest.kt
@@ -34,7 +34,7 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `decide resolves the checker id from the security identity and returns the mapped response`() = runBlocking {
+    fun `decide resolves the checker id from the security identity and returns the mapped response`(): Unit = runBlocking {
         val decidedAt = OffsetDateTime.parse("2026-07-12T00:00:00Z")
         val approval = PendingApproval(
             id = "appr-1",
@@ -58,7 +58,7 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `decide falls back to anonymous when the security identity has no principal`() = runBlocking {
+    fun `decide falls back to anonymous when the security identity has no principal`(): Unit = runBlocking {
         val store = mockk<ApprovalStore>()
         coEvery { store.decide("appr-2", "anonymous", false) } returns null
 
@@ -68,7 +68,7 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `decide throws NotFoundException when the store finds no matching pending approval`() = runBlocking {
+    fun `decide throws NotFoundException when the store finds no matching pending approval`(): Unit = runBlocking {
         val store = mockk<ApprovalStore>()
         coEvery { store.decide("missing", "checker", true) } returns null
 

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceTest.kt
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.ws.rs.NotFoundException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.security.Principal
+import java.time.OffsetDateTime
+
+/** Unit coverage for [ApprovalResource.decide] (ADR-0155) — the checker-id resolution and
+ *  not-found branch, without booting a full @QuarkusTest. */
+class ApprovalResourceTest {
+
+    private fun resourceWith(store: ApprovalStore, principalName: String?): ApprovalResource {
+        val resource = ApprovalResource(store)
+        val identity = mockk<SecurityIdentity>()
+        val principal = principalName?.let {
+            mockk<Principal>().also { p -> io.mockk.every { p.name } returns it }
+        }
+        io.mockk.every { identity.principal } returns principal
+        resource.identity = identity
+        return resource
+    }
+
+    @Test
+    fun `decide resolves the checker id from the security identity and returns the mapped response`() = runBlocking {
+        val decidedAt = OffsetDateTime.parse("2026-07-12T00:00:00Z")
+        val approval = PendingApproval(
+            id = "appr-1",
+            action = "transaction.reverse",
+            resourceId = "txn-1",
+            makerId = "maker",
+            status = ApprovalStatus.APPROVED,
+            createdAt = decidedAt.minusHours(1),
+            decidedBy = "checker",
+            decidedAt = decidedAt,
+        )
+        val store = mockk<ApprovalStore>()
+        coEvery { store.decide("appr-1", "checker", true) } returns approval
+
+        val response = resourceWith(store, "checker").decide("appr-1", DecideApprovalRequest(approve = true))
+
+        assertThat(response.status).isEqualTo(200)
+        val body = response.entity as ApprovalResponse
+        assertThat(body.id).isEqualTo("appr-1")
+        assertThat(body.status).isEqualTo("APPROVED")
+    }
+
+    @Test
+    fun `decide falls back to anonymous when the security identity has no principal`() = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.decide("appr-2", "anonymous", false) } returns null
+
+        assertThatThrownBy {
+            runBlocking { resourceWith(store, null).decide("appr-2", DecideApprovalRequest(approve = false)) }
+        }.isInstanceOf(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `decide throws NotFoundException when the store finds no matching pending approval`() = runBlocking {
+        val store = mockk<ApprovalStore>()
+        coEvery { store.decide("missing", "checker", true) } returns null
+
+        assertThatThrownBy {
+            runBlocking { resourceWith(store, "checker").decide("missing", DecideApprovalRequest(approve = true)) }
+        }.isInstanceOf(NotFoundException::class.java)
+            .hasMessageContaining("missing")
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/ApprovalResourceTest.kt
@@ -34,28 +34,29 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `decide resolves the checker id from the security identity and returns the mapped response`(): Unit = runBlocking {
-        val decidedAt = OffsetDateTime.parse("2026-07-12T00:00:00Z")
-        val approval = PendingApproval(
-            id = "appr-1",
-            action = "transaction.reverse",
-            resourceId = "txn-1",
-            makerId = "maker",
-            status = ApprovalStatus.APPROVED,
-            createdAt = decidedAt.minusHours(1),
-            decidedBy = "checker",
-            decidedAt = decidedAt,
-        )
-        val store = mockk<ApprovalStore>()
-        coEvery { store.decide("appr-1", "checker", true) } returns approval
+    fun `decide resolves the checker id from the security identity and returns the mapped response`(): Unit =
+        runBlocking {
+            val decidedAt = OffsetDateTime.parse("2026-07-12T00:00:00Z")
+            val approval = PendingApproval(
+                id = "appr-1",
+                action = "transaction.reverse",
+                resourceId = "txn-1",
+                makerId = "maker",
+                status = ApprovalStatus.APPROVED,
+                createdAt = decidedAt.minusHours(1),
+                decidedBy = "checker",
+                decidedAt = decidedAt,
+            )
+            val store = mockk<ApprovalStore>()
+            coEvery { store.decide("appr-1", "checker", true) } returns approval
 
-        val response = resourceWith(store, "checker").decide("appr-1", DecideApprovalRequest(approve = true))
+            val response = resourceWith(store, "checker").decide("appr-1", DecideApprovalRequest(approve = true))
 
-        assertThat(response.status).isEqualTo(200)
-        val body = response.entity as ApprovalResponse
-        assertThat(body.id).isEqualTo("appr-1")
-        assertThat(body.status).isEqualTo("APPROVED")
-    }
+            assertThat(response.status).isEqualTo(200)
+            val body = response.entity as ApprovalResponse
+            assertThat(body.id).isEqualTo("appr-1")
+            assertThat(body.status).isEqualTo("APPROVED")
+        }
 
     @Test
     fun `decide falls back to anonymous when the security identity has no principal`(): Unit = runBlocking {

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/it/PostgresRedpandaTestResource.kt
@@ -7,22 +7,27 @@ package com.openbank.transaction.it
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import org.opentest4j.TestAbortedException
 import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.redpanda.RedpandaContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
- * CI infra sweep (issue #578). Isolated PostgreSQL + Redpanda (Kafka API) per test JVM
- * via Testcontainers, injected as highest-precedence config to override the shared-stack
- * localhost values. transaction-service has an outgoing Kafka channel
+ * CI infra sweep (issue #578). Isolated PostgreSQL + Redpanda (Kafka API) + Valkey (Redis)
+ * per test JVM via Testcontainers, injected as highest-precedence config to override the
+ * shared-stack localhost values. transaction-service has an outgoing Kafka channel
  * (@Channel("transaction-events-out") Emitter) that initialises at boot, so a real broker
- * is needed — Redpanda provides the Kafka API. Docker Hub images -> served by the
- * in-cluster registry-mirror; Ryuk disabled fleet-wide -> stop() tears them down.
+ * is needed — Redpanda provides the Kafka API. Redis was added for ADR-0155's four-eyes
+ * ApprovalStore (issue #413) — quarkus-redis-client registers a readiness health check, so
+ * ANY test booting the full app via this resource now needs a reachable Redis or
+ * `/q/health/ready` reports DOWN. Docker Hub images -> served by the in-cluster
+ * registry-mirror; Ryuk disabled fleet-wide -> stop() tears them down.
  */
 class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
 
     private var postgres: PostgreSQLContainer<*>? = null
     private var redpanda: RedpandaContainer? = null
+    private var redis: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
         if (!DockerClientFactory.instance().isDockerAvailable) {
@@ -46,6 +51,10 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
         }
         redpanda = rp
 
+        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:7.2-alpine")).withExposedPorts(6379)
+        rd.start()
+        redis = rd
+
         val host = pg.host
         val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
         val bootstrap = rp.bootstrapServers
@@ -56,11 +65,13 @@ class PostgresRedpandaTestResource : QuarkusTestResourceLifecycleManager {
             "quarkus.datasource.password" to "openbank_secret",
             "kafka.bootstrap.servers" to bootstrap,
             "mp.messaging.connector.smallrye-kafka.bootstrap.servers" to bootstrap,
+            "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
             "quarkus.devservices.enabled" to "false",
         )
     }
 
     override fun stop() {
+        redis?.stop()
         redpanda?.stop()
         postgres?.stop()
     }


### PR DESCRIPTION
## Summary
Rolls out the ADR-0155 maker-checker mechanism to `openbank-transaction-service` (issue
#413 batch 2), gating `transaction.reverse`. Mirrors the account-service/sepa-payment pilot.

`transaction-service` had no prior Redis client — reuses the `payments` namespace's
**existing shared Redis instance** (already backing sepa-payment/domestic-payment/
sepa-instant idempotency) rather than deploying a redundant one. No NetworkPolicy
change needed — the existing same-namespace ingress rule already covers it.

- `ApprovalConfig`: per-service `@Produces ApprovalStore` via `RedisApprovalStore`.
- `ApprovalResource`: checker-facing `PATCH /api/v1/transactions/approvals/{id}`,
  `@RolesAllowed(OPERATOR, ADMIN)` + `@Authorize(action="transaction.approval.decide")`.
  Doc comment notes `transaction.reverse` itself also permits `ROLE_SERVICE` (M2M)
  makers, unchanged by this PR.
- `ExceptionMappers`: `SelfApprovalNotAllowedMapper` (403), `InvalidApprovalStateMapper` (409).
- `application.yaml`: `authz.four-eyes.enforce` (default `false`) — mechanism only.
- Threat model: new STRIDE supplement + change log.

## Money-path
`transaction-service` is money-path — 2-approval + threat-model review per ADR-0030.

## Test plan
- [x] `ktlintCheck` + `quarkusBuild` both pass
- [x] The shared `payments-services.yaml` edit is scoped to exactly transaction-service's
      own env block (5 lines, one insertion point) — verified no other service in that
      file was touched
- [ ] Post-merge: decide endpoint reachable, no impact to sibling services in the shared
      gitops file

Refs #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)