### PR TITLE
chore(gitops): deploy balance-service sandbox-71c2f7f2 (EoD watchdog + V10 repair)

### DIFF
--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -45,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: balance-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-balance-service:sandbox-e3a4c19d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-balance-service:sandbox-71c2f7f2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## What
Rolls **balance-service** forward from the live `sandbox-e3a4c19d` (2026-07-11) to **`sandbox-71c2f7f2`** (= current `main` HEAD, balance-service 1.10.1).

Clean forward-roll — `e3a4c19d` is an ancestor of `71c2f7f2`, so no regression vs the running pod.

## Why now (direct bump, not auto-deploy)
The fleet auto-deploy is stuck in a **concurrency-cancellation spiral** — every balance deploy run today (#939 image build, the libs fleet-redeploy, a manual `workflow_dispatch`) was **cancelled** under parallel-merge churn, so the watchdog never rolled out. Verified over ~90 min: live pod stayed on `e3a4c19d` while runs cycled queued→cancelled. This bypasses the build step (image already built).

## Brings live
- **`ReconciliationFreshnessWatchdog` (#863)** — hourly ERROR alert when the daily EoD tie-out goes stale/absent. The live pod predates it, so a missed daily control is currently silent.
- **V10 booked-change replay double-count repair (#939).**

## Safety
- `sandbox-71c2f7f2` is already **cosign-signed + SBOM-attested** in ECR (`.sig`/`.att` present for digest `7565f353…`) → Kyverno admission satisfied.
- Image = current `main` HEAD, so zero lag.

Refs #855