### PR TITLE
fix(sepa-payment): correct invalid TransactionType in the transaction-service pact

### DIFF
--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentTransactionServicePactConsumerTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/contract/SepaPaymentTransactionServicePactConsumerTest.kt
@@ -27,10 +27,16 @@ import org.junit.jupiter.api.extension.ExtendWith
 @PactTestFor(providerName = "openbank-transaction-service", pactVersion = PactSpecVersion.V3)
 class SepaPaymentTransactionServicePactConsumerTest {
 
+    // "type" must be a valid transaction-service TransactionType (DEBIT/CREDIT/TRANSFER/FEE/
+    // INTEREST/REVERSAL/ADJUSTMENT) — the payment scheme itself is carried separately in "rail".
+    // SettlementAdapter.kt sends type="TRANSFER" in production; this pact previously hardcoded
+    // the (invalid) rail-scheme name "SEPA_CREDIT_TRANSFER" here, which transaction-service
+    // rejects with 400 (No enum constant ...TransactionType.SEPA_CREDIT_TRANSFER) — confirmed
+    // live via Pact Broker verification result #2342.
     private val requestBody = """
         {
           "idempotencyKey": "pact-sepa-txn-001",
-          "type": "SEPA_CREDIT_TRANSFER",
+          "type": "TRANSFER",
           "sourceAccountId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
           "amount": 250.00,
           "currencyCode": "EUR",

--- a/pacts/openbank-sepa-payment-openbank-transaction-service.json
+++ b/pacts/openbank-sepa-payment-openbank-transaction-service.json
@@ -18,7 +18,7 @@
           "idempotencyKey": "pact-sepa-txn-001",
           "rail": "SEPA",
           "sourceAccountId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-          "type": "SEPA_CREDIT_TRANSFER",
+          "type": "TRANSFER",
           "valueDate": "2026-01-20"
         },
         "headers": {


### PR DESCRIPTION
## Summary
- `SepaPaymentTransactionServicePactConsumerTest`'s request body hardcoded `type="SEPA_CREDIT_TRANSFER"` — not a valid transaction-service `TransactionType` (`DEBIT`/`CREDIT`/`TRANSFER`/`FEE`/`INTEREST`/`REVERSAL`/`ADJUSTMENT`). The payment scheme itself is already carried separately via `"rail": "SEPA"`; `type` is the generic transaction taxonomy.
- Production code (`SettlementAdapter.kt`) sends `type="TRANSFER"` — the pact simply never matched what the real client sends.
- Confirmed live via Pact Broker verification result #2342: `transaction-service` correctly rejects the pact's request with 400 (`No enum constant ...TransactionType.SEPA_CREDIT_TRANSFER`), which is what's been blocking `can-i-deploy` for `openbank-sepa-payment`.
- The other failure in that same verification result (`MissingStateChangeMethod` for `"a valid source account exists"`) was already fixed on `main` in #840 — this PR is the one remaining gap.

## Test plan
- [x] `:openbank-sepa-payment:compileTestKotlin` — BUILD SUCCESSFUL
- [x] `:openbank-sepa-payment:ktlintCheck` — BUILD SUCCESSFUL
- [ ] CI: the consumer test regenerates+publishes the corrected pact; the `pactbroker.url`-gated `TransactionPactProviderVerificationTest` (transaction-service) then re-verifies it — the actual validation channel, since it's local-skipped without a broker.

Refs #310. Found while investigating `can-i-deploy` blocking `sepa-payment`'s deploy during an unrelated SBOM-attestation/ARC-runner incident today.