### PR TITLE
fix(infra): add the 6 new control/governance agents to auto-deploy fleet

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -99,7 +99,15 @@ jobs:
           # (falls back to 8080 if absent). Added openbank-anacredit-service/Dockerfile
           # (EXPOSE 8137, matching the gitops manifest) alongside this entry so the port
           # extraction is correct, not just defaulted.
-          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service'
+          # The 6 ADR-0163/ADR-0164-0168 control/governance agents (control-liveness-
+          # sentinel, governance-auditor, release-steward, docs-truth-agent,
+          # authz-policy-auditor, flaky-test-hunter) shipped with the exact same gap:
+          # merged, released, gitops manifest present — but never in ALL_SERVICES, so
+          # every one of their Deployments sat perpetually blocked at the placeholder
+          # `sandbox-pending` tag (Kyverno's SBOM-attestation/cosign-signature policies
+          # reject a tag that was never pushed) with zero auto-deploy coverage, and none
+          # had a per-service Dockerfile either. Added both here.
+          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service openbank-control-liveness-sentinel openbank-governance-auditor openbank-release-steward openbank-docs-truth-agent openbank-authz-policy-auditor openbank-flaky-test-hunter'
 
           # Manual dispatch: rebuild the requested module(s), or the full deployable
           # fleet when no input is given. Only services that actually carry a gitops

--- a/openbank-authz-policy-auditor/Dockerfile
+++ b/openbank-authz-policy-auditor/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY openbank-libs /build/openbank-libs
+COPY openbank-authz-policy-auditor /build/openbank-authz-policy-auditor
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-authz-policy-auditor:quarkusBuild :openbank-authz-policy-auditor:cyclonedxBom \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-authz-policy-auditor/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-authz-policy-auditor/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-authz-policy-auditor/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-authz-policy-auditor/build/quarkus-app/quarkus/ /app/quarkus/
+
+# CycloneDX SBOM baked into the image; served live by libs SbomResource at
+# /q/openbank/sbom (admin-ui Tech Inventory reads it). Travels with the image,
+# so what the service reports is exactly what was built.
+COPY --from=build /build/openbank-authz-policy-auditor/build/reports/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
+
+EXPOSE 8147
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-control-liveness-sentinel/Dockerfile
+++ b/openbank-control-liveness-sentinel/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY openbank-libs /build/openbank-libs
+COPY openbank-control-liveness-sentinel /build/openbank-control-liveness-sentinel
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-control-liveness-sentinel:quarkusBuild :openbank-control-liveness-sentinel:cyclonedxBom \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-control-liveness-sentinel/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-control-liveness-sentinel/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-control-liveness-sentinel/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-control-liveness-sentinel/build/quarkus-app/quarkus/ /app/quarkus/
+
+# CycloneDX SBOM baked into the image; served live by libs SbomResource at
+# /q/openbank/sbom (admin-ui Tech Inventory reads it). Travels with the image,
+# so what the service reports is exactly what was built.
+COPY --from=build /build/openbank-control-liveness-sentinel/build/reports/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
+
+EXPOSE 8144
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-docs-truth-agent/Dockerfile
+++ b/openbank-docs-truth-agent/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY openbank-libs /build/openbank-libs
+COPY openbank-docs-truth-agent /build/openbank-docs-truth-agent
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-docs-truth-agent:quarkusBuild :openbank-docs-truth-agent:cyclonedxBom \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-docs-truth-agent/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-docs-truth-agent/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-docs-truth-agent/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-docs-truth-agent/build/quarkus-app/quarkus/ /app/quarkus/
+
+# CycloneDX SBOM baked into the image; served live by libs SbomResource at
+# /q/openbank/sbom (admin-ui Tech Inventory reads it). Travels with the image,
+# so what the service reports is exactly what was built.
+COPY --from=build /build/openbank-docs-truth-agent/build/reports/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
+
+EXPOSE 8146
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-flaky-test-hunter/Dockerfile
+++ b/openbank-flaky-test-hunter/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY openbank-libs /build/openbank-libs
+COPY openbank-flaky-test-hunter /build/openbank-flaky-test-hunter
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-flaky-test-hunter:quarkusBuild :openbank-flaky-test-hunter:cyclonedxBom \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-flaky-test-hunter/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-flaky-test-hunter/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-flaky-test-hunter/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-flaky-test-hunter/build/quarkus-app/quarkus/ /app/quarkus/
+
+# CycloneDX SBOM baked into the image; served live by libs SbomResource at
+# /q/openbank/sbom (admin-ui Tech Inventory reads it). Travels with the image,
+# so what the service reports is exactly what was built.
+COPY --from=build /build/openbank-flaky-test-hunter/build/reports/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
+
+EXPOSE 8148
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-governance-auditor/Dockerfile
+++ b/openbank-governance-auditor/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY openbank-libs /build/openbank-libs
+COPY openbank-governance-auditor /build/openbank-governance-auditor
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-governance-auditor:quarkusBuild :openbank-governance-auditor:cyclonedxBom \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-governance-auditor/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-governance-auditor/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-governance-auditor/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-governance-auditor/build/quarkus-app/quarkus/ /app/quarkus/
+
+# CycloneDX SBOM baked into the image; served live by libs SbomResource at
+# /q/openbank/sbom (admin-ui Tech Inventory reads it). Travels with the image,
+# so what the service reports is exactly what was built.
+COPY --from=build /build/openbank-governance-auditor/build/reports/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
+
+EXPOSE 8143
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]

--- a/openbank-release-steward/Dockerfile
+++ b/openbank-release-steward/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+COPY gradle /build/gradle
+COPY gradlew build.gradle.kts settings.gradle.kts /build/
+COPY openbank-libs /build/openbank-libs
+COPY openbank-release-steward /build/openbank-release-steward
+
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-release-steward:quarkusBuild :openbank-release-steward:cyclonedxBom \
+      -Dquarkus.package.jar.type=fast-jar \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-release-steward/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-release-steward/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-release-steward/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-release-steward/build/quarkus-app/quarkus/ /app/quarkus/
+
+# CycloneDX SBOM baked into the image; served live by libs SbomResource at
+# /q/openbank/sbom (admin-ui Tech Inventory reads it). Travels with the image,
+# so what the service reports is exactly what was built.
+COPY --from=build /build/openbank-release-steward/build/reports/bom.json /app/sbom/bom.json
+ENV OPENBANK_SBOM_PATH=/app/sbom/bom.json
+
+EXPOSE 8145
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]


### PR DESCRIPTION
## Summary

Fixes why PR #1087 merged cleanly but produced zero deployment: `auto-deploy.yml`'s static `ALL_SERVICES` list never included any of the 6 ADR-0163/ADR-0164-0168 agents (control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent, authz-policy-auditor, flaky-test-hunter) — the exact same drift class the file's own comments already document for billing-service/anacredit-service. Confirmed live: the post-merge auto-deploy run printed "No deployable services changed" even though `openbank-control-liveness-sentinel/src/main/**` changed.

Root cause chain for control-liveness-sentinel specifically (all now fixed):
1. ECR repository never existed → Kyverno blocked the Deployment (fixed live: repo created, image built/signed/attested locally to confirm).
2. `auto-deploy.yml` never knew the service existed → zero CI-driven build/deploy coverage (this PR).
3. No per-service Dockerfile → port would default to 8080 instead of the real containerPort (this PR).

All 6 agents shared gaps 2 and 3; I found and fixed gap 1 (missing ECR repo) live in AWS for all 6 the same way.

## Type of change

- [x] fix (bug fix)

## Linked issues

N/A — operational follow-up discovered while verifying PR #1087's deployment; no tracking issue opened.

## Changes

- `ALL_SERVICES` in `.github/workflows/auto-deploy.yml`: added the 6 new agents (each already has a gitops manifest with an `image:sandbox-*` pin, the existing filter's own eligibility check).
- Added `openbank-<agent>/Dockerfile` for all 6, mirroring `openbank-account-service/Dockerfile`'s canonical template with each service's real `containerPort` (8143-8148) from its gitops Deployment.

## Definition of Done

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Live verification: next push touching one of these 6 services' `src/main` should now build+push+sign+attest and open a gitops-tag-bump PR

Refs ADR-0163, ADR-0164, ADR-0165, ADR-0166, ADR-0167, ADR-0168.