### PR TITLE
fix(ci): stage pitest artifacts into per-service build path, not repo root

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -336,11 +336,20 @@ jobs:
             [ -n "${art_id}" ] || continue
             if api "https://api.github.com/repos/${REPO}/actions/artifacts/${art_id}/zip" \
                 -L -o "/tmp/${art_name}.zip" 2>/dev/null; then
-              unzip -q "/tmp/${art_name}.zip" -d . 2>/dev/null || true
+              # The artifact is named pitest-<service>; its zip top-level is the pitest
+              # report contents (mutations.xml, index.html, com.openbank.*/ …) because
+              # actions/upload-artifact@v7 strips the <service>/build/reports/pitest/
+              # prefix (pitest.yml uploads that dir as `path`). Reconstruct that exact
+              # path so collect-quality-report.mjs finds it — never `-d .`, which dumps
+              # a full report into the repo root and gets it committed (#1104).
+              svc="${art_name#pitest-}"
+              dest="${svc}/build/reports/pitest"
+              mkdir -p "${dest}"
+              unzip -q "/tmp/${art_name}.zip" -d "${dest}" 2>/dev/null || true
               DOWNLOADED=$((DOWNLOADED + 1))
             fi
           done <<< "${ARTIFACTS}"
-          COUNT=$(find . -name "mutations.xml" | wc -l | tr -d ' ')
+          COUNT=$(find . -path "*/build/reports/pitest/mutations.xml" | wc -l | tr -d ' ')
           echo "Staged ${COUNT} mutations.xml files from ${DOWNLOADED} artifacts."
 
       - name: Collect production-readiness scorecard


### PR DESCRIPTION
## Summary

The admin-ui-deploy **"Stage pitest mutation results"** step unzipped each
`pitest-<service>` artifact into the checkout root (`unzip -d .`). Because
`actions/upload-artifact@v7` strips the `<service>/build/reports/pitest/`
prefix, the zip top-level *is* the report (`mutations.xml`, `index.html`,
`style.css`, `com.openbank.*/`) — so `-d .` scattered a full PITest report
across the repo root. This is a root-cause follow-up to the #1104 cleanup,
which removed the committed report but left the staging step that produced it.

## Type of change

- [x] fix (bug fix)

## Linked issues

N/A — no tracking issue. Root-cause follow-up to the #1104 cleanup (that PR
removed the committed report and added `.gitignore` guards; this PR fixes the
staging step that dumped it there in the first place).

## Changes

- In `.github/workflows/admin-ui-deploy.yml`, the pitest staging loop now
  derives the service from the artifact name (`svc="${art_name#pitest-}"`)
  and extracts into `${svc}/build/reports/pitest/` (`mkdir -p` first) instead
  of `-d .`, mirroring the adjacent test-results staging step.
- Scoped the `find` count to `*/build/reports/pitest/mutations.xml`.

## Why this fixes both symptoms

- **Repo-root pollution:** nothing is extracted to `.` anymore, so a report
  can never be committed to root again (belt-and-suspenders with #1104's
  `.gitignore` rules).
- **Empty mutations tab:** `openbank-admin-ui/scripts/collect-quality-report.mjs`
  reads `<service>/build/reports/pitest/mutations.xml` — exactly the path this
  step now populates — so the admin-ui quality/mutations report gets real data.

## Verification

Simulated the fixed loop against a zip built to match the real artifact layout
(the exact files #1104 removed from root): the zip top-level is the report
contents, extraction lands `openbank-ledger-service/build/reports/pitest/mutations.xml`
(the collector's expected path), the repo root stays clean, and the `find`
count reports 1. `python3 yaml.safe_load` confirms the workflow still parses.

## Definition of Done

- [x] Workflow-only change; no service source, no domain/API surface touched.
- [x] No version bump required (no `<service>/src/main/**` change).
- [x] No secrets/PII introduced.

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (CI workflow change; takes effect on next
  `admin-ui-deploy.yml` run).
- Rollback plan: revert this commit.
- Data migration reversible: N/A

## Reviewer notes

Scoped deliberately to this one staging step. The `unzip … 2>/dev/null || true`
best-effort posture is preserved, so a missing/broken artifact still can't
abort the deploy.
