### PR TITLE
chore(infra): bump document-service image to sandbox-2da7ba6e

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -54,7 +54,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-7e49b9b5
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-2da7ba6e
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
## Summary
Bumps the document-service gitops image tag to the build with the letterhead + editor-UX fix (#1083). Built, cosign v2 signed, CycloneDX-SBOM attested by hand.

## Linked issues
N/A — infra follow-up to #1083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)