### PR TITLE
feat(product-catalog): seed documentTemplateCode on CURRENT_PERSONAL T&C

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/ProductSeed.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/ProductSeed.kt
@@ -264,6 +264,7 @@ object ProductSeed {
                         effectiveFrom = LocalDate.of(2024, 11, 1),
                         language = "cs",
                         summary = "Osobní účet — obchodní podmínky v3.0",
+                        documentTemplateCode = "UCET_SMLOUVA_CS",
                     ),
                 ),
                 versionHistory = listOf(
@@ -1215,6 +1216,6 @@ object ProductSeed {
                     "0.5% FX margin, cross-pocket transfers",
                 createdAt = Instant.parse("2025-01-01T10:00:00Z"),
                 updatedAt = Instant.parse("2025-01-01T10:00:00Z"),
-            ),
+        ),
     )
 }


### PR DESCRIPTION
## Summary

Seeds `documentTemplateCode = "UCET_SMLOUVA_CS"` on the v3.0 terms & conditions of the
`prod-003` / `CURRENT_PERSONAL` product. Follow-up to #1103: the onboarding flow already
resolves a product's `termsAndConditions[].documentTemplateCode` from openbank-product-catalog,
but no product seeded that field, so onboarding silently no-ops (fail-open) in the demo.

## Type of change

- [x] feat (new functionality)

## Linked issues

N/A — ADR-0162 onboarding continuation / follow-up to #1103 (seed-data completion, not an issue-tracked task).

## Changes

- `ProductSeed.kt` — set `documentTemplateCode = "UCET_SMLOUVA_CS"` on the `version = "3.0"`
  `TermsAndConditions` block of `prod-003` (`CURRENT_PERSONAL`). This is the template code seeded in
  document-service `DocumentTemplateSeed.kt`, so onboarding
  (`AccountCreatedConsumer` → `OnboardingDocumentService` → `ProductCatalogPort.findDocumentTemplateCode`)
  now resolves a real template instead of fail-open no-op.
- `ProductSeed.kt` — dedent the closing bracket of the last product (`prod-015` /
  `CURRENT_MULTICURRENCY_UMBRELLA`) by 4 spaces. This corrects a **pre-existing, latent** ktlint
  `indent` violation (`should be 8`) that path-scoped CI never surfaced because it only lints changed
  files; touching this file makes it fail. This is the minimal reindent ktlint requires — not a
  whole-file reformat.

## Definition of Done

- [x] Hexagonal layering preserved (domain has zero framework imports) — pure domain seed data.
- [ ] Unit tests added/updated — N/A, seed-data value change; existing
      `ProductRequestDocumentTemplateRefTest` already covers `documentTemplateCode` pass-through.
- [ ] Integration tests added/updated — N/A, no service boundary change.
- [ ] Contract tests updated — N/A, no public API change.
- [x] `ktlintCheck` passes (`:openbank-product-catalog:ktlintMainSourceSetCheck` BUILD SUCCESSFUL);
      `:openbank-product-catalog:compileKotlin` BUILD SUCCESSFUL.
- [x] No new lint warnings.
- [x] OpenAPI spec — N/A, no REST API/schema change (seed data only).
- [x] Flyway migration — N/A, no DB schema change.
- [x] Avro schema — N/A, no event change.
- [ ] Docs — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@Suppress` / unsafe casts.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code — not changed.
- [x] PII path — not changed.
- [x] Cardholder data path — not changed.

## Compliance impact

- [x] None

The onboarding document flow already existed; this only supplies the template reference it was
missing. No new data path or runtime behavior beyond resolving an already-modelled optional field.

## Rollout / Rollback

- Deployment strategy: rolling (standard product-catalog deploy; seed re-applied on boot).
- Rollback plan: revert the commit — onboarding returns to the prior fail-open no-op.
- Data migration reversible: N/A (in-code seed, no DB migration).

## Reviewer notes

- `version.txt` is intentionally untouched — release-please bumps product-catalog (minor) from this
  `feat` commit.
- The second hunk (prod-015 dedent) is unrelated to the seed value but unavoidable: it clears a
  latent ktlint violation that blocks CI the moment `ProductSeed.kt` is edited. Verified minimal
  (single closing bracket) — `ktlintFormat` over the whole source set would reformat ~1200 lines
  plus three other files, which was deliberately avoided.
- `UCET_SMLOUVA_CS` is confirmed present in
  `openbank-document-service/.../DocumentTemplateSeed.kt`, so the reference is not dangling.
