### PR TITLE
fix(infra): add missing KafkaTopic CRs for 8 services

### DIFF
--- a/openbank-infra/gitops/components/dispute-service/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/dispute-service/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by dispute-service. Declared explicitly (the broker does
+# not auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
+# outbox producer has a destination. The service's KafkaUser (kafka-dispute-mtls.yaml)
+# already grants Write/Describe on this topic — this CR was the missing piece. Single
+# partition + RF 1 for the single-broker sandbox; prod should raise partitions for
+# parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.dispute.events
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/fx-service/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/fx-service/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by fx-service. Declared explicitly (the broker does not
+# auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
+# outbox producer has a destination. The service's KafkaUser (kafka-fx-mtls.yaml) already
+# grants Write/Describe on this topic — this CR was the missing piece. Single partition +
+# RF 1 for the single-broker sandbox; prod should raise partitions for parallelism and RF
+# to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.fx.conversion.completed
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/interest-service/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/interest-service/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by interest-service. Declared explicitly (the broker does
+# not auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
+# outbox producer has a destination. The service's KafkaUser (kafka-interest-mtls.yaml)
+# already grants Write/Describe on this topic — this CR was the missing piece. Single
+# partition + RF 1 for the single-broker sandbox; prod should raise partitions for
+# parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.interest.accrual.event
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/pid/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/pid/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by pid-service. Declared explicitly (the broker does not
+# auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
+# outbox producer has a destination. The service's KafkaUser (kafka-pid-mtls.yaml)
+# already grants Write/Describe on this topic — this CR was the missing piece. Single
+# partition + RF 1 for the single-broker sandbox; prod should raise partitions for
+# parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.pid.events
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/psd2-service/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/psd2-service/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by psd2-service. Declared explicitly (the broker does not
+# auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
+# outbox producer has a destination. The service's KafkaUser (kafka-psd2-mtls.yaml)
+# already grants Write/Describe on this topic — this CR was the missing piece. Single
+# partition + RF 1 for the single-broker sandbox; prod should raise partitions for
+# parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.psd2.events
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/sdd/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/sdd/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by sdd-service. Declared explicitly (the broker does not
+# auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
+# outbox producer has a destination. The service's KafkaUser (kafka-sdd-mtls.yaml)
+# already grants Write/Describe on this topic — this CR was the missing piece. Single
+# partition + RF 1 for the single-broker sandbox; prod should raise partitions for
+# parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.sdd.event
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/statements/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/statements/kafka-topic.yaml
@@ -1,0 +1,20 @@
+# Domain event topic produced by statement-service (ADR-0035). Declared explicitly (the
+# broker does not auto-create topics — kafka.yaml) so the Strimzi topic operator manages
+# it and the outbox producer channel `statement-events-out` has a destination. The
+# service's KafkaUser (kafka-statement-mtls.yaml) already grants Write/Describe on this
+# topic — this CR was the missing piece, so the outbox dispatcher was silently failing to
+# publish (attempt_count never advancing). Single partition + RF 1 for the single-broker
+# sandbox; prod should raise partitions for parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.statement.event
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/tpp-registry/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/kafka-topic.yaml
@@ -1,0 +1,19 @@
+# Domain event topic produced by tpp-registry-service. Declared explicitly (the broker
+# does not auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and
+# the outbox producer has a destination. The service's KafkaUser
+# (kafka-tpp-registry-mtls.yaml) already grants Write/Describe on this topic — this CR
+# was the missing piece. Single partition + RF 1 for the single-broker sandbox; prod
+# should raise partitions for parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.tpp.registry.event
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete


### PR DESCRIPTION
## Summary

statement-service (and 7 other services) each have a deployed `KafkaUser` granting `Write`/`Describe` on their output topic, but no matching `KafkaTopic` CR anywhere in the repo. Since the Strimzi cluster has `allow.everyone.if.no.acl.found: "false"` and topics are provisioned by the topic operator (not broker auto-create), each of these outbox dispatchers has been silently failing to publish.

## Type of change

- [x] fix (bug fix)

## Linked issues

N/A — discovered via ad-hoc audit while investigating statement-service's gitops gap; no existing tracked issue covers this.

## Changes

- Add `kafka-topic.yaml` for `openbank.statement.event` (statement-service)
- Add `kafka-topic.yaml` for `openbank.dispute.events` (dispute-service)
- Add `kafka-topic.yaml` for `openbank.fx.conversion.completed` (fx-service)
- Add `kafka-topic.yaml` for `openbank.interest.accrual.event` (interest-service)
- Add `kafka-topic.yaml` for `openbank.pid.events` (pid)
- Add `kafka-topic.yaml` for `openbank.psd2.events` (psd2-service)
- Add `kafka-topic.yaml` for `openbank.sdd.event` (sdd)
- Add `kafka-topic.yaml` for `openbank.tpp.registry.event` (tpp-registry)

Each follows the existing per-service pattern (single partition, RF 1, 7-day retention, `messaging` namespace, `strimzi.io/cluster: openbank-cluster` label) — matching e.g. `openbank-infra/gitops/components/lending/kafka-topic.yaml`.

## Definition of Done

- [x] No application code touched — gitops manifests only, no service version bump needed.
- [ ] Docs updated (README, ADR if architectural) — N/A, no architectural change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new dependency.

## Compliance impact

- [x] None (additive infra manifest only; restores already-declared producer intent — the KafkaUser ACLs already existed).

## Rollout / Rollback

- Deployment strategy: ArgoCD auto-sync (each component Application already watches its directory).
- Rollback plan: revert the PR; topic operator deletes the KafkaTopic CR (topic itself persists per Strimzi defaults unless explicitly configured otherwise).
- Data migration reversible: N/A

## Reviewer notes

`fx-service` is a `money_path_services` entry (rules.yaml) — flagging for visibility, though this is a pure additive infra fix (restores a topic the service's own ACL already assumed existed), not new money-path logic.