### PR TITLE
feat(document-service): fail-closed go-live gate for real signatures

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
@@ -67,6 +67,14 @@ class OpenBaoClientSignatureAdapter(
     @ConfigProperty(name = "openbank.signature.client-pki.ttl", defaultValue = "300s")
     private val ttl: String,
 
+    // Go-live gate (ADR-0162 D4 continued): when set, the DEV-ONLY ephemeral fallback below is
+    // DISABLED — a signing act that cannot obtain a real OpenBao-rooted certificate fails loud
+    // instead of silently producing an evidence-worthless signature. Defaults off so the service
+    // stays runnable before the pki-document-signing engine is provisioned; flip
+    // OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true in the deployment env once it is (runbook 0008).
+    @ConfigProperty(name = "openbank.signature.require-trusted-issuer", defaultValue = "false")
+    private val requireTrustedIssuer: Boolean,
+
     private val objectMapper: ObjectMapper,
 ) : ClientSignatureIssuerPort {
 
@@ -84,20 +92,35 @@ class OpenBaoClientSignatureAdapter(
     @Suppress("TooGenericExceptionCaught")
     private fun issueOneTimeIdentity(partyRef: String): SigningIdentity {
         if (!Files.exists(Path.of(saTokenPath))) {
-            logDevFallback("no projected ServiceAccount token")
-            return PadesSigning.generateEphemeralIdentity(partyRef, EPHEMERAL_VALIDITY_DAYS)
+            return devFallbackOrFail(partyRef, "no projected ServiceAccount token")
         }
         return try {
             val token = login(Files.readString(Path.of(saTokenPath)).trim())
             issueFromOpenBao(token, partyRef)
         } catch (e: Exception) {
-            // Deliberately log only the exception TYPE, never e.message: a Vault/OpenBao HTTP
+            // Deliberately pass only the exception TYPE, never e.message: a Vault/OpenBao HTTP
             // client exception's message can embed response-body fragments, which must never
             // reach a log line (CodeQL java/log-injection -- "insertion of sensitive information
             // into log files"). The class name is enough to diagnose which failure mode fired.
-            logDevFallback(e.javaClass.simpleName)
-            PadesSigning.generateEphemeralIdentity(partyRef, EPHEMERAL_VALIDITY_DAYS)
+            devFallbackOrFail(partyRef, e.javaClass.simpleName)
         }
+    }
+
+    /**
+     * Either takes the DEV-ONLY ephemeral fallback (logging a loud warning) or, when
+     * [requireTrustedIssuer] is set, refuses outright so a SIGNED decision is never recorded against
+     * an evidentially worthless signature (fail-closed — [signAsClient] propagates the failure up
+     * into the ceremony, which does not persist the decision). The failure message carries only the
+     * reason code, never [partyRef] (same CodeQL sensitive-data-in-logs reasoning as [logDevFallback]).
+     */
+    private fun devFallbackOrFail(partyRef: String, reason: String): SigningIdentity {
+        check(!requireTrustedIssuer) {
+            "Refusing to issue a client electronic signature without an OpenBao-rooted one-time " +
+                "certificate ($reason). openbank.signature.require-trusted-issuer is set, so the " +
+                "DEV-ONLY ephemeral fallback is disabled (ADR-0162 D4 continued, runbook 0008)."
+        }
+        logDevFallback(reason)
+        return PadesSigning.generateEphemeralIdentity(partyRef, EPHEMERAL_VALIDITY_DAYS)
     }
 
     // No partyRef (or any other per-signer identifier) in this log line, deliberately: CodeQL's

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
@@ -45,6 +45,14 @@ class PdfBoxPadesSealAdapter(
 
     @ConfigProperty(name = "openbank.signature.keystore-password")
     keystorePassword: Optional<String>,
+
+    // Go-live gate (ADR-0162 D4 continued), shared with OpenBaoClientSignatureAdapter: when set, the
+    // service refuses to start with a DEV-ONLY ephemeral seal identity — better to fail boot than to
+    // apply seals that are worthless as evidence. Defaults off so the service is runnable before a
+    // real organizational keystore is provisioned; flip OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true
+    // in the deployment env once it is.
+    @ConfigProperty(name = "openbank.signature.require-trusted-issuer", defaultValue = "false")
+    requireTrustedIssuer: Boolean,
 ) : SignatureSealPort {
 
     private val logger = Logger.getLogger(PdfBoxPadesSealAdapter::class.java)
@@ -60,6 +68,12 @@ class PdfBoxPadesSealAdapter(
         identity = if (keystorePath.isPresent && Files.exists(Path.of(keystorePath.get()))) {
             loadFromKeystore(keystorePath.get(), keystorePassword.orElse(""))
         } else {
+            check(!requireTrustedIssuer) {
+                "openbank.signature.keystore-path is not configured (or the file is not present) " +
+                    "while openbank.signature.require-trusted-issuer is set — refusing to start with " +
+                    "a DEV-ONLY ephemeral seal identity. Configure a real organizational PKCS12 " +
+                    "keystore (OpenBao KV, ADR-0162 D4 continued) before sealing real documents."
+            }
             logger.warn(
                 "openbank.signature.keystore-path is not configured, or the file does not exist yet " +
                     "at that path — PdfBoxPadesSealAdapter is generating an EPHEMERAL, in-memory, " +

--- a/openbank-document-service/src/main/resources/application.yaml
+++ b/openbank-document-service/src/main/resources/application.yaml
@@ -147,6 +147,14 @@ openbank:
   # nothing needs overriding here for production. Locally/in tests, the projected ServiceAccount
   # token simply doesn't exist at that path, so the adapter falls back to its own DEV-ONLY ephemeral
   # identity without any config needed either.
+  signature:
+    # ADR-0162 D4 continued — go-live gate for real (non-DEV-ONLY) signatures. Default off keeps the
+    # service runnable on the ephemeral fallback (both the seal's in-memory cert and the client's
+    # ephemeral leaf). Flip OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true in the deployment env once
+    # a real seal keystore + the OpenBao pki-document-signing engine are provisioned: any signing act
+    # that then cannot obtain a trusted certificate fails loud (fail-closed) rather than silently
+    # producing evidence-worthless output, and the service refuses to boot without a real seal key.
+    require-trusted-issuer: ${OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER:false}
 
 mp:
   messaging:

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
@@ -10,6 +10,7 @@ import org.apache.pdfbox.Loader
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 
@@ -21,12 +22,13 @@ import java.io.ByteArrayOutputStream
  */
 class OpenBaoClientSignatureAdapterTest {
 
-    private val adapter = OpenBaoClientSignatureAdapter(
+    private fun adapter(requireTrustedIssuer: Boolean = false) = OpenBaoClientSignatureAdapter(
         baoAddr = "http://openbao.invalid:8200",
         role = "document-service-signing",
         issuePath = "pki-document-signing/issue/client-signing",
         saTokenPath = "/nonexistent/path/token",
         ttl = "300s",
+        requireTrustedIssuer = requireTrustedIssuer,
         objectMapper = ObjectMapper(),
     )
 
@@ -34,11 +36,20 @@ class OpenBaoClientSignatureAdapterTest {
     fun `falls back to a valid ephemeral one-time signature when OpenBao is not reachable`(): Unit = runBlocking {
         val pdf = blankPdf()
 
-        val signed = adapter.signAsClient(pdf, "party-42")
+        val signed = adapter().signAsClient(pdf, "party-42")
 
         val signatures = Loader.loadPDF(signed).use { it.signatureDictionaries }
         assertThat(signatures).hasSize(1)
         assertThat(signatures[0].name).isEqualTo("party-42")
+    }
+
+    @Test
+    fun `fails loud instead of falling back when require-trusted-issuer is set`(): Unit = runBlocking {
+        // Fail-closed go-live gate: with no real OpenBao reachable and the guard on, a signing act
+        // must refuse rather than silently produce an evidence-worthless ephemeral signature.
+        assertThatThrownBy { runBlocking { adapter(requireTrustedIssuer = true).signAsClient(blankPdf(), "party-42") } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("require-trusted-issuer")
     }
 
     private fun blankPdf(): ByteArray {

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapterTest.kt
@@ -12,6 +12,7 @@ import org.apache.pdfbox.Loader
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.time.Instant
@@ -30,6 +31,7 @@ class PdfBoxPadesSealAdapterTest {
         val adapter = PdfBoxPadesSealAdapter(
             keystorePath = Optional.of("/nonexistent/path/keystore.p12"),
             keystorePassword = Optional.of("irrelevant"),
+            requireTrustedIssuer = false,
         )
 
         val signed = adapter.sealPades(blankPdf(), ceremony())
@@ -41,12 +43,31 @@ class PdfBoxPadesSealAdapterTest {
 
     @Test
     fun `an absent keystore path also falls back to the ephemeral identity`(): Unit = runBlocking {
-        val adapter = PdfBoxPadesSealAdapter(keystorePath = Optional.empty(), keystorePassword = Optional.empty())
+        val adapter = PdfBoxPadesSealAdapter(
+            keystorePath = Optional.empty(),
+            keystorePassword = Optional.empty(),
+            requireTrustedIssuer = false,
+        )
 
         val signed = adapter.sealPades(blankPdf(), ceremony())
 
         val signatures = Loader.loadPDF(signed).use { it.signatureDictionaries }
         assertThat(signatures).hasSize(1)
+    }
+
+    @Test
+    fun `with no usable keystore and the guard on, refuses to start (fail-closed)`() {
+        // Go-live gate: with require-trusted-issuer set and no real keystore, the bean must refuse
+        // to construct (fail boot) rather than seal with an evidence-worthless ephemeral identity.
+        assertThatThrownBy {
+            PdfBoxPadesSealAdapter(
+                keystorePath = Optional.empty(),
+                keystorePassword = Optional.empty(),
+                requireTrustedIssuer = true,
+            )
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("require-trusted-issuer")
     }
 
     private fun ceremony() = SignatureCeremony(


### PR DESCRIPTION
## Summary

Adds a **fail-closed go-live gate** for the two-tier e-signature feature (shipped in #1102):
`openbank.signature.require-trusted-issuer` (env `OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER`,
**default off**). When set, neither signature adapter is allowed to fall back to its DEV-ONLY
ephemeral identity — so a real deployment can never silently produce evidence-worthless signatures.

## Type of change

- [x] feat (new functionality)
- [ ] fix · refactor · perf · docs · chore · security · breaking change

## Linked issues

N/A — ADR-0162 D4 continuation (go-live hardening for the feature merged in #1102). Related
follow-ups found while reviewing that feature: #1110 (Kafka ACL), #1111 (OpenBao egress
NetworkPolicy), #1112 (robustness).

## Changes

- `OpenBaoClientSignatureAdapter`: when it cannot obtain an OpenBao-rooted one-time certificate and
  the guard is on, it **refuses to sign** (fail-closed) instead of issuing an ephemeral leaf —
  `signAsClient` propagates the `IllegalStateException` and the ceremony never records `SIGNED`.
- `PdfBoxPadesSealAdapter`: when no real keystore is usable and the guard is on, the bean **refuses
  to construct** — the service fails boot instead of sealing with an in-memory identity.
- `application.yaml`: `openbank.signature.require-trusted-issuer: ${OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER:false}`.
- Tests: fail-closed path for both adapters (sign refused / boot refused), plus the existing
  ephemeral-fallback tests still pass with the guard off.

## Definition of Done

- [x] Hexagonal layering preserved (adapters only; domain untouched).
- [x] Unit tests added/updated.
- [ ] Integration tests (n/a — no new service boundary; existing boot smoke test still green).
- [ ] Contract tests (n/a — no REST/API change).
- [x] `detekt ktlintCheck test quarkusBuild` pass locally (JDK 25).
- [ ] OpenAPI / Flyway / Avro (n/a — no API/DB/event change).

## Security checklist

- [x] No secrets/PII in code, config, tests, logs. **Hardening from #1102 preserved**: the new
      guard messages carry only a reason code — never `partyRef`, never the OpenBao exception
      `message` (CodeQL sensitive-data-in-logs / log-injection). The seal keeps its
      `keystorePath.isPresent && Files.exists(...)` guard against a boot crash-loop.
- [x] Auth / crypto code changed → please apply `security-review-required`.

## Compliance impact

- [x] PSD2 / SCA / RTS · GDPR — same posture as #1102; this only adds a fail-closed switch.
- [ ] PCI DSS · DORA · AML · CNB — none.

## Rollout / Rollback

- **Feature-flagged, default off** → zero runtime behaviour change on the current sandbox (both
  adapters keep their DEV-ONLY ephemeral fallback until key custody exists and the flag is flipped).
- Go-live step: set `OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true` in the deployment env **after**
  a real seal keystore + the OpenBao `pki-document-signing` engine are provisioned (and after #1110
  / #1111 land, or the guard-on path will fail-closed on blocked Kafka/egress).
- Rollback: revert the commit; no schema/event/API migration.

## Reviewer notes

Follow-up to #1102 (which merged the e-signature/onboarding feature). This PR is intentionally the
**only** new thing a now-closed duplicate branch (#1103) carried — re-done here on top of current
`main` so the #1102 hardening is preserved rather than reverted.
