### PR TITLE
feat(sdd): book the debtor debit for an authorised SDD collection (#1000)

### DIFF
--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -507,6 +507,9 @@ spec:
               kubernetes.io/metadata.name: platform
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: sdd
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -83,6 +83,9 @@ spec:
                   name: sdd-service-oidc
                   key: OIDC_CLIENT_SECRET
                   optional: true
+            # #1000: book the debtor-side debit for an authorised collection.
+            - name: TRANSACTION_SERVICE_URL
+              value: http://transaction-service.payments.svc:8102
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-sdd-service/build.gradle.kts
+++ b/openbank-sdd-service/build.gradle.kts
@@ -25,6 +25,11 @@ dependencies {
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.quarkus.smallrye.fault.tolerance)
+    // #1000: book the debtor-side debit for an authorised SDD collection via transaction-service,
+    // with an openbank-services M2M token minted by the oidc-client filter.
+    implementation(libs.quarkus.rest.client.reactive)
+    implementation(libs.quarkus.rest.client.reactive.jackson)
+    implementation(libs.quarkus.oidc.client.reactive.filter)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactive)
     implementation(libs.jackson.module.kotlin)

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/client/TransactionServiceClient.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/client/TransactionServiceClient.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sdd.infrastructure.client
+
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * REST client for `openbank-transaction-service` — books the debtor-side debit for an authorised
+ * SEPA Direct Debit collection (#1000). OIDC service-to-service auth is propagated by
+ * [OidcClientRequestReactiveFilter]; this consumer runs on a plain `@Incoming` suspend handler
+ * (not a Temporal activity), so the filter-based token attachment is safe here — unlike
+ * domestic-payment's `SettlementAdapter`, which needs an explicit-token workaround specifically
+ * because a Temporal activity thread loses the Vert.x context the filter relies on.
+ */
+@RegisterRestClient(configKey = "transaction-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/transactions")
+interface TransactionServiceClient {
+
+    @POST
+    fun initiateTransaction(request: InitiateTransactionRequest): Uni<Response>
+}
+
+/**
+ * Payload sent to transaction-service to book the collection debit. `targetAccountId` is
+ * deliberately absent (always external): an SDD creditor is, in the general case, a merchant at
+ * another bank — never an internal openbank account — so the debit books against the bank's cash
+ * clearing suspense, same as any other external outbound payment (mirrors domestic-payment's
+ * `SettlementAdapter`, which resolves a non-null target only for the narrower in-house-transfer
+ * case that does not apply to SDD collections).
+ */
+data class InitiateTransactionRequest(
+    val idempotencyKey: String,
+    val type: String,
+    val sourceAccountId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val description: String,
+    val valueDate: String,
+    val rail: String,
+    val instructionType: String,
+)

--- a/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumer.kt
+++ b/openbank-sdd-service/src/main/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumer.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sdd.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.sdd.infrastructure.client.InitiateTransactionRequest
+import com.openbank.sdd.infrastructure.client.TransactionServiceClient
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.math.RoundingMode
+
+/**
+ * Books the debtor-side debit for an authorised SEPA Direct Debit collection (#1000).
+ *
+ * `openbank.sdd.event` carries every mandate lifecycle event on one topic; this consumer filters
+ * for `sdd.collection.authorised.v1` (published by [com.openbank.sdd.application.usecase.SddMandateService.authorise]
+ * on [com.openbank.sdd.domain.authorise.AuthorisationResult.Accept]) and ignores the rest. That
+ * event is self-sufficient — accountId, debtorIban, amount, currency, mandateId, umr — no
+ * cross-service lookup is needed to book it, unlike #889's standing-order fix.
+ *
+ * Idempotency: `so-sdd-{mandateId}-{umr}-{dueDate}` (deterministic per collection) is both the
+ * outbound Idempotency-Key implied by transaction-service's own idempotencyKey field and this
+ * consumer's dedup key, so a Kafka redelivery replays the same booking instead of double-debiting.
+ *
+ * **Scope note (deliberate, tracked as follow-up — see issue #1000):** this consumer books the
+ * happy-path debit only. It does not yet generate or handle an R-transaction (SDD scheme return —
+ * insufficient funds discovered late, mandate disputed post-collection, etc.), and does not
+ * persist a per-collection outcome record (no such entity exists yet; [com.openbank.sdd.domain.model.SddMandate]
+ * only carries a `lastCollectionDate` high-water mark, stamped at authorisation time). A failed
+ * debit is logged at ERROR — paging-worthy, since an authorised collection that fails to debit is
+ * a real money-path defect — but is not automatically retried or reversed. Designing the return
+ * path is real design work, not a mechanical extension of this consumer.
+ */
+@ApplicationScoped
+class SddCollectionDebitConsumer(
+    private val objectMapper: ObjectMapper,
+    @RestClient private val transactionClient: TransactionServiceClient,
+) {
+    private val log = Logger.getLogger(SddCollectionDebitConsumer::class.java)
+
+    @Incoming("sdd-collection-authorised-in")
+    // Poison-pill safety: this boundary must swallow ANY failure (parse, rail call) and ack, so
+    // one bad event cannot wedge the consumer group.
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun consume(payload: String) {
+        try {
+            val node = objectMapper.readTree(payload)
+            if (node.path("eventType").asText() != EVENT_COLLECTION_AUTHORISED) return
+
+            val mandateId = node.path("mandateId").asText()
+            val umr = node.path("umr").asText()
+            val dueDate = node.path("dueDate").asText()
+            val currency = node.path("currency").asText()
+            val idempotencyKey = "so-sdd-$mandateId-$umr-$dueDate"
+
+            // EUR (SDD's only currency, CollectionAuthorisationPolicy FF05) has 2 fraction digits;
+            // transaction-service rejects an amount whose scale exceeds the currency's — normalise
+            // defensively (same footgun domestic-payment's SettlementAdapter already hit).
+            val fractionDigits = runCatching { java.util.Currency.getInstance(currency).defaultFractionDigits }
+                .getOrDefault(2).coerceAtLeast(0)
+            val amount = node.path("amount").decimalValue().setScale(fractionDigits, RoundingMode.HALF_UP)
+
+            val request = InitiateTransactionRequest(
+                idempotencyKey = idempotencyKey,
+                type = "DEBIT",
+                sourceAccountId = java.util.UUID.fromString(node.path("accountId").asText()),
+                amount = amount,
+                currencyCode = currency,
+                description = "SEPA Direct Debit ${node.path(
+                    "creditorIdentifier",
+                ).asText()} / $umr".take(MAX_DESCRIPTION),
+                valueDate = dueDate,
+                rail = "SEPA_CT",
+                instructionType = "DIRECT_DEBIT",
+            )
+
+            val response = transactionClient.initiateTransaction(request).awaitSuspending()
+            when {
+                response.statusInfo.family == Response.Status.Family.SUCCESSFUL -> {
+                    log.infof(
+                        "[sdd-collection-debit] mandate=%s umr=%s debited (HTTP %d)",
+                        mandateId,
+                        umr,
+                        response.status,
+                    )
+                }
+                response.status == HTTP_CONFLICT -> {
+                    log.infof(
+                        "[sdd-collection-debit] mandate=%s umr=%s already booked (409) — idempotent success",
+                        mandateId,
+                        umr,
+                    )
+                }
+                else -> {
+                    log.errorf(
+                        "[sdd-collection-debit] mandate=%s umr=%s FAILED to debit (HTTP %d) — an authorised " +
+                            "collection did not move money. R-transaction/return generation is not yet built " +
+                            "(#1000 follow-up); this requires manual investigation.",
+                        mandateId,
+                        umr,
+                        response.status,
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "[sdd-collection-debit] failed to handle collection-authorised event: %.300s", payload)
+        }
+    }
+
+    private companion object {
+        const val EVENT_COLLECTION_AUTHORISED = "sdd.collection.authorised.v1"
+        const val HTTP_CONFLICT = 409
+        const val MAX_DESCRIPTION = 140
+    }
+}

--- a/openbank-sdd-service/src/main/resources/application.yaml
+++ b/openbank-sdd-service/src/main/resources/application.yaml
@@ -47,6 +47,20 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+  # Outbound service-to-service token (#1000): the transaction-service rest-client mints an
+  # openbank-services M2M token (ROLE_OPERATOR) via this oidc-client. Disabled under %test (units
+  # call the consumer directly; the boot IT never books a debit).
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+  rest-client:
+    transaction-service:
+      url: ${TRANSACTION_SERVICE_URL:http://localhost:8102}
+      scope: jakarta.inject.Singleton
   shutdown:
     timeout: 30S
   log:
@@ -99,6 +113,8 @@ quarkus:
       enabled: false
     oidc:
       enabled: false
+    oidc-client:
+      enabled: false
     # ADR-0050: disable the @Scheduled outbox tick under test so the integration test
     # drives dispatcher.dispatch() explicitly and never races the assertions.
     scheduler:
@@ -143,3 +159,14 @@ mp:
         topic: openbank.sdd.event
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
+    incoming:
+      # #1000: self-consume the collection-authorised events this service itself publishes, and
+      # book the debtor-side debit. group.id / auto.offset.reset deliberately NOT set as YAML keys
+      # (SmallRye's dotted-key footgun, #686/#703) — defaults are what we want: group.id falls back
+      # to quarkus.application.name (a service-scoped consumer group), auto.offset.reset stays
+      # `latest` so a fresh deploy does not replay historical authorisations and re-debit them.
+      sdd-collection-authorised-in:
+        connector: smallrye-kafka
+        topic: openbank.sdd.event
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumerTest.kt
+++ b/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/infrastructure/kafka/SddCollectionDebitConsumerTest.kt
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sdd.infrastructure.kafka
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.sdd.infrastructure.client.InitiateTransactionRequest
+import com.openbank.sdd.infrastructure.client.TransactionServiceClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class SddCollectionDebitConsumerTest {
+
+    private val mapper = jacksonObjectMapper()
+    private val transactionClient = mockk<TransactionServiceClient>()
+    private val consumer = SddCollectionDebitConsumer(mapper, transactionClient)
+
+    private val mandateId = UUID.fromString("00000000-0000-0000-0000-0000000000d1")
+    private val accountId = UUID.fromString("00000000-0000-0000-0000-0000000000d2")
+
+    private fun collectionAuthorisedEvent(
+        eventType: String = "sdd.collection.authorised.v1",
+        amount: String = "2200.00",
+        currency: String = "EUR",
+    ): String = mapper.writeValueAsString(
+        mapOf(
+            "eventType" to eventType,
+            "mandateId" to mandateId,
+            "accountId" to accountId,
+            "debtorIban" to "DE89370400440532013001",
+            "creditorIdentifier" to "DE98ZZZ09999999999",
+            "umr" to "UMR-2026-001",
+            "scheme" to "CORE",
+            "sequenceType" to "RCUR",
+            "amount" to amount.toBigDecimal(),
+            "currency" to currency,
+            "dueDate" to "2026-07-13",
+            "occurredAt" to "2026-07-13T10:00:00Z",
+        ),
+    )
+
+    @Test
+    fun `books the debtor debit for a collection-authorised event and swallows a 2xx as success`(): Unit = runBlocking {
+        val req = slot<InitiateTransactionRequest>()
+        every { transactionClient.initiateTransaction(capture(req)) } returns
+            Uni.createFrom().item(Response.status(201).build())
+
+        consumer.consume(collectionAuthorisedEvent())
+
+        assertThat(req.captured.idempotencyKey).isEqualTo("so-sdd-$mandateId-UMR-2026-001-2026-07-13")
+        assertThat(req.captured.type).isEqualTo("DEBIT")
+        assertThat(req.captured.sourceAccountId).isEqualTo(accountId)
+        assertThat(req.captured.amount).isEqualByComparingTo("2200.00")
+        assertThat(req.captured.currencyCode).isEqualTo("EUR")
+        assertThat(req.captured.rail).isEqualTo("SEPA_CT")
+        assertThat(req.captured.instructionType).isEqualTo("DIRECT_DEBIT")
+    }
+
+    @Test
+    fun `a 409 from transaction-service is treated as an idempotent success, no error logged`(): Unit = runBlocking {
+        every { transactionClient.initiateTransaction(any()) } returns
+            Uni.createFrom().item(Response.status(409).build())
+
+        // Must not throw — the poison-pill boundary swallows nothing here because 409 is a
+        // recognized, non-exceptional outcome.
+        consumer.consume(collectionAuthorisedEvent())
+
+        verify(exactly = 1) { transactionClient.initiateTransaction(any()) }
+    }
+
+    @Test
+    fun `a non-2xx-non-409 response is handled without throwing (logged as a failure)`(): Unit = runBlocking {
+        every { transactionClient.initiateTransaction(any()) } returns
+            Uni.createFrom().item(Response.status(500).build())
+
+        consumer.consume(collectionAuthorisedEvent())
+
+        verify(exactly = 1) { transactionClient.initiateTransaction(any()) }
+    }
+
+    @Test
+    fun `a mandate lifecycle event (not collection-authorised) is ignored`(): Unit = runBlocking {
+        consumer.consume(collectionAuthorisedEvent(eventType = "sdd.mandate.amended.v1"))
+
+        verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+    }
+
+    @Test
+    fun `a malformed payload is swallowed, not thrown`(): Unit = runBlocking {
+        consumer.consume("{bad-json")
+
+        verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+    }
+
+    @Test
+    fun `amount scale is normalised to the currency's fraction digits`(): Unit = runBlocking {
+        val req = slot<InitiateTransactionRequest>()
+        every { transactionClient.initiateTransaction(capture(req)) } returns
+            Uni.createFrom().item(Response.status(201).build())
+
+        consumer.consume(collectionAuthorisedEvent(amount = "2200.000000"))
+
+        assertThat(req.captured.amount.scale()).isEqualTo(2)
+        assertThat(req.captured.amount).isEqualByComparingTo("2200.00")
+    }
+}

--- a/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/integration/SddBootSmokeIT.kt
+++ b/openbank-sdd-service/src/test/kotlin/com/openbank/sdd/integration/SddBootSmokeIT.kt
@@ -32,6 +32,7 @@ class SddBootSmokeIT {
     class InMemoryKafkaResource : QuarkusTestResourceLifecycleManager {
         override fun start(): Map<String, String> {
             val props = InMemoryConnector.switchOutgoingChannelsToInMemory("sdd-events-out").toMutableMap()
+            props.putAll(InMemoryConnector.switchIncomingChannelsToInMemory("sdd-collection-authorised-in"))
             props["quarkus.kafka.devservices.enabled"] = "false"
             return props
         }


### PR DESCRIPTION
## What & why

sdd-service authorised SEPA Direct Debit collections and stamped `lastCollectionDate`, but the actual debit against the debtor's account never fired anywhere — an authorised collection produced **zero downstream effect**. No consumer existed at all for `sdd.collection.authorised.v1` (the most severe finding of the #996 triage).

## How

Reuses the exact orchestration pattern already proven for #889/#994: `SddCollectionDebitConsumer` self-consumes the event this service itself publishes and books the debit via a new `TransactionServiceClient` REST call (M2M oidc-client token, filter-based — same approach as standing-order's `SepaPaymentClient`; this consumer runs on a plain `@Incoming` suspend handler, not a Temporal activity, so the simpler filter-based token attachment applies here, unlike domestic-payment's `SettlementAdapter` which needs an explicit-token workaround specifically for Temporal thread-context loss).

The collection-authorised event (`mandateId`, `accountId`, `debtorIban`, `amount`, `currency`, `dueDate`, `umr`) is fully self-sufficient — no cross-service lookup needed, unlike #889 which required a separate fix to capture debtor IBAN at creation time. `targetAccountId` is deliberately always `null`: an SDD creditor is, in general, external (a merchant at another bank), never an internal openbank account.

**Idempotency**: deterministic `so-sdd-{mandateId}-{umr}-{dueDate}` key — a Kafka redelivery replays the same booking instead of double-debiting.

## Deliberate scope boundary (per the design discussion on #1000)

This PR books the **happy-path debit only**. It does **NOT**:
- generate or handle an **R-transaction** (SDD scheme return — insufficient funds discovered late, mandate disputed post-collection, etc.)
- persist a **per-collection outcome record** (no such entity exists yet — `SddMandate` only carries a `lastCollectionDate` high-water mark)

A failed debit is logged at ERROR (paging-worthy — an authorised collection that doesn't move money is a real defect) but is not automatically retried or reversed. Designing the return path is real design work, explicitly flagged as a follow-up, not a mechanical extension of this consumer.

## gitops

`TRANSACTION_SERVICE_URL` env var added to the sdd-service deployment. `gen-network-policies.py` regenerated (adds `sdd` → `payments/transaction-service` ingress) — verified via diff, no manual edit.

## Testing

6 new `SddCollectionDebitConsumerTest` cases: success, 409-idempotent, failure (logged not thrown), non-matching eventType ignored, malformed payload swallowed, amount-scale normalization. `openbank-sdd-service`: ktlint + detekt + test + quarkusBuild (CDI wiring) all green locally.

## Linked issues

Refs #1000, Refs #889

## Notes

`sdd-service` — check if already in `rules.yaml: money_path_services` (this PR makes it initiate real money movement for the first time, same "reclassification" note left on #994) — needs 2 approvals regardless given the debit posting. Not merging myself.