### PR TITLE
fix(ci): strip origin/ prefix correctly in branch-cleanup prune loop

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -116,7 +116,7 @@ jobs:
                    date -u -v-${STALE_DAYS}d +%s)  # GNU / BSD date
 
           while IFS= read -r branch; do
-            branch="${branch#origin/}"
+            branch="${branch#origin/}"   # 'origin/feat/x' -> 'feat/x' (input is whitespace-free)
 
             # Immutable whitelist
             [[ "$branch" == "main" ]]              && { SKIPPED=$(( SKIPPED + 1 )); continue; }
@@ -154,7 +154,15 @@ jobs:
                 echo "  WARNING: push delete failed for $branch — skipping"
             fi
             DELETED=$(( DELETED + 1 ))
-          done < <(git branch -r | grep "^  origin/" | grep -v "HEAD")
+          # --format='%(refname:short)' yields clean 'origin/<name>' with NO leading
+          # whitespace. The old `git branch -r | grep '^  origin/'` kept git's 2-space
+          # indent ('  origin/main'), which `${branch#origin/}` below could NOT strip
+          # (the string starts with spaces, not 'origin/'), so every whitelist / open-PR
+          # / age check silently missed and the real (non-dry-run) delete built a
+          # malformed refspec that always failed — the prune loop deleted nothing since
+          # it was added (why stale branches piled up; caught by a dry-run 2026-07-14).
+          # grep drops the 'origin'/'origin/HEAD' symref (its short form is bare 'origin').
+          done < <(git branch -r --format='%(refname:short)' | grep -vE '^origin(/HEAD)?$')
 
           echo ""
           echo "Summary: deleted=$DELETED  skipped=$SKIPPED  dry_run=$DRY_RUN"


### PR DESCRIPTION
## Summary

The `prune-stale-branches` loop in `branch-cleanup.yml` never actually deleted
anything since it was added, because it could not parse branch names. It read
`git branch -r | grep '^  origin/'`, which keeps git's two-space indent
(`  origin/main`); `branch="${branch#origin/}"` then failed to strip the prefix
(the string starts with **spaces**, not `origin/`), leaving `  origin/<name>`.
Every guard silently missed — the `main`/`release-please--*`/`dependabot/*`
whitelist, the open-PR skip, and the age check (`git log` on the malformed ref
returned empty → `LAST=0` → ~20000d "old"). In a real scheduled run the delete
built a malformed refspec `:refs/heads/  origin/<name>` that always failed, so the
cron was a silent no-op — which is why stale branches piled up (57 of a 76-branch
manual sweep on 2026-07-14).

A **dry-run dispatch** of the just-merged #1106 surfaced it: the run listed
`origin/main`, every `release-please--*`, every `dependabot/*`, and open-PR heads
under "DRY-RUN delete", all aged `20648d`.

## Type of change

- [x] fix (bug fix) — CI tooling

## Linked issues

N/A — CI hygiene fix; corrects the prune-loop parsing bug surfaced by the #1106 dry-run. No user-visible change.

## Changes

- Source branches via `git branch -r --format='%(refname:short)'` (clean
  `origin/<name>`, no leading indent) and drop the `origin` / `origin/HEAD` symref,
  so `${branch#origin/}` yields the real branch name and every guard works.

## Definition of Done

- [x] `python3 yaml.safe_load` parses; `actionlint` clean (incl. shellcheck).
- [x] Verified by simulating the full prune loop against the live repo: `main`,
      `release-please--*`, `dependabot/*`, and all open-PR heads are skipped; the
      would-delete set is empty and never contains `main`.
- [x] No service source, API, DB, or event surface touched.

## Security checklist

- [x] No secrets/PII. Whitelist + open-PR protection now actually enforced (was inert before).

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment: workflow change, effective on next Monday cron / next `workflow_dispatch`.
- Rollback: `git revert`.
- Data migration reversible: N/A

## Reviewer notes

- The event-driven `delete-closed-deploy-branch` job (added in #1106) was **not**
  affected by this bug — it uses `github.event.pull_request.head.ref` directly, no
  parsing. Only the cron `prune-stale-branches` loop was broken.
- Please sanity-check that `%(refname:short)` for `origin/HEAD` is the bare `origin`
  (filtered by `grep -vE '^origin(/HEAD)?$'`) and that no real branch is named exactly
  `origin`.
