### PR TITLE
chore(infra): bump document-service image to sandbox-7e49b9b5

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -54,7 +54,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-ed34a077
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-7e49b9b5
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
Bumps the document-service gitops image tag to the build containing the bodyHtml fix (#1073). Built, cosign v2 signed, and CycloneDX-SBOM attested by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)