### PR TITLE
fix(ci): delete closed auto-deploy branches to stop stale-branch buildup

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -53,7 +53,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.event.pull_request.head.ref, 'chore/gitops-auto-deploy-') ||
-       startsWith(github.event.pull_request.head.ref, 'chore/admin-ui-deploy-'))
+      startsWith(github.event.pull_request.head.ref, 'chore/admin-ui-deploy-'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -100,8 +100,12 @@ jobs:
           set -euo pipefail
           git fetch --prune origin
 
-          # Open PR heads — never touch these
-          OPEN_HEADS=$(gh api \
+          # Open PR heads — never touch these. --paginate: without it only the first
+          # 100 open PRs are protected, and since deploy-snapshot branches no longer
+          # get an age grace, a fresh deploy PR beyond page 1 during a large fleet
+          # sweep (>100 open PRs) could otherwise be classified "no open PR" and have
+          # its head deleted, aborting an in-flight deploy.
+          OPEN_HEADS=$(gh api --paginate \
             "repos/$GITHUB_REPOSITORY/pulls?state=open&per_page=100" \
             --jq '.[].head.ref' | sort)
 

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,11 +1,26 @@
 name: Branch cleanup
 
-# Každé pondělí 4:00 UTC smaže větve, které nemají otevřený PR a jejichž poslední
-# commit je starší než 14 dní. Chrání: main, release-please-*, dependabot/*.
-# Auto-delete on merge (GitHub setting) pokrývá čerstvé mergnuté větve okamžitě;
-# tento workflow zachytí stragglery (ruční větve, failed auto-delete, worktree leftovers).
+# Two mechanisms keep the branch list from accumulating stale refs:
+#
+# 1. Event-driven (pull_request: closed) — deletes the head branch of a bot
+#    auto-deploy PR the instant it closes, MERGED OR NOT. GitHub's "Automatically
+#    delete head branches" setting and peter-evans `delete-branch: true` both fire
+#    only on MERGE; a superseded deploy PR is CLOSED-unmerged (a newer deploy won the
+#    race), so neither removes it and the per-SHA branch orphans forever. Left alone,
+#    a rolling backlog of chore/admin-ui-deploy-<sha> / chore/gitops-auto-deploy-<sha>
+#    branches builds up (they were 57 of a 76-branch manual sweep on 2026-07-14).
+#    This job closes the leak at the source — scoped to the disposable bot patterns
+#    only, same-repo only, never a human or fork branch.
+#
+# 2. Weekly cron backstop — sweeps anything the event missed (e.g. branches created
+#    while this workflow was disabled/failing). Bot deploy-snapshot branches are
+#    deleted as soon as they have no open PR; every other straggler keeps a 14-day
+#    grace so in-flight local work is never cut. Protects: main, release-please--*,
+#    dependabot/*, and any open-PR head.
 
 on:
+  pull_request:
+    types: [closed]
   schedule:
     - cron: '0 4 * * 1'
   workflow_dispatch:
@@ -16,12 +31,59 @@ on:
         default: 'false'
 
 # Restrictive top-level default (Scorecard Token-Permissions wants an explicit top-level
-# block); the prune job below declares its own override for the write access it needs.
+# block); each job below declares its own override for the write access it needs.
 permissions:
   contents: read
 
+# A burst of deploy PRs closing together would otherwise race deletes against the same
+# ref namespace. Serialize per-branch (scheduled/dispatch runs fall back to a unique
+# run-id group so they never cancel each other or an in-flight delete).
+concurrency:
+  group: branch-cleanup-${{ github.event.pull_request.head.ref || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
+  # ── 1. Event-driven: delete a bot deploy branch the moment its PR closes ──────
+  delete-closed-deploy-branch:
+    name: Delete closed deploy branch
+    # Only the disposable bot auto-deploy snapshot branches, and only from this repo
+    # (never a fork head). Merged OR closed-unmerged — both leave the per-SHA branch
+    # behind unless removed here (GitHub auto-delete only covers the merged case).
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.event.pull_request.head.ref, 'chore/gitops-auto-deploy-') ||
+       startsWith(github.event.pull_request.head.ref, 'chore/admin-ui-deploy-'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 5
+    steps:
+      - name: Delete head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BR: ${{ github.event.pull_request.head.ref }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "PR #${PR_NUMBER} closed (merged=${MERGED}); head branch = ${BR}"
+          # Idempotent: GitHub's auto-delete-on-merge may have removed it already
+          # (404/422). That is success, not failure — only a genuine error should fail.
+          if gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BR}" \
+               >/dev/null 2>/tmp/gh-err; then
+            echo "Deleted ${BR}"
+          elif grep -qE 'HTTP 404|HTTP 422|Reference does not exist|Not Found' /tmp/gh-err; then
+            echo "Already gone (auto-delete beat us): ${BR}"
+          else
+            echo "::error::could not delete ${BR}"; cat /tmp/gh-err; exit 1
+          fi
+
+  # ── 2. Weekly backstop: sweep stragglers the event-driven job missed ─────────
   prune-stale-branches:
+    name: Prune stale branches
+    # Never on pull_request — the event-driven job above owns that path.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -62,18 +124,28 @@ jobs:
               SKIPPED=$(( SKIPPED + 1 )); continue
             fi
 
-            # Age check: skip if last commit is recent
-            LAST=$(git log -1 --format="%ct" "origin/$branch" 2>/dev/null || echo 0)
-            if [[ "$LAST" -gt "$CUTOFF" ]]; then
-              echo "KEEP (recent):  $branch"
-              SKIPPED=$(( SKIPPED + 1 )); continue
+            # Bot deploy-snapshot branches are disposable the moment their PR is gone —
+            # the pull_request:closed job above normally deletes them first; this is the
+            # backstop for any created while it was disabled/failing. No age grace: they
+            # are per-SHA machine artifacts and never hold human work.
+            if [[ "$branch" == chore/gitops-auto-deploy-* || \
+                  "$branch" == chore/admin-ui-deploy-* ]]; then
+              REASON="deploy-snapshot, no open PR"
+            else
+              # Age check: skip if last commit is recent (protects in-flight local work)
+              LAST=$(git log -1 --format="%ct" "origin/$branch" 2>/dev/null || echo 0)
+              if [[ "$LAST" -gt "$CUTOFF" ]]; then
+                echo "KEEP (recent):  $branch"
+                SKIPPED=$(( SKIPPED + 1 )); continue
+              fi
+              AGE=$(( ($(date -u +%s) - LAST) / 86400 ))
+              REASON="${AGE}d old"
             fi
 
-            AGE=$(( ($(date -u +%s) - LAST) / 86400 ))
             if [[ "$DRY_RUN" == "true" ]]; then
-              echo "DRY-RUN delete: $branch  (${AGE}d old)"
+              echo "DRY-RUN delete: $branch  (${REASON})"
             else
-              echo "Deleting:       $branch  (${AGE}d old)"
+              echo "Deleting:       $branch  (${REASON})"
               git push origin ":refs/heads/$branch" || \
                 echo "  WARNING: push delete failed for $branch — skipping"
             fi


### PR DESCRIPTION
## Summary

Stop the auto-deploy pipelines from permanently orphaning branches. Both
`admin-ui-deploy.yml` and `auto-deploy.yml` open their GitOps PR on a **unique
per-SHA branch** (`chore/admin-ui-deploy-<sha>` / `chore/gitops-auto-deploy-<sha>`).
When a newer deploy supersedes an older one, the older PR is **CLOSED unmerged** —
and neither GitHub's *"Automatically delete head branches"* setting nor
peter-evans `delete-branch: true` removes it, because **both act on MERGE only**.
A manual sweep on 2026-07-14 found **57 of 76** stale remote branches were exactly
these closed-unmerged deploy snapshots.

## Type of change

- [x] fix (bug fix) — CI tooling / repo hygiene

## Linked issues

N/A — CI hygiene fix; closes the stale-branch leak found during the 2026-07-14 manual branch sweep. No user-visible change.

## Changes

- `branch-cleanup.yml`: add a `pull_request: [closed]` job that deletes the head
  branch the moment a bot deploy PR closes (merged **or** not). Scoped by an
  explicit `if:` to the two disposable per-SHA patterns **and** same-repo heads
  only — it can never touch a human branch or a fork head. The delete is
  idempotent (404/422 from GitHub's own auto-delete is treated as success).
- Strengthen the existing weekly cron backstop: deploy-snapshot branches with no
  open PR are pruned with **no 14-day grace** (they are per-SHA machine artifacts,
  never human work); every other straggler keeps the age guard so in-flight local
  work is never cut. The cron job is now gated `if: github.event_name != 'pull_request'`.

## Definition of Done

- [x] `python3 -c yaml.load` parses, no duplicate keys; `actionlint` clean (incl. shellcheck on run steps).
- [x] Whitelist preserved: `main`, `release-please--*`, `dependabot/*`, and any open-PR head are never deleted.
- [x] No service source, API, DB, or event surface touched.

## Security checklist

- [x] No secrets, tokens, PII. Uses the default `GITHUB_TOKEN` with `contents: write` scoped to each job.
- [x] Fork-safe: the delete job requires `head.repo.full_name == github.repository`, so a fork PR closing cannot trigger a delete.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: workflow change, effective on next PR close / next Monday cron.
- Rollback plan: `git revert` restores the previous `branch-cleanup.yml`.
- Data migration reversible: N/A

## Reviewer notes

- The event-driven job intentionally deletes on **both** merged and unmerged close:
  GitHub auto-delete already handles the merged case, so this is belt-and-suspenders
  there and the sole mechanism for the closed-unmerged case that was leaking.
- Root cause is left in place on purpose — the per-SHA branch naming exists so two
  concurrent deploys don't clobber a shared branch (see the concurrency comments in
  `auto-deploy.yml`). Rather than change the proven deploy pipeline, this reaps the
  disposable branch at close time.
- Verified locally with `actionlint` (clean) and a YAML duplicate-key check.
