### PR TITLE
fix(infra): grant document-service Kafka Read ACL for account.created onboarding consumer

### DIFF
--- a/openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml
+++ b/openbank-infra/gitops/components/document-service/kafka-document-service-mtls.yaml
@@ -3,9 +3,12 @@
 # every deployed Kafka client needs an explicit KafkaUser + ACL before its first
 # deploy — same requirement notification-service/statement-service already meet).
 #
-# document-service is a pure PRODUCER: it publishes document lifecycle events to
-# openbank.documents.document.event via its outbox dispatcher (ADR-0161/ADR-0162).
-# It consumes nothing, so no consumer-group ACL is needed.
+# document-service PRODUCES document lifecycle events to
+# openbank.documents.document.event via its outbox dispatcher (ADR-0161/ADR-0162),
+# and CONSUMES openbank.accounts.account.created (group openbank-document-service,
+# ADR-0162 D7) to issue onboarding documents off the account-opening path (ADR-0086).
+# It therefore needs a Read/Describe ACL on that topic plus a consumer-group ACL,
+# mirroring balance-service, which consumes the same topic.
 #
 # Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one principal
 # for all of this service's Kafka traffic. These resources live in `messaging`
@@ -38,6 +41,19 @@ spec:
           name: openbank.documents.document.event
           patternType: literal
         operations: [Write, Describe]
+        host: "*"
+      # ADR-0162 D7: consume account.created to issue onboarding documents.
+      - resource:
+          type: topic
+          name: openbank.accounts.account.created
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: openbank-document-service
+          patternType: literal
+        operations: [Read]
         host: "*"
 ---
 # ── ExternalSecret: document-service keystore ─────────────────────────────────


### PR DESCRIPTION
## Summary
The `AccountCreatedConsumer` shipped in #1102 (ADR-0162 D7) consumes `openbank.accounts.account.created` (group `openbank-document-service`), but the document-service KafkaUser was still declared a **pure producer**. With fleet-wide `allow.everyone.if.no.acl.found=false` (ADR-0137), Kafka authorization denies the consumer and onboarding-document issuance silently never fires in-cluster.

## Type of change
- [x] fix (bug fix — missing infra ACL)

## Linked issues
Closes #1110

## Changes
- Add `Read, Describe` ACL on topic `openbank.accounts.account.created` and `Read` on consumer group `openbank-document-service` to the document-service KafkaUser, mirroring balance-service on the same topic.
- Correct the now-stale 'pure PRODUCER' header comment.

## Definition of Done
- [x] YAML validates (all documents parse).
- [ ] DB/API/event/OpenAPI — N/A (gitops ACL only; no service source change, no version bump).

## Security checklist
- [x] No secrets/PII. Grants the minimum Read scope the consumer needs; no broadened access.

## Rollout / Rollback
- ArgoCD syncs the KafkaUser; Strimzi User Operator updates the mTLS principal's ACL. Rollback: revert.
- Data migration reversible: N/A.