### PR TITLE
fix(audit): consume clearing.batch.event + security.ict/scan.event

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -35,11 +35,7 @@ class AuditConsumer {
                 id = UUID.randomUUID(),
                 eventType = node["eventType"]?.asText() ?: "UNKNOWN",
                 aggregateType = node["aggregateType"]?.asText() ?: inferAggregateType(node),
-                aggregateId = node["accountId"]?.asText()
-                    ?: node["partyId"]?.asText()
-                    ?: node["transactionId"]?.asText()
-                    ?: node["consentId"]?.asText()
-                    ?: "unknown",
+                aggregateId = inferAggregateId(node),
                 actorId = node["requestedBy"]?.asText()
                     ?: node["actorId"]?.asText()
                     // transaction.initiated events carry the customer identity here (ADR-0021).
@@ -57,12 +53,28 @@ class AuditConsumer {
         }
     }
 
+    private fun inferAggregateId(node: JsonNode): String = node["accountId"]?.asText()
+        ?: node["partyId"]?.asText()
+        ?: node["transactionId"]?.asText()
+        ?: node["consentId"]?.asText()
+        // clearing.batch.event: publishBatchSettled/publishItemCleared carry batchId/itemId, not a
+        // shared aggregate field name (PR #1007).
+        ?: node["batchId"]?.asText()
+        ?: node["itemId"]?.asText()
+        // security.ict.incident: IctIncidentService.publishEvent nests the incident under
+        // "incident" rather than a top-level id field (PR #1007).
+        ?: node["incident"]?.get("id")?.asText()
+        ?: "unknown"
+
     private fun inferAggregateType(node: JsonNode): String = when {
         node.has("accountId") -> "ACCOUNT"
         node.has("partyId") -> "PARTY"
         node.has("transactionId") -> "TRANSACTION"
         node.has("consentId") -> "CONSENT"
         node.has("kycCaseId") -> "KYC_CASE"
+        node.has("batchId") -> "CLEARING_BATCH"
+        node.has("itemId") -> "CLEARING_ITEM"
+        node.has("incident") -> "ICT_INCIDENT"
         else -> "UNKNOWN"
     }
 }

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -116,7 +116,14 @@ mp:
       audit-events-in:
         connector: smallrye-kafka
         client.id: audit-service-${quarkus.uuid}
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit
+        # clearing.batch.event / security.ict.incident / security.scan.event added (ADR-0160 #996
+        # triage): each publisher's own docs name audit-service as the SOLE intended consumer
+        # (clearing: "downstream audit consumers persist it for the statutory period"; scanner:
+        # "Consumed by audit-service for tamper-evident 10-year retention" per DORA Art. 17). All
+        # three were publish-with-zero-consumer since introduction. AuditConsumer.consume() is
+        # generic (stores payload verbatim, best-effort field extraction with "unknown" fallbacks)
+        # — no code change needed to accept a new topic's shape.
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -67,6 +67,68 @@ class AuditConsumerTest {
     }
 
     @Test
+    fun `consume extracts batchId as aggregateId for a clearing batch-settled event`(): Unit = runBlocking {
+        val batchId = UUID.randomUUID()
+        val payload = """
+            {"eventType":"openbank.clearing.batch.settled","batchId":"$batchId","rail":"SEPA"}
+        """.trimIndent()
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.eventType == "openbank.clearing.batch.settled" &&
+                        it.aggregateType == "CLEARING_BATCH" &&
+                        it.aggregateId == batchId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts itemId as aggregateId for a clearing item-cleared event`(): Unit = runBlocking {
+        val itemId = UUID.randomUUID()
+        val payload = """{"eventType":"openbank.clearing.item.cleared","itemId":"$itemId"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "CLEARING_ITEM" && it.aggregateId == itemId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts the nested incident id for an ICT incident event`(): Unit = runBlocking {
+        val incidentId = UUID.randomUUID()
+        val payload = """
+            {"eventType":"ICT_INCIDENT_REPORTED","incident":{"id":"$incidentId","severity":"P1_CRITICAL"}}
+        """.trimIndent()
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.eventType == "ICT_INCIDENT_REPORTED" &&
+                        it.aggregateType == "ICT_INCIDENT" &&
+                        it.aggregateId == incidentId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
     fun `consume swallows malformed payloads without persisting`() {
         assertThatCode {
             runBlocking { consumer.consume("{bad-json") }

--- a/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherImpl.kt
+++ b/openbank-clearing-service/src/main/kotlin/com/openbank/clearing/infrastructure/kafka/ClearingEventPublisherImpl.kt
@@ -32,6 +32,9 @@ class ClearingEventPublisherImpl @Inject constructor(
             eventType = BATCH_SETTLED_EVENT,
             payload = objectMapper.writeValueAsString(
                 mapOf(
+                    // eventType is also on OutboxMessage.eventType (-> Kafka header, ce-type), but
+                    // AuditConsumer (PR #1007) reads only the JSON body, so it is duplicated here.
+                    "eventType" to BATCH_SETTLED_EVENT,
                     "batchId" to batch.id,
                     "batchReference" to batch.batchReference,
                     "rail" to batch.rail.name,
@@ -53,6 +56,7 @@ class ClearingEventPublisherImpl @Inject constructor(
             eventType = ITEM_CLEARED_EVENT,
             payload = objectMapper.writeValueAsString(
                 mapOf(
+                    "eventType" to ITEM_CLEARED_EVENT,
                     "itemId" to item.id,
                     "batchId" to item.batchId,
                     "paymentId" to item.paymentId,

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -2,9 +2,13 @@
 #
 # Identity model (ADR-0137): mTLS gives each service exactly one client cert =
 # one KafkaUser = one principal for ALL of its Kafka traffic. The audit-service
-# is a pure consumer of domain events across 7 topics; it only needs Read+Describe
+# is a pure consumer of domain events across 10 topics; it only needs Read+Describe
 # ACLs on those topics and Read on its consumer group. Topics not listed here
 # stay open under allow.everyone.if.no.acl.found=true (see kafka.yaml).
+#
+# clearing.batch.event / security.ict.incident / security.scan.event added (ADR-0160
+# #996 triage): each was published with zero consumers since introduction — audit-service
+# is the sole intended consumer per the publishing services' own docs.
 #
 # Strimzi User Operator mints a per-user Secret in `messaging` (user.crt/key/p12
 # + user.password + ca.crt). Those secrets are projected into the `audit` namespace
@@ -64,6 +68,24 @@ spec:
       - resource:
           type: topic
           name: openbank.customer.audit
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.clearing.batch.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.security.ict.incident
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.security.scan.event
           patternType: literal
         operations: [Read, Describe]
         host: "*"


### PR DESCRIPTION
## What & why

Found via ADR-0160's event-consumer-liveness gate (#996 triage). Three topics were published with zero consumers since introduction, each with the publishing service's own docs naming `audit-service` as the sole intended consumer:

- `openbank.clearing.batch.event` — clearing-service docs: *"downstream audit consumers persist it for the statutory period"*
- `openbank.security.ict.incident` / `openbank.security.scan.event` — security-scanner docs: *"Consumed by audit-service for tamper-evident 10-year retention... required by DORA Art. 17 and CNB inspection requirements"*

Unlike some of the other #996 findings (e.g. `sepa.payment.events`), these three have **no other** documented downstream consumer beyond audit — the entire intended purpose is the compliance audit trail, so adding them to `audit-service`'s existing multi-topic listener fully closes the gap (not a partial fix).

## Changes

1. `openbank-audit-service/src/main/resources/application.yaml`: 3 topics added to `audit-events-in`'s `topics:` list. `AuditConsumer.consume()` is a generic, defensive parser (stores the raw payload verbatim; best-effort field extraction with `"unknown"` fallbacks) — no code change needed.
2. `openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml`: matching `Read+Describe` ACLs added to the audit-service `KafkaUser`. Neither `clearing-service` nor `security-scanner` has its own mTLS `KafkaUser`, so both already publish under `allow.everyone.if.no.acl.found=true` — no publisher-side change needed.

## Verified

- `check-event-consumer-liveness.py`: violation count drops **17 → 15**.
- `gen-network-policies.py`: no diff.
- `openbank-audit-service`: ktlint + detekt + test + quarkusBuild all green locally.

## Linked issues

Refs #996

## Notes

`audit-service` is not in `rules.yaml: money_path_services` — standard (not 2-approval) review applies, but still not merging without one.