### PR TITLE
fix(audit): consume sepa.instant.events, correcting issue #1034's premise

### DIFF
--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -33,7 +33,9 @@ class AuditConsumer {
             val node: JsonNode = objectMapper.readTree(payload)
             val entry = AuditEntry(
                 id = UUID.randomUUID(),
-                eventType = node["eventType"]?.asText() ?: "UNKNOWN",
+                // sepa.instant.events (KafkaSctInstEventPublisher) names its discriminator "type",
+                // not "eventType" — the only #996-consumed producer that does so.
+                eventType = node["eventType"]?.asText() ?: node["type"]?.asText() ?: "UNKNOWN",
                 aggregateType = node["aggregateType"]?.asText() ?: inferAggregateType(node),
                 aggregateId = inferAggregateId(node),
                 actorId = node["requestedBy"]?.asText()

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -64,6 +64,12 @@ class AuditConsumer {
         // security.ict.incident: IctIncidentService.publishEvent nests the incident under
         // "incident" rather than a top-level id field (PR #1007).
         ?: node["incident"]?.get("id")?.asText()
+        // cards.events (CardStatusChanged has no accountId/partyId), dispute.events,
+        // domestic.payment.events + sepa.payment.events, sanctions.screening.event (#996 round 2).
+        ?: node["cardId"]?.asText()
+        ?: node["disputeId"]?.asText()
+        ?: node["paymentId"]?.asText()
+        ?: node["id"]?.asText()
         ?: "unknown"
 
     private fun inferAggregateType(node: JsonNode): String = when {
@@ -75,6 +81,10 @@ class AuditConsumer {
         node.has("batchId") -> "CLEARING_BATCH"
         node.has("itemId") -> "CLEARING_ITEM"
         node.has("incident") -> "ICT_INCIDENT"
+        node.has("cardId") -> "CARD"
+        node.has("disputeId") -> "DISPUTE"
+        node.has("paymentId") -> "PAYMENT"
+        node.has("id") -> "SANCTIONS_CHECK"
         else -> "UNKNOWN"
     }
 }

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -127,13 +127,16 @@ mp:
         # cards.events / dispute.events / domestic.payment.events / sepa.payment.events /
         # statement.event / sanctions.screening.event added in the same #996 sweep, round 2 — each
         # verified to have a REAL producer (a genuine outbox-row write, not just a declared Kafka
-        # channel) before being added here. Two other #996 candidates in this same batch,
-        # fx.conversion.completed and sepa.instant.events, were found to have NO producer at all
-        # (the outbox message type exists but nothing in the use-case layer ever constructs one) —
-        # deliberately NOT added here; adding a consumer for an event that is never published would
-        # only silence the CI gate without fixing anything. Tracked as their own bugs, not a #996
-        # consumer-side gap (see issues opened in the same PR as this change).
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event
+        # channel) before being added here. openbank.fx.conversion.completed was found to have NO
+        # producer at all (KafkaFxEventPublisher.publish() was a no-op stub) — deliberately NOT
+        # added here until #1033 wires a real publisher; adding a consumer for an event that is
+        # never published would only silence the CI gate without fixing anything.
+        # openbank.sepa.instant.events, by contrast, DOES have a real, working producer
+        # (KafkaSctInstEventPublisher, called from SctInstPaymentService at every lifecycle
+        # transition) — an initial #996 triage pass mistook a separate, dead/unused outbox port
+        # (SctInstOutboxPort) for the only pipeline and wrongly concluded nothing was ever
+        # published; corrected here.
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -123,7 +123,17 @@ mp:
         # three were publish-with-zero-consumer since introduction. AuditConsumer.consume() is
         # generic (stores payload verbatim, best-effort field extraction with "unknown" fallbacks)
         # — no code change needed to accept a new topic's shape.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event
+        #
+        # cards.events / dispute.events / domestic.payment.events / sepa.payment.events /
+        # statement.event / sanctions.screening.event added in the same #996 sweep, round 2 — each
+        # verified to have a REAL producer (a genuine outbox-row write, not just a declared Kafka
+        # channel) before being added here. Two other #996 candidates in this same batch,
+        # fx.conversion.completed and sepa.instant.events, were found to have NO producer at all
+        # (the outbox message type exists but nothing in the use-case layer ever constructs one) —
+        # deliberately NOT added here; adding a consumer for an event that is never published would
+        # only silence the CI gate without fixing anything. Tracked as their own bugs, not a #996
+        # consumer-side gap (see issues opened in the same PR as this change).
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -183,6 +183,29 @@ class AuditConsumerTest {
     }
 
     @Test
+    fun `consume falls back to the type field for eventType on a SEPA Instant event`(): Unit = runBlocking {
+        val paymentId = UUID.randomUUID()
+        // KafkaSctInstEventPublisher's wire shape: {"type": <event class name>, "paymentId",
+        // "occurredAt"} — no "eventType" key.
+        val payload =
+            """{"type":"SctInstPaymentSettled","paymentId":"$paymentId","occurredAt":"2026-07-14T00:00:00Z"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.eventType == "SctInstPaymentSettled" &&
+                        it.aggregateType == "PAYMENT" &&
+                        it.aggregateId == paymentId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
     fun `consume extracts the bare id as aggregateId for a sanctions screening event`(): Unit = runBlocking {
         val checkId = UUID.randomUUID()
         val payload = """{"eventType":"sanctions.check.completed.v1","id":"$checkId","status":"CLEAR"}"""

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -129,6 +129,78 @@ class AuditConsumerTest {
     }
 
     @Test
+    fun `consume extracts cardId as aggregateId for a card status-changed event`(): Unit = runBlocking {
+        val cardId = UUID.randomUUID()
+        val payload = """{"eventType":"CARD_STATUS_CHANGED","cardId":"$cardId","newStatus":"BLOCKED"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "CARD" && it.aggregateId == cardId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts disputeId as aggregateId for a dispute-resolved event`(): Unit = runBlocking {
+        val disputeId = UUID.randomUUID()
+        val payload = """{"eventType":"dispute.resolved","disputeId":"$disputeId","outcome":"UPHELD"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "DISPUTE" && it.aggregateId == disputeId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts paymentId as aggregateId for a payment status-changed event`(): Unit = runBlocking {
+        val paymentId = UUID.randomUUID()
+        val payload = """{"eventType":"PAYMENT_STATUS_CHANGED","paymentId":"$paymentId","status":"VALIDATED"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "PAYMENT" && it.aggregateId == paymentId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts the bare id as aggregateId for a sanctions screening event`(): Unit = runBlocking {
+        val checkId = UUID.randomUUID()
+        val payload = """{"eventType":"sanctions.check.completed.v1","id":"$checkId","status":"CLEAR"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "SANCTIONS_CHECK" && it.aggregateId == checkId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
     fun `consume swallows malformed payloads without persisting`() {
         assertThatCode {
             runBlocking { consumer.consume("{bad-json") }

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -10,6 +10,15 @@
 # #996 triage): each was published with zero consumers since introduction — audit-service
 # is the sole intended consumer per the publishing services' own docs.
 #
+# dispute.events / statement.event / sanctions.screening.event added (#996 round 2) —
+# each publisher has its own mTLS KafkaUser with a Write ACL on its topic, which makes
+# that topic ACL-guarded (no longer covered by allow.everyone.if.no.acl.found=true), so
+# audit-service needs an explicit Read+Describe grant to actually consume it. Verified
+# each has a real producer (a genuine outbox-row write) before adding — cards.events /
+# domestic.payment.events / sepa.payment.events have no dedicated mTLS KafkaUser and stay
+# open under allow-everyone, same as clearing/security-scanner above; no ACL change needed
+# for those three.
+#
 # Strimzi User Operator mints a per-user Secret in `messaging` (user.crt/key/p12
 # + user.password + ca.crt). Those secrets are projected into the `audit` namespace
 # by External Secrets below.
@@ -86,6 +95,24 @@ spec:
       - resource:
           type: topic
           name: openbank.security.scan.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.dispute.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.statement.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.sanctions.screening.event
           patternType: literal
         operations: [Read, Describe]
         host: "*"


### PR DESCRIPTION
## What & why

Stacks on #1032 (same file, `AuditConsumer.kt`/`application.yaml`) — should merge **after** #1032.

Corrects a factual mistake in #1034. That issue claimed `openbank.sepa.instant.events` had **no producer at all**. Investigating further while implementing this fix found that's wrong: sepa-instant has two parallel event-publishing pipelines, and the #996 triage only checked one of them.

- **`SctInstOutboxPort`** (`SctInstOutboxMessage`/`SctInstOutboxRepository`/dispatcher/backlog-gauge) — genuinely dead. Nothing in the use-case layer ever constructs an `SctInstOutboxMessage`. This is what #1034 found and (wrongly) assumed was the only pipeline.
- **`SctInstEventPublisher` / `KafkaSctInstEventPublisher`** — real and working. Called directly from `SctInstPaymentService` at every actual lifecycle transition (submit, settle, reject, recall). Events have been reaching `openbank.sepa.instant.events` the whole time.

So the real #996 gap here was the ordinary one: no consumer. Same class of fix as #1032's other 6 topics.

## Changes

1. `openbank-audit-service/src/main/resources/application.yaml`: adds `openbank.sepa.instant.events` to `audit-events-in`, and corrects the stale comment that mischaracterized this topic as producer-less.
2. `AuditConsumer.kt`: `KafkaSctInstEventPublisher`'s wire shape names its discriminator field `"type"`, not `"eventType"` like every other producer this consumer handles — added as a fallback. `paymentId`/`PAYMENT` inference already exists (from #1032).
3. Test added.

## Verified

No dedicated sepa-instant `KafkaUser` grants a Write ACL on this topic (open by `allow-everyone.if.no.acl.found`, same as round-1's `cards.events`/`domestic.payment.events`) — no ACL change needed. ktlint/detekt/test/quarkusBuild all green locally.

## Follow-up (not in this PR)

`SctInstOutboxPort.kt` and its unused `SctInstOutboxDispatcher`/backlog-gauge/repository-impl are genuinely dead code — worth a cleanup issue, out of scope here.

## Linked issues

Refs #996, corrects #1034 (see correction comment on that issue)