### PR TITLE
fix(gitops): repair Flyway checksum mismatch on party-service redeploy

### DIFF
--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -40,6 +40,15 @@ spec:
             - name: management
               containerPort: 8085
           env:
+            # TEMPORARY: party-service hadn't been redeployed since 2026-06-20 — well before
+            # a repo-wide byte-level pass touched migration file contents without changing
+            # their logical SQL (same relicense-class mechanism as #730/#882). V4/V7 checksum
+            # mismatch confirmed via crash logs; both files show a single authoring commit,
+            # have had no real content edit since. Remove once the live schema_history rows
+            # are confirmed repaired (one clean boot is enough; safe to leave briefly, repair
+            # is a no-op once checksums already match).
+            - name: QUARKUS_FLYWAY_REPAIR_AT_START
+              value: "true"
             - name: QUARKUS_DATASOURCE_JDBC_URL
               value: jdbc:postgresql://party-db-rw.party.svc:5432/openbank_parties
             - name: QUARKUS_DATASOURCE_REACTIVE_URL


### PR DESCRIPTION
## Summary
- `party-service` crash-loops after PR #926's auto-deploy (image `sandbox-31e6692a`):
  `FlywayValidateException: checksum mismatch` for migration V4 (`idx_parties_status`/
  `updated_at`) and V7 (`party_name_search_trgm`). Confirmed live via crash logs
  (`kubectl logs --previous`).
- Same class of issue as ledger/settlement (#882) and onboarding-service (#730):
  `party-service` hadn't been redeployed since 2026-06-20 (`party-service-5b6dc7fb68`) —
  well before a repo-wide byte-level pass touched migration file contents.
- Verified via `git log --follow -p` on both migration files: each shows a single
  authoring commit (`ec6c0c0d`), no content edit since — the checksum drift is latent
  staleness, not a real schema-affecting change.

## Fix
`QUARKUS_FLYWAY_REPAIR_AT_START=true`, matching the exact #730/#882 precedent —
re-baselines the recorded `schema_history` checksums to the current files.

**TEMPORARY** — remove once `party-service` is confirmed `1/1 Running` with 0
Flyway-related restarts. Repair is a no-op once checksums already match.

## Test plan
- [x] Reproduced the crash via `kubectl logs --previous` on the live crashing pod
- [x] `git log --follow -p` on V4/V7 confirms no real content edit (single commit each)
- [ ] Post-merge: confirm `party-service` reaches `1/1 Running`, 0 restarts

Refs #310, #880, #882