### PR TITLE
fix(audit): consume cards/dispute/domestic.payment/sepa.payment/statement/sanctions events

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -64,6 +64,12 @@ class AuditConsumer {
         // security.ict.incident: IctIncidentService.publishEvent nests the incident under
         // "incident" rather than a top-level id field (PR #1007).
         ?: node["incident"]?.get("id")?.asText()
+        // cards.events (CardStatusChanged has no accountId/partyId), dispute.events,
+        // domestic.payment.events + sepa.payment.events, sanctions.screening.event (#996 round 2).
+        ?: node["cardId"]?.asText()
+        ?: node["disputeId"]?.asText()
+        ?: node["paymentId"]?.asText()
+        ?: node["id"]?.asText()
         ?: "unknown"
 
     private fun inferAggregateType(node: JsonNode): String = when {
@@ -75,6 +81,10 @@ class AuditConsumer {
         node.has("batchId") -> "CLEARING_BATCH"
         node.has("itemId") -> "CLEARING_ITEM"
         node.has("incident") -> "ICT_INCIDENT"
+        node.has("cardId") -> "CARD"
+        node.has("disputeId") -> "DISPUTE"
+        node.has("paymentId") -> "PAYMENT"
+        node.has("id") -> "SANCTIONS_CHECK"
         else -> "UNKNOWN"
     }
 }

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -123,7 +123,17 @@ mp:
         # three were publish-with-zero-consumer since introduction. AuditConsumer.consume() is
         # generic (stores payload verbatim, best-effort field extraction with "unknown" fallbacks)
         # — no code change needed to accept a new topic's shape.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event
+        #
+        # cards.events / dispute.events / domestic.payment.events / sepa.payment.events /
+        # statement.event / sanctions.screening.event added in the same #996 sweep, round 2 — each
+        # verified to have a REAL producer (a genuine outbox-row write, not just a declared Kafka
+        # channel) before being added here. Two other #996 candidates in this same batch,
+        # fx.conversion.completed and sepa.instant.events, were found to have NO producer at all
+        # (the outbox message type exists but nothing in the use-case layer ever constructs one) —
+        # deliberately NOT added here; adding a consumer for an event that is never published would
+        # only silence the CI gate without fixing anything. Tracked as their own bugs, not a #996
+        # consumer-side gap (see issues opened in the same PR as this change).
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -129,6 +129,78 @@ class AuditConsumerTest {
     }
 
     @Test
+    fun `consume extracts cardId as aggregateId for a card status-changed event`(): Unit = runBlocking {
+        val cardId = UUID.randomUUID()
+        val payload = """{"eventType":"CARD_STATUS_CHANGED","cardId":"$cardId","newStatus":"BLOCKED"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "CARD" && it.aggregateId == cardId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts disputeId as aggregateId for a dispute-resolved event`(): Unit = runBlocking {
+        val disputeId = UUID.randomUUID()
+        val payload = """{"eventType":"dispute.resolved","disputeId":"$disputeId","outcome":"UPHELD"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "DISPUTE" && it.aggregateId == disputeId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts paymentId as aggregateId for a payment status-changed event`(): Unit = runBlocking {
+        val paymentId = UUID.randomUUID()
+        val payload = """{"eventType":"PAYMENT_STATUS_CHANGED","paymentId":"$paymentId","status":"VALIDATED"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "PAYMENT" && it.aggregateId == paymentId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts the bare id as aggregateId for a sanctions screening event`(): Unit = runBlocking {
+        val checkId = UUID.randomUUID()
+        val payload = """{"eventType":"sanctions.check.completed.v1","id":"$checkId","status":"CLEAR"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "SANCTIONS_CHECK" && it.aggregateId == checkId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
     fun `consume swallows malformed payloads without persisting`() {
         assertThatCode {
             runBlocking { consumer.consume("{bad-json") }

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -10,6 +10,15 @@
 # #996 triage): each was published with zero consumers since introduction — audit-service
 # is the sole intended consumer per the publishing services' own docs.
 #
+# dispute.events / statement.event / sanctions.screening.event added (#996 round 2) —
+# each publisher has its own mTLS KafkaUser with a Write ACL on its topic, which makes
+# that topic ACL-guarded (no longer covered by allow.everyone.if.no.acl.found=true), so
+# audit-service needs an explicit Read+Describe grant to actually consume it. Verified
+# each has a real producer (a genuine outbox-row write) before adding — cards.events /
+# domestic.payment.events / sepa.payment.events have no dedicated mTLS KafkaUser and stay
+# open under allow-everyone, same as clearing/security-scanner above; no ACL change needed
+# for those three.
+#
 # Strimzi User Operator mints a per-user Secret in `messaging` (user.crt/key/p12
 # + user.password + ca.crt). Those secrets are projected into the `audit` namespace
 # by External Secrets below.
@@ -86,6 +95,24 @@ spec:
       - resource:
           type: topic
           name: openbank.security.scan.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.dispute.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.statement.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.sanctions.screening.event
           patternType: literal
         operations: [Read, Describe]
         host: "*"


### PR DESCRIPTION
## What & why

Round 2 of #996 (ADR-0160 event-consumer-liveness triage). Six topics were verified to have a **real producer** (a genuine outbox-row write in the use-case layer, checked call-site by call-site — not just a declared Kafka channel) before being added to audit-service's consumer list:

| Topic | Producer verified at |
|---|---|
| `openbank.cards.events` | `CardService.outboxMessage()` → `repo.save(updated, ...)` |
| `openbank.dispute.events` | `DisputeService` → `disputeRepo.update(updated, messages)` |
| `openbank.domestic.payment.events` | `DomesticPaymentActivitiesImpl` → `paymentRepository.update(...)` |
| `openbank.sepa.payment.events` | `SepaPaymentActivitiesImpl` → `paymentRepository.update(...)` |
| `openbank.statement.event` | `CloseOrchestrator`/`StatementService` → `outbox.append(...)` |
| `openbank.sanctions.screening.event` | `SanctionsRepositoryImpl.saveWithEvent` (transactional) |

Each publisher's own docs name audit-service as an intended consumer; `sepa.payment.events` and `sanctions.screening.event` additionally have a structured `governance.yaml: relationType: topic` lineage entry.

## Changes

1. `openbank-audit-service/src/main/resources/application.yaml`: 6 topics added to `audit-events-in`.
2. `openbank-audit-service/.../AuditConsumer.kt`: `inferAggregateId`/`inferAggregateType` extended with `cardId`/`disputeId`/`paymentId`/`id` so these events get meaningful metadata instead of "unknown" — same quality bar #1007 set. Tests added per new field.
3. `openbank-infra/gitops/.../kafka-audit-mtls.yaml`: Read+Describe ACL grants for `dispute.events`/`statement.event`/`sanctions.screening.event` — each has its own mTLS `KafkaUser` with a Write ACL (ACL-guarded, not open-by-default). `cards.events`/`domestic.payment.events`/`sepa.payment.events` have no dedicated `KafkaUser` and need no ACL change.

## Important: two candidates deliberately NOT included

Investigating this batch surfaced that `openbank.fx.conversion.completed` and `openbank.sepa.instant.events` have **no real producer at all** — not a #996 consumer-gap, a different and more serious bug (an event silently never fires). Filed as separate money-path bug issues rather than papering over them with a pointless audit-service subscription. See the linked issues.

## Verified

- `check-event-consumer-liveness.py`: violation count drops **11 → 4** (the 4 remaining: the 2 dead-producer bugs above, `interest.accrual.event` — WIP tracked separately, `swift.event` — needs real AML business logic, tracked separately).
- ktlint + detekt + test + quarkusBuild all green locally.

## Linked issues

Refs #996

## Notes

Not money-path (audit-service). Not merging without review.