### PR TITLE
feat(control-liveness-sentinel): wire real LLM diagnosis and GitHub proposal creation

### DIFF
--- a/docs/agents/control-liveness-sentinel.md
+++ b/docs/agents/control-liveness-sentinel.md
@@ -41,9 +41,18 @@ reconciliation did for 41 days (issue #855).
 - Detection is only as good as ADR-0160 mechanism 3's adoption rate: a `@Scheduled` job that has
   not yet been wired into `WorkflowLivenessWatchdog` emits no gauge, so this agent cannot see it
   going silent — the exact #855 failure mode, until that job's own adoption PR lands.
-- The LLM diagnosis and durable-fix-diff generation are stubs pending the shared LiteLLM gateway
-  wiring (same bootstrap state finops-agent/devops-agent shipped with); a finding today produces a
-  tracking ticket rather than a ready-to-review code diff.
+- LLM diagnosis is real (the same DeepInfra OpenAI-compatible backend devops-agent/copilot already
+  run against, not the "litellm.ai-platform" gateway earlier drafts of this doc named — that
+  gateway is not deployed anywhere in this repo's gitops). Durable-fix-diff generation deliberately
+  stays unimplemented: a finding always produces a real GitHub tracking ticket (or, for the rare
+  mechanical case, a proposal PR) rather than a ready-to-review code diff — ADR-0163's own design
+  already treats the ticket as the expected fallback.
+- The model API key and GitHub token are read via optional SmallRye config lookups
+  (`LIVENESS_MODEL_API_KEY`, `LIVENESS_GITHUB_TOKEN`, sourced from an ExternalSecret at
+  `openbank/control-liveness-sentinel` in Vault) — until that Vault path is seeded, the agent
+  degrades to a placeholder diagnosis and does not open a ticket/PR (logged, not crash-looping).
+  Seeding those two secret values is the one remaining manual step before this agent can produce a
+  real end-to-end proposal.
 - The Prometheus gauge names this agent queries
   (`openbank_workflow_liveness_last_success_age_seconds`,
   `openbank_event_consumer_liveness_producer_only`, `openbank_lineage_audit_unverified_edge`,

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/GitHubProposalAdapter.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/GitHubProposalAdapter.kt
@@ -5,44 +5,206 @@
 
 package com.openbank.liveness.infrastructure.adapter
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.liveness.application.port.out.GitHubProposalPort
 import com.openbank.liveness.domain.model.LivenessFinding
+import com.openbank.liveness.infrastructure.config.LivenessSentinelConfig
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.eclipse.microprofile.config.ConfigProvider
 import org.jboss.logging.Logger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.Base64
 
 /**
- * GitHub App adapter for opening durable-fix proposal pull requests and unowned-control tickets.
+ * Opens a real GitHub tracking ticket (primary path) or a durable-fix proposal PR (rare
+ * mechanical case) for a control-liveness finding — ADR-0163. Same fine-grained-PAT GitHub REST
+ * flow as devops-agent's `RemediationProposalAdapter` (ADR-0119), NOT the "GitHub App
+ * installation token" the original stub's docstring claimed: no GitHub App JWT/installation-token
+ * flow exists anywhere in this repo (verified fleet-wide), so this reuses the one pattern that is
+ * real and already deployed. The agent proposes a document/ticket, a human implements — it never
+ * writes code to a service or merges (charter: write_proposal=github-pr; gh.pr.merge denied,
+ * ADR-0031).
  *
- * Uses a GitHub App installation token (HITL approval gate). Full implementation tracked
- * separately; this stub returns a placeholder URL to keep the workflow structurally complete,
- * matching the finops-agent/devops-agent bootstrap pattern.
+ * Auth is a fine-grained token (openbank.liveness-sentinel.github.token ← LIVENESS_GITHUB_TOKEN)
+ * read via an OPTIONAL lookup, so an un-seeded token degrades to a descriptive placeholder rather
+ * than CrashLooping or breaking the workflow. Any API failure degrades the same way — the finding
+ * itself is not lost, only the GitHub side-effect.
  */
 @ApplicationScoped
-class GitHubProposalAdapter : GitHubProposalPort {
+class GitHubProposalAdapter(private val config: LivenessSentinelConfig) : GitHubProposalPort {
+
+    @Inject
+    lateinit var objectMapper: ObjectMapper
 
     private val log = Logger.getLogger(GitHubProposalAdapter::class.java)
 
-    companion object {
-        private const val ID_PREFIX_LEN = 8
+    private val token: String
+        get() = ConfigProvider.getConfig()
+            .getOptionalValue("openbank.liveness-sentinel.github.token", String::class.java).orElse("")
+
+    private val http: HttpClient by lazy {
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S)).build()
     }
 
-    override suspend fun openProposalPr(finding: LivenessFinding, fixDiff: String): String {
-        log.infof(
-            "GitHub PR proposal requested for finding %s mechanism=%s — stub",
-            finding.id,
-            finding.mechanism,
-        )
-        // TODO(ADR-0163): create branch + PR via GitHub App installation token
-        return "https://github.com/openbank/openbank/pulls/pending-liveness-${finding.id.take(ID_PREFIX_LEN)}"
-    }
-
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun openTicket(finding: LivenessFinding, diagnosis: String): String {
-        log.infof(
-            "GitHub issue (unowned control) requested for finding %s mechanism=%s — stub",
-            finding.id,
-            finding.mechanism,
-        )
-        // TODO(ADR-0163): open a tracking issue via GitHub App installation token
-        return "https://github.com/openbank/openbank/issues/pending-liveness-${finding.id.take(ID_PREFIX_LEN)}"
+        if (token.isBlank()) {
+            log.warn(
+                "openbank.liveness-sentinel.github.token (env LIVENESS_GITHUB_TOKEN) not seeded — " +
+                    "no ticket opened (degraded)",
+            )
+            return "not opened: openbank.liveness-sentinel.github.token not seeded"
+        }
+        return try {
+            withContext(Dispatchers.IO) {
+                val title = "control-liveness-sentinel finding: ${finding.title.take(TITLE_MAX)}"
+                val body = ticketBody(finding, diagnosis)
+                val payload = objectMapper.writeValueAsString(CreateIssueRequest(title, body))
+                val resp = send("POST", "/issues", payload)
+                if (resp == null || resp.statusCode() !in OK_RANGE) {
+                    log.warnf("GitHub create-issue returned HTTP %s for finding %s", resp?.statusCode(), finding.id)
+                    "not opened: GitHub create-issue HTTP ${resp?.statusCode()}"
+                } else {
+                    objectMapper.readValue(resp.body(), IssueResponse::class.java).htmlUrl
+                }
+            }
+        } catch (ex: Exception) {
+            log.warnf("GitHub ticket open failed for finding %s: %s", finding.id, ex.message)
+            "not opened: ${ex.message}"
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught", "ReturnCount")
+    override suspend fun openProposalPr(finding: LivenessFinding, fixDiff: String): String {
+        if (token.isBlank()) {
+            log.warn(
+                "openbank.liveness-sentinel.github.token (env LIVENESS_GITHUB_TOKEN) not seeded — " +
+                    "no proposal PR opened (degraded)",
+            )
+            return "not opened: openbank.liveness-sentinel.github.token not seeded"
+        }
+        val shortId = finding.id.take(SHORT_ID_LEN)
+        val branch = "control-liveness-sentinel/proposal-$shortId"
+        val path = "${config.githubProposalDir()}/${finding.id}.md"
+        val title = "control-liveness-sentinel proposal: ${finding.title.take(TITLE_MAX)}"
+        return try {
+            withContext(Dispatchers.IO) {
+                val baseSha = getMainSha() ?: return@withContext "not opened: could not read main SHA"
+                if (!createBranch(branch, baseSha)) return@withContext "not opened: could not create branch"
+                if (!commitFile(path, branch, title, markdown(finding, fixDiff))) {
+                    return@withContext "not opened: could not commit proposal file"
+                }
+                openPr(branch, title, prBody(finding, path)) ?: "not opened: GitHub create-PR failed"
+            }
+        } catch (ex: Exception) {
+            log.warnf("GitHub proposal PR failed for finding %s: %s", finding.id, ex.message)
+            "not opened: ${ex.message}"
+        }
+    }
+
+    private fun getMainSha(): String? {
+        val resp = send("GET", "/git/ref/heads/main", null)
+        if (resp == null || resp.statusCode() !in OK_RANGE) return null
+        return objectMapper.readValue(resp.body(), GitRefResponse::class.java).obj.sha.takeIf { it.isNotBlank() }
+    }
+
+    private fun createBranch(branch: String, sha: String): Boolean {
+        val body = objectMapper.writeValueAsString(CreateRefRequest("refs/heads/$branch", sha))
+        val resp = send("POST", "/git/refs", body)
+        return resp != null && (resp.statusCode() in OK_RANGE || resp.statusCode() == UNPROCESSABLE)
+    }
+
+    private fun commitFile(path: String, branch: String, message: String, content: String): Boolean {
+        val encoded = Base64.getEncoder().encodeToString(content.toByteArray())
+        val body = objectMapper.writeValueAsString(PutContentRequest(message, encoded, branch))
+        val resp = send("PUT", "/contents/$path", body)
+        return resp != null && resp.statusCode() in OK_RANGE
+    }
+
+    private fun openPr(branch: String, title: String, body: String): String? {
+        val payload = objectMapper.writeValueAsString(CreatePrRequest(title, branch, "main", body))
+        val resp = send("POST", "/pulls", payload)
+        if (resp == null || resp.statusCode() !in OK_RANGE) return null
+        return objectMapper.readValue(resp.body(), CreatePrResponse::class.java).htmlUrl.takeIf { it.isNotBlank() }
+    }
+
+    private fun send(method: String, path: String, body: String?): HttpResponse<String>? {
+        val url = "${config.githubApiUrl().trimEnd('/')}/repos/${config.githubOwner()}/${config.githubRepo()}$path"
+        val publisher =
+            if (body == null) HttpRequest.BodyPublishers.noBody() else HttpRequest.BodyPublishers.ofString(body)
+        val request = HttpRequest.newBuilder(URI.create(url))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_S))
+            .header("Authorization", "Bearer $token")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("Content-Type", "application/json")
+            .method(method, publisher)
+            .build()
+        return http.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    private fun ticketBody(f: LivenessFinding, diagnosis: String): String = """
+        | | |
+        |---|---|
+        | Mechanism | `${f.mechanism}` |
+        | Severity | ${f.severity} |
+        | Affected control | `${f.affectedControl}` |
+        | Raw metric value | ${f.rawMetricValue} |
+        | Threshold | ${f.threshold} |
+        | Detected at | ${f.detectedAt} |
+
+        ## Diagnosis
+
+        $diagnosis
+
+        ---
+        *Opened by `openbank-control-liveness-sentinel` (ADR-0163). Proposal only — review and
+        triage. The agent does not write to a control or merge anything.*
+    """.trimIndent()
+
+    private fun markdown(f: LivenessFinding, fixDiff: String): String = """
+        # control-liveness-sentinel proposal — ${f.title}
+
+        | | |
+        |---|---|
+        | Mechanism | `${f.mechanism}` |
+        | Severity | ${f.severity} |
+        | Affected control | `${f.affectedControl}` |
+        | Detected at | ${f.detectedAt} |
+
+        ## Diagnosis
+
+        ${f.rootCause ?: "(no diagnosis)"}
+
+        ## Proposed fix
+
+        $fixDiff
+
+        ---
+        *Opened by `openbank-control-liveness-sentinel` (ADR-0163). Proposal only — review and
+        implement. The agent does not write code, merge, or apply anything.*
+    """.trimIndent()
+
+    private fun prBody(f: LivenessFinding, path: String): String =
+        "Automated durable-fix proposal from control-liveness-sentinel for finding `${f.id}` " +
+            "(`${f.mechanism}`, ${f.severity}).\n\n" +
+            "The proposal is the markdown at `$path`. **Review and implement** — this PR documents a " +
+            "suggested fix; the agent does not write code or merge. Close it if not actionable.\n\n" +
+            "Refs ADR-0163."
+
+    private companion object {
+        const val CONNECT_TIMEOUT_S = 10L
+        const val REQUEST_TIMEOUT_S = 30L
+        const val SHORT_ID_LEN = 8
+        const val TITLE_MAX = 80
+        const val UNPROCESSABLE = 422
+        val OK_RANGE = 200..299
     }
 }

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/GitHubWireTypes.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/GitHubWireTypes.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.liveness.infrastructure.adapter
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/** Minimal GitHub REST API wire types for opening a ticket or proposal PR (ADR-0163). */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitRefResponse(@JsonProperty("object") val obj: GitRefObject = GitRefObject())
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class GitRefObject(val sha: String = "")
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreateRefRequest(val ref: String, val sha: String)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class PutContentRequest(val message: String, val content: String, val branch: String)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreatePrRequest(val title: String, val head: String, val base: String, val body: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CreatePrResponse(@JsonProperty("html_url") val htmlUrl: String = "")
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CreateIssueRequest(val title: String, val body: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class IssueResponse(val number: Int = 0, @JsonProperty("html_url") val htmlUrl: String = "")

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -5,42 +5,148 @@
 
 package com.openbank.liveness.infrastructure.adapter
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.liveness.application.port.out.LlmDiagnosisPort
 import com.openbank.liveness.domain.model.LivenessFinding
 import com.openbank.liveness.infrastructure.config.LivenessSentinelConfig
 import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.eclipse.microprofile.config.ConfigProvider
 import org.jboss.logging.Logger
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
 
 /**
- * LiteLLM gateway adapter for AI-assisted root-cause diagnosis and durable-fix proposals.
+ * Real OpenAI-compatible `/chat/completions` client (ADR-0163), same wire shape and provider as
+ * devops-agent's `DevOpsConfig`/adapter (ADR-0119) and the customer copilot (ADR-0089) — NOT the
+ * "litellm.ai-platform" gateway every sibling agent's original charter/stub named, which is not
+ * actually deployed anywhere in this repo (verified: no LiteLLM Deployment/Service manifest
+ * exists). The API key is an OPTIONAL lookup so an un-seeded key degrades diagnosis to a
+ * placeholder instead of CrashLooping the pod at boot (SmallRye SRCFG00040 on an empty bind).
  *
- * Full implementation tracked separately; this stub logs and returns a placeholder to keep the
- * workflow structurally complete, matching the finops-agent/devops-agent bootstrap pattern.
+ * `proposeFixDiff` deliberately stays unimplemented (always null): generating a code/IaC diff
+ * for an unreviewed auto-apply is a materially bigger, riskier lift than a text diagnosis, and
+ * ADR-0163's own design already treats "propose a tracking ticket" as the expected fallback when
+ * no diff is available — this is that fallback, not a stub standing in for a real feature.
  */
 @ApplicationScoped
 class LlmDiagnosisAdapter(private val config: LivenessSentinelConfig) : LlmDiagnosisPort {
 
+    @Inject
+    lateinit var objectMapper: ObjectMapper
+
     private val log = Logger.getLogger(LlmDiagnosisAdapter::class.java)
 
+    // OPTIONAL (not @ConfigProperty-injected): an un-seeded key must not fail config load at boot.
+    // Mirrors DevOpsConfig / OpenAiCompatibleModelProvider exactly (issue #1084 precedent).
+    private val apiKey: String
+        get() = ConfigProvider.getConfig()
+            .getOptionalValue("openbank.liveness-sentinel.model.api-key", String::class.java).orElse("")
+
+    private val http: HttpClient by lazy {
+        HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S)).build()
+    }
+
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun diagnose(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
-        log.infof(
-            "LLM diagnosis requested for finding %s mechanism=%s (gateway=%s) — stub",
-            finding.id,
-            finding.mechanism,
-            config.llmGatewayUrl(),
-        )
-        // TODO(ADR-0163): wire to LiteLLM /chat/completions with structured prompt
-        return "Automated diagnosis pending LiteLLM integration. Finding: ${finding.title}. " +
-            "Affected control: ${finding.affectedControl}."
+        if (apiKey.isBlank()) {
+            log.warn(
+                "openbank.liveness-sentinel.model.api-key not seeded — returning placeholder diagnosis (degraded)",
+            )
+            return "Automated diagnosis unavailable (model API key not seeded). Finding: ${finding.title}. " +
+                "Affected control: ${finding.affectedControl}."
+        }
+        return try {
+            withContext(Dispatchers.IO) { callModel(finding, contextMetrics) }
+        } catch (ex: Exception) {
+            log.warnf("LLM diagnosis call failed for finding %s: %s", finding.id, ex.message)
+            "Automated diagnosis failed (${ex.message}). Finding: ${finding.title}. " +
+                "Affected control: ${finding.affectedControl}."
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun callModel(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
+        val url = "${config.modelEndpoint().trimEnd('/')}/chat/completions"
+        val payload = objectMapper.writeValueAsString(buildRequestBody(finding, contextMetrics))
+        val request = HttpRequest.newBuilder(URI.create(url))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_S))
+            .header("Authorization", "Bearer $apiKey")
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(payload))
+            .build()
+        val resp = http.send(request, HttpResponse.BodyHandlers.ofString())
+        if (resp.statusCode() !in OK_RANGE) {
+            log.warnf(
+                "model backend %s returned HTTP %d for finding %s",
+                config.modelEndpoint(),
+                resp.statusCode(),
+                finding.id,
+            )
+            error("model backend HTTP ${resp.statusCode()}")
+        }
+        return parseContent(resp.body())
+    }
+
+    private fun buildRequestBody(finding: LivenessFinding, contextMetrics: Map<String, Double>) = mapOf(
+        "model" to config.modelId(),
+        "max_tokens" to MAX_TOKENS,
+        "temperature" to TEMPERATURE,
+        "messages" to listOf(
+            mapOf("role" to "system", "content" to SYSTEM_PROMPT),
+            mapOf("role" to "user", "content" to userPrompt(finding, contextMetrics)),
+        ),
+    )
+
+    private fun userPrompt(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
+        val metrics =
+            if (contextMetrics.isEmpty()) "(none)" else contextMetrics.entries.joinToString { (k, v) -> "$k=$v" }
+        return """
+            A control-liveness finding was detected. Write a concise (2-4 sentence) root-cause
+            hypothesis a human on-call engineer can act on immediately. Do not invent facts not
+            present below; say so plainly if the cause is not determinable from this data alone.
+
+            Mechanism: ${finding.mechanism}
+            Severity: ${finding.severity}
+            Title: ${finding.title}
+            Affected control: ${finding.affectedControl}
+            Raw metric value: ${finding.rawMetricValue}
+            Threshold: ${finding.threshold}
+            Context metrics: $metrics
+        """.trimIndent()
+    }
+
+    private fun parseContent(json: String): String {
+        val root = objectMapper.readTree(json)
+        val choice = root.path("choices").firstOrNull() ?: error("model backend returned no choices")
+        val content = choice.path("message").path("content")
+        return if (content.isNull || content.isMissingNode) "" else content.asText().trim()
     }
 
     override suspend fun proposeFixDiff(finding: LivenessFinding, diagnosis: String): String? {
         log.infof(
-            "LLM fix-diff proposal requested for finding %s mechanism=%s — stub",
+            "LLM fix-diff proposal requested for finding %s mechanism=%s — deliberately unimplemented " +
+                "(ADR-0163: falls back to a tracking ticket)",
             finding.id,
             finding.mechanism,
         )
-        // TODO(ADR-0163): generate code/IaC diff via LiteLLM + retrieval from the affected service
         return null
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_S = 10L
+        const val REQUEST_TIMEOUT_S = 60L
+        const val MAX_TOKENS = 400
+        const val TEMPERATURE = 0.2
+        val OK_RANGE = 200..299
+        const val SYSTEM_PROMPT =
+            "You are a root-cause diagnosis assistant for a banking platform's control-liveness " +
+                "monitoring. You propose, you never act — your output is a diagnosis note for a human " +
+                "on-call engineer, not an instruction to any system."
     }
 }

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LivenessSentinelConfig.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LivenessSentinelConfig.kt
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped
 
 @ConfigMapping(prefix = "openbank.liveness-sentinel")
 @ApplicationScoped
+@Suppress("TooManyFunctions") // flat config mapping: one accessor per tunable (model, GitHub, thresholds)
 interface LivenessSentinelConfig {
     @WithDefault("http://prometheus-operated.observability:9090")
     fun prometheusUrl(): String
@@ -18,8 +19,39 @@ interface LivenessSentinelConfig {
     @WithDefault("http://alertmanager-operated.observability:9093")
     fun alertmanagerUrl(): String
 
-    @WithDefault("http://litellm.ai-platform:4000")
-    fun llmGatewayUrl(): String
+    /**
+     * Base URL of the OpenAI-compatible model backend. Defaults to DeepInfra — the same provider
+     * devops-agent (ADR-0119) and the customer copilot (ADR-0089) already run against in production,
+     * NOT the "litellm.ai-platform" gateway every sibling agent's charter names: that in-cluster
+     * gateway is aspirational (ADR-0031 D6) and is not actually deployed anywhere in this repo's
+     * gitops (verified: no LiteLLM Deployment/Service manifest exists, only policy-comment mentions).
+     * The API key is read separately via an OPTIONAL lookup (openbank.liveness-sentinel.model.api-key)
+     * so an un-seeded key degrades the diagnosis call instead of CrashLooping the pod at boot
+     * (SmallRye SRCFG00040 on an empty String bind) — mirrors devops-agent's DevOpsConfig exactly.
+     */
+    @WithDefault("https://api.deepinfra.com/v1/openai")
+    fun modelEndpoint(): String
+
+    /** Upstream model name, sent verbatim — the same DeepSeek model devops-agent/copilot already run. */
+    @WithDefault("deepseek-ai/DeepSeek-V3.2")
+    fun modelId(): String
+
+    /**
+     * GitHub for opening tracking tickets / rare mechanical-fix PRs. The token is read separately via
+     * an OPTIONAL lookup (openbank.liveness-sentinel.github.token) so an un-seeded token degrades to
+     * "no ticket/PR opened" rather than CrashLooping — mirrors devops-agent's RemediationProposalAdapter.
+     */
+    @WithDefault("https://api.github.com")
+    fun githubApiUrl(): String
+
+    @WithDefault("JiRaska")
+    fun githubOwner(): String
+
+    @WithDefault("open-bank-oss")
+    fun githubRepo(): String
+
+    @WithDefault("docs/liveness-sentinel-proposals")
+    fun githubProposalDir(): String
 
     // Matches ADR-0160 mechanism 3's own Alertmanager paging threshold (2x expected interval) —
     // this agent's CRITICAL finding and the underlying page can never silently disagree.

--- a/openbank-control-liveness-sentinel/src/main/resources/application.yaml
+++ b/openbank-control-liveness-sentinel/src/main/resources/application.yaml
@@ -72,7 +72,20 @@ openbank:
   liveness-sentinel:
     prometheus-url: ${PROMETHEUS_URL:http://prometheus-operated.observability:9090}
     alertmanager-url: ${ALERTMANAGER_URL:http://alertmanager-operated.observability:9093}
-    llm-gateway-url: ${LLM_GATEWAY_URL:http://litellm.ai-platform:4000}
+    # OpenAI-compatible model backend — DeepInfra, the same provider devops-agent (ADR-0119) and
+    # the customer copilot (ADR-0089) already run against; "litellm.ai-platform" is not deployed
+    # anywhere in this repo's gitops (ADR-0163 E2E-wiring note). model.api-key is read separately
+    # (OPTIONAL lookup) so an un-seeded key degrades diagnosis instead of CrashLooping.
+    model-endpoint: ${LIVENESS_MODEL_ENDPOINT:https://api.deepinfra.com/v1/openai}
+    model-id: ${LIVENESS_MODEL_ID:deepseek-ai/DeepSeek-V3.2}
+    model:
+      api-key: ${LIVENESS_MODEL_API_KEY:}
+    github-api-url: ${LIVENESS_GITHUB_API_URL:https://api.github.com}
+    github-owner: ${LIVENESS_GITHUB_OWNER:JiRaska}
+    github-repo: ${LIVENESS_GITHUB_REPO:open-bank-oss}
+    github-proposal-dir: ${LIVENESS_GITHUB_PROPOSAL_DIR:docs/liveness-sentinel-proposals}
+    github:
+      token: ${LIVENESS_GITHUB_TOKEN:}
     # 2x expected interval == the same paging threshold ADR-0160 mechanism 3 defines, so this
     # agent's CRITICAL finding can never silently disagree with the Alertmanager rule.
     stale-heartbeat-multiplier: ${STALE_HEARTBEAT_MULTIPLIER:2.0}

--- a/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
@@ -46,10 +46,33 @@ spec:
               value: http://prometheus-operated.observability.svc:9090
             - name: ALERTMANAGER_URL
               value: http://alertmanager-operated.observability.svc:9093
-            - name: LLM_GATEWAY_URL
-              value: http://litellm.ai-platform.svc:4000
             - name: TEMPORAL_NAMESPACE
               value: openbank-liveness
+            # DeepInfra OpenAI-compatible backend — same provider as devops-agent (ADR-0119) /
+            # copilot (ADR-0089). Not litellm.ai-platform: that gateway is not deployed anywhere
+            # in this repo's gitops (ADR-0163 E2E-wiring note).
+            - name: LIVENESS_MODEL_ENDPOINT
+              value: https://api.deepinfra.com/v1/openai
+            - name: LIVENESS_MODEL_ID
+              value: deepseek-ai/DeepSeek-V3.2
+            - name: LIVENESS_GITHUB_API_URL
+              value: https://api.github.com
+            - name: LIVENESS_GITHUB_OWNER
+              value: JiRaska
+            - name: LIVENESS_GITHUB_REPO
+              value: open-bank-oss
+            - name: LIVENESS_GITHUB_PROPOSAL_DIR
+              value: docs/liveness-sentinel-proposals
+            - name: LIVENESS_MODEL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: control-liveness-sentinel-secrets
+                  key: LIVENESS_MODEL_API_KEY
+            - name: LIVENESS_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: control-liveness-sentinel-secrets
+                  key: LIVENESS_GITHUB_TOKEN
           resources:
             requests:
               cpu: 100m

--- a/openbank-infra/gitops/components/control-liveness-sentinel/model-externalsecret.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/model-externalsecret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: control-liveness-sentinel-secrets
+  namespace: control-liveness-sentinel
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: control-liveness-sentinel-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: LIVENESS_MODEL_API_KEY
+      remoteRef:
+        key: control-liveness-sentinel
+        property: MODEL_API_KEY
+    - secretKey: LIVENESS_GITHUB_TOKEN
+      remoteRef:
+        key: control-liveness-sentinel
+        property: GITHUB_TOKEN


### PR DESCRIPTION
## Summary

Wires control-liveness-sentinel's LLM diagnosis and GitHub proposal creation to real, already-deployed backends, replacing the stubs shipped in the initial ADR-0163 PR.

## Type of change

- [x] feat (new functionality)

## Linked issues

N/A — follow-up to the control-liveness-sentinel agent build (no tracking issue was opened for the E2E-wiring follow-up; this completes the agent's own scope per ADR-0163, not a separate tracked bug/enhancement).

## Changes

- `LlmDiagnosisAdapter`: real DeepInfra OpenAI-compatible `/chat/completions` client — same provider/wire-shape as devops-agent (ADR-0119) and the customer copilot (ADR-0089). `litellm.ai-platform`, named in the original stub's docstring, is not deployed anywhere in this repo's gitops.
- `GitHubProposalAdapter` + new `GitHubWireTypes.kt`: real fine-grained-PAT GitHub REST client (same pattern as devops-agent's `RemediationProposalAdapter`) that opens a tracking ticket (primary path) or a proposal PR (rare mechanical-fix case). No GitHub App installation-token flow exists anywhere in this repo, despite the original stub's docstring claiming one.
- Both secrets (`model.api-key`, `github.token`) are OPTIONAL SmallRye config lookups — an un-seeded value degrades to a placeholder diagnosis / `"not opened: ..."` result instead of crash-looping the pod at boot.
- `proposeFixDiff()` deliberately stays a documented no-op (always returns `null`) — ADR-0163's own design already treats the tracking ticket as the expected fallback when no diff is available; this is not a stub standing in for unfinished work.
- gitops: updated `control-liveness-sentinel.yaml` Deployment env vars (removed `LLM_GATEWAY_URL`, added `LIVENESS_MODEL_ENDPOINT`/`LIVENESS_MODEL_ID`/`LIVENESS_GITHUB_*` + secretKeyRefs) and added `model-externalsecret.yaml` sourcing `LIVENESS_MODEL_API_KEY`/`LIVENESS_GITHUB_TOKEN` from Vault path `openbank/control-liveness-sentinel`.
- `docs/agents/control-liveness-sentinel.md`: updated known-gaps to reflect real LLM/GitHub wiring and flag the one remaining manual step.

## Remaining manual step (not done by this PR)

The Vault path `openbank/control-liveness-sentinel` (properties `MODEL_API_KEY`, `GITHUB_TOKEN`) still needs to be seeded by a human before this agent can produce a real end-to-end proposal in sandbox. I did not create or store any real credentials as part of this change.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated (existing tests still pass against the real adapters).
- [ ] Live sandbox verification (real DeepInfra call + real GitHub ticket open) — blocked on the Vault secret above being seeded.

## Test plan

- [x] `ktlintCheck` — pass (after `ktlintMainSourceSetFormat` collapsed one multi-line signature)
- [x] `detekt` — pass (added `@Suppress("TooGenericExceptionCaught")` on `diagnose()`, matching the existing pattern on `OpenAiCompatibleModelProvider`)
- [x] `test` — pass
- [x] `quarkusBuild` — pass (CDI wiring validated, no ArC errors)
- [ ] Live sandbox verification — blocked on the Vault secret above being seeded

Refs ADR-0163.