### PR TITLE
chore(gitops): auto-deploy services @ 8a35e3adfd4202339209aa67237082475dc7018d

### DIFF
--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: anacredit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-8a35e3ad
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -26,7 +26,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: interest-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-8a35e3ad
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8125}


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 8a35e3adfd4202339209aa67237082475dc7018d.

**Changed services:** ["openbank-interest-service","openbank-anacredit-service"]

Each image tag was updated to `sandbox-8a35e3adfd4202339209aa67237082475dc7018d` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.