### PR TITLE
fix(ledger): include REVERSED entries in all balance-reading queries

### DIFF
--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheJournalRepository.kt
@@ -389,6 +389,15 @@ class PanacheJournalRepository(
     }
 
     companion object {
+        // Balance queries include BOTH 'POSTED' and 'REVERSED' entries (only 'PENDING' is
+        // excluded). A reversal is stored as the original entry (status flipped to REVERSED) plus
+        // a compensating POSTED entry with mirrored sides — immutable history, the pair nets to
+        // zero. Filtering to POSTED alone drops the original's legs while keeping the reversal's,
+        // skewing every touched account by the original's net (issue #939: the deposit-control
+        // balance was off by the reversed originals' sum, and the global debit==credit tie-out
+        // can't catch it because the surviving reversal entry is internally balanced too).
+        private const val BOOKED_STATUSES = "('POSTED', 'REVERSED')"
+
         private val TRIAL_BALANCE_SQL = """
             select ga.id, ga.code, ga.name, ga.type, jl.base_currency,
                    coalesce(sum(case when jl.side = 'D' then jl.base_amount else 0 end), 0) as total_debit,
@@ -396,12 +405,12 @@ class PanacheJournalRepository(
             from journal_lines jl
             join journal_entries je on je.id = jl.journal_id
             join gl_accounts ga on ga.id = jl.gl_account_id
-            where je.status = 'POSTED' and je.entry_date <= :asOf
+            where je.status in $BOOKED_STATUSES and je.entry_date <= :asOf
             group by ga.id, ga.code, ga.name, ga.type, jl.base_currency
             order by ga.code
         """.trimIndent()
 
-        // Fiscal-period aggregation behind the entity-level year close (ADR-0078 D5): POSTED
+        // Fiscal-period aggregation behind the entity-level year close (ADR-0078 D5): booked
         // activity with entry_date INSIDE the period, per GL account. Same shape as
         // TRIAL_BALANCE_SQL, but range-bounded instead of cumulative-to-date.
         private val TRIAL_BALANCE_PERIOD_SQL = """
@@ -411,12 +420,12 @@ class PanacheJournalRepository(
             from journal_lines jl
             join journal_entries je on je.id = jl.journal_id
             join gl_accounts ga on ga.id = jl.gl_account_id
-            where je.status = 'POSTED' and je.entry_date >= :fromDate and je.entry_date <= :toDate
+            where je.status in $BOOKED_STATUSES and je.entry_date >= :fromDate and je.entry_date <= :toDate
             group by ga.id, ga.code, ga.name, ga.type, jl.base_currency
             order by ga.code
         """.trimIndent()
 
-        // Per-customer deposit-control sub-ledger (ADR-0039 Phase B). Only POSTED lines that carry
+        // Per-customer deposit-control sub-ledger (ADR-0039 Phase B). Only booked lines that carry
         // a sub_account_id contribute, grouped by (sub_account_id, base_currency).
         private val SUB_LEDGER_BALANCE_SQL = """
             select jl.sub_account_id, jl.base_currency,
@@ -424,7 +433,7 @@ class PanacheJournalRepository(
                    coalesce(sum(case when jl.side = 'C' then jl.base_amount else 0 end), 0) as total_credit
             from journal_lines jl
             join journal_entries je on je.id = jl.journal_id
-            where je.status = 'POSTED' and je.entry_date <= :asOf and jl.sub_account_id is not null
+            where je.status in $BOOKED_STATUSES and je.entry_date <= :asOf and jl.sub_account_id is not null
             group by jl.sub_account_id, jl.base_currency
             order by jl.sub_account_id, jl.base_currency
         """.trimIndent()
@@ -435,19 +444,19 @@ class PanacheJournalRepository(
                    coalesce(sum(case when jl.side = 'C' then jl.base_amount else 0 end), 0) as total_credit
             from journal_lines jl
             join journal_entries je on je.id = jl.journal_id
-            where je.status = 'POSTED' and je.entry_date <= :asOf and jl.sub_account_id = :subAccountId
+            where je.status in $BOOKED_STATUSES and je.entry_date <= :asOf and jl.sub_account_id = :subAccountId
             group by jl.sub_account_id, jl.base_currency
             order by jl.base_currency
         """.trimIndent()
 
-        // Tie-out: GL aggregate for a control account per currency (ALL posted lines).
+        // Tie-out: GL aggregate for a control account per currency (ALL booked lines).
         private val CONTROL_ACCOUNT_GL_BALANCE_SQL = """
             select jl.base_currency,
                    coalesce(sum(case when jl.side = 'D' then jl.base_amount else 0 end), 0) as total_debit,
                    coalesce(sum(case when jl.side = 'C' then jl.base_amount else 0 end), 0) as total_credit
             from journal_lines jl
             join journal_entries je on je.id = jl.journal_id
-            where je.status = 'POSTED'
+            where je.status in $BOOKED_STATUSES
               and je.entry_date <= :asOf
               and jl.gl_account_id = :controlAccountId
             group by jl.base_currency
@@ -462,7 +471,7 @@ class PanacheJournalRepository(
                    coalesce(sum(case when jl.side = 'C' then jl.base_amount else 0 end), 0) as total_credit
             from journal_lines jl
             join journal_entries je on je.id = jl.journal_id
-            where je.status = 'POSTED'
+            where je.status in $BOOKED_STATUSES
               and je.entry_date <= :asOf
               and jl.gl_account_id = :controlAccountId
               and jl.sub_account_id is not null

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerApiIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerApiIT.kt
@@ -248,4 +248,75 @@ class LedgerApiIT {
             body("status", equalTo("REVERSED"))
         }
     }
+
+    // Regression for #939: a posted-then-reversed pair must be balance-neutral on the trial
+    // balance. The original entry flips to REVERSED and the compensating entry posts with
+    // mirrored sides — immutable history, netting to zero. A status filter of POSTED alone
+    // drops the original's legs but keeps the reversal's, skewing every touched account by the
+    // original's net. The global debit==credit tie-out CANNOT catch that (the surviving
+    // reversal entry is internally balanced too), so this asserts the per-account NET.
+    @Test
+    @Order(11)
+    @TestSecurity(user = "00000000-0000-0000-0000-000000000099", roles = ["ROLE_OPERATOR"])
+    fun `a reversed pair is balance-neutral on the trial balance per account`() {
+        val glAssetId = "a0000000-0000-0000-0000-000000000001"
+        val glLiabilityId = "a0000000-0000-0000-0000-000000000002"
+        val today = LocalDate.now().toString()
+
+        fun netByAccount(): Map<String, java.math.BigDecimal> {
+            val resp = Given { this } When { get("/api/v1/journals/trial-balance?asOf=$today") } Then {
+                statusCode(200)
+            }
+            val lines = resp.extract().jsonPath().getList<Map<String, Any>>("lines")
+            return lines.filter { it["currency"] == "CZK" }.associate {
+                val credit = java.math.BigDecimal(it["totalCredit"].toString())
+                val debit = java.math.BigDecimal(it["totalDebit"].toString())
+                // stripTrailingZeros: BigDecimal.equals is scale-sensitive (300.0 != 300.00) and
+                // the JSON scale grows with the decimals of the amounts posted so far.
+                it["code"] as String to (credit - debit).stripTrailingZeros()
+            }
+        }
+
+        val netBefore = netByAccount()
+
+        val payload = """
+            {
+              "idempotencyKey": "${UUID.randomUUID()}",
+              "transactionId": "${UUID.randomUUID()}",
+              "entryDate": "$today",
+              "valueDate": "$today",
+              "description": "Reversal-neutrality regression (#939)",
+              "createdBy": "$operatorId",
+              "lines": [
+                {"glAccountId": "$glAssetId", "side": "DEBIT", "amount": "123.45",
+                 "currencyCode": "CZK", "baseAmount": "123.45", "baseCurrencyCode": "CZK"},
+                {"glAccountId": "$glLiabilityId", "side": "CREDIT", "amount": "123.45",
+                 "currencyCode": "CZK", "baseAmount": "123.45", "baseCurrencyCode": "CZK"}
+              ]
+            }
+        """.trimIndent()
+        val journalId = (
+            Given {
+                contentType("application/json")
+                body(payload)
+            } When {
+                post("/api/v1/journals")
+            } Then {
+                statusCode(201)
+            }
+            ).extract().jsonPath().getString("id")
+
+        Given {
+            contentType("application/json")
+            body("""{"reason": "Reversal-neutrality regression", "reversedBy": "$operatorId"}""")
+        } When {
+            post("/api/v1/journals/$journalId/reverse")
+        } Then {
+            statusCode(200)
+            body("status", equalTo("REVERSED"))
+        }
+
+        // Post + reverse must leave every account's net position exactly where it started.
+        assertThat(netByAccount()).isEqualTo(netBefore)
+    }
 }


### PR DESCRIPTION
## What
Six balance-reading SQLs in `PanacheJournalRepository` filtered `je.status = 'POSTED'`, silently excluding reversed originals while keeping their compensating POSTED reversals — skewing every touched GL/customer account by the reversed originals' net.

A reversal is immutable-history: the original entry flips to `REVERSED` and a compensating entry posts with mirrored sides; the pair nets to zero. Both must be counted, or neither.

## Live impact (issue #939)
CZK deposit-control balance reported **3,219,564** where the true position is **3,219,764** — a 200 CZK skew from 2 reversed entries on sandbox. The global debit==credit trial-balance tie-out **cannot** catch this: the surviving reversal entry is internally balanced, so totals still tie even though per-account positions are wrong. This also means #860's reconciliation "target" was off by 200 the whole time.

## Change
`status IN ('POSTED','REVERSED')` across all six queries: `TRIAL_BALANCE_SQL`, `TRIAL_BALANCE_PERIOD_SQL` (year-close, ADR-0078 D5), `SUB_LEDGER_BALANCE_SQL`, `SUB_LEDGER_BALANCE_SQL_FILTERED`, `CONTROL_ACCOUNT_GL_BALANCE_SQL`, `CONTROL_ACCOUNT_SUB_LEDGER_SQL`. Extracted the status set to a `BOOKED_STATUSES` constant with the rationale inline.

## Test
`LedgerApiIT`: new regression asserting a posted-then-reversed pair leaves every account's per-account net (credit − debit) exactly where it started — a defect that a POSTED-only filter fails and the global tie-out misses. Full `:openbank-ledger-service:build` green.

## No API / DB change
Response shapes unchanged; no `openapi.yaml` bump, no migration. Pure query-correctness fix.

## Money-path
`ledger` is money-path (2 approvals + threat model). Threat model already exists (`docs/threat-models/openbank-ledger-service.md`); no new attack surface — this only corrects which rows an existing read aggregates.

## Linked issues
Refs #939