### PR TITLE
chore(gitops): auto-deploy services @ 237c397cfb408f0cc1f0581fffa41557ffe08082

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -69,7 +69,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -42,7 +42,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: agent-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-agent-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-agent-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/aml/aml-service.yaml
+++ b/openbank-infra/gitops/components/aml/aml-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: aml-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-aml-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-aml-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: anacredit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-8a35e3ad
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-anacredit-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/audit/audit-service.yaml
+++ b/openbank-infra/gitops/components/audit/audit-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: audit-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-audit-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-audit-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -40,7 +40,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: copilot-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-copilot-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-copilot-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
+++ b/openbank-infra/gitops/components/devops-agent/devops-agent.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: devops-agent
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-devops-agent:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-devops-agent:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
+++ b/openbank-infra/gitops/components/dispute-service/dispute-service.yaml
@@ -22,7 +22,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: dispute-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-dispute-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-dispute-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8135}

--- a/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
+++ b/openbank-infra/gitops/components/finops-agent/finops-agent.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: finops-agent
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finops-agent:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finops-agent:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -32,7 +32,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: fx-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fx-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fx-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8119}

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -26,7 +26,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: interest-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-8a35e3ad
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8125}

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1376,7 +1376,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: clearing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-clearing-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-clearing-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1660,7 +1660,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: standing-order-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-standing-order-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-standing-order-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1791,7 +1791,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: card-issuance-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-card-issuance-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-card-issuance-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -2449,7 +2449,7 @@ spec:
         - name: swift-service
 
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-swift-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-swift-service:sandbox-237c397c
 
           imagePullPolicy: IfNotPresent
           ports:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: pid-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-pid-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-pid-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
+++ b/openbank-infra/gitops/components/psd2-service/psd2-service.yaml
@@ -25,7 +25,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: psd2-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-psd2-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-psd2-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8107}

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -60,7 +60,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sanctions-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sanctions-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sanctions-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: sdd-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sdd-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sdd-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
+++ b/openbank-infra/gitops/components/security-scanner/security-scanner-service.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: security-scanner-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-security-scanner:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-security-scanner:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/statements/statement-service.yaml
+++ b/openbank-infra/gitops/components/statements/statement-service.yaml
@@ -41,7 +41,7 @@ spec:
           # Kyverno's verify-openbank-image-sbom-attestation policy blocked every pod
           # (Deployment stuck at 0/1) → the EoM close / Closings screen read "not
           # responding". sandbox-a407c3ae is the #706 main build with a valid attestation.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-statement-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-statement-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
+++ b/openbank-infra/gitops/components/tpp-registry/tpp-registry-service.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: tpp-registry-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-tpp-registry-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-tpp-registry-service:sandbox-237c397c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 237c397cfb408f0cc1f0581fffa41557ffe08082.

**Changed services:** ["openbank-account-service","openbank-ledger-service","openbank-transaction-service","openbank-pid-service","openbank-balance-service","openbank-consent-service","openbank-psd2-service","openbank-tpp-registry-service","openbank-agent-service","openbank-copilot-service","openbank-sca-service","openbank-party-service","openbank-notification-service","openbank-audit-service","openbank-kyc-service","openbank-sepa-payment","openbank-domestic-payment","openbank-aml-service","openbank-card-issuance-service","openbank-fx-service","openbank-standing-order-service","openbank-swift-service","openbank-sanctions-service","openbank-fraud-service","openbank-security-scanner","openbank-product-catalog","openbank-clearing-service","openbank-interest-service","openbank-dispute-service","openbank-sepa-instant","openbank-lending-service","openbank-statement-service","openbank-sdd-service","openbank-customer-edge","openbank-onboarding-service","openbank-settlement-service","openbank-finops-agent","openbank-devops-agent","openbank-billing-service","openbank-anacredit-service"]

Each image tag was updated to `sandbox-237c397cfb408f0cc1f0581fffa41557ffe08082` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.