### PR TITLE
chore(gitops): auto-deploy services @ a75d88781ad8843ea9734b60b173d1e22c6234ee

### DIFF
--- a/openbank-infra/gitops/components/authz-policy-auditor/authz-policy-auditor.yaml
+++ b/openbank-infra/gitops/components/authz-policy-auditor/authz-policy-auditor.yaml
@@ -28,7 +28,7 @@ spec:
         - name: authz-policy-auditor
           # Pending first CI build (ADR-0167 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-authz-policy-auditor:sandbox-pending
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-authz-policy-auditor:sandbox-a75d8878
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
@@ -28,7 +28,7 @@ spec:
         - name: control-liveness-sentinel
           # Pending first CI build (ADR-0163 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-control-liveness-sentinel:sandbox-pending
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-control-liveness-sentinel:sandbox-a75d8878
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/docs-truth-agent/docs-truth-agent.yaml
+++ b/openbank-infra/gitops/components/docs-truth-agent/docs-truth-agent.yaml
@@ -28,7 +28,7 @@ spec:
         - name: docs-truth-agent
           # Pending first CI build (ADR-0166 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-docs-truth-agent:sandbox-pending
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-docs-truth-agent:sandbox-a75d8878
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml
+++ b/openbank-infra/gitops/components/flaky-test-hunter/flaky-test-hunter.yaml
@@ -28,7 +28,7 @@ spec:
         - name: flaky-test-hunter
           # Pending first CI build (ADR-0168 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-flaky-test-hunter:sandbox-pending
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-flaky-test-hunter:sandbox-a75d8878
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/governance-auditor/governance-auditor.yaml
+++ b/openbank-infra/gitops/components/governance-auditor/governance-auditor.yaml
@@ -28,7 +28,7 @@ spec:
         - name: governance-auditor
           # Pending first CI build (ADR-0164 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-governance-auditor:sandbox-pending
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-governance-auditor:sandbox-a75d8878
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/release-steward/release-steward.yaml
+++ b/openbank-infra/gitops/components/release-steward/release-steward.yaml
@@ -28,7 +28,7 @@ spec:
         - name: release-steward
           # Pending first CI build (ADR-0165 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-release-steward:sandbox-pending
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-release-steward:sandbox-a75d8878
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit a75d88781ad8843ea9734b60b173d1e22c6234ee.

**Changed services:** ["openbank-control-liveness-sentinel","openbank-governance-auditor","openbank-release-steward","openbank-docs-truth-agent","openbank-authz-policy-auditor","openbank-flaky-test-hunter"]

Each image tag was updated to `sandbox-a75d88781ad8843ea9734b60b173d1e22c6234ee` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.