### PR TITLE
fix(sanctions): fail loud, not silent, when a stored entry row is malformed

### DIFF
--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.openbank.sanctions.application.port.out.SanctionsEntryRepository
 import com.openbank.sanctions.domain.model.*
+import io.quarkus.logging.Log
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.mutiny.pgclient.PgPool
 import io.vertx.mutiny.sqlclient.Tuple
@@ -129,16 +130,57 @@ class SanctionsEntryRepositoryImpl(private val pool: PgPool, private val clock: 
         return rows.iterator().next().getLong("cnt") ?: 0L
     }
 
+    /**
+     * Parses a stored enum/JSON column, falling back to [default] on a malformed value — but
+     * LOUDLY: a silent `runCatching{}.getOrDefault()` here previously made a corrupted DB value
+     * (e.g. a `list_type` string that no longer matches [SanctionsListType], or malformed
+     * `aliases_json`) indistinguishable from genuinely absent data, with zero operator-visible
+     * signal. [rowId] is logged so a bad row can actually be found and repaired.
+     */
+    internal fun <T> parseColumnOrWarn(
+        rowId: String,
+        column: String,
+        raw: String,
+        default: T,
+        parse: (String) -> T,
+    ): T = runCatching { parse(raw) }.getOrElse {
+        Log.warnf(
+            "sanctions_entries row %s has an unparseable '%s' column (%s: %s) — falling back to %s",
+            rowId,
+            column,
+            it.javaClass.simpleName,
+            it.message,
+            default,
+        )
+        default
+    }
+
     private fun rowToEntry(row: io.vertx.mutiny.sqlclient.Row): SanctionsEntry {
         val idStr = row.getString("id") ?: UUID.randomUUID().toString()
-        val listTypeStr = row.getString("list_type") ?: ""
-        val listType = runCatching { SanctionsListType.valueOf(listTypeStr) }.getOrDefault(SanctionsListType.OFAC_SDN)
-        val entityTypeStr = row.getString("entity_type") ?: "INDIVIDUAL"
-        val entityType = runCatching { EntityType.valueOf(entityTypeStr) }.getOrDefault(EntityType.INDIVIDUAL)
-
-        val aliasesJson = row.getString("aliases_json") ?: "[]"
-        val nationalitiesJson = row.getString("nationalities") ?: "[]"
-        val programsJson = row.getString("programs") ?: "[]"
+        val listType =
+            parseColumnOrWarn(idStr, "list_type", row.getString("list_type") ?: "", SanctionsListType.OFAC_SDN) {
+                SanctionsListType.valueOf(it)
+            }
+        val entityType =
+            parseColumnOrWarn(
+                idStr,
+                "entity_type",
+                row.getString("entity_type") ?: "INDIVIDUAL",
+                EntityType.INDIVIDUAL,
+            ) {
+                EntityType.valueOf(it)
+            }
+        val aliases =
+            parseColumnOrWarn(idStr, "aliases_json", row.getString("aliases_json") ?: "[]", emptyList<String>()) {
+                mapper.readValue<List<String>>(it)
+            }
+        val nationalities =
+            parseColumnOrWarn(idStr, "nationalities", row.getString("nationalities") ?: "[]", emptyList<String>()) {
+                mapper.readValue<List<String>>(it)
+            }
+        val programs = parseColumnOrWarn(idStr, "programs", row.getString("programs") ?: "[]", emptyList<String>()) {
+            mapper.readValue<List<String>>(it)
+        }
 
         val createdAt = row.getOffsetDateTime("created_at")?.toInstant() ?: Instant.now(clock)
         val updatedAt = row.getOffsetDateTime("updated_at")?.toInstant() ?: Instant.now(clock)
@@ -149,10 +191,10 @@ class SanctionsEntryRepositoryImpl(private val pool: PgPool, private val clock: 
             externalId = row.getString("external_id"),
             entityType = entityType,
             primaryName = row.getString("primary_name") ?: "",
-            aliases = runCatching { mapper.readValue<List<String>>(aliasesJson) }.getOrDefault(emptyList()),
+            aliases = aliases,
             dateOfBirth = row.getString("date_of_birth"),
-            nationalities = runCatching { mapper.readValue<List<String>>(nationalitiesJson) }.getOrDefault(emptyList()),
-            programs = runCatching { mapper.readValue<List<String>>(programsJson) }.getOrDefault(emptyList()),
+            nationalities = nationalities,
+            programs = programs,
             searchText = "", // not needed after fetch, only used on insert
             active = row.getBoolean("active") ?: true,
             createdAt = createdAt,

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImplTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImplTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.infrastructure.persistence.repository
+
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.SanctionsListType
+import io.mockk.mockk
+import io.vertx.mutiny.pgclient.PgPool
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+
+/**
+ * Unit coverage for [SanctionsEntryRepositoryImpl.parseColumnOrWarn] — the loud-fallback helper
+ * that replaced a silent `runCatching{}.getOrDefault()` in `rowToEntry` (a corrupted `list_type`/
+ * `aliases_json`/etc. column used to fall back to a default with zero operator-visible signal).
+ * Regression guard: a well-formed column must still parse to its real value (not silently take
+ * the default), and a malformed one must fall back safely rather than throw.
+ */
+class SanctionsEntryRepositoryImplTest {
+
+    private val repo = SanctionsEntryRepositoryImpl(mockk<PgPool>(), Clock.systemUTC())
+
+    @Test
+    fun `a well-formed enum column parses to its real value, not the default`() {
+        val result = repo.parseColumnOrWarn("row-1", "list_type", "EU_CONSOLIDATED", SanctionsListType.OFAC_SDN) {
+            SanctionsListType.valueOf(it)
+        }
+        assertThat(result).isEqualTo(SanctionsListType.EU_CONSOLIDATED)
+    }
+
+    @Test
+    fun `a malformed enum column falls back to the default instead of throwing`() {
+        val result = repo.parseColumnOrWarn("row-2", "list_type", "NOT_A_REAL_LIST", SanctionsListType.OFAC_SDN) {
+            SanctionsListType.valueOf(it)
+        }
+        assertThat(result).isEqualTo(SanctionsListType.OFAC_SDN)
+    }
+
+    @Test
+    fun `a well-formed JSON list column parses to its real values, not the default`() {
+        val result = repo.parseColumnOrWarn(
+            "row-3",
+            "aliases_json",
+            """["Vova Putin","V. Putin"]""",
+            emptyList<String>(),
+        ) {
+            com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readValue(it, Array<String>::class.java).toList()
+        }
+        assertThat(result).containsExactly("Vova Putin", "V. Putin")
+    }
+
+    @Test
+    fun `malformed JSON falls back to the default instead of throwing`() {
+        val result = repo.parseColumnOrWarn("row-4", "aliases_json", "{not valid json", emptyList<String>()) {
+            com.fasterxml.jackson.module.kotlin.jacksonObjectMapper().readValue(it, Array<String>::class.java).toList()
+        }
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `entity type falls back to INDIVIDUAL on a malformed value`() {
+        val result = repo.parseColumnOrWarn("row-5", "entity_type", "GARBAGE", EntityType.INDIVIDUAL) {
+            EntityType.valueOf(it)
+        }
+        assertThat(result).isEqualTo(EntityType.INDIVIDUAL)
+    }
+}

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImplTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImplTest.kt
@@ -9,8 +9,14 @@ import com.openbank.sanctions.domain.model.SanctionsListType
 import io.mockk.mockk
 import io.vertx.mutiny.pgclient.PgPool
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Clock
+import java.util.logging.Handler
+import java.util.logging.Level
+import java.util.logging.LogRecord
+import java.util.logging.Logger
 
 /**
  * Unit coverage for [SanctionsEntryRepositoryImpl.parseColumnOrWarn] — the loud-fallback helper
@@ -18,10 +24,36 @@ import java.time.Clock
  * `aliases_json`/etc. column used to fall back to a default with zero operator-visible signal).
  * Regression guard: a well-formed column must still parse to its real value (not silently take
  * the default), and a malformed one must fall back safely rather than throw.
+ *
+ * The value-only tests below would still pass if a future edit silently dropped the `Log.warnf`
+ * call and reverted to the old bare `runCatching{}.getOrDefault()` — the returned value is
+ * identical either way. The `logs a WARN` tests close that gap by attaching a [Handler] directly
+ * to the class's logger (the name `io.quarkus.logging.Log` rewrites `Log.warnf` calls to at
+ * build time) and asserting a record is actually published — the thing this whole PR is about.
  */
 class SanctionsEntryRepositoryImplTest {
 
     private val repo = SanctionsEntryRepositoryImpl(mockk<PgPool>(), Clock.systemUTC())
+
+    private val captured = mutableListOf<LogRecord>()
+    private val captureHandler = object : Handler() {
+        override fun publish(record: LogRecord) {
+            captured += record
+        }
+        override fun flush() = Unit
+        override fun close() = Unit
+    }
+    private val repoLogger = Logger.getLogger(SanctionsEntryRepositoryImpl::class.java.name)
+
+    @BeforeEach
+    fun attachHandler() {
+        repoLogger.addHandler(captureHandler)
+    }
+
+    @AfterEach
+    fun detachHandler() {
+        repoLogger.removeHandler(captureHandler)
+    }
 
     @Test
     fun `a well-formed enum column parses to its real value, not the default`() {
@@ -66,5 +98,26 @@ class SanctionsEntryRepositoryImplTest {
             EntityType.valueOf(it)
         }
         assertThat(result).isEqualTo(EntityType.INDIVIDUAL)
+    }
+
+    @Test
+    fun `a malformed column logs a WARN naming the row id and column`() {
+        repo.parseColumnOrWarn("row-corrupt-42", "list_type", "NOT_A_REAL_LIST", SanctionsListType.OFAC_SDN) {
+            SanctionsListType.valueOf(it)
+        }
+
+        assertThat(captured).hasSize(1)
+        val record = captured.single()
+        assertThat(record.level).isEqualTo(Level.WARNING)
+        assertThat(record.message).contains("row-corrupt-42", "list_type")
+    }
+
+    @Test
+    fun `a well-formed column logs nothing`() {
+        repo.parseColumnOrWarn("row-clean-1", "list_type", "EU_CONSOLIDATED", SanctionsListType.OFAC_SDN) {
+            SanctionsListType.valueOf(it)
+        }
+
+        assertThat(captured).isEmpty()
     }
 }


### PR DESCRIPTION
## Summary
- `SanctionsEntryRepositoryImpl.rowToEntry()` used `runCatching{}.getOrDefault()` on `list_type`, `entity_type`, `aliases_json`, `nationalities`, and `programs` — a corrupted DB value silently fell back to a default with zero operator-visible signal.
- Verified the actual screening match query (`word_similarity` against the precomputed `search_text` column, populated correctly at import time) does **not** go through this fallback — so this was never a missed-match risk. But a caller reading/displaying an already-matched entry could see a silently wrong `list_type`/`entity_type` or an incomplete alias list with no way to tell.
- Replaces the five ad-hoc `runCatching{}.getOrDefault()` sites with a single `parseColumnOrWarn()` helper: same fail-safe default, but logs a warning (`Log.warnf`, this service's existing convention) naming the row id and column, so a corrupted row can actually be found and repaired.
- `parseColumnOrWarn` is `internal` specifically so it's unit-testable without mocking Vert.x's `Row`.

## Test plan
- [x] New `SanctionsEntryRepositoryImplTest` (5 cases): well-formed enum/JSON columns parse to their real values (not silently the default); malformed enum/JSON columns fall back safely instead of throwing — this is the regression guard against reverting to the old silent-swallow pattern
- [x] `:openbank-sanctions-service:compileTestKotlin` + `ktlintCheck` + `detekt` + `test --tests "*SanctionsEntryRepositoryImplTest*"` — all pass (5/5, 0 failures)
- [x] Confirmed the warning actually logs for malformed input during the test run (visible in test console output) and does not log for well-formed input

## Linked issues
N/A — found live during a fleet sweep for silent-failure patterns (same sweep as #1097); no pre-existing tracking issue covers this.