### PR TITLE
feat(document-service): client e-signature tier, event-driven onboarding, and fail-closed signing guard

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/in/DocumentUseCases.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/in/DocumentUseCases.kt
@@ -47,6 +47,8 @@ data class OpenCeremonyCommand(
     val signatureLevel: SignatureLevel,
 )
 
+data class IssueOnboardingDocumentCommand(val accountId: UUID, val partyRef: String, val productId: UUID)
+
 /** Authoring and publication of document templates. */
 interface DocumentTemplateUseCase {
     suspend fun createTemplate(cmd: CreateTemplateCommand): DocumentTemplate
@@ -96,4 +98,14 @@ interface SignatureCeremonyUseCase {
         evidenceRef: String? = null,
     ): SignatureCeremony
     suspend fun getCeremony(id: UUID): SignatureCeremony?
+}
+
+/**
+ * Reacts to a new account (ADR-0086 event-driven, non-money-path — never a synchronous gate on
+ * account opening): renders the product's bound onboarding document (if any) and opens a
+ * signature ceremony for the account holder. Idempotent — safe under at-least-once Kafka delivery
+ * / replay (see [com.openbank.document.application.usecase.OnboardingDocumentService]).
+ */
+interface OnboardingDocumentUseCase {
+    suspend fun issueOnboardingDocument(cmd: IssueOnboardingDocumentCommand)
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
@@ -104,3 +104,30 @@ interface SignatureSealPort {
 interface SignerVerificationPort {
     suspend fun verify(partyRef: String, evidenceRef: String): Boolean
 }
+
+/**
+ * Applies [partyRef]'s own **electronic signature** (eIDAS terms: a natural person's signature,
+ * distinct from [SignatureSealPort]'s institutional **electronic seal**) to [pdf] — a fresh,
+ * single-use certificate is issued for this one signing act and the private key is never
+ * persisted beyond it (ADR-0162 D4 continued). Unlike the seal's stable organizational identity,
+ * the *value* being protected here is that this specific act was authorized by a certificate
+ * freshly minted for it — the chain of trust (who issued it, when, to whom) is what stays
+ * auditable, rooted in the issuing CA (production: OpenBao's PKI secrets engine), not the leaf
+ * certificate's own lifetime.
+ */
+interface ClientSignatureIssuerPort {
+    suspend fun signAsClient(pdf: ByteArray, partyRef: String): ByteArray
+}
+
+/**
+ * Read-only lookup into `openbank-product-catalog`, scoped to exactly what the onboarding flow
+ * needs: which document template (if any) is bound to a product, via `TermsAndConditions.documentTemplateCode`
+ * (a `code`, never a pinned version — ADR-0162 D1/version-resolution policy). Fails open: an
+ * unreachable/unknown product-catalog resolves to `null`, same fail-open stance
+ * `account-service`'s own `ProductCatalogPort` takes for the same reference-data dependency —
+ * a missing onboarding-document binding must never block account opening (that already happened,
+ * upstream, by the time this is consulted).
+ */
+interface ProductCatalogPort {
+    suspend fun findDocumentTemplateCode(productId: UUID): String?
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.application.usecase
+
+import com.openbank.document.application.port.`in`.DocumentQueryUseCase
+import com.openbank.document.application.port.`in`.DocumentRenderUseCase
+import com.openbank.document.application.port.`in`.IssueOnboardingDocumentCommand
+import com.openbank.document.application.port.`in`.OnboardingDocumentUseCase
+import com.openbank.document.application.port.`in`.OpenCeremonyCommand
+import com.openbank.document.application.port.`in`.RenderDocumentCommand
+import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
+import com.openbank.document.application.port.out.ProductCatalogPort
+import com.openbank.document.domain.model.SignatureLevel
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+
+/**
+ * Wires templating + e-signature into account onboarding (ADR-0162 D7): consuming
+ * `account.created` is what actually exercises the version-resolution policy
+ * (`RenderDocumentCommand.templateVersion = null` — always the current PUBLISHED version) and
+ * product-catalog's `documentTemplateCode` reference end to end, for the first time.
+ */
+@ApplicationScoped
+class OnboardingDocumentService(
+    private val productCatalogPort: ProductCatalogPort,
+    private val renderUseCase: DocumentRenderUseCase,
+    private val documentQueryUseCase: DocumentQueryUseCase,
+    private val ceremonyUseCase: SignatureCeremonyUseCase,
+) : OnboardingDocumentUseCase {
+
+    private val log = Logger.getLogger(OnboardingDocumentService::class.java)
+
+    override suspend fun issueOnboardingDocument(cmd: IssueOnboardingDocumentCommand) {
+        val caseRef = cmd.accountId.toString()
+        // Idempotent: at-least-once Kafka delivery / a replayed event must not render (and open a
+        // ceremony for) the same account's onboarding contract twice.
+        val alreadyIssued = documentQueryUseCase.listByParty(cmd.partyRef).any { it.caseRef == caseRef }
+        if (alreadyIssued) {
+            log.infof("Onboarding document already issued for account %s — skipping.", cmd.accountId)
+            return
+        }
+
+        val templateCode = productCatalogPort.findDocumentTemplateCode(cmd.productId)
+        if (templateCode == null) {
+            log.infof(
+                "Product %s has no documentTemplateCode bound — no onboarding document to issue for account %s.",
+                cmd.productId,
+                cmd.accountId,
+            )
+            return
+        }
+
+        val document = renderUseCase.render(
+            RenderDocumentCommand(
+                templateCode = templateCode,
+                templateVersion = null,
+                data = emptyMap(),
+                contentType = "application/pdf",
+                partyRef = cmd.partyRef,
+                caseRef = caseRef,
+                productRef = cmd.productId.toString(),
+                retainUntil = null,
+            ),
+        )
+
+        ceremonyUseCase.openCeremony(
+            OpenCeremonyCommand(
+                documentId = document.id,
+                signerPartyRefs = listOf(cmd.partyRef),
+                signatureLevel = SignatureLevel.ADVANCED,
+            ),
+        )
+        log.infof(
+            "Issued onboarding document %s + ceremony for account %s (template %s)",
+            document.id,
+            cmd.accountId,
+            templateCode,
+        )
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.document.application.port.`in`.OpenCeremonyCommand
 import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
 import com.openbank.document.application.port.out.CeremonyRepositoryPort
+import com.openbank.document.application.port.out.ClientSignatureIssuerPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
 import com.openbank.document.application.port.out.SignatureSealPort
 import com.openbank.document.application.port.out.SignerVerificationPort
@@ -25,10 +26,13 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * Orchestrates e-signature ceremonies. A SIGNED decision must first pass the SCA-bound
- * [SignerVerificationPort] check (ADR-0162 D4, ADR-0021) — a DECLINED decision does not. On
- * completion it PAdES-seals the stored document bytes via [SignatureSealPort] and emits a
- * [SignatureCeremonyCompleted] outbox event.
+ * Orchestrates e-signature ceremonies (ADR-0162 D4 continued — the two-tier signature model). A
+ * SIGNED decision must first pass the SCA-bound [SignerVerificationPort] check (ADR-0021) — a
+ * DECLINED decision does not. Once verified, the signer's own **electronic signature** is applied
+ * immediately via [ClientSignatureIssuerPort] (a fresh one-time certificate per signing act).
+ * Once every signer reaches a terminal decision, the bank's institutional **electronic seal** is
+ * applied last via [SignatureSealPort] (a stable organizational identity), and a
+ * [SignatureCeremonyCompleted] outbox event is emitted.
  */
 @ApplicationScoped
 class SignatureCeremonyService(
@@ -36,6 +40,7 @@ class SignatureCeremonyService(
     private val documentRepo: DocumentRepositoryPort,
     private val objectStore: ObjectStorePort,
     private val sealPort: SignatureSealPort,
+    private val clientSignaturePort: ClientSignatureIssuerPort,
     private val signerVerificationPort: SignerVerificationPort,
     private val clock: Clock,
     private val objectMapper: ObjectMapper,
@@ -63,13 +68,17 @@ class SignatureCeremonyService(
         decision: SignerStatus,
         evidenceRef: String?,
     ): SignatureCeremony {
+        val ceremony = ceremonyRepo.findById(ceremonyId) ?: error("Ceremony not found: $ceremonyId")
         if (decision == SignerStatus.SIGNED) {
             val verified = evidenceRef != null && signerVerificationPort.verify(partyRef, evidenceRef)
             if (!verified) {
                 error("SCA verification failed for signer $partyRef on ceremony $ceremonyId")
             }
+            // Apply this signer's own one-time electronic signature BEFORE persisting the SIGNED
+            // decision: a decision must never be recorded as SIGNED without a corresponding
+            // signature actually landing on the document.
+            signAsClient(ceremony, partyRef)
         }
-        val ceremony = ceremonyRepo.findById(ceremonyId) ?: error("Ceremony not found: $ceremonyId")
         val now = Instant.now(clock)
         val updated = ceremony.recordDecision(partyRef, decision, now)
         if (updated.status != CeremonyStatus.COMPLETED) {
@@ -96,6 +105,14 @@ class SignatureCeremonyService(
     }
 
     override suspend fun getCeremony(id: UUID): SignatureCeremony? = ceremonyRepo.findById(id)
+
+    private suspend fun signAsClient(ceremony: SignatureCeremony, partyRef: String) {
+        val document = documentRepo.findById(ceremony.documentId)
+            ?: error("Cannot sign ceremony ${ceremony.id}: document ${ceremony.documentId} not found")
+        val pdf = objectStore.get(document.storageKey)
+        val signed = clientSignaturePort.signAsClient(pdf, partyRef)
+        objectStore.put(document.storageKey, signed, document.contentType)
+    }
 
     private suspend fun sealDocument(ceremony: SignatureCeremony) {
         val document = documentRepo.findById(ceremony.documentId)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogAdapter.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.client
+
+import com.openbank.document.application.port.out.ProductCatalogPort
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * **Fail-open** [ProductCatalogPort] adapter (mirrors `account-service`'s own fail-open
+ * `ProductCatalogAdapter`): an unreachable/unknown product-catalog must never block issuing an
+ * onboarding document from blocking anything downstream of it either — it just means no document
+ * gets issued this time, logged for operators to notice, not a hard failure.
+ */
+@ApplicationScoped
+class ProductCatalogAdapter : ProductCatalogPort {
+
+    @Inject
+    @RestClient
+    lateinit var client: ProductCatalogClient
+
+    private val log = Logger.getLogger(ProductCatalogAdapter::class.java)
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun findDocumentTemplateCode(productId: UUID): String? = try {
+        client.getById(productId.toString()).awaitSuspending()
+            .termsAndConditions.firstNotNullOfOrNull { it.documentTemplateCode }
+    } catch (e: Exception) {
+        log.warnf("product-catalog unavailable for %s; no onboarding document will be issued: %s", productId, e.message)
+        null
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogClient.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogClient.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * RestClient binding to `openbank-product-catalog`'s product read endpoint — narrow, mirroring
+ * `openbank-account-service`'s own `ProductCatalogClient`. The only field this service actually
+ * needs is `termsAndConditions[].documentTemplateCode` (ADR-0162 D1), the product's onboarding
+ * document reference.
+ */
+@RegisterRestClient(configKey = "product-catalog-api")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Produces(MediaType.APPLICATION_JSON)
+interface ProductCatalogClient {
+    @GET
+    @Path("/api/v1/products/{id}")
+    fun getById(@PathParam("id") id: String): Uni<ProductClientResponse>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ProductClientResponse(
+    val id: String,
+    val code: String,
+    val termsAndConditions: List<TermsAndConditionsClientResponse> = emptyList(),
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TermsAndConditionsClientResponse(val documentTemplateCode: String? = null)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumer.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumer.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.document.application.port.`in`.IssueOnboardingDocumentCommand
+import com.openbank.document.application.port.`in`.OnboardingDocumentUseCase
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.reactive.messaging.Incoming
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * Event-driven onboarding-document issuance (ADR-0162 D7, mirrors `balance-service`'s
+ * `BalanceInitConsumer` for the same `account.created` topic): consuming the event, rather than
+ * `account-service` calling this service synchronously, keeps document-service off the money-path
+ * account-opening gate entirely (ADR-0086) — a slow/unreachable document-service can never delay
+ * or fail an account opening.
+ *
+ * Poison-pill safe (an unparseable payload is logged and skipped, never crashes the consumer) and
+ * idempotent (delegated to [OnboardingDocumentUseCase], which no-ops on replay).
+ */
+@ApplicationScoped
+class AccountCreatedConsumer(
+    private val onboardingUseCase: OnboardingDocumentUseCase,
+    private val objectMapper: ObjectMapper,
+) {
+    private val log = Logger.getLogger(AccountCreatedConsumer::class.java)
+
+    // TooGenericExceptionCaught: deliberate -- any parse failure on an untrusted event payload must
+    // be logged and skipped, never crash this consumer (poison-pill safety), regardless of the
+    // specific exception Jackson happens to throw for a given malformed input.
+    @Suppress("TooGenericExceptionCaught")
+    @Incoming("account-created-in")
+    suspend fun consume(payload: String) {
+        val node: JsonNode = try {
+            objectMapper.readTree(payload)
+        } catch (e: Exception) {
+            log.errorf(e, "Unparseable account.created event, skipping: %s", payload.take(PAYLOAD_LOG_CHARS))
+            return
+        }
+        if (node["eventType"]?.asText() != EVENT_TYPE) return
+
+        val accountId = node["aggregateId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val partyId = node["partyId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        val productId = node["productId"]?.asText()?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+        if (accountId == null || partyId == null || productId == null) {
+            log.warnf(
+                "AccountCreated missing accountId/partyId/productId, skipping: %s",
+                payload.take(PAYLOAD_LOG_CHARS),
+            )
+            return
+        }
+
+        onboardingUseCase.issueOnboardingDocument(
+            IssueOnboardingDocumentCommand(accountId = accountId, partyRef = partyId.toString(), productId = productId),
+        )
+    }
+
+    private companion object {
+        const val EVENT_TYPE = "AccountCreated"
+        const val PAYLOAD_LOG_CHARS = 200
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.render
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.document.application.port.out.ClientSignatureIssuerPort
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.openssl.PEMParser
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
+import java.io.StringReader
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse.BodyHandlers
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import java.time.Duration
+
+/**
+ * [ClientSignatureIssuerPort] adapter (ADR-0162 D4 continued): issues a fresh, single-use
+ * certificate from OpenBao's `pki-document-signing` PKI secrets engine for each signing act,
+ * signs with it, and lets the private key go out of scope immediately after — never written to
+ * disk, a keystore, or OpenBao itself (the engine's issuing role is configured `no_store=true`).
+ * The CA root that issues these leaves stays in OpenBao (runbook 0008); only the audited,
+ * short-TTL leaf issuance ever touches this process. Mirrors the exact Kubernetes-auth
+ * login-then-issue flow `openbank-admin-ui`'s `svidMint.ts` already uses for `pki-agent`
+ * (ADR-0031 D3b) — same OpenBao, same auth method, a different dedicated PKI mount/role.
+ *
+ * Falls back to a local ephemeral self-signed identity (same DEV-ONLY fallback
+ * [PdfBoxPadesSealAdapter] uses) when the projected ServiceAccount token isn't present (i.e. not
+ * running in a real pod bound to the signing role) or the OpenBao call itself fails — so local
+ * dev/tests never need a live OpenBao, at the cost of an ephemeral leaf being worthless as
+ * evidence, exactly like the seal's own dev fallback.
+ */
+@ApplicationScoped
+class OpenBaoClientSignatureAdapter(
+    @ConfigProperty(name = "openbank.signature.client-pki.bao-addr", defaultValue = "http://openbao.vault.svc:8200")
+    private val baoAddr: String,
+
+    @ConfigProperty(name = "openbank.signature.client-pki.role", defaultValue = "document-service-signing")
+    private val role: String,
+
+    @ConfigProperty(
+        name = "openbank.signature.client-pki.issue-path",
+        defaultValue = "pki-document-signing/issue/client-signing",
+    )
+    private val issuePath: String,
+
+    @ConfigProperty(
+        name = "openbank.signature.client-pki.sa-token-path",
+        defaultValue = "/var/run/secrets/kubernetes.io/serviceaccount/token",
+    )
+    private val saTokenPath: String,
+
+    @ConfigProperty(name = "openbank.signature.client-pki.ttl", defaultValue = "300s")
+    private val ttl: String,
+
+    // Go-live gate (ADR-0162 D4 continued): when set, the DEV-ONLY ephemeral fallback below is
+    // DISABLED and a signing act that cannot obtain a real OpenBao-rooted certificate fails loud
+    // instead of silently producing a signature that is worthless as evidence. Defaults off so the
+    // service stays runnable before the pki-document-signing engine is provisioned; flip
+    // OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true in the deployment env once it is (runbook 0008).
+    @ConfigProperty(name = "openbank.signature.require-trusted-issuer", defaultValue = "false")
+    private val requireTrustedIssuer: Boolean,
+
+    private val objectMapper: ObjectMapper,
+) : ClientSignatureIssuerPort {
+
+    private val logger = Logger.getLogger(OpenBaoClientSignatureAdapter::class.java)
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+        .build()
+
+    override suspend fun signAsClient(pdf: ByteArray, partyRef: String): ByteArray = withContext(Dispatchers.IO) {
+        val identity = issueOneTimeIdentity(partyRef)
+        PadesSigning.applySignature(pdf, identity, partyRef, SIGNATURE_REASON)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun issueOneTimeIdentity(partyRef: String): SigningIdentity {
+        if (!Files.exists(Path.of(saTokenPath))) {
+            return devFallbackOrFail(partyRef, "no projected ServiceAccount token at $saTokenPath")
+        }
+        return try {
+            val token = login(Files.readString(Path.of(saTokenPath)).trim())
+            issueFromOpenBao(token, partyRef)
+        } catch (e: Exception) {
+            devFallbackOrFail(partyRef, e.message ?: e.javaClass.simpleName)
+        }
+    }
+
+    /**
+     * Either takes the DEV-ONLY ephemeral fallback (logging a loud warning) or, when
+     * [requireTrustedIssuer] is set, refuses outright so a SIGNED decision is never recorded against
+     * an evidentially worthless signature (fail-closed — the caller [signAsClient] propagates the
+     * failure up into the ceremony, which does not persist the decision).
+     */
+    private fun devFallbackOrFail(partyRef: String, reason: String): SigningIdentity {
+        check(!requireTrustedIssuer) {
+            "Refusing to issue a client electronic signature for party $partyRef without an " +
+                "OpenBao-rooted one-time certificate ($reason). openbank.signature.require-trusted-issuer " +
+                "is set, so the DEV-ONLY ephemeral fallback is disabled (ADR-0162 D4 continued, runbook 0008)."
+        }
+        logger.warn(
+            "Could not issue a OpenBao-rooted one-time signing certificate for party $partyRef ($reason) — " +
+                "falling back to an EPHEMERAL, in-memory, non-CA-issued certificate. This is DEV-ONLY: the " +
+                "resulting signature is worthless as evidence (no auditable issuing CA). Production must run " +
+                "with a bound ServiceAccount + a reachable OpenBao pki-document-signing engine " +
+                "(ADR-0162 D4 continued, runbook 0008).",
+        )
+        return PadesSigning.generateEphemeralIdentity(partyRef, EPHEMERAL_VALIDITY_DAYS)
+    }
+
+    private fun login(jwt: String): String {
+        val body = objectMapper.writeValueAsString(mapOf("role" to role, "jwt" to jwt))
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$baoAddr/v1/auth/kubernetes/login"))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString(body))
+            .build()
+        val response = httpClient.send(request, BodyHandlers.ofString())
+        check(response.statusCode() == HTTP_OK) {
+            "OpenBao kubernetes-auth login failed: HTTP ${response.statusCode()}"
+        }
+        return objectMapper.readTree(response.body())["auth"]["client_token"].asText()
+    }
+
+    private fun issueFromOpenBao(token: String, partyRef: String): SigningIdentity {
+        val body = objectMapper.writeValueAsString(
+            mapOf("common_name" to partyRef, "ttl" to ttl, "private_key_format" to "pkcs8"),
+        )
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("$baoAddr/v1/$issuePath"))
+            .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+            .header("Content-Type", "application/json")
+            .header("X-Vault-Token", token)
+            .POST(BodyPublishers.ofString(body))
+            .build()
+        val response = httpClient.send(request, BodyHandlers.ofString())
+        check(response.statusCode() == HTTP_OK) { "OpenBao pki issuance failed: HTTP ${response.statusCode()}" }
+        val data = objectMapper.readTree(response.body())["data"]
+        val caChain = data["ca_chain"]?.map { it.asText() }.orEmpty()
+        return SigningIdentity(
+            privateKey = parsePrivateKey(data["private_key"].asText()),
+            certificate = parseCertificate(data["certificate"].asText()),
+            certificateChain = listOf(parseCertificate(data["certificate"].asText())) + caChain.map(::parseCertificate),
+        )
+    }
+
+    private fun parseCertificate(pem: String): X509Certificate = PEMParser(StringReader(pem)).use { parser ->
+        val holder = parser.readObject() as X509CertificateHolder
+        JcaX509CertificateConverter().setProvider(PadesSigning.BC_PROVIDER).getCertificate(holder)
+    }
+
+    private fun parsePrivateKey(pem: String): PrivateKey = PEMParser(StringReader(pem)).use { parser ->
+        val keyInfo = parser.readObject() as PrivateKeyInfo
+        JcaPEMKeyConverter().setProvider(PadesSigning.BC_PROVIDER).getPrivateKey(keyInfo)
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_SECONDS = 5L
+        const val REQUEST_TIMEOUT_SECONDS = 10L
+        const val HTTP_OK = 200
+        const val EPHEMERAL_VALIDITY_DAYS = 1L
+        const val SIGNATURE_REASON = "Client electronic signature (one-time certificate)"
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.render
+
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureInterface
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureOptions
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.jcajce.JcaCertStore
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.cms.CMSProcessableByteArray
+import org.bouncycastle.cms.CMSSignedDataGenerator
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.Security
+import java.security.cert.X509Certificate
+import java.time.Duration
+import java.time.Instant
+import java.util.Calendar
+import java.util.Date
+
+/** A signing identity (private key + leaf cert + full chain) ready to produce a CMS signature. */
+data class SigningIdentity(
+    val privateKey: PrivateKey,
+    val certificate: X509Certificate,
+    val certificateChain: List<X509Certificate>,
+)
+
+/**
+ * Shared PAdES-B (`SubFilter: ETSI.CAdES.detached`) signing mechanics — Apache PDFBox's
+ * external-signing API plus a Bouncy Castle detached CMS/PKCS7 signature — used by BOTH signature
+ * layers a ceremony applies (ADR-0162 D4 continued):
+ *  - [PdfBoxPadesSealAdapter]: the bank's institutional **electronic seal**, a stable long-lived
+ *    organizational identity.
+ *  - [OpenBaoClientSignatureAdapter]: each signer's **electronic signature**, a fresh one-time
+ *    identity issued per signing act.
+ *
+ * The two differ only in WHICH [SigningIdentity] they supply and the signature's `Name`/`Reason`
+ * metadata — the cryptographic mechanics (and PDF's native support for multiple, incremental
+ * signatures layered onto the same document) are identical, so this is the one place that
+ * mechanics is implemented.
+ */
+object PadesSigning {
+    const val BC_PROVIDER = "BC"
+    const val SIGNATURE_ALGORITHM = "SHA256withRSA"
+    const val RSA_KEY_SIZE = 2048
+    private const val NOT_BEFORE_SKEW_MINUTES = 5L
+    private const val EPHEMERAL_VALIDITY_DAYS = 365L
+
+    init {
+        if (Security.getProvider(BC_PROVIDER) == null) {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
+
+    /**
+     * A throwaway, self-signed, in-memory-only identity — the DEV-ONLY fallback shared by every
+     * PAdES adapter when it has no real key custody configured (a keystore file for the seal, a
+     * reachable OpenBao for a client signature). Worthless as evidence: never issued by any
+     * trusted CA, never persisted, gone on restart.
+     */
+    fun generateEphemeralIdentity(commonName: String, validityDays: Long = EPHEMERAL_VALIDITY_DAYS): SigningIdentity {
+        val keyPairGenerator = KeyPairGenerator.getInstance("RSA", BC_PROVIDER)
+        keyPairGenerator.initialize(RSA_KEY_SIZE)
+        val keyPair = keyPairGenerator.generateKeyPair()
+
+        val now = Instant.now()
+        val subject = X500Name("CN=$commonName, O=OpenBank")
+        val certificateBuilder = JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(now.toEpochMilli()),
+            Date.from(now.minus(Duration.ofMinutes(NOT_BEFORE_SKEW_MINUTES))),
+            Date.from(now.plus(Duration.ofDays(validityDays))),
+            subject,
+            keyPair.public,
+        )
+        val contentSigner = JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
+            .setProvider(BC_PROVIDER)
+            .build(keyPair.private)
+        val certificate = JcaX509CertificateConverter()
+            .setProvider(BC_PROVIDER)
+            .getCertificate(certificateBuilder.build(contentSigner))
+
+        return SigningIdentity(
+            privateKey = keyPair.private,
+            certificate = certificate,
+            certificateChain = listOf(certificate),
+        )
+    }
+
+    /** Appends one more PAdES signature (an incremental PDF update) using [identity]. */
+    fun applySignature(pdf: ByteArray, identity: SigningIdentity, name: String, reason: String): ByteArray =
+        Loader.loadPDF(pdf).use { document ->
+            val signature = PDSignature().apply {
+                setFilter(PDSignature.FILTER_ADOBE_PPKLITE)
+                setSubFilter(PDSignature.SUBFILTER_ETSI_CADES_DETACHED)
+                setName(name)
+                setReason(reason)
+                setSignDate(Calendar.getInstance())
+            }
+            val signatureOptions = SignatureOptions()
+            try {
+                signatureOptions.preferredSignatureSize = SignatureOptions.DEFAULT_SIGNATURE_SIZE * 2
+                document.addSignature(signature, Pkcs7SignatureInterface(identity), signatureOptions)
+                val output = ByteArrayOutputStream()
+                document.saveIncremental(output)
+                output.toByteArray()
+            } finally {
+                signatureOptions.close()
+            }
+        }
+
+    /**
+     * PDFBox's external-signing callback: given the exact byte range PDFBox has carved out around
+     * the signature placeholder (the PDF `ByteRange`), produce the detached CMS/PKCS7 signature
+     * bytes to embed. The content is read fully into memory — acceptable for the document sizes
+     * this service handles (statements/contracts, not multi-GB files).
+     */
+    private class Pkcs7SignatureInterface(private val identity: SigningIdentity) : SignatureInterface {
+        override fun sign(content: InputStream): ByteArray {
+            val digestCalculatorProvider = JcaDigestCalculatorProviderBuilder()
+                .setProvider(BC_PROVIDER)
+                .build()
+            val contentSigner = JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
+                .setProvider(BC_PROVIDER)
+                .build(identity.privateKey)
+            val signerInfoGenerator = JcaSignerInfoGeneratorBuilder(digestCalculatorProvider)
+                .build(contentSigner, identity.certificate)
+
+            val generator = CMSSignedDataGenerator()
+            generator.addSignerInfoGenerator(signerInfoGenerator)
+            generator.addCertificates(JcaCertStore(identity.certificateChain))
+
+            val signedData = generator.generate(CMSProcessableByteArray(content.readBytes()), false)
+            return signedData.encoded
+        }
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
@@ -9,42 +9,20 @@ import com.openbank.document.domain.model.SignatureCeremony
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.apache.pdfbox.Loader
-import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature
-import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureInterface
-import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureOptions
-import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.cert.jcajce.JcaCertStore
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
-import org.bouncycastle.cms.CMSProcessableByteArray
-import org.bouncycastle.cms.CMSSignedDataGenerator
-import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
-import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
-import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
-import java.io.InputStream
-import java.math.BigInteger
-import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PrivateKey
-import java.security.Security
 import java.security.cert.X509Certificate
-import java.time.Duration
-import java.time.Instant
-import java.util.Calendar
-import java.util.Date
 import java.util.Optional
 
 /**
- * Phase-1 [SignatureSealPort] adapter (ADR-0162 D4): applies a server-side **PAdES-B** seal —
- * `SubFilter: ETSI.CAdES.detached` (`PDSignature.SUBFILTER_ETSI_CADES_DETACHED`), the standard
- * PAdES-Basic subfilter — using Apache PDFBox's external-signing API and a Bouncy Castle detached
- * CMS/PKCS7 signature over the PDF's signed byte range.
+ * Phase-1 [SignatureSealPort] adapter (ADR-0162 D4): applies the bank's institutional
+ * **electronic seal** — a server-side **PAdES-B** signature (`SubFilter: ETSI.CAdES.detached`) —
+ * using a STABLE, long-lived organizational identity (contrast with
+ * [OpenBaoClientSignatureAdapter]'s per-signer one-time identity). Mechanics (PDFBox +
+ * Bouncy Castle CMS/PKCS7) live in [PadesSigning], shared by both adapters.
  *
  * This is legally an *advanced* electronic signature (AdES), combined with the SCA-bound evidence
  * captured by [com.openbank.document.application.port.out.SignerVerificationPort] and the
@@ -65,6 +43,14 @@ class PdfBoxPadesSealAdapter(
 
     @ConfigProperty(name = "openbank.signature.keystore-password")
     keystorePassword: Optional<String>,
+
+    // Go-live gate (ADR-0162 D4 continued), shared with OpenBaoClientSignatureAdapter: when set, the
+    // service refuses to start with a DEV-ONLY ephemeral seal identity — better to fail boot than to
+    // apply seals that are worthless as evidence. Defaults off so the service is runnable before a
+    // real organizational keystore is provisioned; flip OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true
+    // in the deployment env once it is.
+    @ConfigProperty(name = "openbank.signature.require-trusted-issuer", defaultValue = "false")
+    requireTrustedIssuer: Boolean,
 ) : SignatureSealPort {
 
     private val logger = Logger.getLogger(PdfBoxPadesSealAdapter::class.java)
@@ -72,10 +58,15 @@ class PdfBoxPadesSealAdapter(
     private val identity: SigningIdentity
 
     init {
-        Security.addProvider(BouncyCastleProvider())
         identity = if (keystorePath.isPresent) {
             loadFromKeystore(keystorePath.get(), keystorePassword.orElse(""))
         } else {
+            check(!requireTrustedIssuer) {
+                "openbank.signature.keystore-path is not configured while " +
+                    "openbank.signature.require-trusted-issuer is set — refusing to start with a DEV-ONLY " +
+                    "ephemeral seal identity. Configure a real organizational PKCS12 keystore " +
+                    "(OpenBao KV, ADR-0162 D4 continued) before sealing real documents."
+            }
             logger.warn(
                 "openbank.signature.keystore-path is not configured — PdfBoxPadesSealAdapter is " +
                     "generating an EPHEMERAL, in-memory, non-persisted self-signed X.509 certificate " +
@@ -83,67 +74,17 @@ class PdfBoxPadesSealAdapter(
                     "seal applied while this warning fires is worthless as evidence (the private key " +
                     "vanishes on restart and was never issued by any trusted CA). Production MUST " +
                     "configure openbank.signature.keystore-path / openbank.signature.keystore-password " +
-                    "with a real organizational PKCS12 certificate before this service handles a real " +
-                    "signature ceremony.",
+                    "with a real organizational PKCS12 certificate (OpenBao KV, ADR-0162 D4 continued) " +
+                    "before this service handles a real signature ceremony.",
             )
-            generateEphemeralIdentity()
+            PadesSigning.generateEphemeralIdentity("OpenBank Document Service (DEV-ONLY EPHEMERAL)")
         }
     }
 
     override suspend fun sealPades(pdf: ByteArray, ceremony: SignatureCeremony): ByteArray =
         withContext(Dispatchers.IO) {
-            Loader.loadPDF(pdf).use { document ->
-                val signature = PDSignature().apply {
-                    setFilter(PDSignature.FILTER_ADOBE_PPKLITE)
-                    setSubFilter(PDSignature.SUBFILTER_ETSI_CADES_DETACHED)
-                    setName(ORGANIZATION_NAME)
-                    setReason(SEAL_REASON)
-                    setSignDate(Calendar.getInstance())
-                }
-                val signatureOptions = SignatureOptions()
-                try {
-                    signatureOptions.preferredSignatureSize = SignatureOptions.DEFAULT_SIGNATURE_SIZE * 2
-                    document.addSignature(signature, Pkcs7SignatureInterface(), signatureOptions)
-                    val output = ByteArrayOutputStream()
-                    document.saveIncremental(output)
-                    output.toByteArray()
-                } finally {
-                    signatureOptions.close()
-                }
-            }
+            PadesSigning.applySignature(pdf, identity, ORGANIZATION_NAME, SEAL_REASON)
         }
-
-    /**
-     * PDFBox's external-signing callback: given the exact byte range PDFBox has carved out around
-     * the signature placeholder (the PDF `ByteRange`), produce the detached CMS/PKCS7 signature
-     * bytes to embed. The content is read fully into memory — acceptable for the document sizes
-     * this service handles (statements/contracts, not multi-GB files).
-     */
-    private inner class Pkcs7SignatureInterface : SignatureInterface {
-        override fun sign(content: InputStream): ByteArray {
-            val digestCalculatorProvider = JcaDigestCalculatorProviderBuilder()
-                .setProvider(BC_PROVIDER)
-                .build()
-            val contentSigner = JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
-                .setProvider(BC_PROVIDER)
-                .build(identity.privateKey)
-            val signerInfoGenerator = JcaSignerInfoGeneratorBuilder(digestCalculatorProvider)
-                .build(contentSigner, identity.certificate)
-
-            val generator = CMSSignedDataGenerator()
-            generator.addSignerInfoGenerator(signerInfoGenerator)
-            generator.addCertificates(JcaCertStore(identity.certificateChain))
-
-            val signedData = generator.generate(CMSProcessableByteArray(content.readBytes()), false)
-            return signedData.encoded
-        }
-    }
-
-    private data class SigningIdentity(
-        val privateKey: PrivateKey,
-        val certificate: X509Certificate,
-        val certificateChain: List<X509Certificate>,
-    )
 
     private fun loadFromKeystore(path: String, password: String): SigningIdentity {
         val keyStore = KeyStore.getInstance("PKCS12")
@@ -155,43 +96,7 @@ class PdfBoxPadesSealAdapter(
         return SigningIdentity(privateKey, certificate, chain)
     }
 
-    private fun generateEphemeralIdentity(): SigningIdentity {
-        val keyPairGenerator = KeyPairGenerator.getInstance("RSA", BC_PROVIDER)
-        keyPairGenerator.initialize(RSA_KEY_SIZE)
-        val keyPair = keyPairGenerator.generateKeyPair()
-
-        val now = Instant.now()
-        val subject = X500Name(
-            "CN=OpenBank Document Service (DEV-ONLY EPHEMERAL), O=OpenBank, OU=openbank-document-service",
-        )
-        val certificateBuilder = JcaX509v3CertificateBuilder(
-            subject,
-            BigInteger.valueOf(now.toEpochMilli()),
-            Date.from(now.minus(Duration.ofMinutes(EPHEMERAL_NOT_BEFORE_SKEW_MINUTES))),
-            Date.from(now.plus(Duration.ofDays(EPHEMERAL_VALIDITY_DAYS))),
-            subject,
-            keyPair.public,
-        )
-        val contentSigner = JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
-            .setProvider(BC_PROVIDER)
-            .build(keyPair.private)
-        val certificate = JcaX509CertificateConverter()
-            .setProvider(BC_PROVIDER)
-            .getCertificate(certificateBuilder.build(contentSigner))
-
-        return SigningIdentity(
-            privateKey = keyPair.private,
-            certificate = certificate,
-            certificateChain = listOf(certificate),
-        )
-    }
-
     private companion object {
-        const val BC_PROVIDER = "BC"
-        const val SIGNATURE_ALGORITHM = "SHA256withRSA"
-        const val RSA_KEY_SIZE = 2048
-        const val EPHEMERAL_VALIDITY_DAYS = 365L
-        const val EPHEMERAL_NOT_BEFORE_SKEW_MINUTES = 5L
         const val ORGANIZATION_NAME = "OpenBank"
         const val SEAL_REASON = "Document signed via OpenBank signature ceremony"
     }

--- a/openbank-document-service/src/main/resources/application.yaml
+++ b/openbank-document-service/src/main/resources/application.yaml
@@ -62,6 +62,10 @@ quarkus:
     sca-service:
       url: ${SCA_SERVICE_URL:http://localhost:8121}
       scope: jakarta.inject.Singleton
+    product-catalog-api:
+      url: ${PRODUCT_CATALOG_SERVICE_URL:http://localhost:8104}
+      connect-timeout: 3000
+      read-timeout: 5000
   redis:
     hosts: redis://localhost:6379
   smallrye-reactive-messaging:
@@ -137,6 +141,20 @@ openbank:
   # (same Optional<String> reasoning as objectstore.s3.endpoint-override above) — leaving them
   # wholly absent is what makes PdfBoxPadesSealAdapter fall back to its DEV-ONLY ephemeral
   # certificate. Production sets both via real config/secrets, never a blank-string default.
+  #
+  # ADR-0162 D4 continued: client-pki.* all have code-level defaults (OpenBaoClientSignatureAdapter's
+  # @ConfigProperty defaultValue) pointing at the real in-cluster OpenBao address/mount/role, so
+  # nothing needs overriding here for production. Locally/in tests, the projected ServiceAccount
+  # token simply doesn't exist at that path, so the adapter falls back to its own DEV-ONLY ephemeral
+  # identity without any config needed either.
+  signature:
+    # ADR-0162 D4 continued — go-live gate for real (non-DEV-ONLY) signatures. Default off keeps the
+    # service runnable on the ephemeral fallback (both the seal's in-memory cert and the client's
+    # ephemeral leaf). Flip OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true in the deployment env once
+    # a real seal keystore + the OpenBao pki-document-signing engine are provisioned: any signing act
+    # that then cannot obtain a trusted certificate fails loud (fail-closed) rather than silently
+    # producing evidence-worthless output, and the service refuses to boot without a real seal key.
+    require-trusted-issuer: ${OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER:false}
 
 mp:
   messaging:
@@ -156,6 +174,16 @@ mp:
         topic: openbank.documents.document.event
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
         key.serializer: org.apache.kafka.common.serialization.StringSerializer
+    incoming:
+      # ADR-0162 D7: onboarding wiring — consumes account-service's own AccountCreated event
+      # (same topic balance-service's BalanceInitConsumer already consumes) so document-service
+      # stays off the synchronous account-opening path (ADR-0086) entirely.
+      account-created-in:
+        connector: smallrye-kafka
+        topic: openbank.accounts.account.created
+        group.id: openbank-document-service
+        value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+        auto.offset.reset: earliest
 
 # OPA sidecar (ADR-0034). Advisory mode by default.
 opa:

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/OnboardingDocumentServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/OnboardingDocumentServiceTest.kt
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.application.usecase
+
+import com.openbank.document.application.port.`in`.DocumentQueryUseCase
+import com.openbank.document.application.port.`in`.DocumentRenderUseCase
+import com.openbank.document.application.port.`in`.IssueOnboardingDocumentCommand
+import com.openbank.document.application.port.`in`.OpenCeremonyCommand
+import com.openbank.document.application.port.`in`.RenderDocumentCommand
+import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
+import com.openbank.document.application.port.out.ProductCatalogPort
+import com.openbank.document.domain.model.Document
+import com.openbank.document.domain.model.DocumentStatus
+import com.openbank.document.domain.model.SignatureLevel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * ADR-0162 D7: the onboarding wiring exercises product-catalog's `documentTemplateCode` reference
+ * and the render use-case's version-resolution policy (`templateVersion = null`) end to end for
+ * the first time — this test pins that contract, plus the idempotency guarantee a Kafka consumer
+ * calling this under at-least-once delivery relies on.
+ */
+class OnboardingDocumentServiceTest {
+
+    private val productCatalogPort: ProductCatalogPort = mockk()
+    private val renderUseCase: DocumentRenderUseCase = mockk()
+    private val documentQueryUseCase: DocumentQueryUseCase = mockk()
+    private val ceremonyUseCase: SignatureCeremonyUseCase = mockk()
+    private val service =
+        OnboardingDocumentService(productCatalogPort, renderUseCase, documentQueryUseCase, ceremonyUseCase)
+
+    private val accountId: UUID = UUID.randomUUID()
+    private val productId: UUID = UUID.randomUUID()
+    private val partyRef = "party-1"
+
+    @Test
+    fun `renders the product's bound template with no pinned version and opens a ceremony`(): Unit = runBlocking {
+        coEvery { documentQueryUseCase.listByParty(partyRef) } returns emptyList()
+        coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
+        val document = document()
+        coEvery { renderUseCase.render(any()) } returns document
+        coEvery { ceremonyUseCase.openCeremony(any()) } returns mockk()
+
+        service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
+
+        coVerify(exactly = 1) {
+            renderUseCase.render(
+                RenderDocumentCommand(
+                    templateCode = "RAMCOVA_SMLOUVA_CS",
+                    templateVersion = null,
+                    data = emptyMap(),
+                    contentType = "application/pdf",
+                    partyRef = partyRef,
+                    caseRef = accountId.toString(),
+                    productRef = productId.toString(),
+                    retainUntil = null,
+                ),
+            )
+        }
+        coVerify(exactly = 1) {
+            ceremonyUseCase.openCeremony(
+                OpenCeremonyCommand(
+                    documentId = document.id,
+                    signerPartyRefs = listOf(partyRef),
+                    signatureLevel = SignatureLevel.ADVANCED,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `skips when this account already has an issued document (idempotent replay)`(): Unit = runBlocking {
+        val existing = document().copy(caseRef = accountId.toString())
+        coEvery { documentQueryUseCase.listByParty(partyRef) } returns listOf(existing)
+
+        service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
+
+        coVerify(exactly = 0) { renderUseCase.render(any()) }
+        coVerify(exactly = 0) { ceremonyUseCase.openCeremony(any()) }
+    }
+
+    @Test
+    fun `does nothing when the product has no documentTemplateCode bound`(): Unit = runBlocking {
+        coEvery { documentQueryUseCase.listByParty(partyRef) } returns emptyList()
+        coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns null
+
+        service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
+
+        coVerify(exactly = 0) { renderUseCase.render(any()) }
+        coVerify(exactly = 0) { ceremonyUseCase.openCeremony(any()) }
+    }
+
+    private fun document() = Document(
+        id = UUID.randomUUID(),
+        templateCode = "RAMCOVA_SMLOUVA_CS",
+        templateVersion = "1.1.0",
+        sha256 = "abc",
+        storageKey = "documents/1",
+        contentType = "application/pdf",
+        sizeBytes = 10,
+        status = DocumentStatus.GENERATED,
+        metadata = emptyMap(),
+        partyRef = partyRef,
+        caseRef = null,
+        productRef = productId.toString(),
+        retainUntil = null,
+        createdAt = Instant.parse("2026-01-15T10:15:30Z"),
+    )
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.application.usecase
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.openbank.document.application.port.out.CeremonyRepositoryPort
+import com.openbank.document.application.port.out.ClientSignatureIssuerPort
+import com.openbank.document.application.port.out.DocumentRepositoryPort
+import com.openbank.document.application.port.out.SignatureSealPort
+import com.openbank.document.application.port.out.SignerVerificationPort
+import com.openbank.document.domain.model.CeremonyStatus
+import com.openbank.document.domain.model.Document
+import com.openbank.document.domain.model.DocumentStatus
+import com.openbank.document.domain.model.SignatureCeremony
+import com.openbank.document.domain.model.SignatureLevel
+import com.openbank.document.domain.model.Signer
+import com.openbank.document.domain.model.SignerStatus
+import com.openbank.libs.storage.ObjectStorePort
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * ADR-0162 D4 continued: a SIGNED decision applies the signer's own one-time signature
+ * ([ClientSignatureIssuerPort]) BEFORE persisting the decision; the bank's seal
+ * ([SignatureSealPort]) applies only once, LAST, after every signer reaches a terminal decision.
+ */
+class SignatureCeremonyServiceTest {
+
+    private val ceremonyRepo: CeremonyRepositoryPort = mockk()
+    private val documentRepo: DocumentRepositoryPort = mockk()
+    private val objectStore: ObjectStorePort = mockk()
+    private val sealPort: SignatureSealPort = mockk()
+    private val clientSignaturePort: ClientSignatureIssuerPort = mockk()
+    private val signerVerificationPort: SignerVerificationPort = mockk()
+    private val service = SignatureCeremonyService(
+        ceremonyRepo = ceremonyRepo,
+        documentRepo = documentRepo,
+        objectStore = objectStore,
+        sealPort = sealPort,
+        clientSignaturePort = clientSignaturePort,
+        signerVerificationPort = signerVerificationPort,
+        clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC),
+        objectMapper = ObjectMapper().registerModule(JavaTimeModule()),
+    )
+
+    @Test
+    fun `a single-signer ceremony applies the client signature then the bank seal`(): Unit = runBlocking {
+        val ceremony = ceremony(listOf(signer("party-1")))
+        val document = document()
+        val pdf = "pdf-bytes".toByteArray()
+        val clientSigned = "client-signed".toByteArray()
+        val sealed = "sealed".toByteArray()
+        coEvery { ceremonyRepo.findById(ceremony.id) } returns ceremony
+        coEvery { documentRepo.findById(ceremony.documentId) } returns document
+        coEvery { signerVerificationPort.verify("party-1", "evidence-1") } returns true
+        // First get() (inside signAsClient) sees the original bytes; the second (inside
+        // sealDocument) sees what signAsClient just put -- simulating the object store's own
+        // read-your-writes behavior across the two sequential steps.
+        coEvery { objectStore.get(document.storageKey) } returns pdf andThen clientSigned
+        coEvery { clientSignaturePort.signAsClient(pdf, "party-1") } returns clientSigned
+        coEvery { objectStore.put(document.storageKey, clientSigned, document.contentType) } returns Unit
+        coEvery { sealPort.sealPades(clientSigned, any()) } returns sealed
+        coEvery { objectStore.put(document.storageKey, sealed, document.contentType) } returns Unit
+        coEvery { ceremonyRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
+
+        val result = service.recordDecision(ceremony.id, "party-1", SignerStatus.SIGNED, "evidence-1")
+
+        assertThat(result.status).isEqualTo(CeremonyStatus.COMPLETED)
+        coVerifyOrder {
+            clientSignaturePort.signAsClient(pdf, "party-1")
+            sealPort.sealPades(clientSigned, any())
+        }
+    }
+
+    @Test
+    fun `a two-signer ceremony signs each signer without sealing until the last one`(): Unit = runBlocking {
+        val ceremony = ceremony(listOf(signer("party-1", order = 1), signer("party-2", order = 2)))
+        val document = document()
+        val pdf = "pdf-bytes".toByteArray()
+        coEvery { ceremonyRepo.findById(ceremony.id) } returns ceremony
+        coEvery { documentRepo.findById(ceremony.documentId) } returns document
+        coEvery { signerVerificationPort.verify("party-1", "evidence-1") } returns true
+        coEvery { objectStore.get(document.storageKey) } returns pdf
+        coEvery { clientSignaturePort.signAsClient(any(), "party-1") } returns pdf
+        coEvery { objectStore.put(any(), any(), any()) } returns Unit
+        coEvery { ceremonyRepo.save(any()) } answers { firstArg() }
+
+        val result = service.recordDecision(ceremony.id, "party-1", SignerStatus.SIGNED, "evidence-1")
+
+        assertThat(result.status).isEqualTo(CeremonyStatus.PARTIALLY_SIGNED)
+        coVerify(exactly = 1) { clientSignaturePort.signAsClient(any(), "party-1") }
+        coVerify(exactly = 0) { sealPort.sealPades(any(), any()) }
+        coVerify(exactly = 0) { ceremonyRepo.saveWithOutbox(any(), any()) }
+    }
+
+    @Test
+    fun `a DECLINED decision applies neither the client signature nor the seal`(): Unit = runBlocking {
+        val ceremony = ceremony(listOf(signer("party-1")))
+        coEvery { ceremonyRepo.findById(ceremony.id) } returns ceremony
+        coEvery { ceremonyRepo.save(any()) } answers { firstArg() }
+
+        val result = service.recordDecision(ceremony.id, "party-1", SignerStatus.DECLINED, null)
+
+        assertThat(result.status).isEqualTo(CeremonyStatus.DECLINED)
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { sealPort.sealPades(any(), any()) }
+    }
+
+    @Test
+    fun `a failed SCA verification never applies the client signature`(): Unit = runBlocking {
+        val ceremony = ceremony(listOf(signer("party-1")))
+        coEvery { ceremonyRepo.findById(ceremony.id) } returns ceremony
+        coEvery { signerVerificationPort.verify("party-1", "bad-evidence") } returns false
+
+        assertThatThrownBy {
+            runBlocking { service.recordDecision(ceremony.id, "party-1", SignerStatus.SIGNED, "bad-evidence") }
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+    }
+
+    private fun signer(partyRef: String, order: Int = 1) =
+        Signer(partyRef = partyRef, order = order, status = SignerStatus.PENDING, signedAt = null)
+
+    private fun ceremony(signers: List<Signer>) = SignatureCeremony(
+        id = UUID.randomUUID(),
+        documentId = UUID.randomUUID(),
+        signers = signers,
+        status = CeremonyStatus.PENDING,
+        signatureLevel = SignatureLevel.ADVANCED,
+        createdAt = FIXED_NOW,
+    )
+
+    private fun document() = Document(
+        id = UUID.randomUUID(),
+        templateCode = "VOP_CS",
+        templateVersion = "1.1.0",
+        sha256 = "abc",
+        storageKey = "documents/1",
+        contentType = "application/pdf",
+        sizeBytes = 10,
+        status = DocumentStatus.PENDING_SIGNATURE,
+        metadata = emptyMap(),
+        partyRef = "party-1",
+        caseRef = null,
+        productRef = null,
+        retainUntil = null,
+        createdAt = FIXED_NOW,
+    )
+
+    private companion object {
+        val FIXED_NOW: Instant = Instant.parse("2026-01-15T10:15:30Z")
+    }
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumerTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumerTest.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.kafka
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.document.application.port.`in`.IssueOnboardingDocumentCommand
+import com.openbank.document.application.port.`in`.OnboardingDocumentUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/** Poison-pill safety + field-presence guards for [AccountCreatedConsumer] (mirrors BalanceInitConsumer). */
+class AccountCreatedConsumerTest {
+
+    private val onboardingUseCase: OnboardingDocumentUseCase = mockk()
+    private val consumer = AccountCreatedConsumer(onboardingUseCase, ObjectMapper())
+
+    @Test
+    fun `delegates to the onboarding use case for a well-formed AccountCreated event`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        val productId = UUID.randomUUID()
+        coEvery { onboardingUseCase.issueOnboardingDocument(any()) } returns Unit
+
+        consumer.consume(accountCreatedPayload(accountId, partyId, productId))
+
+        coVerify(exactly = 1) {
+            onboardingUseCase.issueOnboardingDocument(
+                IssueOnboardingDocumentCommand(accountId, partyId.toString(), productId),
+            )
+        }
+    }
+
+    @Test
+    fun `ignores an event of a different type`(): Unit = runBlocking {
+        consumer.consume("""{"eventType":"AccountClosed","aggregateId":"${UUID.randomUUID()}"}""")
+
+        coVerify(exactly = 0) { onboardingUseCase.issueOnboardingDocument(any()) }
+    }
+
+    @Test
+    fun `ignores an unparseable payload instead of throwing`(): Unit = runBlocking {
+        consumer.consume("not json at all {{{")
+
+        coVerify(exactly = 0) { onboardingUseCase.issueOnboardingDocument(any()) }
+    }
+
+    @Test
+    fun `ignores an AccountCreated event missing productId`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        val payload = """{"eventType":"AccountCreated","aggregateId":"$accountId","partyId":"$partyId"}"""
+
+        consumer.consume(payload)
+
+        coVerify(exactly = 0) { onboardingUseCase.issueOnboardingDocument(any()) }
+    }
+
+    private fun accountCreatedPayload(accountId: UUID, partyId: UUID, productId: UUID) = """
+        {"eventType":"AccountCreated","aggregateId":"$accountId","partyId":"$partyId","productId":"$productId","currency":"CZK"}
+    """.trimIndent()
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.render
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.runBlocking
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+/**
+ * No real OpenBao is available in this test (or in local dev) — a nonexistent ServiceAccount
+ * token path is exactly the signal [OpenBaoClientSignatureAdapter] uses to take its DEV-ONLY
+ * ephemeral fallback, so this test exercises that path (the real-OpenBao path is verified live in
+ * the sandbox, ADR-0162 D4 continued / runbook 0008).
+ */
+class OpenBaoClientSignatureAdapterTest {
+
+    private fun adapter(requireTrustedIssuer: Boolean = false) = OpenBaoClientSignatureAdapter(
+        baoAddr = "http://openbao.invalid:8200",
+        role = "document-service-signing",
+        issuePath = "pki-document-signing/issue/client-signing",
+        saTokenPath = "/nonexistent/path/token",
+        ttl = "300s",
+        requireTrustedIssuer = requireTrustedIssuer,
+        objectMapper = ObjectMapper(),
+    )
+
+    @Test
+    fun `falls back to a valid ephemeral one-time signature when OpenBao is not reachable`(): Unit = runBlocking {
+        val pdf = blankPdf()
+
+        val signed = adapter().signAsClient(pdf, "party-42")
+
+        val signatures = Loader.loadPDF(signed).use { it.signatureDictionaries }
+        assertThat(signatures).hasSize(1)
+        assertThat(signatures[0].name).isEqualTo("party-42")
+    }
+
+    @Test
+    fun `fails loud instead of falling back when require-trusted-issuer is set`(): Unit = runBlocking {
+        // Fail-closed go-live gate: with no real OpenBao reachable and the guard on, a signing act
+        // must refuse rather than silently produce an evidence-worthless ephemeral signature.
+        assertThatThrownBy { runBlocking { adapter(requireTrustedIssuer = true).signAsClient(blankPdf(), "party-42") } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("require-trusted-issuer")
+    }
+
+    private fun blankPdf(): ByteArray {
+        PDDocument().use { document ->
+            document.addPage(PDPage())
+            val output = ByteArrayOutputStream()
+            document.save(output)
+            return output.toByteArray()
+        }
+    }
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PadesSigningTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PadesSigningTest.kt
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.render
+
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.assertj.core.api.Assertions.assertThat
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cms.CMSProcessableByteArray
+import org.bouncycastle.cms.CMSSignedData
+import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder
+import org.bouncycastle.util.Selector
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+/**
+ * Real cryptographic coverage for the mechanics both signature layers share (ADR-0162 D4
+ * continued): a signature applied via [PadesSigning.applySignature] must actually verify against
+ * its own embedded certificate, and PDF's native multi-signature support must genuinely hold —
+ * the client's one-time signature and the bank's seal are two independent, layered signatures over
+ * the same evolving document, not a single overwritten one.
+ */
+class PadesSigningTest {
+
+    @Test
+    fun `a single applied signature verifies against its own certificate`() {
+        val pdf = blankPdf()
+        val identity = PadesSigning.generateEphemeralIdentity("Test Signer")
+
+        val signed = PadesSigning.applySignature(pdf, identity, "Test Signer", "unit test signature")
+
+        val signatures = Loader.loadPDF(signed).use { it.signatureDictionaries }
+        assertThat(signatures).hasSize(1)
+        assertThat(signatures[0].name).isEqualTo("Test Signer")
+        assertThat(signatures[0].reason).isEqualTo("unit test signature")
+        assertThat(verifies(signatures[0].getContents(signed), signatures[0].getSignedContent(signed))).isTrue()
+    }
+
+    @Test
+    fun `two signatures layered on the same document both verify independently`() {
+        val pdf = blankPdf()
+        val clientIdentity = PadesSigning.generateEphemeralIdentity("party-42")
+        val bankIdentity = PadesSigning.generateEphemeralIdentity("OpenBank")
+
+        val clientSigned = PadesSigning.applySignature(pdf, clientIdentity, "party-42", "client signature")
+        val fullySigned = PadesSigning.applySignature(clientSigned, bankIdentity, "OpenBank", "institutional seal")
+
+        val signatures = Loader.loadPDF(fullySigned).use { it.signatureDictionaries }
+        assertThat(signatures).hasSize(2)
+        assertThat(signatures.map { it.name }).containsExactly("party-42", "OpenBank")
+        signatures.forEach { sig ->
+            assertThat(verifies(sig.getContents(fullySigned), sig.getSignedContent(fullySigned))).isTrue()
+        }
+    }
+
+    /** Verifies a detached CMS/PKCS7 signature against the certificate embedded in it. */
+    @Suppress("UNCHECKED_CAST")
+    private fun verifies(cmsBytes: ByteArray, signedContent: ByteArray): Boolean {
+        val signedData = CMSSignedData(CMSProcessableByteArray(signedContent), cmsBytes)
+        val signerInfo = signedData.signerInfos.signers.first()
+        val selector = signerInfo.sid as Selector<X509CertificateHolder>
+        val certHolder = signedData.certificates.getMatches(selector).first() as X509CertificateHolder
+        return signerInfo.verify(JcaSimpleSignerInfoVerifierBuilder().build(certHolder))
+    }
+
+    private fun blankPdf(): ByteArray {
+        PDDocument().use { document ->
+            document.addPage(PDPage())
+            val output = ByteArrayOutputStream()
+            document.save(output)
+            return output.toByteArray()
+        }
+    }
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapterTest.kt
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.render
+
+import com.openbank.document.domain.model.CeremonyStatus
+import com.openbank.document.domain.model.SignatureCeremony
+import com.openbank.document.domain.model.SignatureLevel
+import com.openbank.document.domain.model.Signer
+import com.openbank.document.domain.model.SignerStatus
+import kotlinx.coroutines.runBlocking
+import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * The seal adapter's DEV-ONLY ephemeral fallback (no keystore configured) versus its fail-closed
+ * go-live gate (ADR-0162 D4 continued): with [requireTrustedIssuer] set, the bean must refuse to
+ * construct rather than boot the service on an evidence-worthless in-memory seal identity.
+ */
+class PdfBoxPadesSealAdapterTest {
+
+    @Test
+    fun `with no keystore and the guard off, applies a DEV-ONLY ephemeral seal`(): Unit = runBlocking {
+        val adapter = PdfBoxPadesSealAdapter(
+            keystorePath = Optional.empty(),
+            keystorePassword = Optional.empty(),
+            requireTrustedIssuer = false,
+        )
+
+        val sealed = adapter.sealPades(blankPdf(), ceremony())
+
+        val signatures = Loader.loadPDF(sealed).use { it.signatureDictionaries }
+        assertThat(signatures).hasSize(1)
+        assertThat(signatures[0].name).isEqualTo("OpenBank")
+    }
+
+    @Test
+    fun `with no keystore and the guard on, refuses to start (fail-closed)`() {
+        assertThatThrownBy {
+            PdfBoxPadesSealAdapter(
+                keystorePath = Optional.empty(),
+                keystorePassword = Optional.empty(),
+                requireTrustedIssuer = true,
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("require-trusted-issuer")
+    }
+
+    private fun ceremony() = SignatureCeremony(
+        id = UUID.randomUUID(),
+        documentId = UUID.randomUUID(),
+        signers = listOf(
+            Signer(partyRef = "party-1", order = 1, status = SignerStatus.SIGNED, signedAt = Instant.EPOCH),
+        ),
+        status = CeremonyStatus.COMPLETED,
+        signatureLevel = SignatureLevel.ADVANCED,
+        createdAt = Instant.EPOCH,
+    )
+
+    private fun blankPdf(): ByteArray {
+        PDDocument().use { document ->
+            document.addPage(PDPage())
+            val output = ByteArrayOutputStream()
+            document.save(output)
+            return output.toByteArray()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the per-signer **electronic-signature** layer to the document signature ceremony and wires
templating + e-signature into **account onboarding** (ADR-0162 D4/D7). Also lands a **fail-closed
go-live guard** so a real deployment can never silently produce evidence-worthless signatures once
key custody is provisioned.

## Type of change

- [x] feat (new functionality)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (performance)
- [ ] docs
- [ ] chore (build / tooling)
- [ ] security (private until disclosed)
- [ ] breaking change

## Linked issues

N/A — ADR-0162 D4/D7 continuation (architecture decision, not an issue-tracked task).

## Changes

- **`PadesSigning`** — shared PAdES-B (`SubFilter: ETSI.CAdES.detached`) mechanics: PDFBox
  external-signing + Bouncy Castle detached CMS/PKCS7, plus PDF-native incremental multi-signature.
  One place, used by both signature layers.
- **`OpenBaoClientSignatureAdapter`** (`ClientSignatureIssuerPort`) — issues a fresh, single-use
  certificate per signing act from OpenBao's `pki-document-signing` engine (K8s-auth login → issue);
  the private key never leaves the signing act. `SignatureCeremonyService` applies the signer's own
  signature **before** persisting a `SIGNED` decision, and applies the bank seal once, **last**.
- **Onboarding (ADR-0162 D7)** — `AccountCreatedConsumer` consumes `account.created` **off the
  money path** (ADR-0086); `OnboardingDocumentService` renders the product's bound template at its
  current PUBLISHED version (version-resolution policy) and opens a ceremony. Idempotent on replay;
  fail-open on an unreachable product-catalog (`ProductCatalogAdapter`/`ProductCatalogClient`).
- **Fail-closed go-live guard** — `openbank.signature.require-trusted-issuer`
  (`OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER`, **default off**). When set, both adapters refuse the
  DEV-ONLY ephemeral fallback: the seal refuses to boot, the client signature refuses to sign.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports).
- [x] Unit tests added/updated.
- [x] Integration tests added/updated (if service boundary involved).
- [ ] Contract tests updated (if public API changed). — N/A, no REST contract change (event-driven).
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes. — verified locally (JDK 25):
      ktlintCheck, detekt, 60 unit tests + 9 Testcontainers ITs, and `quarkusBuild` all green.
- [x] No new lint warnings.
- [ ] OpenAPI spec regenerated (if REST API changed). — N/A, no new/changed REST endpoint.
- [ ] Flyway migration added + rollback note (if DB changed). — N/A, no schema change.
- [ ] Avro schema versioned backward-compatibly (if event changed). — N/A, consumes the existing
      `account.created` topic; emits the existing `signature-ceremony.completed.v1`.
- [x] Docs updated — ADR-0162 already covers D4/D7; config documented inline in `application.yaml`.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] `@Suppress("TooGenericExceptionCaught")` justifications stated in-code: OpenBao issuance falls
      back / fails-closed on *any* transport error; `AccountCreatedConsumer` is poison-pill-safe
      (an unparseable event is logged + skipped); `ProductCatalogAdapter` is fail-open.
- [x] No new third-party dependency (PDFBox + Bouncy Castle already on the classpath, Apache-2.0 /
      permissive BC license — phase-1 AdES, **not** the LGPL EU-DSS phase-2 path).
- [x] Auth / crypto code changed → please apply `security-review-required`.
- [ ] PII path changed? → `gdpr-review-required` (the signed document is a customer contract).
- [ ] Cardholder data path changed? → N/A.

## Compliance impact

- [x] PSD2 / SCA / RTS — a `SIGNED` decision is gated on the SCA-bound `SignerVerificationPort`
      (ADR-0021); a client signature is only applied after that check passes.
- [x] GDPR — the rendered document is a customer contract (PII); storage/retention unchanged.
- [ ] PCI DSS · DORA · AML / 5AMLD · CNB reporting — none.

eIDAS: phase-1 **advanced** electronic signature (AdES) + institutional seal; phase-2 QES/PAdES-LTA
(EU DSS, LGPL, legal sign-off) remains explicitly out of scope.

## Rollout / Rollback

- Deployment strategy: rolling. The signature hardening is behind a **feature flag**
  (`OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER`), default **off** — this PR changes no runtime
  behaviour on the current sandbox (both adapters keep their DEV-ONLY ephemeral fallback until key
  custody is provisioned and the flag is flipped).
- Rollback plan: revert the squash commit; no schema/event/API migration to unwind.
- Data migration reversible: N/A.

## Reviewer notes

- **The fail-closed guard defaults OFF on purpose.** Real key custody isn't provisioned yet (no seal
  keystore configured; the OpenBao `pki-document-signing` engine is new) — forcing the guard on now
  would fail the service's boot in the sandbox. Flipping `OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true`
  is the deliberate go-live step once custody exists (same graduation pattern as `AUTHZ_ENFORCE`).
- Follow-up (separate PR): seed `documentTemplateCode = "UCET_SMLOUVA_CS"` on the `CURRENT_PERSONAL`
  product in `openbank-product-catalog` so onboarding resolves a template end-to-end. Left out here to
  keep this PR single-service and avoid an unrelated pre-existing ktlint reformat of `ProductSeed.kt`.
- This is phase-1 AdES: the DEV-ONLY ephemeral fallbacks are loudly `WARN`-logged and documented as
  worthless-as-evidence; production hardening is the guard above.
