### PR TITLE
fix(pact): bridge reactive-Panache @State handlers onto a Vert.x context

### DIFF
--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
@@ -110,6 +110,11 @@ class FxPactProviderVerificationTest {
 
     @State("an EUR/CZK rate exists")
     fun stateEurCzkRateExists() = runOnVertxContext {
+        // pact-jvm 4.7.3 invokes each @State SETUP callback twice per interaction (same behavior
+        // documented in party-service's PartyEventPactProviderVerificationTest) — without this
+        // guard, a second run.save() would insert a second, duplicate EUR/CZK SPOT row (no unique
+        // constraint on the pair/type/source/validFrom, so it wouldn't even fail loudly).
+        if (rateRepo.findLatest("EUR", "CZK", RateType.SPOT) != null) return@runOnVertxContext
         val now = Instant.now()
         rateRepo.save(
             FxRate(

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/contract/FxPactProviderVerificationTest.kt
@@ -18,8 +18,13 @@ import com.openbank.fx.domain.model.RateType
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
 import jakarta.inject.Inject
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
@@ -28,6 +33,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 /**
  * Provider-side verification for the FX rate contract published by transaction-service
@@ -59,10 +67,39 @@ class FxPactProviderVerificationTest {
     @Inject
     lateinit var rateRepo: FxRateRepository
 
+    @Inject
+    lateinit var vertx: Vertx
+
     @BeforeEach
     fun configureTarget(context: PactVerificationContext?) {
         context?.target = HttpTestTarget("localhost", testPort.toInt())
         context?.addStateChangeHandlers(this)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods directly via reflection on the JUnit test thread, which has no
+     * Vert.x context — `Panache.withTransaction`/`withSession` (used by [rateRepo]) requires one,
+     * so a bare `runBlocking { rateRepo.save(...) }` throws `IllegalStateException: No current
+     * Vertx context found`. Same class of bug found live in sca-service's
+     * `ScaPactProviderVerificationTest` (blocking consent-service's deploy); this file has the
+     * identical pattern. Same fix as balance-service's `BalancePactProviderVerificationTest`
+     * (which documents why a plain `vertx.runOnContext { runBlocking { ... } }` is NOT sufficient).
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
     }
 
     @TestTemplate
@@ -72,7 +109,7 @@ class FxPactProviderVerificationTest {
     }
 
     @State("an EUR/CZK rate exists")
-    fun stateEurCzkRateExists(): Unit = runBlocking {
+    fun stateEurCzkRateExists() = runOnVertxContext {
         val now = Instant.now()
         rateRepo.save(
             FxRate(

--- a/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactProviderVerificationTest.kt
+++ b/openbank-sca-service/src/test/kotlin/com/openbank/sca/contract/ScaPactProviderVerificationTest.kt
@@ -19,8 +19,13 @@ import com.openbank.sca.domain.model.ScaStatus
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
+import io.quarkus.vertx.core.runtime.context.VertxContextSafetyToggle
+import io.vertx.core.Vertx
+import io.vertx.core.impl.ContextInternal
 import jakarta.inject.Inject
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
@@ -28,6 +33,9 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.OffsetDateTime
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 /**
  * Provider-side verification for the SCA challenge GET contract published by consent-service
@@ -56,10 +64,40 @@ class ScaPactProviderVerificationTest {
     @Inject
     lateinit var challengeRepo: ScaChallengeRepository
 
+    @Inject
+    lateinit var vertx: Vertx
+
     @BeforeEach
     fun configureTarget(context: PactVerificationContext?) {
         context?.target = HttpTestTarget("localhost", testPort.toInt())
         context?.addStateChangeHandlers(this)
+    }
+
+    /**
+     * Bridges a reactive-Panache block into Pact-JVM's synchronous `@State` callback. Pact-JVM
+     * invokes `@State` methods directly via reflection on the JUnit test thread, which has no
+     * Vert.x context — `Panache.withTransaction`/`withSession` (used by [challengeRepo]) requires
+     * one, so a bare `runBlocking { challengeRepo.save(...) }` throws `IllegalStateException: No
+     * current Vertx context found`. Confirmed live: this silently broke every
+     * consent-service<->sca-service pact verification (result 2026-07-14T11:28:06Z) without ever
+     * being noticed, because the failure only actually blocks a deploy once `can-i-deploy` is
+     * reached. Same fix as balance-service's `BalancePactProviderVerificationTest` (which
+     * documents why a plain `vertx.runOnContext { runBlocking { ... } }` is NOT sufficient).
+     */
+    private fun runOnVertxContext(block: suspend () -> Unit) {
+        val future = CompletableFuture<Unit>()
+        val duplicated = (vertx.orCreateContext as ContextInternal).duplicate()
+        VertxContextSafetyToggle.setContextSafe(duplicated, true)
+        val dispatcher = Executor { command -> duplicated.runOnContext { command.run() } }.asCoroutineDispatcher()
+        CoroutineScope(dispatcher).launch {
+            try {
+                block()
+                future.complete(Unit)
+            } catch (t: Throwable) {
+                future.completeExceptionally(t)
+            }
+        }
+        future.get(10, TimeUnit.SECONDS)
     }
 
     @TestTemplate
@@ -69,7 +107,7 @@ class ScaPactProviderVerificationTest {
     }
 
     @State("a PENDING SCA challenge exists")
-    fun statePendingChallengeExists(): Unit = runBlocking {
+    fun statePendingChallengeExists() = runOnVertxContext {
         challengeRepo.save(
             ScaChallenge(
                 id = CHALLENGE_ID,


### PR DESCRIPTION
## Summary
- `fx-service` and `sca-service`'s Pact provider verification tests seed `@State` fixtures with a bare `runBlocking { repo.save(...) }`. Pact-JVM invokes `@State` methods on the JUnit test thread (no Vert.x context) — `Panache.withTransaction`/`withSession` requires one, so this throws `IllegalStateException: No current Vertx context found` every time the state handler runs.
- **Found live**: this was silently blocking `consent-service`'s deploy — `can-i-deploy` reported no successful verification between consent-service's latest pact and sca-service's current sandbox version (verification result 2026-07-14T11:28:06Z, provider version matching sca-service's actual latest commit — not stale).
- `fx-service` has the identical pattern.
- Same fix as `balance-service`'s `BalancePactProviderVerificationTest` (which hit and documented this exact bug earlier): duplicate the Vert.x context, mark it safe via `VertxContextSafetyToggle`, dispatch the coroutine onto it with a `CoroutineDispatcher` that posts via `runOnContext`.
- Swept the fleet: only these two services had a bare `runBlocking` in an `@State` handler without the bridge.

## Test plan
- [x] `:openbank-sca-service:compileTestKotlin` + `:openbank-fx-service:compileTestKotlin` + `ktlintCheck` for both — pass
- [x] Ran both provider verification tests locally against the real sandbox Pact broker (`publishResults=false`, no side effect on broker history): both now pass (`tests="1" failures="0" errors="0"`), previously threw the Vert.x context exception
- [x] The real, publishing verification runs through this PR's own CI once merged — that's what actually unblocks `consent-service`'s deploy

Refs #938