### PR TITLE
feat(document-service): enforce one PUBLISHED version per template code

### DIFF
--- a/docs/adr/0162-document-management-templating-and-e-signature-architecture.md
+++ b/docs/adr/0162-document-management-templating-and-e-signature-architecture.md
@@ -42,9 +42,10 @@ library and rules out embedding AGPL apps (DocuSeal/Documenso) as linked compone
 Document management is its own aggregate set — template registry, rendering, storage,
 lifecycle, and signing ceremony — too distinct to fold into product-catalog (a clean JSONB
 read-model service) and needed by non-product flows anyway. Product-catalog keeps only the
-**reference**: `TermsAndConditions.url` evolves into a `documentTemplateRef(code, version)`
-pointing into document-service. The product↔template *binding* stays with the product; the
-document *machinery* lives in the new service.
+**reference**: `TermsAndConditions` gains `documentTemplateCode`, a `code`-only pointer into
+document-service (see the version-resolution policy under D2 for why not `(code,
+version)`). The product↔template *binding* stays with the product; the document *machinery*
+lives in the new service.
 
 The service is **not money-path** and must stay off the synchronous fund-release path: it
 **emits events** (`DOCUMENT_SIGNED`, `SIGNATURE_CEREMONY_COMPLETED`) that consumers
@@ -68,6 +69,39 @@ RETIRED}`, effective-dated) — unlike product-catalog's soft embedded `versionH
 
 Rendering sits behind `TemplateRenderPort` (data-merge) and `PdfRenderPort` (HTML→PDF), so
 the engine is swappable without touching the domain.
+
+**Version-resolution policy** (added retroactively — this was left implicit long enough
+that a real environment accumulated two coexisting `PUBLISHED` versions of the same
+template `code` with nothing marking either "current"):
+
+- **A `code` has at most one `PUBLISHED` row at any time.** Publishing a new version
+  **retires its predecessor atomically**, in the same transaction — a code is never
+  briefly unpublished, nor ever has two rows simultaneously `PUBLISHED`, not even under a
+  crash mid-operation or two concurrent publish calls. Enforced at two layers: application
+  logic retires the current `PUBLISHED` sibling as part of every publish, and a Postgres
+  **partial unique index** (`uq_document_templates_one_published_per_code`) makes the
+  invariant a hard DB constraint, not just an application convention — a lost race surfaces
+  as an explicit conflict, never a silent second "current" version.
+- **A new document render (or a product's `documentTemplateRef`, D1) that names only a
+  `code` resolves to whatever is currently `PUBLISHED`** — the "latest" a caller gets when
+  it doesn't pin an exact version. A caller pins an exact `(code, version)` only when it
+  deliberately needs a non-current version (e.g. re-rendering against a historical version
+  for a support case).
+- **An already-rendered `Document` keeps the exact `(templateCode, templateVersion)` it was
+  actually generated from, permanently** — snapshotted at render time, never re-resolved.
+  Publishing a newer template version afterwards cannot retroactively change what a
+  customer already saw and signed; a `SignatureCeremony` inherits this same guarantee
+  transitively, since it is scoped to one already-rendered `Document`.
+
+### D1 (continued) — `documentTemplateRef` is a code, not a pinned version
+
+Product-catalog's `TermsAndConditions.documentTemplateCode` (D1) intentionally carries only
+the template **code**, not a `(code, version)` pair: the product should always mean
+"whatever is currently published for this document", so a document-service republish never
+requires touching the product. Combined with the version-resolution policy above, this
+gives both halves of the guarantee this ADR was missing: the product always gets the
+current version, and any document already rendered/signed from an older version is
+unaffected by a later republish.
 
 ### D3 — PDF rendering: `WeasyPrint` default, `Gotenberg` opt-in, behind `PdfRenderPort`
 

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/in/DocumentUseCases.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/in/DocumentUseCases.kt
@@ -27,7 +27,12 @@ data class CreateTemplateCommand(
 
 data class RenderDocumentCommand(
     val templateCode: String,
-    val templateVersion: String,
+    // Null resolves to the current PUBLISHED version for [templateCode] (ADR-0162
+    // version-resolution policy) -- the caller pins an exact version only when it deliberately
+    // needs one that isn't current (e.g. re-rendering against a historical version for a support
+    // case). The [com.openbank.document.domain.model.Document] this produces always snapshots the
+    // exact version it actually resolved to, so the render itself is never ambiguous after the fact.
+    val templateVersion: String?,
     val data: Map<String, Any?>,
     val contentType: String,
     val partyRef: String?,

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
@@ -10,11 +10,29 @@ import com.openbank.document.domain.model.SignatureCeremony
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import java.util.UUID
 
+/**
+ * Thrown by [TemplateRepositoryPort.publishReplacing] when a concurrent publish of the same
+ * template `code` lost the race (a Postgres unique-violation on the partial index that enforces
+ * "at most one PUBLISHED row per code", translated at the persistence-adapter boundary so the
+ * application layer never depends on a framework/SQL exception type — ADR-0002 layering).
+ */
+class TemplatePublishConflictException(message: String) : RuntimeException(message)
+
 /** Persistence port for the [DocumentTemplate] aggregate. */
 interface TemplateRepositoryPort {
     suspend fun save(template: DocumentTemplate): DocumentTemplate
     suspend fun findById(id: UUID): DocumentTemplate?
     suspend fun findPublished(code: String, version: String): DocumentTemplate?
+
+    /**
+     * The current PUBLISHED version for [code] — the "latest" a new render/product reference
+     * resolves to when it pins no exact version (ADR-0162 version-resolution policy). At most one
+     * row can be PUBLISHED per code at a time (enforced by [publishReplacing] plus a DB partial
+     * unique index, `uq_document_templates_one_published_per_code`), so this is a lookup, not a
+     * ranking — the tie-break sort only matters transiently, mid-[publishReplacing], or for
+     * pre-existing data from before that invariant was enforced.
+     */
+    suspend fun findLatestPublished(code: String): DocumentTemplate?
 
     // Named findAllTemplates, not listAll: a Panache-backed implementor already inherits
     // PanacheRepository's own zero-arg `listAll(): Uni<List<Entity>>` — same erased JVM signature,
@@ -26,6 +44,14 @@ interface TemplateRepositoryPort {
     // platform convention used by account-service/ledger-service) is a follow-up if/when the
     // catalog needs stable forward paging past one bounded page.
     suspend fun findAllTemplates(limit: Int): List<DocumentTemplate>
+
+    /**
+     * Publishes [toPublish] and, if [toRetire] is non-null, retires it in the SAME transaction —
+     * so a code's predecessor is never left PUBLISHED alongside its successor, nor briefly
+     * unpublished, even if the process crashes mid-operation (ADR-0162 version-resolution policy:
+     * publishing a version supersedes, and immediately retires, whatever it replaces).
+     */
+    suspend fun publishReplacing(toPublish: DocumentTemplate, toRetire: DocumentTemplate?): DocumentTemplate
 }
 
 /** Persistence port for the [Document] aggregate, including transactional-outbox co-persistence. */

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentRenderService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentRenderService.kt
@@ -38,8 +38,19 @@ class DocumentRenderService(
 ) : DocumentRenderUseCase {
 
     override suspend fun render(cmd: RenderDocumentCommand): Document {
-        val template = templateRepo.findPublished(cmd.templateCode, cmd.templateVersion)
-            ?: error("No published template for ${cmd.templateCode} v${cmd.templateVersion}")
+        // ADR-0162 version-resolution policy: an explicit templateVersion pins to that exact
+        // (immutable) version; omitting it resolves to whatever is currently PUBLISHED for
+        // templateCode. Either way, the resolved template.code/version is what gets snapshotted
+        // onto the resulting Document below, so a later re-publish can never retroactively change
+        // what this already-generated document is considered to have been rendered from.
+        val pinnedVersion = cmd.templateVersion
+        val template = if (pinnedVersion != null) {
+            templateRepo.findPublished(cmd.templateCode, pinnedVersion)
+                ?: error("No published template for ${cmd.templateCode} v$pinnedVersion")
+        } else {
+            templateRepo.findLatestPublished(cmd.templateCode)
+                ?: error("No published template for ${cmd.templateCode}")
+        }
 
         val html = templateRenderPort.renderHtml(template, cmd.data)
         val pdf = pdfRenderPort.htmlToPdf(html)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentTemplateService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentTemplateService.kt
@@ -6,6 +6,7 @@ package com.openbank.document.application.usecase
 
 import com.openbank.document.application.port.`in`.CreateTemplateCommand
 import com.openbank.document.application.port.`in`.DocumentTemplateUseCase
+import com.openbank.document.application.port.out.TemplatePublishConflictException
 import com.openbank.document.application.port.out.TemplateRenderPort
 import com.openbank.document.application.port.out.TemplateRepositoryPort
 import com.openbank.document.domain.model.DocumentTemplate
@@ -44,8 +45,23 @@ class DocumentTemplateService(
 
     // TODO(ADR-0162): emit DocumentTemplatePublished to the outbox on publish once template-scoped
     // outbox co-persistence is wired (the DocumentGenerated path already demonstrates the pattern).
-    override suspend fun publishTemplate(id: UUID): DocumentTemplate =
-        repo.save((repo.findById(id) ?: error("Template not found: $id")).publish())
+    //
+    // Version-resolution policy (ADR-0162): publishing a version supersedes whatever is currently
+    // PUBLISHED for the same `code` — that predecessor is retired atomically in the same
+    // transaction as this publish (repo.publishReplacing), so a code never has two PUBLISHED rows
+    // at once, not even transiently. A concurrent publish of the same code (two operators, or a
+    // retry racing itself) is rejected with a clear conflict rather than silently producing two
+    // "current" versions — the exact defect found live in the seed data before this policy existed.
+    override suspend fun publishTemplate(id: UUID): DocumentTemplate {
+        val template = repo.findById(id) ?: error("Template not found: $id")
+        val toPublish = template.publish()
+        val predecessor = repo.findLatestPublished(template.code)?.takeIf { it.id != template.id }
+        return try {
+            repo.publishReplacing(toPublish, predecessor?.retire())
+        } catch (e: TemplatePublishConflictException) {
+            error("Template ${template.code} is being published concurrently by another request — retry: ${e.message}")
+        }
+    }
 
     override suspend fun retireTemplate(id: UUID): DocumentTemplate =
         repo.save((repo.findById(id) ?: error("Template not found: $id")).retire())

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/domain/DocumentTemplateSeed.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/domain/DocumentTemplateSeed.kt
@@ -33,10 +33,12 @@ object DocumentTemplateSeed {
 
     // v1.1.0 (2026-07-14): added the OpenBank letterhead (inline-SVG logo). Published templates
     // are immutable (DocumentTemplate.publish()/domain rule), so this is a NEW version — new fixed
-    // IDs, not an in-place edit of the v1.0.0 rows already seeded — coexisting with the original
-    // v1.0.0 seed (DocumentTemplateSeeder adds whichever (id) rows are missing, it does not
-    // truncate/replace, so both versions end up in the table; that is correct, not a bug — it is
-    // exactly what "published is immutable, a change ships as a new version" looks like in practice.
+    // IDs, not an in-place edit of the v1.0.0 rows already seeded. Superseding the v1.0.0 rows is
+    // now handled automatically: DocumentTemplateSeeder retires the current PUBLISHED sibling for
+    // a code before inserting its replacement (ADR-0162 version-resolution policy — a code has at
+    // most one PUBLISHED row at a time), and a one-time migration
+    // (V5__enforce_one_published_template_per_code.sql) retired the v1.0.0 rows this list had
+    // already left dangling as PUBLISHED before that policy existed.
     val templates: List<DocumentTemplate> = listOf(
         template(
             id = "1e575a01-0000-4000-9000-000000000011",

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/DocumentTemplateSeeder.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/DocumentTemplateSeeder.kt
@@ -5,6 +5,8 @@
 package com.openbank.document.infrastructure.persistence
 
 import com.openbank.document.domain.DocumentTemplateSeed
+import com.openbank.document.domain.model.DocumentTemplate
+import com.openbank.document.domain.model.TemplateStatus
 import com.openbank.document.infrastructure.persistence.entity.DocumentTemplateEntity
 import com.openbank.document.infrastructure.persistence.mapper.toEntity
 import io.quarkus.runtime.StartupEvent
@@ -20,11 +22,18 @@ import org.jboss.logging.Logger
  * agreement, current account agreement — each cs/en, one row per [DocumentTemplateSeed] entry)
  * from [DocumentTemplateSeed], mirroring `openbank-product-catalog`'s `ProductCatalogSeeder` in
  * mechanism. Adds only the [DocumentTemplateSeed] rows that are missing by fixed `id` — never
- * touches an existing row (an operator-authored template, or an earlier seed version whose fixed
- * id isn't in the current [DocumentTemplateSeed] list, is left untouched) — so a later
- * [DocumentTemplateSeed] update (a new fixed id + version, since published templates are
- * immutable) reaches an already-seeded environment on the next boot instead of only ever running
- * once against an empty table.
+ * mutates an existing row's content (an operator-authored template, or an earlier seed version
+ * whose fixed id isn't in the current [DocumentTemplateSeed] list, keeps its own body/name/etc.
+ * untouched) — so a later [DocumentTemplateSeed] update (a new fixed id + version, since published
+ * templates are immutable) reaches an already-seeded environment on the next boot instead of only
+ * ever running once against an empty table.
+ *
+ * It DOES retire the current PUBLISHED sibling(s) for a code before inserting a new seed version
+ * of that code (ADR-0162 version-resolution policy: a code has at most one PUBLISHED row at a
+ * time — a DB partial unique index enforces this, so seeding a second PUBLISHED row for the same
+ * code without retiring the first would crash boot on that constraint). This is the seed-data
+ * equivalent of what [com.openbank.document.application.usecase.DocumentTemplateService.publishTemplate]
+ * does for an API-driven publish.
  *
  * Deliberately does NOT go through the coroutine (`suspend fun`) [com.openbank.document.application.port.out.TemplateRepositoryPort]
  * the rest of the service uses: a `runBlocking { repo.save(...) } ` call from a plain `@Observes
@@ -52,7 +61,7 @@ class DocumentTemplateSeeder(private val sf: Mutiny.SessionFactory) {
         val inserted = try {
             seed()
         } catch (e: RuntimeException) {
-            if (isUniqueViolation(e)) {
+            if (PostgresConflicts.isUniqueViolation(e)) {
                 log.info("Document templates already seeded by another replica (concurrent first boot) — skipping.")
                 0
             } else {
@@ -72,7 +81,9 @@ class DocumentTemplateSeeder(private val sf: Mutiny.SessionFactory) {
                         if (existing != null) {
                             Uni.createFrom().item(insertedSoFar)
                         } else {
-                            s.persist(template.toEntity()).replaceWith(insertedSoFar + 1)
+                            retireCurrentPublishedSibling(s, template).flatMap {
+                                s.persist(template.toEntity()).replaceWith(insertedSoFar + 1)
+                            }
                         }
                     }
                 }
@@ -80,20 +91,17 @@ class DocumentTemplateSeeder(private val sf: Mutiny.SessionFactory) {
         }
     }
 
-    /** True if [e] (or any cause) is a Postgres unique-violation (SQLState 23505) — a lost seed race. */
-    private fun isUniqueViolation(e: Throwable): Boolean {
-        var cur: Throwable? = e
-        while (cur != null) {
-            val msg = cur.message.orEmpty()
-            val byMessage = "23505" in msg || "duplicate key value" in msg
-            if ((cur as? java.sql.SQLException)?.sqlState == "23505" ||
-                cur is org.hibernate.exception.ConstraintViolationException ||
-                byMessage
-            ) {
-                return true
-            }
-            cur = cur.cause
+    /** Retires any OTHER row currently PUBLISHED for [template]'s code, ahead of seeding it in. */
+    private fun retireCurrentPublishedSibling(s: Mutiny.Session, template: DocumentTemplate): Uni<Void> = s.createQuery(
+        "from DocumentTemplateEntity where code = :code and status = :published and id <> :id",
+        DocumentTemplateEntity::class.java,
+    )
+        .setParameter("code", template.code)
+        .setParameter("published", TemplateStatus.PUBLISHED)
+        .setParameter("id", template.id)
+        .resultList
+        .flatMap { siblings ->
+            siblings.forEach { it.status = TemplateStatus.RETIRED }
+            Uni.createFrom().voidItem()
         }
-        return false
-    }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/PostgresConflicts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/PostgresConflicts.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.persistence
+
+/** Shared Postgres-exception classification for code that must tell a lost race from a real fault. */
+object PostgresConflicts {
+
+    /** True if [e] (or any cause) is a Postgres unique-violation (SQLState 23505) — a lost race. */
+    fun isUniqueViolation(e: Throwable): Boolean {
+        var cur: Throwable? = e
+        while (cur != null) {
+            val msg = cur.message.orEmpty()
+            val byMessage = "23505" in msg || "duplicate key value" in msg
+            if ((cur as? java.sql.SQLException)?.sqlState == "23505" ||
+                cur is org.hibernate.exception.ConstraintViolationException ||
+                byMessage
+            ) {
+                return true
+            }
+            cur = cur.cause
+        }
+        return false
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentTemplateRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentTemplateRepositoryImpl.kt
@@ -4,21 +4,25 @@
 
 package com.openbank.document.infrastructure.persistence.repository
 
+import com.openbank.document.application.port.out.TemplatePublishConflictException
 import com.openbank.document.application.port.out.TemplateRepositoryPort
 import com.openbank.document.domain.model.DocumentTemplate
+import com.openbank.document.infrastructure.persistence.PostgresConflicts
 import com.openbank.document.infrastructure.persistence.entity.DocumentTemplateEntity
 import com.openbank.document.infrastructure.persistence.mapper.toDomain
 import com.openbank.document.infrastructure.persistence.mapper.toEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.quarkus.panache.common.Page
+import io.quarkus.panache.common.Sort
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import org.hibernate.reactive.mutiny.Mutiny
 import java.util.UUID
 
 @ApplicationScoped
-class DocumentTemplateRepositoryImpl :
+class DocumentTemplateRepositoryImpl(private val sf: Mutiny.SessionFactory) :
     TemplateRepositoryPort,
     PanacheRepository<DocumentTemplateEntity> {
 
@@ -46,6 +50,54 @@ class DocumentTemplateRepositoryImpl :
     override suspend fun findAllTemplates(limit: Int): List<DocumentTemplate> =
         Panache.withSession { findAll().page(Page.ofSize(limit)).list() }
             .awaitSuspending().map { it.toDomain() }
+
+    override suspend fun findLatestPublished(code: String): DocumentTemplate? = Panache.withSession {
+        find(
+            "code = ?1 and status = 'PUBLISHED'",
+            Sort.by("createdAt", Sort.Direction.Descending).and("id", Sort.Direction.Descending),
+            code,
+        ).firstResult()
+    }.awaitSuspending()?.toDomain()
+
+    // Retire-then-publish, with an explicit flush in between: Postgres does not support DEFERRABLE
+    // on a *partial* unique index (only non-partial constraint-backed uniques can defer), so
+    // `uq_document_templates_one_published_per_code` is checked immediately, per-statement. Simply
+    // mutating both entities and letting Hibernate flush them in whatever order it likes risks the
+    // publish's UPDATE reaching Postgres before the retire's -- transiently violating the index
+    // even inside one transaction that would have been fine at commit. Flushing the retire first
+    // guarantees the old row is already RETIRED in the database by the time the new row's UPDATE
+    // (which the outer withTransaction's own commit-time flush emits) runs.
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun publishReplacing(toPublish: DocumentTemplate, toRetire: DocumentTemplate?): DocumentTemplate {
+        try {
+            sf.withTransaction { s ->
+                val retired = if (toRetire == null) {
+                    Uni.createFrom().voidItem()
+                } else {
+                    s.find(DocumentTemplateEntity::class.java, toRetire.id).flatMap { foundRetire ->
+                        val retiring = checkNotNull(foundRetire) { "Template not found: ${toRetire.id}" }
+                        retiring.applyFrom(toRetire)
+                        s.flush()
+                    }
+                }
+                retired.flatMap {
+                    s.find(DocumentTemplateEntity::class.java, toPublish.id).map { found ->
+                        val publishing = checkNotNull(found) { "Template not found: ${toPublish.id}" }
+                        publishing.applyFrom(toPublish)
+                        publishing
+                    }
+                }
+            }.awaitSuspending()
+        } catch (e: RuntimeException) {
+            if (PostgresConflicts.isUniqueViolation(e)) {
+                throw TemplatePublishConflictException(
+                    "Template ${toPublish.code} already has a PUBLISHED version (concurrent publish lost the race)",
+                )
+            }
+            throw e
+        }
+        return toPublish
+    }
 
     private fun DocumentTemplateEntity.applyFrom(template: DocumentTemplate) {
         status = template.status

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/rest/dto/DocumentDtos.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/rest/dto/DocumentDtos.kt
@@ -45,7 +45,9 @@ data class TemplateResponse(
 
 data class RenderDocumentRequest(
     val templateCode: String,
-    val templateVersion: String,
+    // Omit to render the current PUBLISHED version of templateCode (ADR-0162 version-resolution
+    // policy) -- pin an exact version only to deliberately render a non-current one.
+    val templateVersion: String? = null,
     val data: Map<String, Any?> = emptyMap(),
     val contentType: String = "application/pdf",
     val partyRef: String? = null,

--- a/openbank-document-service/src/main/resources/db/migration/V5__enforce_one_published_template_per_code.sql
+++ b/openbank-document-service/src/main/resources/db/migration/V5__enforce_one_published_template_per_code.sql
@@ -1,0 +1,28 @@
+-- Version-resolution policy (ADR-0162): a template `code` has at most one PUBLISHED version at
+-- any time -- publishing a version supersedes and retires its predecessor. Rollback: DROP INDEX
+-- uq_document_templates_one_published_per_code; the RETIRED rows this migration produces cannot
+-- be un-retired automatically (their original status wasn't recorded) -- restore individually
+-- from a backup if ever needed.
+
+-- One-time cleanup: before this policy was enforced in application code (PR #1083's letterhead
+-- update added new 1.1.0 seed rows without retiring their 1.0.0 predecessors), a `code` could
+-- accumulate more than one PUBLISHED row. Retire every PUBLISHED row that has a newer PUBLISHED
+-- row for the same code, keeping only the most recent as current. Generic (not id-hardcoded) so
+-- it also cleans up any other pre-existing duplicate, not just the known VOP/framework/account set.
+UPDATE document_templates t
+SET status = 'RETIRED'
+WHERE t.status = 'PUBLISHED'
+  AND EXISTS (
+      SELECT 1
+      FROM document_templates newer
+      WHERE newer.code = t.code
+        AND newer.status = 'PUBLISHED'
+        AND (newer.created_at, newer.id) > (t.created_at, t.id)
+  );
+
+-- Enforce the invariant going forward: a concurrent publish of the same code now fails fast with a
+-- unique-violation (translated to TemplatePublishConflictException at the persistence adapter)
+-- instead of silently leaving two "current" versions.
+CREATE UNIQUE INDEX uq_document_templates_one_published_per_code
+    ON document_templates (code)
+    WHERE status = 'PUBLISHED';

--- a/openbank-document-service/src/main/resources/openapi.yaml
+++ b/openbank-document-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Document Service API
-  version: 1.0.0
+  version: 1.1.0
   description: >-
     Document Management — templates, rendering, storage with lifecycle/retention metadata,
     and e-signature ceremonies. Not on the synchronous money path (emits events, never a
@@ -276,12 +276,16 @@ components:
 
     RenderDocumentRequest:
       type: object
-      required: [templateCode, templateVersion]
+      required: [templateCode]
       properties:
         templateCode:
           type: string
         templateVersion:
           type: string
+          nullable: true
+          description: >-
+            Exact version to render. Omit to render the current PUBLISHED version of
+            templateCode (a template code has at most one PUBLISHED version at a time).
         data:
           type: object
           additionalProperties: true

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/DocumentRenderServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/DocumentRenderServiceTest.kt
@@ -78,9 +78,34 @@ class DocumentRenderServiceTest {
             .isInstanceOf(IllegalStateException::class.java)
     }
 
-    private fun command() = RenderDocumentCommand(
+    @Test
+    fun `render with no templateVersion resolves the current published version`(): Unit = runBlocking {
+        val pdf = "<html>rendered</html>".toByteArray()
+        coEvery { templateRepo.findLatestPublished("LOAN_AGREEMENT") } returns publishedTemplate()
+        coEvery { renderPort.renderHtml(any(), any()) } returns "<html>rendered</html>"
+        coEvery { pdfPort.htmlToPdf(any()) } returns pdf
+        coEvery { objectStore.put(any(), any(), any()) } returns Unit
+        val savedDoc = slot<Document>()
+        coEvery { documentRepo.saveWithOutbox(capture(savedDoc), any()) } answers { savedDoc.captured }
+
+        val result = service.render(command(templateVersion = null))
+
+        assertThat(result.templateVersion).isEqualTo("1.0.0")
+        coVerify(exactly = 1) { templateRepo.findLatestPublished("LOAN_AGREEMENT") }
+        coVerify(exactly = 0) { templateRepo.findPublished(any(), any()) }
+    }
+
+    @Test
+    fun `render with no templateVersion fails when nothing is currently published`(): Unit = runBlocking {
+        coEvery { templateRepo.findLatestPublished(any()) } returns null
+
+        assertThatThrownBy { runBlocking { service.render(command(templateVersion = null)) } }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    private fun command(templateVersion: String? = "1.0.0") = RenderDocumentCommand(
         templateCode = "LOAN_AGREEMENT",
-        templateVersion = "1.0.0",
+        templateVersion = templateVersion,
         data = mapOf("name" to "Alice"),
         contentType = "application/pdf",
         partyRef = "party-1",

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/DocumentTemplateServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/DocumentTemplateServiceTest.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.application.usecase
+
+import com.openbank.document.application.port.out.TemplatePublishConflictException
+import com.openbank.document.application.port.out.TemplateRenderPort
+import com.openbank.document.application.port.out.TemplateRepositoryPort
+import com.openbank.document.domain.model.DocumentTemplate
+import com.openbank.document.domain.model.TemplateEngine
+import com.openbank.document.domain.model.TemplateStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * ADR-0162 version-resolution policy: publishing a template supersedes whatever is currently
+ * PUBLISHED for the same `code` — that predecessor is retired in the same [TemplateRepositoryPort.publishReplacing]
+ * call, atomically, never left coexisting with (or briefly absent alongside) its successor.
+ */
+class DocumentTemplateServiceTest {
+
+    private val repo: TemplateRepositoryPort = mockk()
+    private val renderPort: TemplateRenderPort = mockk()
+    private val service = DocumentTemplateService(
+        repo = repo,
+        renderPort = renderPort,
+        clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC),
+    )
+
+    @Test
+    fun `publishing the first version of a code retires nothing`(): Unit = runBlocking {
+        val draft = draftTemplate()
+        coEvery { repo.findById(draft.id) } returns draft
+        coEvery { repo.findLatestPublished(draft.code) } returns null
+        var retireCallCount = 0
+        var capturedToRetire: DocumentTemplate? = null
+        coEvery { repo.publishReplacing(any(), any()) } coAnswers {
+            retireCallCount++
+            capturedToRetire = secondArg()
+            firstArg()
+        }
+
+        val result = service.publishTemplate(draft.id)
+
+        assertThat(result.status).isEqualTo(TemplateStatus.PUBLISHED)
+        assertThat(retireCallCount).isEqualTo(1)
+        assertThat(capturedToRetire).isNull()
+    }
+
+    @Test
+    fun `publishing a new version retires the currently published sibling of the same code`(): Unit = runBlocking {
+        val draft = draftTemplate(id = OTHER_ID, version = "1.1.0")
+        val predecessor = draftTemplate(version = "1.0.0").publish()
+        coEvery { repo.findById(draft.id) } returns draft
+        coEvery { repo.findLatestPublished(draft.code) } returns predecessor
+        var capturedToPublish: DocumentTemplate? = null
+        var capturedToRetire: DocumentTemplate? = null
+        coEvery { repo.publishReplacing(any(), any()) } coAnswers {
+            capturedToPublish = firstArg()
+            capturedToRetire = secondArg()
+            firstArg()
+        }
+
+        service.publishTemplate(draft.id)
+
+        assertThat(capturedToPublish?.id).isEqualTo(draft.id)
+        assertThat(capturedToPublish?.status).isEqualTo(TemplateStatus.PUBLISHED)
+        assertThat(capturedToRetire?.id).isEqualTo(predecessor.id)
+        assertThat(capturedToRetire?.status).isEqualTo(TemplateStatus.RETIRED)
+    }
+
+    @Test
+    fun `publishing does not try to retire itself when it is its own latest-published lookup result`(): Unit =
+        runBlocking {
+            // Defensive case: findLatestPublished(code) racing a concurrent publish could return the
+            // row being published itself (e.g. re-entrant call) -- must never self-retire.
+            val draft = draftTemplate()
+            coEvery { repo.findById(draft.id) } returns draft
+            coEvery { repo.findLatestPublished(draft.code) } returns draft
+            var capturedToRetire: DocumentTemplate? = null
+            coEvery { repo.publishReplacing(any(), any()) } coAnswers {
+                capturedToRetire = secondArg()
+                firstArg()
+            }
+
+            service.publishTemplate(draft.id)
+
+            assertThat(capturedToRetire).isNull()
+        }
+
+    @Test
+    fun `a concurrent publish race surfaces as a clear, catchable error`(): Unit = runBlocking {
+        val draft = draftTemplate(id = OTHER_ID)
+        coEvery { repo.findById(draft.id) } returns draft
+        coEvery { repo.findLatestPublished(draft.code) } returns null
+        coEvery { repo.publishReplacing(any(), any()) } throws TemplatePublishConflictException("lost the race")
+
+        assertThatThrownBy { runBlocking { service.publishTemplate(draft.id) } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("concurrently")
+    }
+
+    @Test
+    fun `publishing an already-published template is rejected by the domain rule`(): Unit = runBlocking {
+        val published = draftTemplate().publish()
+        coEvery { repo.findById(published.id) } returns published
+
+        assertThatThrownBy { runBlocking { service.publishTemplate(published.id) } }
+            .isInstanceOf(IllegalArgumentException::class.java)
+
+        coVerify(exactly = 0) { repo.publishReplacing(any(), any()) }
+    }
+
+    private fun draftTemplate(id: UUID = FIXED_ID, code: String = "VOP_CS", version: String = "1.0.0") =
+        DocumentTemplate(
+            id = id,
+            code = code,
+            version = version,
+            name = "VOP",
+            engine = TemplateEngine.HANDLEBARS,
+            bodyHtml = "<html>{{name}}</html>",
+            locale = "cs",
+            status = TemplateStatus.DRAFT,
+            productRef = null,
+            classification = "restricted",
+            createdAt = FIXED_NOW,
+            createdBy = "system",
+        )
+
+    private companion object {
+        val FIXED_NOW: Instant = Instant.parse("2026-01-15T10:15:30Z")
+        val FIXED_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000030")
+        val OTHER_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000031")
+    }
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentTemplateRepositoryImplIT.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentTemplateRepositoryImplIT.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.persistence.repository
+
+import com.openbank.document.application.port.out.TemplatePublishConflictException
+import com.openbank.document.domain.model.DocumentTemplate
+import com.openbank.document.domain.model.TemplateEngine
+import com.openbank.document.domain.model.TemplateStatus
+import com.openbank.document.it.PostgresRedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Real-Postgres coverage for the ADR-0162 version-resolution policy: [findLatestPublished] and the
+ * atomicity of [publishReplacing] — including the partial unique index
+ * (`uq_document_templates_one_published_per_code`, V5 migration) that makes "two PUBLISHED rows
+ * for one code" a hard DB error rather than a silent possibility, mirroring the exact defect found
+ * live in the seed data (two coexisting PUBLISHED versions of the same VOP/framework/account codes).
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class DocumentTemplateRepositoryImplIT {
+
+    @Inject
+    lateinit var repo: DocumentTemplateRepositoryImpl
+
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    private fun draft(id: UUID, code: String, version: String, createdAt: Instant) = DocumentTemplate(
+        id = id,
+        code = code,
+        version = version,
+        name = "Template",
+        engine = TemplateEngine.HANDLEBARS,
+        bodyHtml = "<html>body</html>",
+        locale = "en",
+        status = TemplateStatus.DRAFT,
+        productRef = null,
+        classification = "restricted",
+        createdAt = createdAt,
+        createdBy = "test",
+    )
+
+    @Test
+    fun `findLatestPublished returns null when nothing is published for the code`(): Unit = onVertxContext {
+        assertThat(repo.findLatestPublished("NO_SUCH_CODE_${UUID.randomUUID()}")).isNull()
+    }
+
+    @Test
+    fun `findLatestPublished returns the most recently created published row for a code`(): Unit = onVertxContext {
+        val code = "IT_CODE_${UUID.randomUUID()}"
+        val older = repo.save(draft(UUID.randomUUID(), code, "1.0.0", Instant.parse("2026-01-01T00:00:00Z")))
+        val newer = repo.save(draft(UUID.randomUUID(), code, "1.1.0", Instant.parse("2026-02-01T00:00:00Z")))
+        repo.publishReplacing(older.publish(), null)
+        repo.publishReplacing(newer.publish(), older.publish().retire())
+
+        val latest = repo.findLatestPublished(code)
+
+        assertThat(latest?.id).isEqualTo(newer.id)
+        assertThat(latest?.version).isEqualTo("1.1.0")
+    }
+
+    @Test
+    fun `publishReplacing publishes the new version and retires the old one atomically`(): Unit = onVertxContext {
+        val code = "IT_CODE_${UUID.randomUUID()}"
+        val v1 = repo.save(draft(UUID.randomUUID(), code, "1.0.0", Instant.parse("2026-01-01T00:00:00Z")))
+        val v2 = repo.save(draft(UUID.randomUUID(), code, "1.1.0", Instant.parse("2026-02-01T00:00:00Z")))
+        repo.publishReplacing(v1.publish(), null)
+
+        repo.publishReplacing(v2.publish(), v1.publish().retire())
+
+        assertThat(repo.findById(v2.id)?.status).isEqualTo(TemplateStatus.PUBLISHED)
+        assertThat(repo.findById(v1.id)?.status).isEqualTo(TemplateStatus.RETIRED)
+        assertThat(repo.findLatestPublished(code)?.id).isEqualTo(v2.id)
+    }
+
+    @Test
+    fun `publishing a second version of the same code without retiring the first is rejected`(): Unit = onVertxContext {
+        // Exercises the DB-level backstop directly (bypassing the use-case's own retire logic) --
+        // the partial unique index must reject this, not silently leave two PUBLISHED rows.
+        val code = "IT_CODE_${UUID.randomUUID()}"
+        val v1 = repo.save(draft(UUID.randomUUID(), code, "1.0.0", Instant.parse("2026-01-01T00:00:00Z")))
+        val v2 = repo.save(draft(UUID.randomUUID(), code, "1.1.0", Instant.parse("2026-02-01T00:00:00Z")))
+        repo.publishReplacing(v1.publish(), null)
+
+        val rejected = try {
+            repo.publishReplacing(v2.publish(), null)
+            null
+        } catch (e: TemplatePublishConflictException) {
+            e
+        }
+
+        assertThat(rejected).isNotNull
+        assertThat(repo.findById(v1.id)?.status).isEqualTo(TemplateStatus.PUBLISHED)
+        assertThat(repo.findById(v2.id)?.status).isEqualTo(TemplateStatus.DRAFT)
+    }
+
+    @Test
+    fun `publishReplacing with no predecessor just publishes`(): Unit = onVertxContext {
+        val code = "IT_CODE_${UUID.randomUUID()}"
+        val v1 = repo.save(draft(UUID.randomUUID(), code, "1.0.0", Instant.parse("2026-01-01T00:00:00Z")))
+
+        repo.publishReplacing(v1.publish(), null)
+
+        assertThat(repo.findById(v1.id)?.status).isEqualTo(TemplateStatus.PUBLISHED)
+    }
+}

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/Product.kt
@@ -128,6 +128,13 @@ data class TermsAndConditions(
     val effectiveTo: LocalDate? = null,
     val language: String = "cs",
     val summary: String? = null,
+    // Reference by CODE, deliberately not (code, version) (ADR-0162 D1/version-resolution policy):
+    // openbank-document-service enforces at most one PUBLISHED version per code at a time, so a
+    // product always resolves to whatever is currently PUBLISHED for this code -- it never needs
+    // updating just because document-service published a new template version. An already-signed
+    // customer document is unaffected either way: it snapshots the exact template version it was
+    // actually rendered from at render time, not this reference.
+    val documentTemplateCode: String? = null,
 )
 
 data class ProductVersion(

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/application/ProductRequestDocumentTemplateRefTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/application/ProductRequestDocumentTemplateRefTest.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.application
+
+import com.openbank.productcatalog.domain.TermsAndConditions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * ADR-0162 D1: a product's [TermsAndConditions] references an `openbank-document-service` template
+ * by `code` only (not a pinned version) — the reference must survive [ProductRequest.toDomain] and
+ * [ProductRequest.applyTo] unchanged, since it's the whole point of the "code, not (code, version)"
+ * choice: a document-service republish must never require touching the product.
+ */
+class ProductRequestDocumentTemplateRefTest {
+
+    private val clock = Clock.fixed(Instant.parse("2026-01-15T10:00:00Z"), ZoneOffset.UTC)
+
+    @Test
+    fun `toDomain carries documentTemplateCode through unchanged`() {
+        val tac = termsAndConditions(documentTemplateCode = "VOP_CS")
+        val request = baseRequest(termsAndConditions = listOf(tac))
+
+        val product = request.toDomain(clock)
+
+        assertThat(product.termsAndConditions).hasSize(1)
+        assertThat(product.termsAndConditions.single().documentTemplateCode).isEqualTo("VOP_CS")
+    }
+
+    @Test
+    fun `documentTemplateCode is nullable and defaults to null when not supplied`() {
+        val tac = termsAndConditions(documentTemplateCode = null)
+        val request = baseRequest(termsAndConditions = listOf(tac))
+
+        val product = request.toDomain(clock)
+
+        assertThat(product.termsAndConditions.single().documentTemplateCode).isNull()
+    }
+
+    @Test
+    fun `applyTo replaces the whole termsAndConditions list, carrying the ref along`() {
+        val existing = baseRequest(
+            termsAndConditions = listOf(termsAndConditions(documentTemplateCode = "VOP_CS")),
+        ).toDomain(clock)
+        val update = baseRequest(
+            termsAndConditions = listOf(termsAndConditions(documentTemplateCode = "RAMCOVA_SMLOUVA_CS")),
+        )
+
+        val updated = update.applyTo(existing, clock)
+
+        assertThat(updated.termsAndConditions.single().documentTemplateCode).isEqualTo("RAMCOVA_SMLOUVA_CS")
+    }
+
+    @Test
+    fun `applyTo keeps the existing termsAndConditions (and its ref) when the request omits them`() {
+        val existing = baseRequest(
+            termsAndConditions = listOf(termsAndConditions(documentTemplateCode = "VOP_CS")),
+        ).toDomain(clock)
+        val update = baseRequest(termsAndConditions = null)
+
+        val updated = update.applyTo(existing, clock)
+
+        assertThat(updated.termsAndConditions.single().documentTemplateCode).isEqualTo("VOP_CS")
+    }
+
+    private fun termsAndConditions(documentTemplateCode: String?) = TermsAndConditions(
+        version = "1.1.0",
+        url = "https://openbank.example/tac/savings/v1.1",
+        effectiveFrom = LocalDate.of(2026, 1, 1),
+        language = "cs",
+        documentTemplateCode = documentTemplateCode,
+    )
+
+    private fun baseRequest(termsAndConditions: List<TermsAndConditions>?) = ProductRequest(
+        code = "SAVINGS_STD",
+        name = "Standard savings",
+        type = "SAVINGS",
+        currency = "CZK",
+        termsAndConditions = termsAndConditions,
+    )
+}


### PR DESCRIPTION
## Summary

Document templates can accumulate more than one PUBLISHED version of the same `code` today (found live in the seed data: VOP/framework/account templates each have both a 1.0.0 and a 1.1.0 row, both PUBLISHED, nothing marking either "current"). This closes that gap: publishing a version now atomically retires its predecessor, a DB partial unique index backstops the invariant, and rendering can resolve "the current version" instead of every caller having to pin an exact one.

## Type of change

- [x] feat (new functionality)

## Linked issues

N/A — follow-up from a conversation about document/product-catalog version resolution, not a tracked issue.

## Changes

- `TemplateRepositoryPort.publishReplacing(toPublish, toRetire)`: publishes a version and retires its predecessor in one transaction (explicit `Mutiny.Session` + intermediate `flush()`, since Postgres can't make a *partial* unique index `DEFERRABLE` — the retire must hit the DB before the publish, not just be scheduled before it).
- `findLatestPublished(code)`: resolves the current PUBLISHED row for a code.
- `DocumentTemplateService.publishTemplate`: looks up and retires the current published sibling (if any) when publishing a new version; a lost concurrent-publish race surfaces as a new `TemplatePublishConflictException` → `IllegalStateException`, not a silent second "current" version.
- `DocumentRenderService.render` / `RenderDocumentRequest.templateVersion` is now nullable: omit it to render the current PUBLISHED version; an explicit version still pins to that exact one. `Document` still snapshots the exact `(templateCode, templateVersion)` it actually rendered from, permanently — an already-signed document is unaffected by a later republish.
- Migration `V5__enforce_one_published_template_per_code.sql`: retires any pre-existing PUBLISHED row superseded by a newer PUBLISHED row of the same code (generic, not hardcoded to specific IDs), then adds the partial unique index.
- `DocumentTemplateSeeder` now also retires the current PUBLISHED sibling before seeding a new version of a code, so a future seed bump doesn't crash boot on the new constraint.
- `product-catalog`'s `TermsAndConditions` gains `documentTemplateCode: String?` — a reference by *code* (not a pinned version), so a product always means "whatever document-service currently publishes for this code".
- ADR-0162 updated with an explicit version-resolution policy section (this had been implicit).

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports; the Postgres-exception classification stays in infrastructure, translated to a plain `TemplatePublishConflictException` at the port boundary).
- [x] Unit tests added/updated (`DocumentTemplateServiceTest`, `DocumentRenderServiceTest` additions).
- [x] Integration tests added/updated (`DocumentTemplateRepositoryImplIT` — real Postgres, including the partial unique index actually rejecting a bypassed-retire publish; `ProductRequestDocumentTemplateRefTest`).
- [x] Contract tests updated — `RenderDocumentRequest.templateVersion` widened to optional in `openapi.yaml`, version bumped 1.0.0 → 1.1.0 (additive, ADR-0048).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes for both `openbank-document-service` and `openbank-product-catalog`.
- [x] No new lint warnings.
- [x] OpenAPI spec regenerated (document-service `RenderDocumentRequest`).
- [x] Flyway migration added + rollback note (V5, rollback noted in the migration file header).
- [x] Docs updated (ADR-0162).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings`/`as Any`/`@Suppress` beyond the pre-existing `TooGenericExceptionCaught` pattern already used by the sibling seeder code (same justification: translating a low-level Postgres exception at the persistence-adapter boundary).
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed? — no.
- [ ] PII path changed? — no.
- [ ] Cardholder data path changed? — no.

## Compliance impact

- [x] None — non-money-path service (`document-service`, `product-catalog` are not in `rules.yaml: money_path_services`).

## Rollout / Rollback

- Deployment strategy: rolling (standard gitops auto-deploy).
- Rollback plan: revert the commit; the V5 migration's rollback note documents dropping the index (the RETIRED status it sets on superseded rows isn't reversible automatically — restore from backup if ever needed, but RETIRED-vs-PUBLISHED on an old, already-superseded version has no functional impact).
- Data migration reversible: partially (index drop yes, RETIRE of stale duplicates no — see migration file header).

## Reviewer notes

The trickiest part: Postgres does not support `DEFERRABLE` on a *partial* unique index (only non-partial constraint-backed uniques can defer), so `publishReplacing` explicitly flushes the retire before publishing the successor — relying on Hibernate's default dirty-checking flush order here silently reintroduced the exact race this PR closes (caught by `DocumentTemplateRepositoryImplIT` failing against the real Postgres Testcontainers instance, not by unit tests with mocks).