### PR TITLE
chore(infra): first real image build for document-service + renderer

### DIFF
--- a/openbank-infra/gitops/components/document-renderer/document-renderer-service.yaml
+++ b/openbank-infra/gitops/components/document-renderer/document-renderer-service.yaml
@@ -43,13 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-renderer
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-renderer:sandbox-pending-build
-          # NOTE: brand-new image, never pushed to ECR — sandbox-pending-build is a
-          # deliberately-fake placeholder tag (mirrors document-service's own
-          # first-gitops-PR placeholder). It HAS been built + run locally
-          # (docker build -t openbank-document-renderer:local ., per README.md) but
-          # not pushed anywhere — needs a real build+push to ECR before this
-          # Deployment can actually roll out.
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-renderer:sandbox-ed34a077
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -54,13 +54,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-pending-build
-          # NOTE: this service has never been built/pushed to ECR (brand new,
-          # this PR is its first gitops registration) — sandbox-pending-build is a
-          # deliberately-fake placeholder tag, not a real image. Needs a real
-          # openbank-infra/scripts/build-push-service.sh document-service run
-          # (which also generates and COPYs the SBOM, per ADR-0121 Axis 1) before
-          # this Deployment can actually roll out.
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-ed34a077
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
- `openbank-document-service` and `openbank-document-renderer` had never actually been built and pushed to ECR since being scaffolded — both gitops manifests still carried the `sandbox-pending-build` placeholder tag. The shared `Auto deploy` pipeline never picked either up: `can-i-deploy` is currently failing fleet-wide on an unrelated Pact-broker environment-registration bug (`name 'sandbox' is already used by an existing environment`), and neither service has a contract registered there yet anyway.
- Net effect: the pod for document-service never actually ran anywhere, so the demo templates seeded on boot (#1052) were invisible.
- Created both ECR repositories (`openbank-document-service`, `openbank-document-renderer`) — not Terraform-owned, per the existing convention documented in `ecr-image-scanning.tf` (service repos are created on first push).
- Built + pushed + cosign-signed both images by hand: `openbank-infra/scripts/build-push-service.sh document-service --bump` for the Gradle service, a matching manual `docker buildx` + `cosign sign` for the renderer (a plain Python image, not a Gradle module).
- Bumped both gitops manifests to the real tag `sandbox-ed34a077` and removed the now-stale "never built" comments.

## Test plan
- [x] `aws ecr describe-repositories` confirms both repos exist
- [x] Both images pushed and cosign-signed (kyverno admission requires this)
- [ ] Once ArgoCD syncs, verify the document-service pod actually starts and the seeded templates appear in the admin-ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)