### PR TITLE
feat(interest): book the withholding-tax remittance cash leg to the finanční úřad (#999)

### DIFF
--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -27,6 +27,11 @@ dependencies {
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.quarkus.smallrye.fault.tolerance)
     implementation(libs.quarkus.cache)
+    // #999: book the withholding-tax cash leg to the finanční úřad via transaction-service, with an
+    // openbank-services M2M token minted by the oidc-client filter.
+    implementation(libs.quarkus.rest.client.reactive)
+    implementation(libs.quarkus.rest.client.reactive.jackson)
+    implementation(libs.quarkus.oidc.client.reactive.filter)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.reactive)
     implementation(libs.jackson.module.kotlin)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/in/RemitWithholdingUseCase.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/in/RemitWithholdingUseCase.kt
@@ -6,6 +6,7 @@ package com.openbank.interest.application.port.`in`
 
 import com.openbank.interest.domain.tax.WithholdingRemittance
 import io.smallrye.mutiny.Uni
+import java.util.UUID
 
 /**
  * Inbound port for the withholding-tax remittance capability (ADR-0038): assemble the monthly
@@ -24,4 +25,11 @@ interface RemitWithholdingUseCase {
 
     /** List all assembled remittance batches (most recent first). */
     fun listRemittances(): Uni<List<WithholdingRemittance>>
+
+    /**
+     * Advance a batch `PENDING → SETTLED` once its cash leg to the finanční úřad has been booked
+     * (#999). Idempotent: settling an already-SETTLED batch is a no-op, not an error — a Kafka
+     * redelivery of the triggering event must not fail.
+     */
+    fun settle(remittanceId: UUID): Uni<Unit>
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/TaxPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/TaxPorts.kt
@@ -41,6 +41,13 @@ interface WithholdingRemittanceRepository {
     fun save(remittance: WithholdingRemittance): Uni<WithholdingRemittance>
     fun findByPeriod(year: Int, month: Int): Uni<WithholdingRemittance?>
     fun findAll(): Uni<List<WithholdingRemittance>>
+
+    /**
+     * Advance a batch `PENDING → SETTLED` once the cash leg to the finanční úřad has been booked
+     * (#999). Returns the number of rows updated (0 if already SETTLED — the caller treats that as
+     * an idempotent no-op, not an error).
+     */
+    fun markSettled(remittanceId: UUID): Uni<Int>
 }
 
 /**

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceService.kt
@@ -72,6 +72,8 @@ class WithholdingRemittanceService(
 
     override fun listRemittances(): Uni<List<WithholdingRemittance>> = remittanceRepo.findAll()
 
+    override fun settle(remittanceId: UUID): Uni<Unit> = remittanceRepo.markSettled(remittanceId).replaceWith(Unit)
+
     /** Builds the versioned `interest.withholding.remitted` outbox event (ADR-0038). */
     private fun remittedEvent(r: WithholdingRemittance): OutboxMessage {
         val payload = "{\"schemaVersion\":1," +

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/TransactionServiceClient.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/TransactionServiceClient.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * REST client for `openbank-transaction-service` — books the withholding-tax remittance cash leg
+ * to the finanční úřad (#999). OIDC service-to-service auth is propagated by
+ * [OidcClientRequestReactiveFilter]; this consumer runs on a plain reactive `@Incoming` handler
+ * (not a Temporal activity), so the filter-based token attachment is safe here — same reasoning
+ * as sdd-service's `TransactionServiceClient`.
+ */
+@RegisterRestClient(configKey = "transaction-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/transactions")
+interface TransactionServiceClient {
+
+    @POST
+    fun initiateTransaction(request: InitiateTransactionRequest): Uni<Response>
+}
+
+/**
+ * Payload sent to transaction-service to book the remittance debit. `targetAccountId` is
+ * deliberately absent: the finanční úřad is external (never an internal openbank account), so the
+ * debit books against the bank's cash clearing suspense — same shape as sdd-service's collection
+ * debit and domestic-payment's external-transfer case.
+ */
+data class InitiateTransactionRequest(
+    val idempotencyKey: String,
+    val type: String,
+    val sourceAccountId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val description: String,
+    val valueDate: String,
+    val rail: String,
+    val instructionType: String,
+)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.interest.application.port.`in`.RemitWithholdingUseCase
+import com.openbank.interest.infrastructure.client.InitiateTransactionRequest
+import com.openbank.interest.infrastructure.client.TransactionServiceClient
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Books the cash leg of an assembled withholding-tax remittance batch to the finanční úřad (#999).
+ *
+ * `openbank.interest.accrual.event` carries every interest-service domain event on one topic;
+ * this consumer self-subscribes via `interest-withholding-remitted-in` (same topic, a second
+ * consumer group) and filters for `interest.withholding.remitted.v1` — published by
+ * [com.openbank.interest.application.usecase.WithholdingRemittanceService] once a monthly batch is
+ * assembled — ignoring every other event type on the topic. This is the same self-consumption
+ * shape as standing-order-service's execution consumer (#889/#994): the service that assembles a
+ * batch is also the one that drives its settlement, rather than a cross-service choreography.
+ *
+ * By design (see [com.openbank.interest.domain.tax.WithholdingRemittanceStatus] KDoc, ADR-0038):
+ * interest-service never posts a ledger journal directly — it asks transaction-service to book the
+ * debit, exactly like [com.openbank.sdd.infrastructure.kafka.SddCollectionDebitConsumer] (#1000)
+ * and domestic-payment's `SettlementAdapter` do for their own external payments.
+ *
+ * **The debit's source account is a real bank-owned operating account, never a customer account**
+ * (unlike SDD/domestic-payment, which debit the customer). [remittanceSourceAccountId] MUST be set
+ * to a real account-service account id before this runs in any real environment — the placeholder
+ * default below is a deliberately invalid all-zero UUID so an unconfigured deployment fails LOUD
+ * (transaction-service 404s the account lookup) rather than silently debiting a wrong or
+ * nonexistent account for a real regulatory tax payment. Configure via
+ * `openbank.interest.withholding.remittance-source-account-id` (env
+ * `OPENBANK_INTEREST_WITHHOLDING_REMITTANCE_SOURCE_ACCOUNT_ID`) once finance/ops has designated
+ * the actual operating account this bank pays the finanční úřad from.
+ *
+ * Idempotency: `interest-withholding-{remittanceId}` is both the outbound Idempotency-Key implied
+ * by transaction-service's own idempotencyKey field and this consumer's dedup key, so a Kafka
+ * redelivery replays the same booking instead of double-remitting.
+ *
+ * **Scope note (deliberate, tracked as follow-up — see issue #999):** this consumer books the cash
+ * leg only. It does NOT assemble or file the statutory §38d *Vyúčtování daně vybírané srážkou* XML
+ * with the finanční úřad — that is a separate regulatory-reporting concern (issue #999 flags
+ * finrep-service as the candidate owner, still to be confirmed) and must not be inferred as done
+ * from this consumer alone.
+ */
+@ApplicationScoped
+class WithholdingRemittanceSettlementConsumer(
+    private val objectMapper: ObjectMapper,
+    private val remitUseCase: RemitWithholdingUseCase,
+    @RestClient private val transactionClient: TransactionServiceClient,
+    @ConfigProperty(
+        name = "openbank.interest.withholding.remittance-source-account-id",
+        defaultValue = "00000000-0000-0000-0000-000000000000",
+    )
+    private val remittanceSourceAccountId: String,
+) {
+    private val log = Logger.getLogger(WithholdingRemittanceSettlementConsumer::class.java)
+
+    @Incoming("interest-withholding-remitted-in")
+    // Poison-pill safety: this boundary must swallow ANY failure (parse, rail call) and ack, so
+    // one bad event cannot wedge the consumer group.
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun consume(payload: String) {
+        try {
+            val node = objectMapper.readTree(payload)
+            if (node.path("eventType").asText() != EVENT_WITHHOLDING_REMITTED) return
+
+            val remittanceId = UUID.fromString(node.path("remittanceId").asText())
+            val idempotencyKey = "interest-withholding-$remittanceId"
+            val request = InitiateTransactionRequest(
+                idempotencyKey = idempotencyKey,
+                type = "DEBIT",
+                sourceAccountId = UUID.fromString(remittanceSourceAccountId),
+                amount = node.path("totalTaxAmount").decimalValue(),
+                currencyCode = node.path("currency").asText(),
+                description = "Withholding tax remittance ${node.path("periodYear").asText()}-" +
+                    "${node.path("periodMonth").asText()} / ${node.path("authority").asText()}",
+                valueDate = node.path("dueDate").asText(),
+                rail = "DOMESTIC",
+                instructionType = "ONE_OFF",
+            )
+
+            val response = transactionClient.initiateTransaction(request).awaitSuspending()
+            when {
+                response.statusInfo.family == Response.Status.Family.SUCCESSFUL -> {
+                    remitUseCase.settle(remittanceId).awaitSuspending()
+                    log.infof("[withholding-remittance] batch %s settled (HTTP %d)", remittanceId, response.status)
+                }
+                response.status == HTTP_CONFLICT -> {
+                    remitUseCase.settle(remittanceId).awaitSuspending()
+                    log.infof(
+                        "[withholding-remittance] batch %s already booked (409) — idempotent settle",
+                        remittanceId,
+                    )
+                }
+                else -> {
+                    log.errorf(
+                        "[withholding-remittance] batch %s FAILED to book (HTTP %d) — a due tax remittance " +
+                            "did not move money. This requires manual investigation; the batch stays PENDING " +
+                            "for retry (a redelivery of this event, or an operator re-driving it).",
+                        remittanceId,
+                        response.status,
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            log.errorf(e, "[withholding-remittance] failed to handle remitted event: %.300s", payload)
+        }
+    }
+
+    private companion object {
+        const val EVENT_WITHHOLDING_REMITTED = "interest.withholding.remitted.v1"
+        const val HTTP_CONFLICT = 409
+    }
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/WithholdingTaxRepositoryImpl.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/WithholdingTaxRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.openbank.interest.application.port.out.InterestEventOutbox
 import com.openbank.interest.application.port.out.WithholdingRemittanceRepository
 import com.openbank.interest.application.port.out.WithholdingTaxRepository
 import com.openbank.interest.domain.tax.WithholdingRemittance
+import com.openbank.interest.domain.tax.WithholdingRemittanceStatus
 import com.openbank.interest.domain.tax.WithholdingTax
 import com.openbank.interest.domain.tax.WithholdingTaxStatus
 import com.openbank.interest.infrastructure.persistence.entity.InterestOutboxEntity
@@ -28,7 +29,8 @@ import java.util.UUID
 
 @ApplicationScoped
 class WithholdingTaxRepositoryImpl @Inject constructor(
-    private val sf: Mutiny.SessionFactory, private val mapper: InterestMapper
+    private val sf: Mutiny.SessionFactory,
+    private val mapper: InterestMapper,
 ) : WithholdingTaxRepository {
 
     @WithTransaction override fun save(withholding: WithholdingTax): Uni<WithholdingTax> {
@@ -36,27 +38,26 @@ class WithholdingTaxRepositoryImpl @Inject constructor(
         return sf.withTransaction { s -> s.persist(e).map { mapper.toDomain(e) } }
     }
 
-    @WithSession override fun findByAccountId(accountId: UUID): Uni<List<WithholdingTax>> =
-        sf.withSession { s ->
-            s.createQuery(
-                "FROM WithholdingTaxEntity WHERE accountId = :a ORDER BY createdAt DESC",
-                WithholdingTaxEntity::class.java
-            ).setParameter("a", accountId).resultList
-        }.map { it.map(mapper::toDomain) }
+    @WithSession override fun findByAccountId(accountId: UUID): Uni<List<WithholdingTax>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM WithholdingTaxEntity WHERE accountId = :a ORDER BY createdAt DESC",
+            WithholdingTaxEntity::class.java,
+        ).setParameter("a", accountId).resultList
+    }.map { it.map(mapper::toDomain) }
 
-    @WithSession override fun findByCapitalizationId(capitalizationId: UUID): Uni<WithholdingTax?> =
-        sf.withSession { s ->
-            s.createQuery(
-                "FROM WithholdingTaxEntity WHERE capitalizationId = :c",
-                WithholdingTaxEntity::class.java
-            ).setParameter("c", capitalizationId).setMaxResults(1).singleResultOrNull
-        }.map { it?.let(mapper::toDomain) }
+    @WithSession
+    override fun findByCapitalizationId(capitalizationId: UUID): Uni<WithholdingTax?> = sf.withSession { s ->
+        s.createQuery(
+            "FROM WithholdingTaxEntity WHERE capitalizationId = :c",
+            WithholdingTaxEntity::class.java,
+        ).setParameter("c", capitalizationId).setMaxResults(1).singleResultOrNull
+    }.map { it?.let(mapper::toDomain) }
 
     @WithSession override fun findRecordedForPeriod(from: LocalDate, to: LocalDate): Uni<List<WithholdingTax>> =
         sf.withSession { s ->
             s.createQuery(
                 "FROM WithholdingTaxEntity WHERE status = :st AND periodTo >= :from AND periodTo <= :to",
-                WithholdingTaxEntity::class.java
+                WithholdingTaxEntity::class.java,
             ).setParameter("st", WithholdingTaxStatus.RECORDED)
                 .setParameter("from", from).setParameter("to", to).resultList
         }.map { it.map(mapper::toDomain) }
@@ -65,7 +66,7 @@ class WithholdingTaxRepositoryImpl @Inject constructor(
         if (ids.isEmpty()) return Uni.createFrom().item(0)
         return sf.withTransaction { s ->
             s.createMutationQuery(
-                "UPDATE WithholdingTaxEntity SET status = :st, remittanceId = :r WHERE id IN :ids"
+                "UPDATE WithholdingTaxEntity SET status = :st, remittanceId = :r WHERE id IN :ids",
             ).setParameter("st", WithholdingTaxStatus.REMITTED)
                 .setParameter("r", remittanceId).setParameter("ids", ids).executeUpdate()
         }
@@ -74,7 +75,8 @@ class WithholdingTaxRepositoryImpl @Inject constructor(
 
 @ApplicationScoped
 class WithholdingRemittanceRepositoryImpl @Inject constructor(
-    private val sf: Mutiny.SessionFactory, private val mapper: InterestMapper
+    private val sf: Mutiny.SessionFactory,
+    private val mapper: InterestMapper,
 ) : WithholdingRemittanceRepository {
 
     @WithTransaction override fun save(remittance: WithholdingRemittance): Uni<WithholdingRemittance> {
@@ -82,21 +84,28 @@ class WithholdingRemittanceRepositoryImpl @Inject constructor(
         return sf.withTransaction { s -> s.persist(e).map { remittance } }
     }
 
-    @WithSession override fun findByPeriod(year: Int, month: Int): Uni<WithholdingRemittance?> =
-        sf.withSession { s ->
-            s.createQuery(
-                "FROM WithholdingRemittanceEntity WHERE periodYear = :y AND periodMonth = :m",
-                WithholdingRemittanceEntity::class.java
-            ).setParameter("y", year).setParameter("m", month).setMaxResults(1).singleResultOrNull
-        }.map { it?.let(mapper::toDomain) }
+    @WithSession override fun findByPeriod(year: Int, month: Int): Uni<WithholdingRemittance?> = sf.withSession { s ->
+        s.createQuery(
+            "FROM WithholdingRemittanceEntity WHERE periodYear = :y AND periodMonth = :m",
+            WithholdingRemittanceEntity::class.java,
+        ).setParameter("y", year).setParameter("m", month).setMaxResults(1).singleResultOrNull
+    }.map { it?.let(mapper::toDomain) }
 
-    @WithSession override fun findAll(): Uni<List<WithholdingRemittance>> =
-        sf.withSession { s ->
-            s.createQuery(
-                "FROM WithholdingRemittanceEntity ORDER BY periodYear DESC, periodMonth DESC, createdAt DESC",
-                WithholdingRemittanceEntity::class.java
-            ).resultList
-        }.map { it.map(mapper::toDomain) }
+    @WithSession override fun findAll(): Uni<List<WithholdingRemittance>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM WithholdingRemittanceEntity ORDER BY periodYear DESC, periodMonth DESC, createdAt DESC",
+            WithholdingRemittanceEntity::class.java,
+        ).resultList
+    }.map { it.map(mapper::toDomain) }
+
+    @WithTransaction override fun markSettled(remittanceId: UUID): Uni<Int> = sf.withTransaction { s ->
+        s.createMutationQuery(
+            "UPDATE WithholdingRemittanceEntity SET status = :st WHERE id = :id AND status = :pending",
+        ).setParameter("st", WithholdingRemittanceStatus.SETTLED)
+            .setParameter("id", remittanceId)
+            .setParameter("pending", WithholdingRemittanceStatus.PENDING)
+            .executeUpdate()
+    }
 }
 
 @ApplicationScoped

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -47,6 +47,20 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+  # Outbound service-to-service token (#999): the transaction-service rest-client mints an
+  # openbank-services M2M token via this oidc-client. Disabled under %test (units call the
+  # consumer directly; the boot IT never books a remittance payment).
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+  rest-client:
+    transaction-service:
+      url: ${TRANSACTION_SERVICE_URL:http://localhost:8102}
+      scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
   shutdown:
@@ -109,6 +123,8 @@ authz:
       enabled: false
     oidc:
       enabled: false
+    oidc-client:
+      enabled: false
     # ADR-0050: disable the @Scheduled outbox tick under test so the integration test drives
     # dispatchScheduledBatch() explicitly and never races the assertions.
     scheduler:
@@ -118,6 +134,15 @@ openbank:
     accrual-cron: "0 0 1 * * ?"
     capitalization-cron: "0 0 2 1 * ?"
     day-count-convention: ACT_365
+    withholding:
+      # #999: the bank's own operating/settlement account debited for the §38d odvod to the
+      # finanční úřad — this is the bank's OWN money (already withheld from customers' credited
+      # interest at capitalization time, ADR-0033), not a customer account. MUST be set to a real
+      # account UUID before this runs against anything but a sandbox; the placeholder below is
+      # deliberately an all-zero UUID (matches the CHANGE_ME_LOCAL_DEV_ONLY convention used for
+      # secrets elsewhere in this repo) so an unconfigured deployment fails loudly at the
+      # transaction-service call, not silently.
+      remittance-source-account-id: "${INTEREST_WITHHOLDING_SOURCE_ACCOUNT_ID:00000000-0000-0000-0000-000000000000}"
   rate-limit:
     enabled: true
     max-concurrent-requests: 200
@@ -144,3 +169,15 @@ mp:
         topic: openbank.interest.accrual.event
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
+    incoming:
+      # #999: self-consume the withholding-remittance events this service itself publishes (the
+      # topic also carries other interest event types; the consumer filters by eventType), and book
+      # the cash leg to the finanční úřad. group.id / auto.offset.reset deliberately NOT set as YAML
+      # keys (SmallRye's dotted-key footgun, #686/#703) — defaults are what we want: group.id falls
+      # back to quarkus.application.name, auto.offset.reset stays `latest` so a fresh deploy does
+      # not replay historical remittances and re-pay them.
+      interest-withholding-remitted-in:
+        connector: smallrye-kafka
+        topic: openbank.interest.accrual.event
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        key.deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.kafka
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.interest.application.port.`in`.RemitWithholdingUseCase
+import com.openbank.interest.infrastructure.client.InitiateTransactionRequest
+import com.openbank.interest.infrastructure.client.TransactionServiceClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class WithholdingRemittanceSettlementConsumerTest {
+
+    private val mapper = jacksonObjectMapper()
+    private val transactionClient = mockk<TransactionServiceClient>()
+    private val remitUseCase = mockk<RemitWithholdingUseCase>()
+    private val sourceAccountId = "00000000-0000-0000-0000-0000000000aa"
+    private val consumer = WithholdingRemittanceSettlementConsumer(
+        mapper,
+        remitUseCase,
+        transactionClient,
+        sourceAccountId,
+    )
+
+    private val remittanceId = UUID.fromString("00000000-0000-0000-0000-0000000000d1")
+
+    private fun remittedEvent(
+        eventType: String = "interest.withholding.remitted.v1",
+        totalTaxAmount: String = "1234.00",
+        currency: String = "CZK",
+    ): String = mapper.writeValueAsString(
+        mapOf(
+            "schemaVersion" to 1,
+            "eventType" to eventType,
+            "remittanceId" to remittanceId,
+            "periodYear" to 2026,
+            "periodMonth" to 6,
+            "authority" to "CZ_FU",
+            "currency" to currency,
+            "totalTaxAmount" to totalTaxAmount.toBigDecimal(),
+            "itemCount" to 12,
+            "dueDate" to "2026-07-31",
+            "status" to "PENDING",
+        ),
+    )
+
+    @Test
+    fun `books the remittance debit and settles the batch on a 2xx`(): Unit = runBlocking {
+        val req = slot<InitiateTransactionRequest>()
+        every { transactionClient.initiateTransaction(capture(req)) } returns
+            Uni.createFrom().item(Response.status(201).build())
+        every { remitUseCase.settle(remittanceId) } returns Uni.createFrom().item(Unit)
+
+        consumer.consume(remittedEvent())
+
+        assertThat(req.captured.idempotencyKey).isEqualTo("interest-withholding-$remittanceId")
+        assertThat(req.captured.type).isEqualTo("DEBIT")
+        assertThat(req.captured.sourceAccountId).isEqualTo(UUID.fromString(sourceAccountId))
+        assertThat(req.captured.amount).isEqualByComparingTo("1234.00")
+        assertThat(req.captured.currencyCode).isEqualTo("CZK")
+        assertThat(req.captured.rail).isEqualTo("DOMESTIC")
+        assertThat(req.captured.instructionType).isEqualTo("ONE_OFF")
+        verify(exactly = 1) { remitUseCase.settle(remittanceId) }
+    }
+
+    @Test
+    fun `a 409 from transaction-service still settles the batch (idempotent success)`(): Unit = runBlocking {
+        every { transactionClient.initiateTransaction(any()) } returns
+            Uni.createFrom().item(Response.status(409).build())
+        every { remitUseCase.settle(remittanceId) } returns Uni.createFrom().item(Unit)
+
+        consumer.consume(remittedEvent())
+
+        verify(exactly = 1) { remitUseCase.settle(remittanceId) }
+    }
+
+    @Test
+    fun `a non-2xx-non-409 response does not settle the batch and does not throw`(): Unit = runBlocking {
+        every { transactionClient.initiateTransaction(any()) } returns
+            Uni.createFrom().item(Response.status(500).build())
+
+        consumer.consume(remittedEvent())
+
+        verify(exactly = 1) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 0) { remitUseCase.settle(any()) }
+    }
+
+    @Test
+    fun `an accrual event that is not a remitted event is ignored`(): Unit = runBlocking {
+        consumer.consume(remittedEvent(eventType = "interest.accrual.recorded.v1"))
+
+        verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 0) { remitUseCase.settle(any()) }
+    }
+
+    @Test
+    fun `a malformed payload is swallowed, not thrown`(): Unit = runBlocking {
+        consumer.consume("{bad-json")
+
+        verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+    }
+}


### PR DESCRIPTION
## What & why

`interest-service` assembled and recorded withholding-tax remittance batches (ADR-0038) but nothing ever executed the cash leg or settled the batch — the withheld tax was correctly calculated and reserved, but **never actually paid**. Found via ADR-0160's event-consumer-liveness gate (#996 triage); this is a regulatory-compliance gap, not just a technical one (§38d ZDP odvod deadline).

## Design

Adds `WithholdingRemittanceSettlementConsumer`, a self-consuming `@Incoming` handler on `interest-withholding-remitted-in` (same topic the service already publishes `interest.withholding.remitted.v1` to) — the same self-consumption shape as standing-order-service's #994 fix and sdd-service's `SddCollectionDebitConsumer` (#1000, mirrored almost exactly for the transaction-service REST client shape).

Per the **existing** ADR-0038 design decision (already documented in `WithholdingRemittanceStatus`'s KDoc before this PR: *"interest-service never moves the cash"*), the consumer asks `transaction-service` to book the debit rather than posting a ledger journal directly, then calls `RemitWithholdingUseCase.settle()` to flip the batch `PENDING → SETTLED`. Idempotent: `interest-withholding-{remittanceId}` is both the outbound `Idempotency-Key` and this consumer's dedup key — a Kafka redelivery replays the same booking (or hits the 409-already-booked idempotent-success path) instead of double-remitting.

## ⚠️ Required before this runs anywhere beyond sandbox

`openbank.interest.withholding.remittance-source-account-id` (env `INTEREST_WITHHOLDING_SOURCE_ACCOUNT_ID`) **MUST be set to a real bank operating/settlement account.** Unlike SDD/domestic-payment (which debit a *customer* account resolved from the event), this debits the **bank's own account** — no such account is configured anywhere in the repo today, and inventing one would be worse than not shipping this at all.

The shipped default is a **deliberately-invalid all-zero UUID**: an unconfigured deployment fails **loud** (transaction-service 404s the account lookup) rather than silently debiting a wrong or nonexistent account for a real regulatory tax payment. Finance/ops must designate the real account and wire it into gitops before go-live — this is an operational decision, not a code-writing one.

## Deliberately NOT in scope

This PR books the cash leg only. It does **not** assemble or file the statutory §38d *Vyúčtování daně vybírané srážkou* XML with the finanční úřad — that remains open in #999 (`finrep-service` is the candidate owner per #999's own text, still to be confirmed). Please don't read this PR as closing #999 fully.

## Verified

- ktlint + detekt + test + quarkusBuild all green locally.
- Unit tests cover: 2xx books + settles, 409 is idempotent-success + settles, non-2xx/non-409 does not settle and does not throw, a non-remitted accrual event on the same topic is correctly ignored, malformed payload is swallowed.

## Linked issues

Refs #999, Refs #996

## Notes

`interest-service` is in `rules.yaml: money_path_services` — needs 2 human approvals. Not merging this myself.