### PR TITLE
fix(billing): fail closed when product-catalog read fails during fee assessment

### DIFF
--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/application/usecase/FeeAssessmentService.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/application/usecase/FeeAssessmentService.kt
@@ -40,8 +40,29 @@ class FeeAssessmentService(private val accounts: AccountContextPort, private val
                 skipReason = "ACCOUNT_CONTEXT_UNRESOLVED",
                 assessedFees = emptyList(),
             )
-        val assessed = catalog.billableFees(billing.productId, currency)
-            .map { fee -> assessOne(cycleId, accountId, currency, fee, billing.context) }
+
+        // Fail-closed, same as the account-context branch above: a product-catalog read failure
+        // (e.g. transiently unreachable) must be a visible, explicit skip — not a silent "zero
+        // fees" that looks identical to a product that genuinely has none. Confirmed live during
+        // real-environment verification (ADR-0143) that swallowing this exception at the port
+        // level made the two cases indistinguishable.
+        // TooGenericExceptionCaught/SwallowedException: deliberately catch ANY fault (network
+        // error, timeout, unexpected 5xx) — narrowing this would leave a class of catalog faults
+        // unhandled and silently billing on absent data, exactly what this branch exists to prevent.
+        @Suppress("TooGenericExceptionCaught", "SwallowedException")
+        val fees = try {
+            catalog.billableFees(billing.productId, currency)
+        } catch (e: Exception) {
+            return BillingAssessment(
+                cycleId = cycleId,
+                accountId = accountId,
+                currency = currency,
+                skipped = true,
+                skipReason = "PRODUCT_CATALOG_UNREACHABLE",
+                assessedFees = emptyList(),
+            )
+        }
+        val assessed = fees.map { fee -> assessOne(cycleId, accountId, currency, fee, billing.context) }
         return BillingAssessment(
             cycleId = cycleId,
             accountId = accountId,

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/adapter/RealBillingAdapters.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/adapter/RealBillingAdapters.kt
@@ -68,12 +68,26 @@ class RestBillableAccountDiscoveryPort(@RestClient private val accounts: Account
     }
 }
 
-/** Reads a product's billable fee definitions from the product catalogue (ADR-0143 phase 2c). */
+/**
+ * Reads a product's billable fee definitions from the product catalogue (ADR-0143 phase 2c).
+ *
+ * Deliberately does NOT swallow a catalog-read failure into an empty fee list: found live during
+ * real-environment verification (product-catalog scaled to zero) that the previous
+ * `runCatching { ... }.getOrDefault(emptyList())` here silently reported "this product has zero
+ * billable fees" whenever the catalog was merely unreachable — indistinguishable from a product
+ * that genuinely has no fees, and the OPPOSITE of every other read port in this file
+ * ([RestAccountContextPort], [RestBillableAccountDiscoveryPort]), which all fail closed (skip or
+ * abort) rather than silently substituting a confident-looking empty/zero result. A transient
+ * catalog blip during the monthly scheduled sweep would otherwise silently under-charge every
+ * account for that cycle with no operator-visible signal. Let the exception propagate — the
+ * caller ([com.openbank.billing.application.usecase.FeeAssessmentService]) converts it into an
+ * explicit `skipReason`, matching how an unresolvable account context is already handled.
+ */
 @ApplicationScoped
 class RestProductCatalogPort(@RestClient private val catalog: ProductCatalogRestClient) : ProductCatalogPort {
 
     override suspend fun billableFees(productId: String, currency: String): List<BillableFee> {
-        val fees = runCatching { catalog.getProductFees(productId).awaitSuspending() }.getOrDefault(emptyList())
+        val fees = catalog.getProductFees(productId).awaitSuspending()
         return fees
             .filter { it.currency == currency }
             .map { BillableFee(it.id, it.name, it.type, it.amount, it.currency, it.waivable, it.waiveCondition) }

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/FeeAssessmentServiceTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/FeeAssessmentServiceTest.kt
@@ -32,6 +32,17 @@ class FeeAssessmentServiceTest {
         },
     )
 
+    private fun serviceWithUnreachableCatalog(billing: AccountBilling?) = FeeAssessmentService(
+        object : AccountContextPort {
+            override suspend fun resolve(accountId: String, currency: String): AccountBilling? = billing
+        },
+        object : ProductCatalogPort {
+            @Suppress("TooGenericExceptionThrown")
+            override suspend fun billableFees(productId: String, currency: String): List<BillableFee> =
+                throw RuntimeException("product-catalog unreachable")
+        },
+    )
+
     private fun fee(
         id: String,
         amount: String,
@@ -74,6 +85,16 @@ class FeeAssessmentServiceTest {
         val a = service(null, emptyList()).assess("c", "acc", "CZK")
         assertThat(a.skipped).isTrue()
         assertThat(a.skipReason).isEqualTo("ACCOUNT_CONTEXT_UNRESOLVED")
+        assertThat(a.assessedFees).isEmpty()
+        assertThat(a.journalCommands()).isEmpty()
+    }
+
+    @Test
+    fun `an unreachable product catalog skips the assessment and charges nothing`(): Unit = runBlocking {
+        val billing = AccountBilling("prod-1", FeeContext(currency = "CZK"))
+        val a = serviceWithUnreachableCatalog(billing).assess("c", "acc", "CZK")
+        assertThat(a.skipped).isTrue()
+        assertThat(a.skipReason).isEqualTo("PRODUCT_CATALOG_UNREACHABLE")
         assertThat(a.assessedFees).isEmpty()
         assertThat(a.journalCommands()).isEmpty()
     }

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/RestBillingAdaptersTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/RestBillingAdaptersTest.kt
@@ -124,4 +124,15 @@ class RestBillingAdaptersTest {
         assertThat(fees.single().feeId).isEqualTo("f1")
         assertThat(fees.single().amount).isEqualByComparingTo("5")
     }
+
+    @Test
+    fun `billableFees propagates a failed catalog read instead of failing open`(): Unit = runBlocking {
+        val catalog = mockk<ProductCatalogRestClient>()
+        every { catalog.getProductFees(any()) } returns
+            Uni.createFrom().failure(RuntimeException("product-catalog down"))
+
+        val thrown = runCatching { RestProductCatalogPort(catalog).billableFees("prod-1", "CZK") }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(RuntimeException::class.java)
+    }
 }


### PR DESCRIPTION
## Summary
- `RestProductCatalogPort.billableFees()` silently swallowed any product-catalog read failure into an empty fee list (`runCatching{}.getOrDefault(emptyList())`) — indistinguishable from a product that genuinely has zero fees, and the opposite of every sibling read port in the same file (`RestAccountContextPort`, `RestBillableAccountDiscoveryPort`), which all fail closed (skip/abort) instead.
- A transient catalog outage during the monthly scheduled billing sweep would have silently under-charged every account for that cycle, with no operator-visible signal — found live during ADR-0143 real-environment e2e verification (product-catalog was scaled to zero at the time).
- The port now lets the exception propagate; `FeeAssessmentService.assess()` catches it and returns an explicit `skipped=true, skipReason="PRODUCT_CATALOG_UNREACHABLE"`, mirroring the existing `ACCOUNT_CONTEXT_UNRESOLVED` skip path.

## Test plan
- [x] New unit test in `RestBillingAdaptersTest`: `billableFees propagates a failed catalog read instead of failing open`
- [x] New unit test in `FeeAssessmentServiceTest`: `an unreachable product catalog skips the assessment and charges nothing`
- [x] `:openbank-billing-service:compileTestKotlin :openbank-billing-service:test :openbank-billing-service:ktlintCheck :openbank-billing-service:detekt` all green locally (12/12 tests passing)

Refs #548 (that issue is already closed; this is a specific bug uncovered while finishing its e2e-readiness assessment — the live sandbox verification itself continues separately).

Money-path service (ADR-0030) — threat model already on file at `docs/threat-models/openbank-billing-service.md`.