### PR TITLE
docs+feat(adr,governance): ADR-0160 delivery note, mechanism 4 redesign, mechanism 2 implementation

### DIFF
--- a/.github/scripts/check-event-consumer-liveness.py
+++ b/.github/scripts/check-event-consumer-liveness.py
@@ -114,14 +114,11 @@ def load_allowlist(rules_path: pathlib.Path) -> dict[str, str]:
     return allowlist
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--root", default=".")
-    parser.add_argument("--rules", default="openbank-libs/governance/rules.yaml")
-    parser.add_argument("--enforce", action="store_true")
-    args = parser.parse_args()
-
-    root = pathlib.Path(args.root)
+def build_topic_maps(root: pathlib.Path) -> tuple[dict[str, set[str]], dict[str, set[str]], list[pathlib.Path]]:
+    """Fleet-wide (producer_topics, consumer_topics, scanned_files). Reused by
+    check-governance-lineage.py (ADR-0160 mechanism 2) via importlib — see that script for why a
+    hyphenated-filename cross-script import needs spec_from_file_location, matching the existing
+    gen_network_policies_test.py idiom, rather than a normal `import`."""
     all_producers: dict[str, set[str]] = {}
     all_consumers: dict[str, set[str]] = {}
 
@@ -133,6 +130,19 @@ def main() -> int:
             all_producers.setdefault(topic, set()).update(services)
         for topic, services in consumers.items():
             all_consumers.setdefault(topic, set()).update(services)
+
+    return all_producers, all_consumers, yaml_files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--rules", default="openbank-libs/governance/rules.yaml")
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root)
+    all_producers, all_consumers, yaml_files = build_topic_maps(root)
 
     allowlist = load_allowlist(root / args.rules)
 

--- a/.github/scripts/check-governance-lineage.py
+++ b/.github/scripts/check-governance-lineage.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""governance.yaml lineage-vs-code audit (ADR-0160 mechanism 2, rules.yaml: lineage_code_audit).
+
+WHY THIS EXISTS: standing-order-service's governance.yaml declares a `downstream` lineage edge to
+transaction-service (`relationType: api`, `description: creates`) — copy-pasted boilerplate with
+no backing code. The service's only `@RegisterRestClient` calls sepa-payment-service, never
+transaction-service. Nothing ever cross-checked the claim against the actual fleet, the same root
+cause as issue #889 (a *different* unverified claim — "this event has a consumer" rather than
+"this API edge exists" — but the same failure shape: prose describing runtime behaviour, never
+checked against code). This script closes the general case for `governance.yaml` lineage claims,
+reusing check-event-consumer-liveness.py's fleet-wide topic map (ADR-0160 mechanism 1) for the
+`topic` half instead of re-scanning the fleet a second time.
+
+WHAT IT CHECKS: for every service's `governance.yaml`, each `lineage.downstream` edge (an
+UPSTREAM edge is a claim about another service's code, not this one's, so it is out of scope here
+— the corresponding downstream edge on the OTHER service's own governance.yaml is what verifies
+that relationship) must be backed by grep-verifiable code in the SAME service:
+  - `relationType: api`  -> a `@RegisterRestClient(configKey = "<serviceName>")` somewhere under
+    this service's `src/main/kotlin` (exact match, or matching once both sides have any trailing
+    "-service" suffix stripped — `product-catalog` vs `product-catalog-service` naming varies
+    across the fleet).
+  - `relationType: topic` -> at least one topic this service PRODUCES (per mechanism 1's map) is
+    actually consumed by `serviceName`, OR at least one topic `serviceName` produces is consumed
+    by this service — a `topic` edge doesn't name the specific topic, just the service, so this is
+    a service-level cross-reference, not a topic-name match.
+
+A service with no `lineage:` key, or no `downstream` list, is skipped entirely (nothing declared,
+nothing to verify). Findings may be allowlisted with a one-line reason (same idiom as mechanism 1)
+for a legitimate case this heuristic can't see — e.g. a REST call made through a shared/generic
+client class without a per-target configKey.
+
+ADVISORY (ADR-0144 gate-graduation): findings are ::warning:: annotations; exits 0 unless invoked
+with --enforce. Not yet run against the full fleet to establish a first-scan baseline — do that
+before setting target_enforce_date to a real graduation deadline.
+
+stdlib + PyYAML (already installed earlier in the same CI job, matching check-slo-registry.py).
+Usage: check-governance-lineage.py [--root .] [--rules openbank-libs/governance/rules.yaml] [--enforce]
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import pathlib
+import re
+import sys
+
+import yaml
+
+_LIVENESS_SCRIPT = pathlib.Path(__file__).parent / "check-event-consumer-liveness.py"
+_spec = importlib.util.spec_from_file_location("check_event_consumer_liveness", _LIVENESS_SCRIPT)
+liveness = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(liveness)
+
+REGISTER_REST_CLIENT = re.compile(r'@RegisterRestClient\s*\(\s*configKey\s*=\s*"([^"]+)"')
+
+
+def normalize_service_name(name: str) -> str:
+    return name[: -len("-service")] if name.endswith("-service") else name
+
+
+def find_rest_client_config_keys(service_dir: pathlib.Path) -> set[str]:
+    """Every configKey a service's @RegisterRestClient interfaces declare — the ground-truth
+    "this service actually calls that service over REST" signal, not application.yaml's
+    rest-client: block (config binding can lag behind or be structured differently)."""
+    keys: set[str] = set()
+    src = service_dir / "src" / "main" / "kotlin"
+    if not src.exists():
+        return keys
+    for kt_file in src.rglob("*.kt"):
+        text = kt_file.read_text(encoding="utf-8", errors="ignore")
+        for m in REGISTER_REST_CLIENT.finditer(text):
+            keys.add(m.group(1))
+    return keys
+
+
+def load_governance_downstream(gov_path: pathlib.Path) -> list[dict]:
+    if not gov_path.exists():
+        return []
+    data = yaml.safe_load(gov_path.read_text(encoding="utf-8")) or {}
+    lineage = data.get("lineage") or {}
+    return lineage.get("downstream") or []
+
+
+def load_allowlist(rules_path: pathlib.Path) -> dict[str, str]:
+    if not rules_path.exists():
+        return {}
+    data = yaml.safe_load(rules_path.read_text(encoding="utf-8")) or {}
+    rule = (data.get("change_requirements") or {}).get("lineage_code_audit") or {}
+    entries = rule.get("allowlist") or []
+    allowlist: dict[str, str] = {}
+    for entry in entries:
+        key = entry.get("edge")
+        reason = entry.get("reason", "")
+        if key:
+            allowlist[key] = reason
+    return allowlist
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--rules", default="openbank-libs/governance/rules.yaml")
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root)
+    all_producers, all_consumers, _ = liveness.build_topic_maps(root)
+    allowlist = load_allowlist(root / args.rules)
+
+    service_dirs = sorted(d for d in root.glob("openbank-*") if (d / "governance.yaml").exists())
+
+    violations: list[tuple[str, str]] = []
+    allowlisted_hits: list[tuple[str, str]] = []
+    checked = 0
+
+    for service_dir in service_dirs:
+        service = service_dir.name
+        downstream = load_governance_downstream(service_dir / "governance.yaml")
+        if not downstream:
+            continue
+
+        rest_client_keys = None  # lazily computed only if an api edge is present
+        for edge in downstream:
+            target = edge.get("serviceName")
+            relation = edge.get("relationType")
+            if not target or relation not in ("api", "topic"):
+                continue
+            checked += 1
+            edge_key = f"{service}->{target}:{relation}"
+
+            if relation == "api":
+                if rest_client_keys is None:
+                    rest_client_keys = find_rest_client_config_keys(service_dir)
+                normalized_targets = {target, normalize_service_name(target)}
+                normalized_keys = rest_client_keys | {normalize_service_name(k) for k in rest_client_keys}
+                backed = bool(normalized_targets & normalized_keys)
+            else:  # topic
+                produces = {t for t, producers in all_producers.items() if service in producers}
+                consumes = {t for t, consumers in all_consumers.items() if service in consumers}
+                target_produces = {t for t, producers in all_producers.items() if target in producers}
+                target_consumes = {t for t, consumers in all_consumers.items() if target in consumers}
+                backed = bool((produces & target_consumes) or (target_produces & consumes))
+
+            if backed:
+                continue
+            if edge_key in allowlist:
+                allowlisted_hits.append((edge_key, allowlist[edge_key]))
+            else:
+                violations.append((edge_key, relation))
+
+    for edge_key, reason in sorted(allowlisted_hits):
+        print(f"::notice::lineage-code-audit: {edge_key} has no backing code found — allowlisted: {reason}")
+
+    for edge_key, relation in sorted(violations):
+        annotation = "error" if args.enforce else "warning"
+        kind = "a matching @RegisterRestClient(configKey=...)" if relation == "api" else "any actual topic overlap"
+        print(
+            f"::{annotation}::lineage-code-audit: governance.yaml edge {edge_key} has no backing code — "
+            f"{kind} not found. If this is a real dependency implemented differently than this "
+            f"heuristic expects, add it to rules.yaml: lineage_code_audit.allowlist with a one-line "
+            f"reason. If not, this is the #889 failure class — a lineage claim nobody verified."
+        )
+
+    print(
+        f"check-governance-lineage: {checked} downstream edge(s) checked across "
+        f"{len(service_dirs)} service(s) with a governance.yaml; {len(violations)} unallowlisted "
+        f"violation(s), {len(allowlisted_hits)} allowlisted."
+    )
+
+    if violations and args.enforce:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,14 @@ jobs:
       - name: "event-consumer liveness (ADR-0160, advisory)"
         run: python3 .github/scripts/check-event-consumer-liveness.py
 
+      # ADR-0160 mechanism 2 / rules.yaml: change_requirements.lineage_code_audit. Fleet-wide scan
+      # (not diff-scoped): every governance.yaml lineage.downstream edge must be backed by
+      # grep-verifiable code, or a one-line-reasoned allowlist entry. Reuses mechanism 1's topic
+      # map via importlib. ADVISORY (ADR-0144) — findings are ::warning annotations. Flip to
+      # enforced once the 34-edge first-scan triage lands = add --enforce below.
+      - name: "governance lineage-vs-code audit (ADR-0160, advisory)"
+        run: python3 .github/scripts/check-governance-lineage.py
+
       # ADR-0030 D2: every money-path service must ship a structured STRIDE/DFD
       # threat model. stdlib-only gate, ratchets coverage (a new money-path
       # service or a deleted/stubbed model fails here). Part of the always-run,

--- a/docs/adr/0160-end-to-end-integration-liveness-and-drift-detection-standard.md
+++ b/docs/adr/0160-end-to-end-integration-liveness-and-drift-detection-standard.md
@@ -5,6 +5,27 @@ Decision-Status: Accepted
 Delivery-Status: Partial
 Author(s): jiri.raska (paired with Claude Opus 4.8)
 
+> **Delivery note (2026-07-13, updated same day).** Mechanism 1 shipped and validated: PR #995
+> (the gate itself, `check-event-consumer-liveness.py`) and PR #994 (the #889 fix it was built to
+> catch — re-running the gate against #994's branch before merge dropped the violation count,
+> proving the check works). The first fleet scan found the real gap was worse than estimated: 13
+> of 18 producer-only topics were REAL_GAP, not the handful expected. #1005 and #1007 fixed 4 of
+> them (one was a topic-**name** typo, not a missing consumer — `sca.challenge.event` vs.
+> `sca.events`, two separately-provisioned topics; #1007's own self-review caught 2 further
+> extraction bugs in the fix before merge). #1008 allowlisted the 3 LEGITIMATE_NO_CONSUMER
+> findings. Full triage in issue #996; 11 REAL_GAP topics remain queued (each needs real business
+> logic, e.g. AML case-opening semantics for a SWIFT wire — not a mechanical fix, intentionally not
+> rushed). Two of the 13 are regulatory/money-path severity and got their own issues: #999
+> (interest withholding tax never remitted to the tax authority) and #1000 (an authorised SEPA
+> direct-debit collection never posts a debit anywhere — no consumer exists at all).
+>
+> Mechanism 3 shipped: PR #1001 (`DomainMetrics.registerWorkflowLiveness`, piloted on
+> standing-order-service's scheduler, which had zero freshness observability before it).
+>
+> **Mechanism 4's design changed from what's written below** — see the amendment after the
+> Decision section. Mechanism 2 has a concrete implementation plan (also below) but is not yet
+> built.
+
 ## Context
 
 Two incidents investigated back-to-back on 2026-07-13 turned out to share one root cause:
@@ -77,6 +98,17 @@ pointed at the declared target; a `consumes` edge needs a matching `@Incoming` o
 topic. This directly targets the #889 root cause — standing-order-service's lineage entry claiming
 a `transaction-service` edge was copy-pasted boilerplate with no backing code, and nothing noticed.
 
+Concrete implementation plan (not yet built): extend `check-event-consumer-liveness.py` rather
+than write a parallel script — it already parses every service's `mp.messaging.outgoing`/`incoming`
+declarations into a topic → {service} map (mechanism 1's own data). Add a second pass that reads
+each service's `governance.yaml` `lineage` block, and for every edge with `relationType: consumes`
+whose declared topic is NOT in mechanism 1's consumer map for that service, or every
+`relationType: api` edge whose declared target has no matching `@RegisterRestClient`/rest-client
+config key pointed at it, emit the same `::warning::` shape as mechanism 1. Same allowlist idiom
+(`rules.yaml: change_requirements.lineage_code_audit.allowlist`), same ADR-0144 advisory-first
+graduation. Reusing mechanism 1's topic map means this is additive to one script, not new
+infrastructure.
+
 **3. Shared workflow-liveness watchdog primitive.**
 `ReconciliationFreshnessWatchdog` already solves "did this scheduled job actually run and
 succeed recently" for one service. Extract it into `openbank-libs-runtime` as
@@ -85,19 +117,48 @@ with `watchdog.recordSuccess(name)`; a Prometheus gauge age-of-last-success page
 `2 × expectedInterval`. This is the direct fix for the 41-day-dead-reconciliation failure mode:
 "job stopped running" becomes an alert, not a silent gap discovered by accident.
 
-**4. Drift-SLA, not drift-log.**
+**4. Drift-SLA, not drift-log.** *(Superseded by the amendment below — kept here for the original
+rationale; see "Amendment 2026-07-13: mechanism 4 redesign" for the actual decision.)*
 `BalanceReconciliationService` (and any future control-account tie-out) reports `hasDrift` as a
 single-snapshot boolean today, which is exactly what made #860's transient backfill artifact
-indistinguishable from a real defect. Change the reconciliation record to carry a rolling window
-(last N runs) and define drift as **actionable** only when it persists across
-`consecutive_drift_threshold` consecutive runs with no intervening backfill/maintenance marker —
-one bad snapshot logs at INFO, sustained drift pages. This does not weaken the control (day-zero
-drift is still visible in the record for audit) — it moves the *alerting* threshold from "any
-snapshot" to "sustained", which is what actually distinguishes signal from a system caught
-mid-write.
+indistinguishable from a real defect. The *goal* stands: one bad snapshot must log, not page;
+sustained drift must page. The *original mechanism* proposed here — a DB rolling window + an
+application-side `consecutive_drift_threshold` counter — turned out not to be the best available
+tool for this job once mechanism 3 shipped a reusable pattern; see the amendment.
 
 None of these four replace human review or existing gates — they are additive CI/observability
 layers targeting specifically the "looks done, isn't verified" failure class.
+
+## Amendment 2026-07-13: mechanism 4 redesign
+
+Critical re-review of the original mechanism 4 (DB rolling window + `consecutive_drift_threshold`
+counter in `BalanceReconciliationService`) found it was not the best available design, for reasons
+that only became visible after mechanism 3 shipped:
+
+- It requires a Flyway migration on a money-path service's schema (2-approval, behavior-regression
+  risk) to solve what is fundamentally an **alerting threshold** problem, not a data-model problem.
+- It hand-rolls "has this condition held for N consecutive samples" as application code — exactly
+  the kind of bespoke stateful logic that is itself a future source of the "looks done, isn't
+  verified" bugs this ADR exists to eliminate (who tests the counter's reset-on-recovery path?).
+- This repo already runs Prometheus/Pyrra for every other SLO in the fleet (ADR-0088), and
+  Prometheus alerting rules have a **native `for:` clause** built for exactly this need: "this
+  expression must stay true for N minutes before the alert fires." That is a battle-tested,
+  zero-new-code way to turn a snapshot into a sustained-condition alert.
+
+**Revised decision:** `BalanceReconciliationService` publishes the per-run drift as a Micrometer
+gauge — `openbank.balance.reconciliation.drift{currency}` (the signed CZK/EUR/GBP difference) —
+via `DomainMetrics`, using the exact additive, no-op-when-no-registry pattern
+`registerWorkflowLiveness` (mechanism 3) already established. A `PrometheusRule` with
+`for: <N × reconciliation interval>` fires only once the drift metric has been non-zero (beyond
+tolerance) across that entire window — one bad snapshot mid-backfill never crosses the `for:`
+threshold; sustained drift does. No schema change, no new counter field, no migration — the
+reconciliation record (audit trail, unchanged) still carries every snapshot for forensics; only
+the *alerting* layer moves to Prometheus, which is the layer that should own "sustained condition"
+semantics in this fleet's existing architecture.
+
+This does not change the ADR's Decision-Status or the problem mechanism 4 solves — it changes the
+*how*, in the same spirit as this ADR's own thesis: prefer the mechanism this fleet has already
+proven, over a new bespoke one.
 
 ## Alternatives considered
 
@@ -146,8 +207,11 @@ layers targeting specifically the "looks done, isn't verified" failure class.
   non-trivial one-time cost, tracked as a fleet-sweep issue, not absorbed into this ADR.
 - Mechanism 3 touches every `@Scheduled` job that opts in — a fleet-wide adoption sweep, not a
   single-service change; done incrementally, money-path services first.
-- Mechanism 4 changes the reconciliation record schema (rolling window) — a Flyway migration on
-  `balance-service`, money-path, needs the usual two-approval + no-behavior-regression discipline.
+- Mechanism 4 (revised, see amendment): no schema change, but does add a `PrometheusRule` that
+  needs its `for:` window tuned against the reconciliation's real cadence — too short reintroduces
+  false pages on legitimate backfills; too long delays a genuine sustained-drift alert. Money-path
+  service (`balance-service`), still needs the usual two-approval discipline for the
+  `DomainMetrics` call site even though there is no migration.
 - A CI check can itself go stale/lie (the exact meta-risk this ADR is about) — mitigated by
   keeping the checks stdlib-only, small, and reviewed like any other code, and by mechanism 2
   cross-checking mechanism 1's own data source (`governance.yaml`) against code.
@@ -183,3 +247,11 @@ layers targeting specifically the "looks done, isn't verified" failure class.
   existing single-footgun instances of the pattern this ADR generalizes
 - issue #855 — balance reconciliation silently dead for 41 days (root cause for mechanism 3)
 - issue #266 — `SERVICE` principal type dead code (root cause for mechanism 2's motivating case)
+- ADR-0088 — SLO-as-code / Pyrra (the proven Prometheus alerting infrastructure mechanism 4's
+  amendment reuses instead of a bespoke DB counter)
+- #994, #995 — the #889 fix and mechanism 1's gate, validated against each other
+- #1001 — mechanism 3 shipped (`WorkflowLivenessWatchdog`, piloted on standing-order-service)
+- #1005, #1007, #1008 — mechanism 1's first fleet-sweep fixes (4 topics fixed, 3 allowlisted)
+- #996 — full triage tracking issue, 11 REAL_GAP topics remain queued
+- #999, #1000 — the 2 regulatory/money-path-severity findings from the #996 triage, each needing
+  its own design decision before implementation (not mechanical fixes)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -165,11 +165,13 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0160](0160-end-to-end-integration-liveness-and-drift-detection-standard.md) | End-to-end integration liveness and drift-detection standard | Accepted | Partial | — |
 | [0161](0161-object-storage-standard-for-application-documents.md) | Object-storage standard for application binary artifacts | Proposed | Planned | — |
 | [0162](0162-document-management-templating-and-e-signature-architecture.md) | Document management, templating & e-signature architecture | Proposed | Planned | — |
+| [0163](0163-control-liveness-sentinel-ai-agent.md) | Control-liveness-sentinel AI agent | Accepted | Partial | — |
+| [0164](0164-governance-auditor-ai-agent.md) | Governance-auditor AI agent | Accepted | Partial | — |
 | [0165](0165-release-steward-ai-agent.md) | Release-steward AI agent | Accepted | Partial | — |
 
 ---
 
-**Numbering gaps:** 0015 0127 0128 0129 0130 0131 0157 0163 0164 do not correspond to a file in this repo's history —
+**Numbering gaps:** 0015 0127 0128 0129 0130 0131 0157 do not correspond to a file in this repo's history —
 confirmed by `git log --diff-filter=A` across all branches, not just an absent
 current file. ADR-0132 was one of these gaps until it was cited in code/config
 comments before the file existed and has since been written down properly

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "519bfc094e0f7669"
+    openbank.tech/policy-checksum: "d9006a4d1117a34c"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -58,6 +58,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -493,6 +509,112 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
 
       - id: release-steward
         plane: control

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "519bfc094e0f7669"
+        openbank.tech/policy-checksum: "d9006a4d1117a34c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2233af34dfba50fa"
+    openbank.tech/policy-checksum: "e9f913d2d9d4b87c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -453,6 +453,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -889,6 +905,112 @@ data:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
 
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
       - id: release-steward
         plane: control
         charter: "ADR-0165"
@@ -1126,6 +1248,38 @@ data:
             reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
           - topic: "openbank.pid.events"
             reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1558,7 +1712,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1571,16 +1725,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2233af34dfba50fa"
+        openbank.tech/policy-checksum: "e9f913d2d9d4b87c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -40,7 +40,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: copilot-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-copilot-service:sandbox-237c397c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-copilot-service:sandbox-31e6692a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "8b1d30836ae2d63f"
+    openbank.tech/policy-checksum: "9389cf18a9484e92"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -333,6 +333,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -629,6 +645,38 @@ data:
             reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
           - topic: "openbank.pid.events"
             reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1061,7 +1109,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1074,16 +1122,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
@@ -1869,6 +1929,112 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
 
       - id: release-steward
         plane: control

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b1d30836ae2d63f"
+        openbank.tech/policy-checksum: "9389cf18a9484e92"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-237c397c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-31e6692a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "8b1d30836ae2d63f"
+    openbank.tech/policy-checksum: "9389cf18a9484e92"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -333,6 +333,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -629,6 +645,38 @@ data:
             reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
           - topic: "openbank.pid.events"
             reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1061,7 +1109,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1074,16 +1122,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
@@ -1869,6 +1929,112 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
 
       - id: release-steward
         plane: control

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "8b1d30836ae2d63f"
+        openbank.tech/policy-checksum: "9389cf18a9484e92"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "3cc6edfb2bb72445"
+    openbank.tech/policy-checksum: "52ffd3f1a254e619"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -392,6 +392,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -828,6 +844,112 @@ data:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
 
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
       - id: release-steward
         plane: control
         charter: "ADR-0165"
@@ -1065,6 +1187,38 @@ data:
             reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
           - topic: "openbank.pid.events"
             reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1497,7 +1651,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1510,16 +1664,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3cc6edfb2bb72445"
+        openbank.tech/policy-checksum: "52ffd3f1a254e619"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: pid-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-pid-service:sandbox-237c397c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-pid-service:sandbox-31e6692a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -177,6 +177,38 @@ change_requirements:
         reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
       - topic: "openbank.pid.events"
         reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+  lineage_code_audit:
+    # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+    # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+    # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+    # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+    # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+    # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+    # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+    # an actual topic produced/consumed in common with the target service for topic — a topic edge
+    # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+    # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+    # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+    # already tracked for cleanup elsewhere).
+    detect: ["any <service>/governance.yaml lineage.downstream edge"]
+    require:
+      - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+      - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+    gate: lineage-code-audit
+    enforced: advisory
+    target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+    # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+    # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+    # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+    # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+    # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+    # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+    # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+    # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+    # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+    blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+    ci_producer: ".github/scripts/check-governance-lineage.py"
+    allowlist: []
   service_code_change:
     detect: ["<service>/src/main/**"]
     require:


### PR DESCRIPTION
## What & why

Records progress on ADR-0160, corrects one design decision, and implements the next mechanism.

**Delivery note** — mechanisms 1 and 3 are shipped and validated:
- Mechanism 1 (event-consumer-liveness gate): #995, validated against its own motivating fix #994. First fleet scan found 13/18 producer-only topics were real gaps (worse than expected). #1005/#1007 fixed 4, #1008 allowlisted 3 legitimate ones. 11 remain queued in #996, 2 of them severe enough to get their own issues (#999, #1000).
- Mechanism 3 (WorkflowLivenessWatchdog): #1001, piloted on standing-order-service.

**Mechanism 4 redesign (amendment, not silent rewrite)** — the original design (DB rolling window + `consecutive_drift_threshold` counter on `BalanceReconciliationService`) needed a Flyway migration and hand-rolled stateful "sustained condition" logic in application code. Once mechanism 3 shipped a reusable `DomainMetrics` gauge pattern, a strictly better option became visible: publish the per-run drift as a gauge and let a `PrometheusRule`'s native `for:` clause own the sustained-vs-transient distinction — this repo already runs Prometheus/Pyrra for every other SLO (ADR-0088). No schema change, no bespoke counter, reuses proven infrastructure. Recorded as an ADR amendment so the original rationale and why it changed both stay legible. (Implementation is a separate follow-up PR — this PR is the design decision.)

**Mechanism 2 — implemented in this PR**: `check-governance-lineage.py`, a fleet-wide scan of every `governance.yaml` `lineage.downstream` edge against actual code (a `@RegisterRestClient` for `api` edges, an actual topic overlap for `topic` edges — reusing mechanism 1's topic map via importlib). Deliberately a separate script/gate from mechanism 1 (this repo's own convention keeps ADR-0144 gates independently gradable). First scan: **34 of 48 edges have no backing code** — consistent with mechanism 1's own ~72% first-scan rate, and directly confirms standing-order-service's original motivating `->transaction-service:api` edge (the copy-pasted boilerplate that motivated this whole ADR) is still present and now caught. Tracking issue: #1021.

## Linked issues

Refs #996, #999, #1000, #1021, #889

## Notes

The design recommendations for #999/#1000/#996's remaining topics are posted as comments on those issues (not implemented — each needs a human design decision before code, given regulatory/money-path stakes). Mechanism 4's *implementation* (the Prometheus gauge + PrometheusRule) is intentionally a separate follow-up PR from this design-decision PR.

Verified locally: `check-gate-graduation.sh`, `check-duplicate-yaml-keys.sh`, `gen-network-policies.py` (no diff), `opa test` (120/120) + `opa check --strict` + all decision assertions (OPA bundle checksums regenerated, same recurring mechanism as every prior rules.yaml-touching PR this session).