### PR TITLE
fix(infra): grant eso-kafka-cert-reader read access to document-service secret

### DIFF
--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -312,6 +312,7 @@ rules:
       - kyc-service
       - anacredit-service               # issue #638: LoanStageEventConsumer (ADR-0037 follow-up)
       - agent-service                   # issue #686: oversight-triggers consumer, ns platform (first ESO client there)
+      - document-service                # ADR-0161/0162: document lifecycle events, ns documents (first ESO client there)
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
- Root cause of document-service never actually deploying (beyond the missing image fixed in #1064): the Kafka mTLS keystore `ExternalSecret` (`documents/document-service-kafka-keystore`) has been failing since document-service's first gitops registration with `could not get secret data from provider`.
- The `KafkaUser` and its Strimzi-generated secret (`messaging/document-service`) both exist, but the `eso-kafka-cert-reader` `Role` in the `messaging` namespace uses a hardcoded `resourceNames` allowlist that every Kafka-consuming service must be added to — `document-service` was never added.
- Without this, ArgoCD's automated sync retries indefinitely (observed: attempt #10) and never actually creates the Deployment, so the pod has never run in the sandbox cluster.

## Test plan
- [x] `kubectl auth can-i get secret/document-service -n messaging --as=system:serviceaccount:messaging:eso-kafka-cert-reader` currently returns `no` — will re-verify `yes` after merge + sync
- [ ] `ExternalSecret document-service-kafka-keystore` reaches `Ready=True`
- [ ] `document-service` pod reaches `Running`/`Ready` in the `documents` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)