### PR TITLE
fix(audit,governance): #996 round 3 + graduate event-consumer-liveness to enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,11 +345,10 @@ jobs:
       # ADR-0160 mechanism 1 / rules.yaml: change_requirements.event_consumer_liveness.
       # Fleet-wide scan (not diff-scoped): every Kafka topic a service publishes must have a
       # real @Incoming consumer somewhere in the fleet, or a one-line-reasoned allowlist entry.
-      # ADVISORY (ADR-0144) — findings are ::warning annotations; pyyaml is already installed by
-      # the step above. Flip to enforced once the 19-topic first-scan triage lands = add
-      # --enforce below.
-      - name: "event-consumer liveness (ADR-0160, advisory)"
-        run: python3 .github/scripts/check-event-consumer-liveness.py
+      # ENFORCED (graduated 2026-07-14, ADR-0144): the #996 triage that began with issue #889
+      # brought unallowlisted violations to zero across three rounds.
+      - name: "event-consumer liveness (ADR-0160, enforced)"
+        run: python3 .github/scripts/check-event-consumer-liveness.py --enforce
 
       # ADR-0160 mechanism 2 / rules.yaml: change_requirements.lineage_code_audit. Fleet-wide scan
       # (not diff-scoped): every governance.yaml lineage.downstream edge must be backed by

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/application/AuditConsumer.kt
@@ -55,38 +55,44 @@ class AuditConsumer {
         }
     }
 
-    private fun inferAggregateId(node: JsonNode): String = node["accountId"]?.asText()
-        ?: node["partyId"]?.asText()
-        ?: node["transactionId"]?.asText()
-        ?: node["consentId"]?.asText()
-        // clearing.batch.event: publishBatchSettled/publishItemCleared carry batchId/itemId, not a
-        // shared aggregate field name (PR #1007).
-        ?: node["batchId"]?.asText()
-        ?: node["itemId"]?.asText()
-        // security.ict.incident: IctIncidentService.publishEvent nests the incident under
-        // "incident" rather than a top-level id field (PR #1007).
-        ?: node["incident"]?.get("id")?.asText()
-        // cards.events (CardStatusChanged has no accountId/partyId), dispute.events,
-        // domestic.payment.events + sepa.payment.events, sanctions.screening.event (#996 round 2).
-        ?: node["cardId"]?.asText()
-        ?: node["disputeId"]?.asText()
-        ?: node["paymentId"]?.asText()
-        ?: node["id"]?.asText()
-        ?: "unknown"
+    // Ordered (field name -> aggregate type) fallback chain, first match wins. One shared table
+    // backs both inferAggregateId/inferAggregateType instead of two parallel chains that drift —
+    // add a new topic's identifying field here rather than duplicating a branch in both functions
+    // (kept the two in sync by hand across #996 rounds 1-3 until this got too complex; also fixes
+    // a latent inconsistency where kycCaseId had a type but no matching id-extraction branch).
+    // "incident" (security.ict.incident) is the one exception: its id is nested, not a top-level
+    // field, so it is handled separately before this table.
+    private val aggregateFields = listOf(
+        "accountId" to "ACCOUNT",
+        "partyId" to "PARTY",
+        "transactionId" to "TRANSACTION",
+        "consentId" to "CONSENT",
+        "kycCaseId" to "KYC_CASE",
+        "batchId" to "CLEARING_BATCH",
+        "itemId" to "CLEARING_ITEM",
+        "cardId" to "CARD",
+        "disputeId" to "DISPUTE",
+        "paymentId" to "PAYMENT",
+        "documentId" to "DOCUMENT",
+        "ceremonyId" to "SIGNATURE_CEREMONY",
+        "conversionId" to "FX_CONVERSION",
+        "swiftMessageId" to "SWIFT_MESSAGE",
+        "id" to "SANCTIONS_CHECK",
+    )
 
-    private fun inferAggregateType(node: JsonNode): String = when {
-        node.has("accountId") -> "ACCOUNT"
-        node.has("partyId") -> "PARTY"
-        node.has("transactionId") -> "TRANSACTION"
-        node.has("consentId") -> "CONSENT"
-        node.has("kycCaseId") -> "KYC_CASE"
-        node.has("batchId") -> "CLEARING_BATCH"
-        node.has("itemId") -> "CLEARING_ITEM"
-        node.has("incident") -> "ICT_INCIDENT"
-        node.has("cardId") -> "CARD"
-        node.has("disputeId") -> "DISPUTE"
-        node.has("paymentId") -> "PAYMENT"
-        node.has("id") -> "SANCTIONS_CHECK"
-        else -> "UNKNOWN"
+    private fun inferAggregateId(node: JsonNode): String {
+        node["incident"]?.get("id")?.asText()?.let { return it }
+        for ((field, _) in aggregateFields) {
+            node[field]?.asText()?.let { return it }
+        }
+        return "unknown"
+    }
+
+    private fun inferAggregateType(node: JsonNode): String {
+        if (node.has("incident")) return "ICT_INCIDENT"
+        for ((field, type) in aggregateFields) {
+            if (node.has(field)) return type
+        }
+        return "UNKNOWN"
     }
 }

--- a/openbank-audit-service/src/main/resources/application.yaml
+++ b/openbank-audit-service/src/main/resources/application.yaml
@@ -127,16 +127,22 @@ mp:
         # cards.events / dispute.events / domestic.payment.events / sepa.payment.events /
         # statement.event / sanctions.screening.event added in the same #996 sweep, round 2 — each
         # verified to have a REAL producer (a genuine outbox-row write, not just a declared Kafka
-        # channel) before being added here. openbank.fx.conversion.completed was found to have NO
-        # producer at all (KafkaFxEventPublisher.publish() was a no-op stub) — deliberately NOT
-        # added here until #1033 wires a real publisher; adding a consumer for an event that is
-        # never published would only silence the CI gate without fixing anything.
-        # openbank.sepa.instant.events, by contrast, DOES have a real, working producer
-        # (KafkaSctInstEventPublisher, called from SctInstPaymentService at every lifecycle
-        # transition) — an initial #996 triage pass mistook a separate, dead/unused outbox port
-        # (SctInstOutboxPort) for the only pipeline and wrongly concluded nothing was ever
-        # published; corrected here.
-        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events
+        # channel) before being added here. openbank.sepa.instant.events (round 2 correction) DOES
+        # have a real, working producer (KafkaSctInstEventPublisher, called from
+        # SctInstPaymentService at every lifecycle transition) — an initial #996 triage pass
+        # mistook a separate, dead/unused outbox port (SctInstOutboxPort) for the only pipeline
+        # and wrongly concluded nothing was ever published; corrected.
+        # Round 3: openbank.fx.conversion.completed's producer (KafkaFxEventPublisher, previously a
+        # no-op stub) was fixed in #1033/#1054 — now has real events, added here.
+        # openbank.documents.document.event is the new document-service (#1037); its own docs name
+        # audit-service as the intended consumer (DocumentGenerated / SignatureCeremonyCompleted).
+        # openbank.payments.swift.event: verified SwiftService.submitToScheme/settle both call
+        # repo.saveWithOutbox with a real payload (swiftMessageId/status/amount/currency) — a
+        # genuine producer, not a stub (learned from the #1034 mistake: checked the use-case layer
+        # directly rather than assuming from the port/publisher shape alone). #1035's AML-case
+        # design for this topic is a SEPARATE, additional consumer with real business logic
+        # (case-opening criteria) — this audit-trail consumer does not replace or block that work.
+        topics: openbank.accounts.account.created,openbank.transactions.transaction.initiated,openbank.balance.events,openbank.party.events,openbank.kyc.events,openbank.consent.events,openbank.customer.audit,openbank.clearing.batch.event,openbank.security.ict.incident,openbank.security.scan.event,openbank.cards.events,openbank.dispute.events,openbank.domestic.payment.events,openbank.sepa.payment.events,openbank.statement.event,openbank.sanctions.screening.event,openbank.sepa.instant.events,openbank.fx.conversion.completed,openbank.documents.document.event,openbank.payments.swift.event
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
 "%dev":
   quarkus:

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/application/AuditConsumerTest.kt
@@ -206,6 +206,80 @@ class AuditConsumerTest {
     }
 
     @Test
+    fun `consume extracts documentId as aggregateId for a document-generated event`(): Unit = runBlocking {
+        val documentId = UUID.randomUUID()
+        val payload = """{"eventType":"DOCUMENT_GENERATED","documentId":"$documentId","templateCode":"x"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "DOCUMENT" && it.aggregateId == documentId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts ceremonyId as aggregateId for a signature-ceremony-completed event`(): Unit = runBlocking {
+        val ceremonyId = UUID.randomUUID()
+        val payload = """{"eventType":"SIGNATURE_CEREMONY_COMPLETED","ceremonyId":"$ceremonyId"}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "SIGNATURE_CEREMONY" && it.aggregateId == ceremonyId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts conversionId as aggregateId for an fx-conversion-executed event`(): Unit = runBlocking {
+        val conversionId = UUID.randomUUID()
+        val payload = """{"eventType":"fx.conversion.executed.v1","conversionId":"$conversionId","toAmount":100}"""
+
+        coEvery { repo.save(any()) } returns Unit
+
+        consumer.consume(payload)
+
+        coVerify {
+            repo.save(
+                match {
+                    it.aggregateType == "FX_CONVERSION" && it.aggregateId == conversionId.toString()
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `consume extracts swiftMessageId as aggregateId for a swift-message-status-changed event`(): Unit =
+        runBlocking {
+            val swiftMessageId = UUID.randomUUID()
+            val payload =
+                """{"eventType":"SWIFT_MESSAGE_STATUS_CHANGED","swiftMessageId":"$swiftMessageId","status":"SENT"}"""
+
+            coEvery { repo.save(any()) } returns Unit
+
+            consumer.consume(payload)
+
+            coVerify {
+                repo.save(
+                    match {
+                        it.aggregateType == "SWIFT_MESSAGE" && it.aggregateId == swiftMessageId.toString()
+                    },
+                )
+            }
+        }
+
+    @Test
     fun `consume extracts the bare id as aggregateId for a sanctions screening event`(): Unit = runBlocking {
         val checkId = UUID.randomUUID()
         val payload = """{"eventType":"sanctions.check.completed.v1","id":"$checkId","status":"CLEAR"}"""

--- a/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
+++ b/openbank-infra/gitops/components/audit/kafka-audit-mtls.yaml
@@ -117,6 +117,18 @@ spec:
         operations: [Read, Describe]
         host: "*"
       - resource:
+          type: topic
+          name: openbank.fx.conversion.completed
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: topic
+          name: openbank.documents.document.event
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
           type: group
           name: audit-service
           patternType: literal

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "4a84389ba413aad6"
+    openbank.tech/policy-checksum: "9ad4f0341bff8cb8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1405,15 +1405,16 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "11 unallowlisted REAL_GAP topics remain from the #996 triage: 13 original REAL_GAP - 4 fixed (#1005 sca topic mismatch, #1007 audit-service fan-out) + 2 more found once the 3 originally-UNCLEAR topics were resolved (cards.events, fx.conversion.completed are REAL_GAP; pid.events is allowlisted below) = 11 — tracked in issue #996, not resolved by fiat"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
         # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
         allowlist:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4a84389ba413aad6"
+        openbank.tech/policy-checksum: "9ad4f0341bff8cb8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "753223730b0b6784"
+    openbank.tech/policy-checksum: "5a283a52d4713e6f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -627,15 +627,16 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "11 unallowlisted REAL_GAP topics remain from the #996 triage: 13 original REAL_GAP - 4 fixed (#1005 sca topic mismatch, #1007 audit-service fan-out) + 2 more found once the 3 originally-UNCLEAR topics were resolved (cards.events, fx.conversion.completed are REAL_GAP; pid.events is allowlisted below) = 11 — tracked in issue #996, not resolved by fiat"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
         # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
         allowlist:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "753223730b0b6784"
+        openbank.tech/policy-checksum: "5a283a52d4713e6f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "753223730b0b6784"
+    openbank.tech/policy-checksum: "5a283a52d4713e6f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -627,15 +627,16 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "11 unallowlisted REAL_GAP topics remain from the #996 triage: 13 original REAL_GAP - 4 fixed (#1005 sca topic mismatch, #1007 audit-service fan-out) + 2 more found once the 3 originally-UNCLEAR topics were resolved (cards.events, fx.conversion.completed are REAL_GAP; pid.events is allowlisted below) = 11 — tracked in issue #996, not resolved by fiat"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
         # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
         allowlist:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "753223730b0b6784"
+        openbank.tech/policy-checksum: "5a283a52d4713e6f"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "3257446097563812"
+    openbank.tech/policy-checksum: "e50655a0a98ac421"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1344,15 +1344,16 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "11 unallowlisted REAL_GAP topics remain from the #996 triage: 13 original REAL_GAP - 4 fixed (#1005 sca topic mismatch, #1007 audit-service fan-out) + 2 more found once the 3 originally-UNCLEAR topics were resolved (cards.events, fx.conversion.completed are REAL_GAP; pid.events is allowlisted below) = 11 — tracked in issue #996, not resolved by fiat"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
         # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
         allowlist:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3257446097563812"
+        openbank.tech/policy-checksum: "e50655a0a98ac421"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -159,15 +159,16 @@ change_requirements:
     require:
       - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
     gate: event-consumer-liveness
-    enforced: advisory
-    target_enforce_date: "2026-09-15"   # ADR-0144
-    # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-    # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-    # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-    # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-    # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-    # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-    blocked_on: "11 unallowlisted REAL_GAP topics remain from the #996 triage: 13 original REAL_GAP - 4 fixed (#1005 sca topic mismatch, #1007 audit-service fan-out) + 2 more found once the 3 originally-UNCLEAR topics were resolved (cards.events, fx.conversion.completed are REAL_GAP; pid.events is allowlisted below) = 11 — tracked in issue #996, not resolved by fiat"
+    # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+    # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+    # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+    # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+    # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+    # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+    enforced: enforce
+    # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+    # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+    # published with no consumer and no allowlist entry now fails the build.
     ci_producer: ".github/scripts/check-event-consumer-liveness.py"
     # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
     allowlist:


### PR DESCRIPTION
## What & why

This closes out the ADR-0160 event-consumer-liveness sweep (#996) that began with issue #889 at the very start of this session.

### Round 3: three more audit-service consumers, each independently verified

| Topic | Producer verified |
|---|---|
| `openbank.fx.conversion.completed` | Fixed in #1033/#1054 — `KafkaFxEventPublisher` was a no-op stub; now writes through the transactional outbox |
| `openbank.documents.document.event` | New document-service (#1037); its own docs name audit-service as intended consumer |
| `openbank.payments.swift.event` | **Near-miss**: looked exactly like #1034's mistake at first glance (plausible "dead outbox port" story) — but checking `SwiftService.kt`'s use-case layer directly (not just the port/publisher shape) confirmed `submitToScheme`/`settle` both call `repo.saveWithOutbox` with a real payload. Genuinely wired. #1035's separate AML-case design for this topic is additive, not blocked by this. |

### AuditConsumer refactor

Three rounds of adding a field to two parallel `inferAggregateId`/`inferAggregateType` chains finally hit detekt's cyclomatic-complexity ceiling (16/18 vs. threshold 15). Replaced both with a single ordered `(field -> aggregateType)` table both functions iterate — also fixes a latent inconsistency where `kycCaseId` had a type mapping in one chain but no matching id-extraction in the other.

### Gate graduation (ADR-0144)

`rules.yaml: change_requirements.event_consumer_liveness` flips **advisory → enforce**. `check-event-consumer-liveness.py --enforce` now reports **0 unallowlisted violations fleet-wide** (32 topics, 50 services). `ci.yml`'s "Validate manifests" step now passes `--enforce` — a new topic published with no consumer and no allowlist entry fails the build going forward. Same graduation path `check-outbox-dispatch-enabled.sh` proved out.

## Verified

ktlint/detekt/test/quarkusBuild all green. `check-gate-graduation.sh` passes. `check-event-consumer-liveness.py --root . --enforce` exits 0.

## Linked issues

Refs #996, #889

## Notes

audit-service is not money-path, but this is a meaningful governance milestone — recommend a look before merging even without the 2-approval requirement.