### PR TITLE
fix(ci): bake cosign into the runner image, don't download it at runtime (#310)

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -74,35 +74,79 @@ jobs:
             echo "Pin this digest in \`local.runner_image\` (arc-runners.tf) and \`tofu apply\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # cosign is now baked into the image (Dockerfile) — see that file's own comment for
+      # why the previous runtime-download-with-no-retry was the actual root cause of this
+      # workflow's real-world silent attestation failures (issue #310). BUT: this exact
+      # workflow run executes on the runner image that existed BEFORE this fix rolls out
+      # (bootstrapping problem — the fixed image doesn't exist until this run produces it),
+      # so cosign is not guaranteed to be on PATH yet. Fall back to a retrying download only
+      # if it's genuinely missing; once the fixed image is live and pinned in arc-runners.tf,
+      # this whole step becomes a no-op every future run.
+      - name: Ensure cosign is available
+        run: |
+          set -uo pipefail
+          if command -v cosign >/dev/null 2>&1; then
+            echo "cosign already present (baked into the runner image): $(cosign version 2>/dev/null | head -1)"
+            exit 0
+          fi
+          echo "::warning::cosign not baked into this runner image yet (expected on the first run after this fix) — falling back to a retrying download."
+          COSIGN_VERSION="v2.4.3"
+          COSIGN_SHA256="bd0f9763bca54de88699c3656ade2f39c9a1c7a2916ff35601caf23a79be0629"
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+            -o /tmp/cosign-fallback "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-arm64"
+          echo "${COSIGN_SHA256}  /tmp/cosign-fallback" | sha256sum -c -
+          chmod +x /tmp/cosign-fallback
+          sudo mv /tmp/cosign-fallback /usr/local/bin/cosign
+          cosign version
+
       # Supply-chain provenance for the runner image itself (ADR-0030 D4 step 4, issue #310).
       # The kyverno attestation policy (verify-openbank-image-sbom-attestation, Audit) matches
       # openbank-* — the ci-runner image was the last fleet image with neither a signature nor
       # a CycloneDX SBOM attestation, so the Audit PolicyReport could never reach 0 fail and the
       # Enforce graduation stayed blocked. Same KMS key + trivy pattern as auto-deploy.yml.
-      # Non-fatal (continue-on-error): a cosign/trivy hiccup must never block a runner rebuild;
-      # the PolicyReport surfaces a missed attestation on the next audit pass anyway.
+      #
+      # continue-on-error stays: a cosign/trivy hiccup must still never block a runner
+      # rebuild. What changes is the silence — the verify step below makes a real failure
+      # loud (job summary + a dedicated, separately-watchable step) instead of a
+      # single easy-to-miss ::warning buried in this step's log.
       - name: Sign + attest runner image SBOM (cosign + KMS)
-        timeout-minutes: 15
+        id: attest
+        timeout-minutes: 10
         continue-on-error: true
         run: |
           set -uo pipefail
           COSIGN_KEY="awskms:///alias/openbank-cosign-signing"
-          COSIGN_VERSION="v2.4.3"
-          arch="$(uname -m)"; case "$arch" in aarch64) arch=arm64 ;; x86_64) arch=amd64 ;; esac
-          bin="$(command -v cosign || true)"
-          if ! { [ -n "$bin" ] && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; }; then
-            bin="${RUNNER_TEMP}/cosign2"
-            curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-${arch}"
-            chmod +x "$bin"
-          fi
           echo "==> cosign sign ${IMAGE_DIGEST_REF}"
-          COSIGN_YES=true "$bin" sign --key "$COSIGN_KEY" "$IMAGE_DIGEST_REF" \
-            || echo "::warning::cosign sign failed"
+          COSIGN_YES=true cosign sign --key "$COSIGN_KEY" "$IMAGE_DIGEST_REF" \
+            || { echo "::warning::cosign sign failed"; exit 1; }
           sbom="${RUNNER_TEMP}/ci-runner.cdx.json"
-          if trivy image --format cyclonedx --output "$sbom" "$IMAGE_DIGEST_REF" 2>/dev/null; then
-            echo "==> cosign attest (cyclonedx) ${IMAGE_DIGEST_REF}"
-            COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type cyclonedx --predicate "$sbom" "$IMAGE_DIGEST_REF" \
-              || echo "::warning::cosign attest failed"
-          else
-            echo "::warning::trivy image SBOM generation failed — attestation skipped"
+          trivy image --format cyclonedx --output "$sbom" "$IMAGE_DIGEST_REF" \
+            || { echo "::warning::trivy SBOM generation failed"; exit 1; }
+          echo "==> cosign attest (cyclonedx) ${IMAGE_DIGEST_REF}"
+          COSIGN_YES=true cosign attest --key "$COSIGN_KEY" --type cyclonedx --predicate "$sbom" "$IMAGE_DIGEST_REF" \
+            || { echo "::warning::cosign attest failed"; exit 1; }
+
+      # Makes a Sign+attest failure IMPOSSIBLE to miss — the step above can fail silently
+      # from GitHub's UI perspective (continue-on-error), so this step independently
+      # verifies the signature/attestation actually landed and fails LOUDLY (this step has
+      # no continue-on-error) if either is missing, rather than relying on the next Kyverno
+      # Audit pass to eventually notice.
+      - name: Verify signature + attestation actually landed
+        if: always()
+        run: |
+          set -uo pipefail
+          COSIGN_KEY="awskms:///alias/openbank-cosign-signing"
+          FAIL=0
+          if ! cosign verify --key "$COSIGN_KEY" "$IMAGE_DIGEST_REF" >/dev/null 2>&1; then
+            echo "::error::openbank-ci-runner image signature verification FAILED — this image will be rejected by verify-openbank-image-signatures once any pod tries to use it."
+            FAIL=1
           fi
+          if ! cosign verify-attestation --key "$COSIGN_KEY" --type cyclonedx "$IMAGE_DIGEST_REF" >/dev/null 2>&1; then
+            echo "::error::openbank-ci-runner image SBOM attestation verification FAILED — this image will be rejected by verify-openbank-image-sbom-attestation once that policy is Enforce."
+            FAIL=1
+          fi
+          if [ "$FAIL" -eq 1 ]; then
+            echo "See the 'Sign + attest runner image SBOM' step's log above for the underlying error." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "✅ signature + SBOM attestation both verified present on ${IMAGE_DIGEST_REF}"

--- a/openbank-infra/aws/envs/sandbox-platform/runner-image/Dockerfile
+++ b/openbank-infra/aws/envs/sandbox-platform/runner-image/Dockerfile
@@ -10,6 +10,16 @@
 #   * trivy                         — Trivy fs/config scan.
 #   * gitleaks                      — secret-scan.
 #   * yq (+ jq)                      — manifest / label workflows.
+#   * cosign                        — image signing/attestation (runner-image.yml's own
+#                                      supply-chain step, ADR-0030 D4 step 4). Previously
+#                                      downloaded at runtime with no retry logic — a
+#                                      transient GitHub-releases fetch failure silently
+#                                      dropped the runner image's own SBOM attestation
+#                                      (continue-on-error), which is what caused the
+#                                      Kyverno Enforce graduation deadlock (issue #310):
+#                                      no ARC runner using the unattested image could ever
+#                                      start, including the one needed to rebuild it. Baking
+#                                      it in removes the runtime network dependency entirely.
 #   * aws CLI v2                    — _service-ci.yml "Configure CodeArtifact
 #                                      Maven mirror" fetches the repo token via
 #                                      IRSA; without the CLI the step soft-skips
@@ -65,6 +75,8 @@ ARG TRIVY_VERSION=0.70.0
 ARG TRIVY_SHA256=2f6bb988b553a1bbac6bdd1ce890f5e412439564e17522b88a4541b4f364fc8d
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
+ARG COSIGN_VERSION=v2.4.3
+ARG COSIGN_SHA256=bd0f9763bca54de88699c3656ade2f39c9a1c7a2916ff35601caf23a79be0629
 ARG YQ_VERSION=v4.53.2
 ARG AWSCLI_VERSION=2.33.14
 ARG AWSCLI_SHA256=d4914cdbcfccfe151d1f4672bf7aeb81bd7cdfc5edc41425a9e54c900cddab24
@@ -110,6 +122,13 @@ RUN curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEA
  && tar -xz -C /usr/local/bin -f /tmp/gitleaks.tgz gitleaks \
  && rm /tmp/gitleaks.tgz \
  && gitleaks version
+
+# cosign — pinned release binary (not the mutable install script). Verified against
+# cosign's own published cosign_checksums.txt for this release before pinning here.
+RUN curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-arm64" -o /usr/local/bin/cosign \
+ && echo "${COSIGN_SHA256}  /usr/local/bin/cosign" | sha256sum -c - \
+ && chmod +x /usr/local/bin/cosign \
+ && cosign version
 
 # aws CLI v2 — pinned installer zip (sha256 computed from the versioned, immutable
 # release URL; AWS publishes only PGP sigs, no checksum file). Used by the


### PR DESCRIPTION
## Summary

Root cause of the ARC runner deadlock fixed by #908's temporary `PolicyException`:
`runner-image.yml` downloaded `cosign` from GitHub releases at runtime with **no retry
logic**, under `continue-on-error`. A transient fetch failure silently left
`openbank-ci-runner` permanently unattested, and once
`verify-openbank-image-sbom-attestation` graduated to Enforce, no ARC runner using that
image could ever start — including the runner needed to rebuild it. `trivy` was already
baked into the image via a pinned release tarball and was never the actual problem;
`cosign` was the one tool still fetched at runtime.

## Fix

- Bake `cosign` into the Dockerfile using the exact same pinned-version +
  sha256-verified pattern already used for `trivy`/`gitleaks`/`aws-cli` (checksum
  cross-verified against cosign's own published `cosign_checksums.txt` for `v2.4.3`).
  This removes the runtime network dependency entirely going forward.
- **Bootstrapping note**: this workflow run executes on the *pre-fix* runner image
  (cosign not yet baked in, since the fixed image doesn't exist until this run produces
  it) — added a retrying "Ensure cosign is available" step that's a no-op once the fixed
  image is live, falling back to a `--retry-all-errors` download only for this
  transitional run.
- Added a dedicated, **non**-`continue-on-error` verification step after sign+attest
  that runs `cosign verify`/`verify-attestation` against the pushed image and fails
  loudly if either is actually missing. The original design intent (a cosign/trivy
  hiccup must never block a runner rebuild, so the attest step itself keeps
  `continue-on-error`) is preserved — but a real failure is no longer a single
  easy-to-miss `::warning` buried in a log.

## Follow-up (NOT this PR, sequenced)

Once this merges and a `runner-image.yml` run confirms the pushed image passes the new
verify step, remove the temporary `arc-runner-image-exception` `PolicyException` entries
added in #908 — they were a deliberate stopgap to break the deadlock, not a permanent
exemption, and shouldn't outlive the actual fix. Filing this as a distinct next step
rather than bundling it here since it needs live confirmation the new image actually
works before it's safe to remove the safety net.

## Test plan
- [x] `yamllint` — clean (pre-existing unrelated warnings on untouched lines only)
- [x] Dockerfile diff reviewed against the established trivy/gitleaks pinned-checksum
      pattern
- [x] cosign v2.4.3 arm64 checksum independently verified against
      `cosign_checksums.txt` published by the sigstore/cosign release itself
- [ ] Post-merge: confirm this workflow run's "Verify signature + attestation actually
      landed" step passes, then proceed with the PolicyException removal follow-up

Refs #310, #908