### PR TITLE
fix(infra): declare document-service OpenBao client-pki egress dependency in gitops env

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -91,6 +91,12 @@ spec:
             # every account.created event. Same in-cluster address billing-service already uses.
             - name: PRODUCT_CATALOG_SERVICE_URL
               value: http://product-catalog.accounts.svc:8104
+            # ADR-0162 D4 (continued): OpenBao pki-document-signing engine address for the client
+            # electronic-signature adapter (OpenBaoClientSignatureAdapter). Declaring it here (rather
+            # than relying only on the @ConfigProperty code default) is what makes gen-network-policies.py
+            # emit the documents -> vault egress edge (ADR-0081) — a code-only default is invisible to it.
+            - name: OPENBANK_SIGNATURE_CLIENT_PKI_BAO_ADDR
+              value: http://openbao.vault.svc:8200
             # ADR-0162 D4 (continued): the bank's stable institutional PAdES-sealing identity,
             # projected from OpenBao KV via es-document-service-signing-keystore.yaml. Absent =
             # PdfBoxPadesSealAdapter falls back to a DEV-ONLY ephemeral cert (loud warning, never


### PR DESCRIPTION
## Summary
Declares the OpenBao `pki-document-signing` address (`OpenBaoClientSignatureAdapter`, ADR-0162 D4) as a gitops Deployment env var, so `gen-network-policies.py` (ADR-0081) can see the `documents → vault` edge — a Kotlin `@ConfigProperty` code default is invisible to it.

## Type of change
- [x] fix (infra hygiene / ADR-0081 dependency declaration)

## Linked issues
Closes #1111

## Changes
- Add `OPENBANK_SIGNATURE_CLIENT_PKI_BAO_ADDR=http://openbao.vault.svc:8200` (same value the code default already uses → runtime behaviour unchanged), consistent with `SCA_SERVICE_URL` / `PRODUCT_CATALOG_SERVICE_URL`.

## Scope correction (honest framing)
The issue posited that a NetworkPolicy *blocks* OpenBao egress. On investigation that premise does **not** hold today: `gen-network-policies.py` emits **no** egress NetworkPolicy for the `documents` namespace (verified — a clean baseline generator run produces no documents policy, and adding this edge still produces none). So nothing currently blocks the OpenBao call; the fail-open fallback in the adapter would trigger only from an *unreachable* OpenBao, not from an NP. This change is therefore **dependency-declaration hygiene + future-proofing** (the edge is declared before any NP coverage lands), not an active-outage fix.

## Definition of Done
- [x] gen-network-policies.py drift gate passes (regenerate → no diff).
- [ ] DB/API/event/version — N/A (gitops env only; value equals the existing code default).

## Security checklist
- [x] No secrets/PII. `openbao.vault.svc:8200` is a standard in-cluster service DNS name.

## Rollout / Rollback
- No runtime change (env value == prior code default). Rollback: revert.