### PR TITLE
fix(gitops): wire LEDGER_SERVICE_URL into billing-service

### DIFF
--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -64,6 +64,14 @@ spec:
               value: http://account-service.accounts.svc:8100
             - name: BALANCE_SERVICE_URL
               value: http://balance-service.balances.svc:8103
+            # ADR-0143 step 2: BillingOutboxDispatcher posts fee charges to ledger-service over
+            # HTTP (not Kafka — billing has no downstream event consumers for the charge itself).
+            # Missing here, LEDGER_SERVICE_URL falls back to application.yaml's dev default
+            # (http://localhost:8101) inside the pod, so every post-intent dead-letters after
+            # exhausting retries with "circuit breaker is open" — found live during ADR-0143
+            # real-environment e2e verification (issue #548 follow-up).
+            - name: LEDGER_SERVICE_URL
+              value: http://ledger-service.ledger.svc:8101
             # Datasource: single billing-db (billing-db.yaml). Reactive URL for the app
             # (Panache); JDBC URL for Flyway. Both username/password variants set, matching
             # the already-working fraud-service pattern (fraud-service.yaml).

--- a/openbank-infra/gitops/components/ledger/network-policies.yaml
+++ b/openbank-infra/gitops/components/ledger/network-policies.yaml
@@ -41,6 +41,9 @@ spec:
               kubernetes.io/metadata.name: balances
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: billing
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: finrep
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## Summary
- `BillingOutboxDispatcher` posts fee-post-intent events to `ledger-service` over HTTP, but `billing-service.yaml` never declared `LEDGER_SERVICE_URL` alongside its `ACCOUNT_SERVICE_URL`/`BALANCE_SERVICE_URL`/`PRODUCT_CATALOG_SERVICE_URL` siblings — inside the pod it fell back to `application.yaml`'s dev default (`http://localhost:8101`), which nothing listens on.
- Every post-intent outbox entry dead-lettered after exhausting retries (`circuit breaker is open`, `attempt_count=10`), with no operator-visible alert distinguishing this from a genuine ledger-service outage.
- Found live during ADR-0143 real-environment e2e verification: `POST /api/v1/fees/assess` and `POST /api/v1/fees/post` both worked correctly end-to-end (fee correctly computed against a real account: 99 CZK monthly fee, not waived — turnover context unavailable, fails closed per design), but the outbox entry never advanced past `PENDING`/`DEAD`.

## Change
- Adds `LEDGER_SERVICE_URL: http://ledger-service.ledger.svc:8101` to `billing-service.yaml`.
- Regenerates `network-policies.yaml` (`openbank-infra/scripts/gen-network-policies.py`) — `ledger-service`'s ingress allow-list now includes the `billing` namespace, previously undeclared (so even a correctly-configured client would have been NetworkPolicy-dropped anyway).

## Test plan
- [x] `gen-network-policies.py` run; `git diff --stat` confirms only the 2 expected files changed, no unrelated drift
- [ ] Post-merge: re-run the live e2e (assess → post → confirm `postingStatus=POSTED` with a real `journalId`) to close out the ADR-0143 go-live gate

Refs #548 (that issue is already closed; this is a specific bug uncovered while finishing its e2e-readiness assessment).

Money-path service (ADR-0030) — threat model already on file at `docs/threat-models/openbank-billing-service.md`. This is an infra/gitops-only change (no `src/main/**` diff), so no service version bump applies.