### PR TITLE
fix(ledger): add broker-based Pact provider verification for billing-service

### DIFF
--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.contract
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider
+import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Broker-side provider verification for ledger-service, published-result counterpart to
+ * [LedgerPactProviderVerificationTest] (issue #1009).
+ *
+ * `_service-ci.yml`'s "Publish consumer pacts to broker" step runs unconditionally for every
+ * consumer service on a main push, including billing-service's `postJournal` contract
+ * (`BillingLedgerPostJournalPactConsumerTest`). But ledger-service's only provider verification
+ * was git-pact (`@PactFolder`, ADR-0063 pilot for balance-service) — nothing ever pulled
+ * billing-service's pact BACK OUT of the broker to verify it and publish a result, so
+ * `can-i-deploy` permanently saw "no verified pact" for billing-service <-> ledger-service and
+ * blocked every ledger-service deploy touching that pair (confirmed live: #945 merged clean,
+ * built green, but sat undeployed on this gate).
+ *
+ * A second `@Provider("openbank-ledger-service")` class is safe here (unlike the collision
+ * CLAUDE.md warns about): that footgun is HTTP vs MESSAGE target dispatch fighting over the same
+ * `@BeforeEach`; ledger-service has no message-consumer contracts, both classes here use
+ * [HttpTestTarget] exclusively, so verifying the same interaction from two pact sources is at
+ * worst redundant, never colliding.
+ *
+ * Gated on `pactbroker.url`: skipped locally and on PR-lane CI (no broker configured there,
+ * matching every other broker-based provider test in the fleet) — the git-pact class keeps
+ * running unconditionally regardless, so balance-service coverage (ADR-0063's whole point:
+ * zero-infra-dependency verification) is unaffected by this addition.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.ledger.it.PostgresRedpandaTestResource::class)
+@TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
+@Provider("openbank-ledger-service")
+@PactBroker
+@IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
+class LedgerPactBrokerProviderVerificationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")
+    lateinit var testPort: String
+
+    @BeforeEach
+    fun configureTarget(context: PactVerificationContext?) {
+        context?.target = HttpTestTarget("localhost", testPort.toInt())
+        context?.addStateChangeHandlers(this)
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider::class)
+    fun verifyPacts(context: PactVerificationContext?) {
+        context?.verifyInteraction()
+    }
+
+    /**
+     * Same state as [LedgerPactProviderVerificationTest.stateWithSeededChartOfAccounts] — no
+     * setup needed, the V3/V5 Flyway migrations seed the standard chart into the fresh
+     * Testcontainer DB (billing-service's postJournal contract posts against real, enabled leaf
+     * GL accounts a0000000-...-002 and a0000000-...-004003).
+     */
+    @State("the standard chart of accounts is seeded")
+    fun stateWithSeededChartOfAccounts() {
+        // No-op — see docstring.
+    }
+}


### PR DESCRIPTION
## What
Adds `LedgerPactBrokerProviderVerificationTest` — a broker-based Pact provider verification for `openbank-ledger-service`, covering billing-service's `postJournal` contract.

## Root cause (issue #1009)
`_service-ci.yml` unconditionally publishes every consumer's pact to the Pact Broker on a main push, including billing-service's `BillingLedgerPostJournalPactConsumerTest`. But ledger-service's only provider verification was **git-pact** (`LedgerPactProviderVerificationTest`, `@PactFolder`, ADR-0063's zero-infra balance-service pilot) — nothing ever pulled billing-service's pact back out of the broker to verify + publish a result. `can-i-deploy` therefore permanently saw "no verified pact" for billing-service ↔ ledger-service and blocked every ledger-service deploy touching that pair.

Confirmed live: #945 (the reversal-entries fix, #939) merged clean and built green, but sat undeployed on this gate for over a day across multiple manual `auto-deploy` re-dispatches — all failing the same `can-i-deploy` check for the same reason, regardless of retry.

## Fix
A second `@Provider("openbank-ledger-service")` class, `@PactBroker` instead of `@PactFolder`, gated on `pactbroker.url` (matching every other broker-based provider test in the fleet: balance/fx/sca/swift/transaction-service). Reuses the existing "the standard chart of accounts is seeded" no-op state handler.

A second `@Provider` class for the same provider is safe here — the HTTP-vs-MESSAGE target collision noted elsewhere in this repo's CLAUDE.md doesn't apply: ledger-service has no message-consumer contracts, both classes use `HttpTestTarget` exclusively, so verifying the same interaction from two pact sources is at worst redundant, never colliding.

## Verification
- Full `:openbank-ledger-service:build` green locally.
- New class skips cleanly locally (`skipped=1`, no `pactbroker.url` — same as every other broker-gated provider test).
- Existing git-pact class unaffected: still 6/6 passing, 0 skipped — ADR-0063's zero-infra balance-service coverage is untouched.
- Real broker verification will only execute on the main-push CI lane (`PACT_BROKER_URL` populated there) — can't be verified pre-merge from this branch; the payoff is the *next* main push unblocking `can-i-deploy` for this pair.

## Linked issues
Refs #1009, #939, #945