### PR TITLE
feat(libs-runtime): WorkflowLivenessWatchdog primitive (ADR-0160 mechanism 3)

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -293,6 +293,44 @@ class DomainMetrics {
         }
     }
 
+    // ── Workflow liveness (ADR-0160 mechanism 3) ────────────────────────────────
+
+    /**
+     * Register the liveness gauges for a scheduled workflow (ADR-0160): age-of-last-success and
+     * its expected interval, both in seconds. A single generic Prometheus rule —
+     * `openbank_workflow_last_success_age_seconds > 2 * on(workflow) openbank_workflow_expected_interval_seconds`
+     * — pages on ANY registered workflow that goes stale, with no per-service alert rule needed.
+     * This exists because a scheduled job can fail SILENTLY (an exception swallowed after logging,
+     * or simply stopping) and leave no record and no alarm — exactly how balance-service's daily
+     * reconciliation ran zero rows for 41 days unnoticed (issue #855) before it got its own
+     * bespoke, log-only watchdog. This is that watchdog, generalized to any `@Scheduled` job.
+     *
+     * Call **once at startup** (e.g. from the caller's constructor) with the workflow's own name
+     * and expected run interval; call [WorkflowLivenessRecorder.recordSuccess] at the end of the
+     * job's success path on every run. A workflow that has never succeeded reads as maximally
+     * stale (age computed from [java.time.Instant.EPOCH]) — no special-casing needed, it is
+     * trivially over any real threshold. Re-registration with the same `workflow` tag is a no-op
+     * gauge re-register (safe, matches [registerOutboxBacklog]); a no-op [WorkflowLivenessRecorder]
+     * is returned when no [MeterRegistry] is resolvable (same fallback as every method above).
+     *
+     * @param workflow          stable low-cardinality name, e.g. `standing-order-execution`
+     * @param expectedInterval  the job's normal run cadence (e.g. `Duration.ofDays(1)` for a daily
+     *                          sweep) — the alert fires at 2x this, so pick the SCHEDULE interval,
+     *                          not a tighter SLA; grace period is baked into the 2x multiplier.
+     */
+    fun registerWorkflowLiveness(workflow: String, expectedInterval: Duration): WorkflowLivenessRecorder {
+        val lastSuccessEpochMillis = java.util.concurrent.atomic.AtomicLong(java.time.Instant.EPOCH.toEpochMilli())
+        reg()?.let { r ->
+            Gauge.builder("openbank.workflow.last_success.age_seconds") {
+                Duration.between(java.time.Instant.ofEpochMilli(lastSuccessEpochMillis.get()), java.time.Instant.now())
+                    .toSeconds().toDouble()
+            }.tag("workflow", workflow).strongReference(true).register(r)
+            Gauge.builder("openbank.workflow.expected_interval_seconds") { expectedInterval.toSeconds().toDouble() }
+                .tag("workflow", workflow).strongReference(true).register(r)
+        }
+        return WorkflowLivenessRecorder(lastSuccessEpochMillis)
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     // Get-or-create the named counter and record one occurrence. Every call site is a
@@ -317,5 +355,18 @@ class DomainMetrics {
             .publishPercentiles(0.5, 0.95, 0.99)
             .publishPercentileHistogram()
             .register(it)
+    }
+}
+
+/**
+ * Handle returned by [DomainMetrics.registerWorkflowLiveness]; call [recordSuccess] at the end of
+ * the workflow's success path on every run. Not a CDI bean — a plain value object held by the
+ * scheduled job that registered it.
+ */
+class WorkflowLivenessRecorder internal constructor(
+    private val lastSuccessEpochMillis: java.util.concurrent.atomic.AtomicLong,
+) {
+    fun recordSuccess() {
+        lastSuccessEpochMillis.set(java.time.Instant.now().toEpochMilli())
     }
 }

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/DomainMetricsTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/observability/DomainMetricsTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import jakarta.enterprise.inject.Instance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
 class DomainMetricsTest {
 
@@ -65,5 +66,46 @@ class DomainMetricsTest {
         dm.registerOutboxBacklog("ledger") { 5 }
         dm.paymentSubmitted("sepa", "EUR")
         dm.outboxDead("ledger")
+        dm.registerWorkflowLiveness("standing-order-execution", Duration.ofDays(1)).recordSuccess()
+    }
+
+    @Test
+    fun `a never-succeeded workflow reads as maximally stale`() {
+        val reg = SimpleMeterRegistry()
+        val dm = withRegistry(reg)
+
+        dm.registerWorkflowLiveness("standing-order-execution", Duration.ofDays(1))
+
+        val age = reg.find("openbank.workflow.last_success.age_seconds")
+            .tag("workflow", "standing-order-execution").gauge()
+        // Age is computed from Instant.EPOCH (1970) — trivially past any real threshold, no
+        // special-casing needed for "this workflow has literally never run".
+        assertThat(age).isNotNull
+        assertThat(age!!.value()).isGreaterThan(Duration.ofDays(365 * 50).toSeconds().toDouble())
+    }
+
+    @Test
+    fun `recordSuccess resets the age gauge close to zero`() {
+        val reg = SimpleMeterRegistry()
+        val dm = withRegistry(reg)
+
+        val recorder = dm.registerWorkflowLiveness("standing-order-execution", Duration.ofDays(1))
+        recorder.recordSuccess()
+
+        val age = reg.find("openbank.workflow.last_success.age_seconds")
+            .tag("workflow", "standing-order-execution").gauge()
+        assertThat(age!!.value()).isLessThan(5.0)
+    }
+
+    @Test
+    fun `expected-interval gauge reports the registered cadence in seconds`() {
+        val reg = SimpleMeterRegistry()
+        val dm = withRegistry(reg)
+
+        dm.registerWorkflowLiveness("balance-reconciliation", Duration.ofHours(25))
+
+        val interval = reg.find("openbank.workflow.expected_interval_seconds")
+            .tag("workflow", "balance-reconciliation").gauge()
+        assertThat(interval!!.value()).isEqualTo(Duration.ofHours(25).toSeconds().toDouble())
     }
 }

--- a/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/scheduler/StandingOrderExecutionScheduler.kt
+++ b/openbank-standing-order-service/src/main/kotlin/com/openbank/standingorder/infrastructure/scheduler/StandingOrderExecutionScheduler.kt
@@ -4,14 +4,19 @@
 
 package com.openbank.standingorder.infrastructure.scheduler
 
+import com.openbank.libs.observability.DomainMetrics
+import com.openbank.libs.observability.WorkflowLivenessRecorder
 import com.openbank.standingorder.application.port.`in`.StandingOrderUseCase
+import io.quarkus.runtime.StartupEvent
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.event.Observes
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.LocalDate
 
 /**
@@ -21,8 +26,15 @@ import java.time.LocalDate
  * The scheduler runs at 03:00 UTC (configurable via openbank.scheduler.execution-cron) with
  * SKIP concurrency so a slow sweep does not overlap with the next day's run.
  *
- * Downstream payment rails (sepa-payment, domestic-payment) consume standing-order.due.v1
- * events; idempotency is keyed on "so-exec-{orderId}-{executionDate}" so redeliveries are safe.
+ * [com.openbank.standingorder.infrastructure.kafka.StandingOrderDueConsumer] self-consumes the
+ * `standing-order.due.v1` events this sweep emits and initiates the real payment (#889) — see
+ * that class for the per-rail dispatch. Idempotency is keyed on
+ * "so-exec-{orderId}-{executionDate}" so redeliveries are safe.
+ *
+ * Carries a [WorkflowLivenessRecorder] (ADR-0160 mechanism 3) so a silently-broken or
+ * silently-stopped sweep pages instead of leaving no trace — the same failure mode that let
+ * balance-service's reconciliation run zero rows for 41 days unnoticed (issue #855) before this
+ * primitive existed to generalize its watchdog to any scheduled job.
  */
 @ApplicationScoped
 class StandingOrderExecutionScheduler {
@@ -33,10 +45,20 @@ class StandingOrderExecutionScheduler {
     @Inject
     lateinit var clock: Clock
 
+    @Inject
+    lateinit var domainMetrics: DomainMetrics
+
     @ConfigProperty(name = "openbank.scheduler.execution-enabled", defaultValue = "true")
     var enabled: Boolean = true
 
     private val log = Logger.getLogger(StandingOrderExecutionScheduler::class.java)
+    private lateinit var liveness: WorkflowLivenessRecorder
+
+    // Registered once at startup (CDI beans are singletons here), not per-run — matches
+    // DomainMetrics.registerOutboxBacklog's own "call once" contract.
+    fun onStart(@Observes @Suppress("UNUSED_PARAMETER") ev: StartupEvent) {
+        liveness = domainMetrics.registerWorkflowLiveness(WORKFLOW_NAME, Duration.ofDays(1))
+    }
 
     @Scheduled(
         cron = "{openbank.scheduler.execution-cron}",
@@ -51,5 +73,13 @@ class StandingOrderExecutionScheduler {
         log.infof("[execution-scheduler] Starting daily execution sweep for %s", today)
         val count = standingOrderUseCase.executeOrders(today)
         log.infof("[execution-scheduler] Daily execution sweep done: %d orders scheduled", count)
+        // Recorded on every successful sweep, including a legitimate "0 orders due today" — the
+        // watchdog tracks that the SWEEP ran, not that it found work; a day with genuinely no due
+        // orders must not read as a missed control.
+        liveness.recordSuccess()
+    }
+
+    private companion object {
+        const val WORKFLOW_NAME = "standing-order-execution"
     }
 }


### PR DESCRIPTION
## What & why

ADR-0160 mechanism 3. `ReconciliationFreshnessWatchdog` (balance-service) already solves "did this scheduled job actually run and succeed recently" — but it's bespoke and log-only, and every OTHER `@Scheduled` job in the fleet has zero equivalent observability. That's exactly how balance-service's own reconciliation ran zero rows for 41 days unnoticed before it got this watchdog (issue #855) — the failure mode isn't service-specific, so the fix shouldn't be either.

## How

`DomainMetrics.registerWorkflowLiveness(workflow, expectedInterval)` — registers two Micrometer gauges per workflow name:
- `openbank.workflow.last_success.age_seconds{workflow="..."}`
- `openbank.workflow.expected_interval_seconds{workflow="..."}`

A **single generic** Prometheus rule (not shipped in this PR — see Follow-ups) covers every registered workflow:
```
openbank_workflow_last_success_age_seconds > 2 * on(workflow) openbank_workflow_expected_interval_seconds
```

A workflow that has never succeeded reads as maximally stale (age computed from `Instant.EPOCH`) with zero special-casing. Same "call once at startup, safe no-op without a `MeterRegistry`" contract as the existing `registerOutboxBacklog`.

## Pilot adopter

`StandingOrderExecutionScheduler`'s daily sweep — #889's own service. It had **zero** freshness observability before this PR (unlike balance-service's reconciliation, which at least had its bespoke watchdog). Registers at startup via `@Observes StartupEvent`; records success at the end of every sweep, including a legitimate "0 orders due today" (the watchdog tracks that the sweep *ran*, not that it *found work* — a quiet day must not read as a missed control).

## Testing

4 new `DomainMetricsTest` cases: gauge samples live, never-succeeded reads as maximally stale, `recordSuccess` resets age near zero, expected-interval gauge reports the registered cadence. `openbank-libs-runtime` (ktlint + detekt + test) and `openbank-standing-order-service` (ktlint + detekt + test + quarkusBuild — CDI wiring) verified green locally.

## Explicitly out of scope for this PR

- Migrating `ReconciliationFreshnessWatchdog` itself onto this primitive, or adopting it on any other `@Scheduled` job — ADR-0160 calls this "a fleet-wide adoption sweep, not a single-service change; done incrementally, money-path services first." One pilot adopter here; the sweep is separate follow-up work.
- The generic Prometheus/`PrometheusRule` CR that actually pages on the two gauges above — the metrics primitive is the prerequisite; wiring the alert rule (and deciding whether it's a plain `PrometheusRule` or folded into the existing Pyrra SLO stack) is a small, separate follow-up.

## Linked issues

Refs #855, Refs ADR-0160

## Notes

No money-path service's *behavior* changes — this is additive observability on one non-money-path scheduler (standing-order-service is not in `rules.yaml: money_path_services`).