### PR TITLE
chore(infra): add control-liveness-sentinel secret-seeding script

### DIFF
--- a/openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
+++ b/openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Uloží model API klíč a GitHub token pro control-liveness-sentinel do OpenBao KV
+# a vynutí refresh jeho ExternalSecretu (ADR-0163 E2E-wiring, PR #1087).
+#
+# Usage:
+#   VAULT_TOKEN=hvs.xxx \
+#   LIVENESS_MODEL_API_KEY=di_xxx \
+#   LIVENESS_GITHUB_TOKEN=github_pat_xxx \
+#     ./openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
+#
+# Vyžaduje:
+#   - kubectl nakonfigurovaný na sandbox cluster (aws eks update-kubeconfig --profile openbank ...)
+#   - VAULT_TOKEN: operator token s write na openbank/* (viz seed-vault-gaps.sh)
+#   - LIVENESS_MODEL_API_KEY: DeepInfra API klíč (https://deepinfra.com/dash/api_keys) —
+#     stejný provider jako devops-agent/copilot; lze i sdílet stávající DeepInfra klíč,
+#     pokud už jeden pro devops-agent existuje (openbank/devops-agent MODEL_API_KEY).
+#   - LIVENESS_GITHUB_TOKEN: fine-grained PAT na JiRaska/open-bank-oss s oprávněním
+#     Issues:write, Contents:write, Pull requests:write (žádný GitHub App flow zde
+#     neexistuje — viz GitHubProposalAdapter.kt).
+set -euo pipefail
+
+: "${VAULT_TOKEN:?Set VAULT_TOKEN to an operator token with write access to openbank/*}"
+: "${LIVENESS_MODEL_API_KEY:?Set LIVENESS_MODEL_API_KEY to a DeepInfra API key}"
+: "${LIVENESS_GITHUB_TOKEN:?Set LIVENESS_GITHUB_TOKEN to a fine-grained GitHub PAT (issues+contents+PRs write)}"
+
+vault_kv_put() {
+  kubectl -n vault exec -i openbao-0 -- \
+    env VAULT_TOKEN="$VAULT_TOKEN" VAULT_ADDR=http://127.0.0.1:8200 \
+    vault kv put "$@" >/dev/null
+}
+
+echo "[1/2] Ukládám MODEL_API_KEY + GITHUB_TOKEN do openbank/control-liveness-sentinel..."
+vault_kv_put openbank/control-liveness-sentinel \
+  MODEL_API_KEY="$LIVENESS_MODEL_API_KEY" \
+  GITHUB_TOKEN="$LIVENESS_GITHUB_TOKEN"
+echo "      OK"
+
+echo "[2/2] Vynucuji refresh ExternalSecret control-liveness-sentinel/control-liveness-sentinel-secrets..."
+kubectl -n control-liveness-sentinel annotate externalsecret control-liveness-sentinel-secrets \
+  force-sync="$(date +%s)" --overwrite 2>/dev/null || true
+echo "      OK"
+
+echo ""
+echo "Ověření:"
+echo "  kubectl -n control-liveness-sentinel get externalsecret control-liveness-sentinel-secrets"
+echo "  kubectl -n control-liveness-sentinel get secret control-liveness-sentinel-secrets"
+echo "  kubectl -n control-liveness-sentinel rollout restart deployment/control-liveness-sentinel"

--- a/openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
+++ b/openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
@@ -2,15 +2,17 @@
 # Uloží model API klíč a GitHub token pro control-liveness-sentinel do OpenBao KV
 # a vynutí refresh jeho ExternalSecretu (ADR-0163 E2E-wiring, PR #1087).
 #
-# Interaktivní — spusť bez ničeho a skript se sám doptá na chybějící hodnoty
-# (vstup se nezobrazuje na terminálu a nikam se neukládá):
+# Interaktivní — spusť bez ničeho. Operator token si skript sám najde v prostředí
+# (zkusí po řadě $VAULT_TOKEN, $BAO_TOKEN, $RT — ať už ho máš exportovaný pod
+# kterýmkoliv z těchto jmen) a na zbylé dvě hodnoty se doptá (vstup se nezobrazuje
+# na terminálu a nikam se neukládá):
 #
 #   ./openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
 #
 # Vyžaduje mít po ruce (skript řekne přesně kde vzít, když se zeptá):
 #   - kubectl nakonfigurovaný na sandbox cluster
-#   - VAULT_TOKEN: operator token s write na openbank/* (stejný, jaký používáš pro
-#     seed-vault-gaps.sh / seed-nvidia-api-key.sh)
+#   - operator token s write na openbank/* pod $VAULT_TOKEN / $BAO_TOKEN / $RT,
+#     jinak se na něj skript zeptá stejně jako na zbytek
 #   - DeepInfra API klíč (https://deepinfra.com/dash/api_keys) — nebo zopakuj ten,
 #     co už má devops-agent (openbank/devops-agent MODEL_API_KEY)
 #   - fine-grained GitHub PAT na JiRaska/open-bank-oss (Settings → Developer settings
@@ -27,7 +29,14 @@ prompt_secret() { # var_name prompt_text
   printf -v "$__var" '%s' "$__val"
 }
 
-prompt_secret VAULT_TOKEN "OpenBao operator token (VAULT_TOKEN)"
+if [[ -z "${VAULT_TOKEN:-}" ]]; then
+  if [[ -n "${BAO_TOKEN:-}" ]]; then
+    VAULT_TOKEN="$BAO_TOKEN"
+  elif [[ -n "${RT:-}" ]]; then
+    VAULT_TOKEN="$RT"
+  fi
+fi
+prompt_secret VAULT_TOKEN "OpenBao operator token — not found in \$VAULT_TOKEN/\$BAO_TOKEN/\$RT, paste it"
 prompt_secret LIVENESS_MODEL_API_KEY "DeepInfra API key (https://deepinfra.com/dash/api_keys)"
 prompt_secret LIVENESS_GITHUB_TOKEN "GitHub fine-grained PAT (Settings > Developer settings > Fine-grained tokens, scoped to JiRaska/open-bank-oss with Issues/Contents/Pull requests: write)"
 

--- a/openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
+++ b/openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
@@ -2,26 +2,34 @@
 # Uloží model API klíč a GitHub token pro control-liveness-sentinel do OpenBao KV
 # a vynutí refresh jeho ExternalSecretu (ADR-0163 E2E-wiring, PR #1087).
 #
-# Usage:
-#   VAULT_TOKEN=hvs.xxx \
-#   LIVENESS_MODEL_API_KEY=di_xxx \
-#   LIVENESS_GITHUB_TOKEN=github_pat_xxx \
-#     ./openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
+# Interaktivní — spusť bez ničeho a skript se sám doptá na chybějící hodnoty
+# (vstup se nezobrazuje na terminálu a nikam se neukládá):
 #
-# Vyžaduje:
-#   - kubectl nakonfigurovaný na sandbox cluster (aws eks update-kubeconfig --profile openbank ...)
-#   - VAULT_TOKEN: operator token s write na openbank/* (viz seed-vault-gaps.sh)
-#   - LIVENESS_MODEL_API_KEY: DeepInfra API klíč (https://deepinfra.com/dash/api_keys) —
-#     stejný provider jako devops-agent/copilot; lze i sdílet stávající DeepInfra klíč,
-#     pokud už jeden pro devops-agent existuje (openbank/devops-agent MODEL_API_KEY).
-#   - LIVENESS_GITHUB_TOKEN: fine-grained PAT na JiRaska/open-bank-oss s oprávněním
-#     Issues:write, Contents:write, Pull requests:write (žádný GitHub App flow zde
-#     neexistuje — viz GitHubProposalAdapter.kt).
+#   ./openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh
+#
+# Vyžaduje mít po ruce (skript řekne přesně kde vzít, když se zeptá):
+#   - kubectl nakonfigurovaný na sandbox cluster
+#   - VAULT_TOKEN: operator token s write na openbank/* (stejný, jaký používáš pro
+#     seed-vault-gaps.sh / seed-nvidia-api-key.sh)
+#   - DeepInfra API klíč (https://deepinfra.com/dash/api_keys) — nebo zopakuj ten,
+#     co už má devops-agent (openbank/devops-agent MODEL_API_KEY)
+#   - fine-grained GitHub PAT na JiRaska/open-bank-oss (Settings → Developer settings
+#     → Fine-grained tokens → Generate new token) s oprávněním Issues:write,
+#     Contents:write, Pull requests:write — žádný GitHub App flow zde neexistuje
+#     (viz GitHubProposalAdapter.kt)
 set -euo pipefail
 
-: "${VAULT_TOKEN:?Set VAULT_TOKEN to an operator token with write access to openbank/*}"
-: "${LIVENESS_MODEL_API_KEY:?Set LIVENESS_MODEL_API_KEY to a DeepInfra API key}"
-: "${LIVENESS_GITHUB_TOKEN:?Set LIVENESS_GITHUB_TOKEN to a fine-grained GitHub PAT (issues+contents+PRs write)}"
+prompt_secret() { # var_name prompt_text
+  local __var="$1" __prompt="$2" __val
+  if [[ -n "${!__var:-}" ]]; then return; fi
+  read -r -s -p "$__prompt: " __val
+  echo >&2
+  printf -v "$__var" '%s' "$__val"
+}
+
+prompt_secret VAULT_TOKEN "OpenBao operator token (VAULT_TOKEN)"
+prompt_secret LIVENESS_MODEL_API_KEY "DeepInfra API key (https://deepinfra.com/dash/api_keys)"
+prompt_secret LIVENESS_GITHUB_TOKEN "GitHub fine-grained PAT (Settings > Developer settings > Fine-grained tokens, scoped to JiRaska/open-bank-oss with Issues/Contents/Pull requests: write)"
 
 vault_kv_put() {
   kubectl -n vault exec -i openbao-0 -- \


### PR DESCRIPTION
## Summary

Adds `seed-control-liveness-sentinel-secrets.sh`, the operational script for the one remaining manual step from PR #1087 (control-liveness-sentinel E2E wiring): seeding `openbank/control-liveness-sentinel` (`MODEL_API_KEY`, `GITHUB_TOKEN`) in OpenBao so the agent's ExternalSecret resolves and it can produce a real diagnosis + GitHub ticket instead of the degraded placeholder path.

## Type of change

- [x] chore (build / tooling)

## Linked issues

N/A — operational follow-up to PR #1087, no tracking issue opened.

## Changes

- New `openbank-infra/scripts/seed-control-liveness-sentinel-secrets.sh`, same GATE 2 pattern as `seed-nvidia-api-key.sh`/`seed-vault-gaps.sh`: `VAULT_TOKEN` + the two secret values are supplied as env vars at runtime, never stored in git. Writes both keys to `openbank/control-liveness-sentinel` in one `vault kv put`, then force-refreshes the ExternalSecret via annotation.

## Definition of Done

- [x] shellcheck clean
- [x] No secrets in git — script only reads from env vars the operator supplies at invocation time

Refs ADR-0163, PR #1087.