### PR TITLE
feat(web): serve apple-app-site-association for iOS native passkeys (ADR-0066 F2)

### DIFF
--- a/openbank-infra/web/deploy.sh
+++ b/openbank-infra/web/deploy.sh
@@ -47,6 +47,15 @@ aws s3 sync "$SITE" "s3://$BUCKET" \
   --content-type "application/xml; charset=utf-8" \
   --cache-control "public, max-age=3600"
 
-# 5) Bust the edge cache.
+# 5) Apple App Site Association — Associated Domains for the iOS app (ADR-0066 F2 native
+#    passkeys, webcredentials → tech.openbank.app). MUST be served as application/json at the
+#    exact extensionless path with no redirect. Uploaded AFTER the .well-known/* text sync in
+#    step 3 (which would otherwise leave it text/plain) so this content-type is the one that wins.
+aws s3 cp "$SITE/.well-known/apple-app-site-association" \
+  "s3://$BUCKET/.well-known/apple-app-site-association" \
+  --content-type "application/json" \
+  --cache-control "public, max-age=3600"
+
+# 6) Bust the edge cache.
 aws cloudfront create-invalidation --distribution-id "$DIST" --paths "/*" >/dev/null
 echo "✓ deployed — https://open-bank.tech"

--- a/openbank-infra/web/landing/.well-known/apple-app-site-association
+++ b/openbank-infra/web/landing/.well-known/apple-app-site-association
@@ -1,0 +1,7 @@
+{
+  "webcredentials": {
+    "apps": [
+      "37YYRR972B.tech.openbank.app"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Publish the Apple App Site Association (AASA) manifest at the `open-bank.tech` apex so iOS can verify the `webcredentials` association for the customer app's **native passkeys** (ADR-0066 F2). This is the missing infra gate: today `https://open-bank.tech/.well-known/apple-app-site-association` returns **404**, so `ASAuthorizationController` (rpId `open-bank.tech`) fails domain verification and the app keeps `AppConfig.useNativePasskey` off.

## Type of change

- [x] feat (new functionality)

## Linked issues

N/A — landing-site static file; unblocks the app-side native-passkey PR (JiRaska/openbank-app#169). No tracked issue in this repo.

## Changes

- Add `openbank-infra/web/landing/.well-known/apple-app-site-association` — `webcredentials → 37YYRR972B.tech.openbank.app` (paid team, bundle `tech.openbank.app`).
- `openbank-infra/web/deploy.sh`: add a dedicated step that uploads the AASA as **`application/json`** (the existing `.well-known/*` sync sets `text/plain`, which is wrong for AASA), at the exact extensionless path, no redirect — same serving path `security.txt` already uses.

## Definition of Done

- [x] JSON validated (`python3 -m json.tool`); `deploy.sh` passes `bash -n`.
- [ ] N/A — not a Gradle module (static web asset); no domain/tests/OpenAPI/Flyway/Avro.
- [ ] Docs: covered by the app-side PR + inline comments here.

## Security checklist

- [x] No secrets/PII. The Team ID + bundle ID are **public** identifiers (they ship in every signed app binary), not credentials.
- [x] No new dependency.
- [ ] Auth path enabler → tag `security-review-required` (passkey/associated-domain related).

## Compliance impact

- [x] PSD2 / SCA / RTS

Enables (does not itself perform) phishing-resistant passwordless SCA for the customer app. No runtime behavior changes until the app flips `useNativePasskey` (separate PR) **and** the App-ID "Associated Domains" capability is enabled in the Apple portal.

## Rollout / Rollback

- Deployment strategy: **manual** — the landing site has no CI apply pipeline. After merge run `AWS_PROFILE=openbank openbank-infra/web/deploy.sh` (S3 sync + CloudFront invalidation).
- Rollback plan: delete the file and re-run `deploy.sh` (or revert this PR then deploy). Purely additive; removing it just reverts native passkeys to the 404 state.
- Data migration reversible: N/A

## Reviewer notes

- Verify after deploy: `curl -sI https://open-bank.tech/.well-known/apple-app-site-association` → `200` + `content-type: application/json`, and `curl -s …/apple-app-site-association | python3 -m json.tool`.
- `applinks` (Universal Links) deliberately **not** added here — that's a separate follow-up (OAuth-redirect hardening) needing its own app entitlement + routing.
