### PR TITLE
docs(adr): correct ADR-0139 delivery status — phase 1 substrate + shadow shipped

### DIFF
--- a/docs/adr/0139-ml-decisioning-platform.md
+++ b/docs/adr/0139-ml-decisioning-platform.md
@@ -2,12 +2,14 @@
 
 Date: 2026-06-29
 Decision-Status: Accepted   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
-Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Delivery-Status: Partial    <!-- Planned | Partial | Shipped | N/A — decision-only -->
 Author(s): Jiri Raska
 
-**Delivery note (updated 2026-06-30):**
+**Delivery note (updated 2026-07-12):**
 - **Foundation** — ✅ Ready: governance substrate (ADR-0031 extended by ADR-0141) in place; feature-store topology and model-serving architecture sketched.
-- **Implementation** — ⬜ Pending: feature definition whitelisting, velocity aggregates (H1/H24/D7 windows), online/offline parity enforcement, model registry/cards, and fraud-service integration not yet started; Phase 1 phased pending ADR-0140/0141.
+- **Phase 1 (substrate + shadow)** — 🟡 Partial: the feature-store side (velocity aggregates as declared features, ADR-0140) and the shadow-mode plane are shipped — `MlModelPort`, `FraudScoringService.runShadow` (computes and logs a score alongside the rule verdict, never affects it), and a zero-drift test. The in-process **ONNX Runtime adapter itself is not built yet** — `BaselineFraudModel` is an explicit throwaway placeholder behind `MlModelPort` ("phase-1b" per its own doc comment) so the shadow path could be proven end-to-end before the real model engine lands. This note previously read "not yet started", which was stale and led to a duplicate feature-store port being built from scratch (reverted, see ADR-0140's delivery note).
+- **Phase 2 (registry, drift, explainability)** — ⬜ Pending, blocked on this phase-1b ONNX adapter and ADR-0141.
+- **Phase 3 (enforce in fraud)** / **Phase 4 (credit decisioning, ADR-0142)** — ⬜ Pending.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -142,7 +142,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0136](0136-agent-services-agpl-in-repo-open-core.md) | Agent services licensed AGPL-3.0-only in-repo (open-core) | Accepted | Shipped | — |
 | [0137](0137-kafka-mtls-scheme-accepted-migration.md) | Kafka mTLS migration — topic-scoped enforcement of payment.scheme-accepted | Accepted | Shipped | — |
 | [0138](0138-configuration-driven-product-fee-rule-engine.md) | Configuration-driven product fee rule engine | Accepted | Partial | — |
-| [0139](0139-ml-decisioning-platform.md) | Real-time ML decisioning platform: feature store, model serving, champion/challenger governance | Accepted | Planned | — |
+| [0139](0139-ml-decisioning-platform.md) | Real-time ML decisioning platform: feature store, model serving, champion/challenger governance | Accepted | Partial | — |
 | [0140](0140-feature-store-topology.md) | Feature store topology and point-in-time correctness | Accepted | Partial | — |
 | [0141](0141-model-registry-provenance.md) | Model registry and provenance for ML decisioning | Proposed | Planned | — |
 | [0142](0142-credit-decisioning-engine.md) | Credit decisioning engine on the ML decisioning platform | Proposed | Planned | — |


### PR DESCRIPTION
## Summary
- ADR-0139's `Delivery-Status` said "Planned" / "Implementation... not yet started", but the feature-store integration (ADR-0140) and the shadow-mode plane (`MlModelPort`, `FraudScoringService.runShadow`, zero-drift test) are already on `main`.
- Follow-up to #950: same stale-status class that caused PR #944's duplicate `FeatureStore` port. Checked ADR-0139 for the same risk before building anything further on top of it, per this session's own recent mistake.
- Only the real ONNX Runtime adapter (phase-1b — `BaselineFraudModel` is an explicit placeholder) and phases 2-4 remain undone. Also verified ADR-0141 (model registry) has no matching implementation anywhere — its "Planned" status is accurate, no fix needed there.
- Regenerated `docs/adr/README.md` (derived index) alongside the status fix.

## Test plan
- [x] Verified by grep against `origin/main`, not the ADR text: `MlModelPort`, `BaselineFraudModel`, `FraudScoringService.runShadow`, `FraudScoringShadowZeroDriftTest` all exist and are wired
- [x] Verified ADR-0141 has no matching code (registry/model-card/champion-challenger) — left as-is
- [x] `bash docs/adr/gen-index.sh` — index now matches front matter
- [ ] CI green

Refs N/A — documentation-drift cleanup, no tracked backlog issue.