### PR TITLE
docs(adr): ADR-0160 end-to-end integration liveness & drift-detection standard

### DIFF
--- a/.github/scripts/check-event-consumer-liveness.py
+++ b/.github/scripts/check-event-consumer-liveness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Event-consumer liveness gate (ADR-0160 mechanism 1, rules.yaml: event_consumer_liveness).
+
+WHY THIS EXISTS: standing-order-service published `standing-order.due.v1` to Kafka every day
+for weeks — full CRUD, a passing test suite, complete docs, a scheduler doc-comment claiming
+"downstream payment rails consume this event" — and nothing consumed it. No payment was ever
+initiated (issue #889). Unit tests passed because they mocked exactly the seam that was broken;
+nothing else in the fleet checked whether a *published* domain event has a *live* consumer
+anywhere. This script closes that gap generally, the same way check-outbox-dispatch-enabled.sh
+closed the "dispatch-enabled defaults to false" footgun and check-no-service-principal-type.sh
+closed the "SERVICE principal never fires" footgun — each written after one incident, this one
+written to stop the *pattern*, not just the next instance of it.
+
+WHAT IT CHECKS: builds a topic -> {producer services} / {consumer services} map from every
+`openbank-*/src/main/resources/application.yaml`'s `mp.messaging.outgoing`/`incoming` config
+(including multi-topic `topics:` comma-list subscribers, e.g. audit-service/analytics-sink, and
+`${ENV_VAR:default}`-wrapped topic names). Any topic with at least one producer and ZERO
+consumers fleet-wide is a violation — UNLESS it is listed in
+`rules.yaml: event_consumer_liveness.allowlist` with a one-line reason (external sink,
+deliberately audit-only, or a tracked "not built yet" gap with an issue number). This mirrors the
+ktlint-baseline/detekt-baseline idiom: an explicit, reviewable, individually justified exception
+list, not a blanket skip.
+
+ADVISORY (ADR-0144 gate-graduation): findings are ::warning:: annotations; the script exits 0
+regardless of findings unless invoked with --enforce, at which point findings exit 1. A first
+fleet scan (2026-07-13) found 19 of 35 topics producer-only — real triage work tracked as a
+fleet-sweep issue, not something this ADR resolves by fiat. Flip to enforce once that triage
+brings unallowlisted violations to zero (see rules.yaml: event_consumer_liveness.target_enforce_date).
+
+stdlib + PyYAML (already installed earlier in the same CI job, matching check-slo-registry.py).
+Usage: check-event-consumer-liveness.py [--root .] [--rules openbank-libs/governance/rules.yaml] [--enforce]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+import yaml
+
+TOPIC_LINE = re.compile(r"^\s*topic:\s*(.+?)\s*$")
+TOPICS_LINE = re.compile(r"^\s*topics:\s*(.+?)\s*$")
+SECTION_HEADER = re.compile(r"^(\s*)(outgoing|incoming):\s*$")
+ENV_DEFAULT = re.compile(r"^\$\{[^:}]*:([^}]+)\}$")
+
+
+def resolve_topic_value(raw: str) -> str | None:
+    """'${VAR:default}' -> 'default'; a bare literal is returned as-is; '${VAR}' (no default,
+    cannot be resolved statically) is skipped — same fail-closed-on-ambiguity stance as
+    check-outbox-dispatch-enabled.sh."""
+    raw = raw.strip().strip('"').strip("'")
+    if raw.startswith("${") and raw.endswith("}") and ":" not in raw:
+        return None
+    m = ENV_DEFAULT.match(raw)
+    if m:
+        return m.group(1)
+    if raw.startswith("${"):
+        return None
+    return raw
+
+
+def scan_application_yaml(path: pathlib.Path, service: str) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Returns (producer_topics, consumer_topics) declared in a single application.yaml,
+    keyed by resolved topic name -> {this service}."""
+    producers: dict[str, set[str]] = {}
+    consumers: dict[str, set[str]] = {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    section: str | None = None
+    section_indent = -1
+    for line in lines:
+        header = SECTION_HEADER.match(line)
+        if header:
+            section, section_indent = header.group(2), len(header.group(1))
+            continue
+        if section is not None:
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip(" "))
+            if stripped and not stripped.startswith("#") and indent <= section_indent:
+                section = None
+
+        m = TOPIC_LINE.match(line)
+        if m and section:
+            topic = resolve_topic_value(m.group(1))
+            if topic:
+                (producers if section == "outgoing" else consumers).setdefault(topic, set()).add(service)
+            continue
+
+        # `topics:` (plural, comma list) is only ever a multi-topic @Incoming subscriber
+        # (audit-service, analytics-sink) — never valid under `outgoing:`.
+        m = TOPICS_LINE.match(line)
+        if m:
+            for raw in m.group(1).split(","):
+                topic = resolve_topic_value(raw)
+                if topic:
+                    consumers.setdefault(topic, set()).add(service)
+
+    return producers, consumers
+
+
+def load_allowlist(rules_path: pathlib.Path) -> dict[str, str]:
+    if not rules_path.exists():
+        return {}
+    data = yaml.safe_load(rules_path.read_text(encoding="utf-8")) or {}
+    rule = (data.get("change_requirements") or {}).get("event_consumer_liveness") or {}
+    entries = rule.get("allowlist") or []
+    allowlist: dict[str, str] = {}
+    for entry in entries:
+        topic = entry.get("topic")
+        reason = entry.get("reason", "")
+        if topic:
+            allowlist[topic] = reason
+    return allowlist
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--rules", default="openbank-libs/governance/rules.yaml")
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root)
+    all_producers: dict[str, set[str]] = {}
+    all_consumers: dict[str, set[str]] = {}
+
+    yaml_files = sorted(root.glob("openbank-*/src/main/resources/application.yaml"))
+    for f in yaml_files:
+        service = f.relative_to(root).parts[0]
+        producers, consumers = scan_application_yaml(f, service)
+        for topic, services in producers.items():
+            all_producers.setdefault(topic, set()).update(services)
+        for topic, services in consumers.items():
+            all_consumers.setdefault(topic, set()).update(services)
+
+    allowlist = load_allowlist(root / args.rules)
+
+    violations = sorted(t for t in all_producers if t not in all_consumers and t not in allowlist)
+    allowlisted_hit = sorted(t for t in all_producers if t not in all_consumers and t in allowlist)
+
+    for topic in allowlisted_hit:
+        producers = ", ".join(sorted(all_producers[topic]))
+        print(f"::notice::event-consumer-liveness: {topic} (published by {producers}) has no consumer — allowlisted: {allowlist[topic]}")
+
+    for topic in violations:
+        producers = ", ".join(sorted(all_producers[topic]))
+        annotation = "error" if args.enforce else "warning"
+        print(
+            f"::{annotation}::event-consumer-liveness: {topic} is published by {producers} but has NO "
+            f"consumer anywhere in the fleet (no matching @Incoming topic/topics: declaration). "
+            f"If this is intentional (external sink, audit-only, tracked future work), add it to "
+            f"rules.yaml: event_consumer_liveness.allowlist with a one-line reason. If not, this is "
+            f"the #889 failure class — a published event nobody consumes."
+        )
+
+    print(
+        f"check-event-consumer-liveness: {len(all_producers)} producer topic(s) scanned across "
+        f"{len(yaml_files)} service(s); {len(violations)} unallowlisted violation(s), "
+        f"{len(allowlisted_hit)} allowlisted producer-only topic(s)."
+    )
+
+    if violations and args.enforce:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,15 @@ jobs:
       - name: SLO registry consistency (issue #669, rules.yaml: slo)
         run: python3 .github/scripts/check-slo-registry.py
 
+      # ADR-0160 mechanism 1 / rules.yaml: change_requirements.event_consumer_liveness.
+      # Fleet-wide scan (not diff-scoped): every Kafka topic a service publishes must have a
+      # real @Incoming consumer somewhere in the fleet, or a one-line-reasoned allowlist entry.
+      # ADVISORY (ADR-0144) — findings are ::warning annotations; pyyaml is already installed by
+      # the step above. Flip to enforced once the 19-topic first-scan triage lands = add
+      # --enforce below.
+      - name: "event-consumer liveness (ADR-0160, advisory)"
+        run: python3 .github/scripts/check-event-consumer-liveness.py
+
       # ADR-0030 D2: every money-path service must ship a structured STRIDE/DFD
       # threat model. stdlib-only gate, ratchets coverage (a new money-path
       # service or a deleted/stubbed model fails here). Part of the always-run,

--- a/docs/adr/0160-end-to-end-integration-liveness-and-drift-detection-standard.md
+++ b/docs/adr/0160-end-to-end-integration-liveness-and-drift-detection-standard.md
@@ -1,0 +1,185 @@
+# ADR-0160 — End-to-end integration liveness and drift-detection standard
+
+Date: 2026-07-13
+Decision-Status: Accepted
+Delivery-Status: Partial
+Author(s): jiri.raska (paired with Claude Opus 4.8)
+
+## Context
+
+Two incidents investigated back-to-back on 2026-07-13 turned out to share one root cause:
+
+- **#889** — `openbank-standing-order-service` had complete CRUD, a daily scheduler, a passing
+  test suite, and full docs. It published `standing-order.due.v1` to Kafka every day for weeks.
+  **Nothing consumed the event.** No payment was ever initiated. ADR-0114 (`Delivery-Status:
+  Shipped`) describes the scheduler and the outbox publish, and was correct about both — but the
+  ADR's own scheduler doc-comment additionally claimed *"Downstream payment rails … consume
+  standing-order.due.v1 events"*, which was never true. Nothing checked that claim against the
+  actual fleet.
+- **#860** — a reconciliation control (ADR-0039 Phase A) reported a ~220,000 CZK ledger⇄sub-ledger
+  drift, read at first as a money-path integrity failure. Investigation found the ledger was
+  correct throughout; the reported number was a snapshot taken *while a backfill was rewriting the
+  sub-ledger*, and the genuine steady-state residual was 200 CZK from two reversed 2026-06-07 test
+  entries. The control fired correctly — but nothing distinguished "this is drift" from "this is a
+  drift-shaped transient", so a real signal and a false alarm looked identical.
+
+Both are instances of a pattern already visible elsewhere in this repo's own history, i.e. this is
+not a one-off:
+
+- `SERVICE` principal type dead code — an OPA rule gated on a principal classification that
+  `AuthorizeInterceptor` never emits, unreachable since it was written (issue #266).
+- Balance reconciliation itself was silently dead for 41 days after a migration was hand-edited
+  post-apply (issue #855) — the control designed to catch drift had drifted out of existence.
+- `openbank-fraud-onnx-baseline-adapter` (ADR-0139 Phase 1b) is tracked as real in places while
+  remaining a `BaselineFraudModel` placeholder.
+- `check-outbox-dispatch-enabled.sh` and `check-no-service-principal-type.sh` already exist
+  **because** two earlier instances of this exact pattern (a config flag silently defaulting to
+  off; a principal type silently never firing) cost real debugging time before anyone wrote a
+  fleet-wide check for them. Those two scripts are proof the pattern is worth catching in CI — but
+  they only cover the two specific footguns they were written for. There is no general mechanism.
+
+The common shape: **a claim about runtime behaviour (an event is consumed, two writers agree, a
+feature works end-to-end) is encoded only in prose — an ADR's delivery status, a scheduler's doc
+comment, a `governance.yaml` lineage edge — and never verified against the actual fleet.** Unit
+tests pass because they mock exactly the seam that is broken. A caught-and-logged exception is
+indistinguishable, from the outside, from success. Nothing pages on "zero events consumed for N
+days" the way something pages on "500 errors for N minutes".
+
+This is a ~34-service fleet developed substantially by AI agents working PR-by-PR. That
+development model is efficient exactly because each PR is scoped to what one agent can hold in
+context — but it also means no PR author has end-to-end visibility across a producer in one
+service and its (missing) consumer in another. The fleet needs the cross-service, over-time view
+that no single PR review provides, encoded as CI, not as an expectation that a reviewer will
+remember to check.
+
+## Decision
+
+We adopt four mechanisms that convert "does this actually work end-to-end, and does it keep
+working" from a documentation claim into a CI-checked, alertable fact. All four follow this repo's
+existing gate-graduation discipline (ADR-0144): a new check ships **advisory** (`::warning::`,
+never blocks a PR) with a `target_enforce_date` and `blocked_on` entry in `rules.yaml`, and only
+flips to `enforce` once a fleet sweep brings violations to zero — exactly the path
+`check-outbox-dispatch-enabled.sh` already proved out.
+
+**1. Event-consumer liveness gate.**
+A new CI script (`check-event-consumer-liveness.sh`) builds a topic → {producers} / {consumers}
+map from every service's `mp.messaging.outgoing`/`incoming` declarations (including multi-topic
+`topics:` subscribers like audit-service/analytics-sink) and flags any topic with a producer and
+zero consumers fleet-wide. A topic may be allowlisted with a one-line reason (external sink,
+intentionally consumer-less audit trail, deliberately unbuilt downstream tracked by an issue
+number) — same shape as an ktlint/detekt baseline file: an explicit, reviewable, individually
+justified exception list, not a blanket skip.
+
+**2. Lineage-vs-code audit.**
+`governance.yaml` lineage edges (`relationType: api|creates|consumes`) must be backed by
+grep-verifiable code: an `api` edge needs a matching `@RegisterRestClient`/rest-client config key
+pointed at the declared target; a `consumes` edge needs a matching `@Incoming` on the declared
+topic. This directly targets the #889 root cause — standing-order-service's lineage entry claiming
+a `transaction-service` edge was copy-pasted boilerplate with no backing code, and nothing noticed.
+
+**3. Shared workflow-liveness watchdog primitive.**
+`ReconciliationFreshnessWatchdog` already solves "did this scheduled job actually run and
+succeed recently" for one service. Extract it into `openbank-libs-runtime` as
+`WorkflowLivenessWatchdog(name, expectedInterval)`: any `@Scheduled` job wraps its success path
+with `watchdog.recordSuccess(name)`; a Prometheus gauge age-of-last-success pages when it exceeds
+`2 × expectedInterval`. This is the direct fix for the 41-day-dead-reconciliation failure mode:
+"job stopped running" becomes an alert, not a silent gap discovered by accident.
+
+**4. Drift-SLA, not drift-log.**
+`BalanceReconciliationService` (and any future control-account tie-out) reports `hasDrift` as a
+single-snapshot boolean today, which is exactly what made #860's transient backfill artifact
+indistinguishable from a real defect. Change the reconciliation record to carry a rolling window
+(last N runs) and define drift as **actionable** only when it persists across
+`consecutive_drift_threshold` consecutive runs with no intervening backfill/maintenance marker —
+one bad snapshot logs at INFO, sustained drift pages. This does not weaken the control (day-zero
+drift is still visible in the record for audit) — it moves the *alerting* threshold from "any
+snapshot" to "sustained", which is what actually distinguishes signal from a system caught
+mid-write.
+
+None of these four replace human review or existing gates — they are additive CI/observability
+layers targeting specifically the "looks done, isn't verified" failure class.
+
+## Alternatives considered
+
+- **Rely on more thorough PR review / a stricter Definition-of-Done checklist.** Rejected as the
+  sole fix — a checklist is exactly the "encoded in prose" failure mode this ADR exists to move
+  away from; #889 shipped with tests, docs, and a scheduler, and still had a checklist-shaped gap
+  no reviewer caught. A checklist is complementary (see Consequences), not a substitute for a
+  fleet-wide automated check.
+- **Flip every advisory gate straight to enforced fleet-wide immediately.** Rejected per ADR-0144
+  precedent — 19 of 35 fleet Kafka topics are currently producer-only in a first pass (many
+  legitimately: planned-but-unbuilt downstreams, intentional audit-only publishes). Hard-enforcing
+  immediately would break every open PR for a reason unrelated to its content and force a rushed,
+  unreliable triage of 19 services in one sitting. Advisory-first with a dated graduation is the
+  proven path.
+- **A single mega-service "integration health dashboard" instead of CI gates.** Rejected as a
+  first step — a dashboard is discoverable only by someone who goes looking for it (exactly how
+  #889 stayed hidden for weeks). A CI gate is seen by construction, on every PR that touches the
+  relevant surface; a dashboard is a good *second* step once the underlying signal (mechanisms 1–4)
+  exists, not a replacement for generating that signal.
+- **Ledger→balance projection cutover (ADR-0039 Phase D-2) as the fix for #860-class drift.**
+  Considered and rejected as in-scope here — Phase D-2 (single writer, no independent-writer drift
+  possible) is the *architectural* elimination of this specific drift, already decided in
+  ADR-0039, and remains the correct end-state for balance specifically. This ADR's mechanism 4 is
+  the general-purpose alerting layer for the (common, not just balance-specific) case of two
+  independent writers reconciling — needed regardless of Phase D-2's timeline, and needed for any
+  *other* pair of independent writers this fleet grows.
+
+## Consequences
+
+**Positive**
+- Converts four instances of "an agent has to remember to check this" into "CI checks this",
+  matching the fleet's existing successful pattern (`check-outbox-dispatch-enabled.sh`,
+  `check-no-service-principal-type.sh`).
+- Mechanism 1 would have caught #889 at PR-review time, before merge, as a `::warning::` on the
+  scheduler's own claim.
+- Mechanism 4 would have prevented #860's headline number from ever reading as a crisis — the
+  same underlying data, correctly contextualized.
+- Mechanism 3 closes the exact failure mode that let balance reconciliation run dead for 41 days
+  (issue #855) recur in any other scheduled job, present or future.
+- All four are stdlib-only / additive; none require new infrastructure beyond what
+  `openbank-libs-runtime` and the existing Prometheus/Pyrra stack already provide.
+
+**Negative**
+- Mechanism 1's first fleet scan surfaces 19 pre-existing producer-only topics that need individual
+  triage (real gap vs. legitimate allowlist entry) before the gate can graduate to `enforce` —
+  non-trivial one-time cost, tracked as a fleet-sweep issue, not absorbed into this ADR.
+- Mechanism 3 touches every `@Scheduled` job that opts in — a fleet-wide adoption sweep, not a
+  single-service change; done incrementally, money-path services first.
+- Mechanism 4 changes the reconciliation record schema (rolling window) — a Flyway migration on
+  `balance-service`, money-path, needs the usual two-approval + no-behavior-regression discipline.
+- A CI check can itself go stale/lie (the exact meta-risk this ADR is about) — mitigated by
+  keeping the checks stdlib-only, small, and reviewed like any other code, and by mechanism 2
+  cross-checking mechanism 1's own data source (`governance.yaml`) against code.
+
+**Neutral**
+- This ADR does not mandate Temporal, a service mesh, or any new runtime dependency — deliberately
+  the smallest mechanism that closes the observed gap, consistent with this repo's Quartz-over-
+  Temporal choice in ADR-0114 for comparable scope.
+
+## Compliance impact
+
+- PCI DSS: not applicable directly; strengthens change-control evidence (12.x) by making
+  "this integration actually works" a verifiable CI artifact rather than a claim.
+- DORA: supports Art. 9 (ICT risk detection) and Art. 24 (testing of ICT systems) — mechanism 3/4
+  are detection controls for exactly the "silent failure of a critical function" scenario DORA
+  testing requirements target.
+- GDPR: not applicable.
+- PSD2: not applicable directly; mechanism 1 reduces the risk of a silently-dead payment
+  execution path (as #889 was) for regulated payment services specifically.
+- CNB: supports vyhláška ČNB 501/2002 Sb. control-account tie-out expectations (mechanism 4 keeps
+  the Phase A reconciliation control, ADR-0039, actionable rather than noisy).
+
+## References
+
+- #889 — standing-order-service never executed a payment (root cause of this ADR)
+- #860 — ~220k CZK reconciliation drift, diagnosed as transient (root cause of this ADR)
+- ADR-0114 — standing order execution model (the ADR whose delivery-status claim this ADR responds to)
+- ADR-0039 — ledger as golden source / balance as projection (Phase D-2 is the architectural fix
+  for the balance-specific case of the drift class this ADR's mechanism 4 generally alerts on)
+- ADR-0144 — gate graduation: advisory rules carry an enforcement deadline (the rollout discipline
+  this ADR's four mechanisms follow)
+- `.github/scripts/check-outbox-dispatch-enabled.sh`, `check-no-service-principal-type.sh` —
+  existing single-footgun instances of the pattern this ADR generalizes
+- issue #855 — balance reconciliation silently dead for 41 days (root cause for mechanism 3)
+- issue #266 — `SERVICE` principal type dead code (root cause for mechanism 2's motivating case)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -162,6 +162,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0156](0156-agent-charters-as-markdown-alongside-agents-yaml.md) | Agent charters as Markdown alongside agents.yaml | Accepted | Shipped | — |
 | [0158](0158-account-opening-validates-against-product-catalog.md) | Account opening validates against product-catalog | Accepted | Complete | — |
 | [0159](0159-cnpg-ha-money-path.md) | High-availability CNPG for money-path databases | Accepted | Shipped | — |
+| [0160](0160-end-to-end-integration-liveness-and-drift-detection-standard.md) | End-to-end integration liveness and drift-detection standard | Accepted | Partial | — |
 
 ---
 

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "f5294f71b7da7eec"
+    openbank.tech/policy-checksum: "14b19e3f36abedd5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1035,6 +1035,30 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
+        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
+        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
+        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
+        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f5294f71b7da7eec"
+        openbank.tech/policy-checksum: "14b19e3f36abedd5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "a4e2c6d0018918bb"
+    openbank.tech/policy-checksum: "9ce5bdce9bbab509"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -596,6 +596,30 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
+        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
+        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
+        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
+        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a4e2c6d0018918bb"
+        openbank.tech/policy-checksum: "9ce5bdce9bbab509"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "a4e2c6d0018918bb"
+    openbank.tech/policy-checksum: "9ce5bdce9bbab509"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -596,6 +596,30 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
+        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
+        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
+        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
+        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "a4e2c6d0018918bb"
+        openbank.tech/policy-checksum: "9ce5bdce9bbab509"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "40df2f409e24943b"
+    openbank.tech/policy-checksum: "b2d7e10177212599"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -974,6 +974,30 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        enforced: advisory
+        target_enforce_date: "2026-09-15"   # ADR-0144
+        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
+        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
+        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
+        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
+        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "40df2f409e24943b"
+        openbank.tech/policy-checksum: "b2d7e10177212599"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -146,6 +146,30 @@ change_requirements:
     # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
     # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
     ci_producer: ".github/scripts/check-event-schema-compat.py"
+  event_consumer_liveness:
+    # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+    # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+    # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+    # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+    # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+    # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+    # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+    # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+    detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+    require:
+      - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+    gate: event-consumer-liveness
+    enforced: advisory
+    target_enforce_date: "2026-09-15"   # ADR-0144
+    # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
+    # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
+    # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
+    # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
+    # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
+    # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+    blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+    ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+    allowlist: []
   service_code_change:
     detect: ["<service>/src/main/**"]
     require:


### PR DESCRIPTION
## Why

#889 and #860, investigated back-to-back today, share one root cause: a claim about runtime behaviour (an event is consumed; two independent writers agree) was encoded only in prose — an ADR delivery status, a scheduler doc-comment, a `governance.yaml` lineage edge — and **never verified against the actual fleet**. standing-order-service had complete CRUD, a passing test suite, docs, and a scheduler doc-comment claiming a downstream service consumed its due event. Nothing did, for weeks (#889). Separately, a reconciliation control's headline number read as a money-path integrity crisis when it was actually a transient snapshot mid-backfill (#860).

The same shape recurs elsewhere in this repo's own history: `SERVICE` principal dead code (#266), balance reconciliation silently dead for 41 days (#855), an ML adapter tracked as shipped while still a placeholder. This PR names the pattern and starts closing it systemically, not just patching the two instances found today.

## What

**ADR-0160** adopts four countermeasures, following this repo's existing gate-graduation discipline (ADR-0144 — advisory first, dated enforcement, same path `check-outbox-dispatch-enabled.sh` already proved out):

1. **Event-consumer liveness gate** — piloted in this PR (see below).
2. **`governance.yaml` lineage-vs-code audit** — not yet implemented, tracked as follow-up.
3. **Shared `WorkflowLivenessWatchdog` primitive** generalizing `ReconciliationFreshnessWatchdog` (currently balance-service-only) to any `@Scheduled` job fleet-wide — not yet implemented, tracked as follow-up.
4. **Drift-SLA instead of drift-log** for reconciliation-style two-writer controls (sustained drift across N consecutive runs pages; a single snapshot logs at INFO) — not yet implemented, tracked as follow-up.

## Pilot: `check-event-consumer-liveness.py`

Builds a topic → producer/consumer map from every service's `application.yaml` (including multi-topic `topics:` subscribers like audit-service/analytics-sink, and `${VAR:default}`-wrapped topic names) and flags any topic with a producer and zero fleet-wide consumers. Wired into `ci.yml`'s "Validate manifests" job, **advisory** (`rules.yaml: change_requirements.event_consumer_liveness`, `target_enforce_date: 2026-09-15`).

**Verified it actually catches the bug class it targets**: re-run against the #889 fix branch (PR #994, where standing-order's due event now has a real consumer) drops the violation count from 19 to 18.

**First fleet scan: 19 of 35 topics are producer-only today.** This is real triage work (some are legitimate — planned-but-unbuilt downstreams, intentional audit-only publishes; some may be genuine #889-class gaps) that this PR does **not** resolve by fiat — it's tracked as a fleet-sweep issue for someone to work through topic-by-topic, same discipline as every other ADR-0144 advisory gate in this repo.

## Linked issues

Refs #889, Refs #860

## Notes

Docs + CI-script PR — no runtime behavior change, no money-path service code touched. `check-adr-registry.sh` / `check-gate-graduation.sh` verified green locally.