### PR TITLE
fix(sca): publish DEVICE_ENROLLED to openbank.sca.events, not sca.challenge.event

### DIFF
--- a/openbank-infra/gitops/components/sca/kafka-sca-mtls.yaml
+++ b/openbank-infra/gitops/components/sca/kafka-sca-mtls.yaml
@@ -3,12 +3,17 @@
 # secret is projected into `sca` via ExternalSecret (kafka-messaging-certs
 # ClusterSecretStore). The cluster-CA truststore is shared and also projected.
 #
-# ACLs: sca-service only publishes SCA challenge events; it does not consume
-# scheme-accepted or any locked-down topic, so only Write+Describe on its own
-# outbound topic is needed. openbank.sca.challenge.event is not ACL-locked
-# (allow.everyone.if.no.acl.found=true covers it), but explicit Write+Describe
-# here ensures the mTLS principal is used and positions the service for a future
-# deny-by-default sweep.
+# ACLs: sca-service publishes the SCA enrollment lifecycle event (DEVICE_ENROLLED) to
+# openbank.sca.events — the topic onboarding-service's read-model projection (ADR-0068)
+# consumes. Bug fix (ADR-0160 #996 triage, 2026-07-13): this ACL previously granted Write
+# only on openbank.sca.challenge.event (the distinct, not-yet-built OTP challenge lifecycle
+# topic) — sca-service's application.yaml matched that same wrong topic name, so the
+# enrollment event was published somewhere nobody (including onboarding, correctly listening
+# on openbank.sca.events) ever consumed. Neither topic is ACL-locked
+# (allow.everyone.if.no.acl.found=true covers both), but explicit Write+Describe here ensures
+# the mTLS principal is used and positions the service for a future deny-by-default sweep. A
+# future OTP-challenge feature adds its own explicit Write grant on
+# openbank.sca.challenge.event when it is actually built — not speculatively kept here.
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
@@ -28,7 +33,7 @@ spec:
     acls:
       - resource:
           type: topic
-          name: openbank.sca.challenge.event
+          name: openbank.sca.events
           patternType: literal
         operations: [Write, Describe]
         host: "*"

--- a/openbank-sca-service/src/main/resources/application.yaml
+++ b/openbank-sca-service/src/main/resources/application.yaml
@@ -140,10 +140,18 @@ mp:
         ssl.truststore.type: ${KAFKA_SSL_TRUSTSTORE_TYPE:PKCS12}
         ssl.truststore.password: ${KAFKA_SSL_TRUSTSTORE_PASSWORD:}
     outgoing:
+      # Bug fix (ADR-0160 #996 triage): this channel only ever publishes DEVICE_ENROLLED — the
+      # long-lived SCA enrollment lifecycle event, per ADR-0068's design and the KafkaTopic
+      # already provisioned for exactly this purpose (openbank-infra/gitops/components/onboarding/
+      # kafka-topics.yaml: "onboarding is the only consumer of the SCA enrollment lifecycle
+      # topic"). It was wired to openbank.sca.challenge.event instead — the OTP CHALLENGE
+      # lifecycle topic (a distinct, not-yet-built feature; see kafka-sca-mtls.yaml) — so
+      # onboarding-service's already-correct sca-events-in listener (subscribed to
+      # openbank.sca.events since its own introduction) never received a single message.
       sca-events-out:
         connector: smallrye-kafka
         client.id: sca-service-${quarkus.uuid}
-        topic: openbank.sca.challenge.event
+        topic: openbank.sca.events
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
 


### PR DESCRIPTION
## What & why

Found via ADR-0160's event-consumer-liveness gate (#996 triage). `sca-service` published every `DEVICE_ENROLLED` event to `openbank.sca.challenge.event`, but nothing ever consumed it — while `onboarding-service`'s `sca-events-in` listener (ADR-0068 read-model projection) has been correctly subscribed to `openbank.sca.events` the whole time. That exact topic is already provisioned in gitops specifically for this purpose (`kafka-topics.yaml`: *"onboarding is the only consumer of the SCA enrollment lifecycle topic"*).

`openbank.sca.challenge.event` is a real, separately-provisioned topic reserved for a **not-yet-built OTP challenge-lifecycle feature** (see `kafka-sca-mtls.yaml`'s old comment) — so this isn't two features sharing a channel, it's a topic-**name** typo/mismatch. The payload sca-service publishes (`eventType`, `partyId`, `credentialId`, `occurredAt`) already matches onboarding's `parseScaEvent` exactly — this is purely a config fix, no behavior/logic change on either side.

## Changes

1. `openbank-sca-service/src/main/resources/application.yaml`: `sca-events-out.topic` → `openbank.sca.events`.
2. `openbank-infra/gitops/components/sca/kafka-sca-mtls.yaml`: sca-service's mTLS `KafkaUser` ACL moved from `Write+Describe` on the wrong topic to the correct one (least-privilege — no lingering grant on the now-unused topic; a future OTP-challenge feature adds its own grant when it's actually built).

## Verified

- `check-event-consumer-liveness.py` (ADR-0160): violation count drops **18 → 17**, `openbank.sca.events`/`openbank.sca.challenge.event` no longer producer-only.
- `gen-network-policies.py`: no diff (topic ACL is orthogonal to pod-network reachability).
- `openbank-sca-service`: ktlint + detekt + test + quarkusBuild (CDI wiring) all green locally.
- No test hardcodes the literal topic string (tests switch by channel name `sca-events-out`, unaffected).

## Linked issues

Refs #996

## Notes

`sca-service` is in `rules.yaml: money_path_services` → needs 2 approvals. Not merging this myself.