### PR TITLE
fix(document-service): poison-pill onboarding consumer + validate decision before signing

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
@@ -69,18 +69,22 @@ class SignatureCeremonyService(
         evidenceRef: String?,
     ): SignatureCeremony {
         val ceremony = ceremonyRepo.findById(ceremonyId) ?: error("Ceremony not found: $ceremonyId")
+        val now = Instant.now(clock)
+        // Validate the decision in the domain FIRST — signer order, not-already-decided, ceremony
+        // status — before any object-store mutation. A rejected decision (wrong signer order, a
+        // replayed duplicate, an already-terminal ceremony) must never leave a phantom client
+        // signature on the stored document, which it would if signing ran before this check.
+        val updated = ceremony.recordDecision(partyRef, decision, now)
         if (decision == SignerStatus.SIGNED) {
             val verified = evidenceRef != null && signerVerificationPort.verify(partyRef, evidenceRef)
             if (!verified) {
                 error("SCA verification failed for signer $partyRef on ceremony $ceremonyId")
             }
-            // Apply this signer's own one-time electronic signature BEFORE persisting the SIGNED
-            // decision: a decision must never be recorded as SIGNED without a corresponding
-            // signature actually landing on the document.
+            // Apply this signer's own one-time electronic signature only after the decision is
+            // validated and SCA-verified, and before persisting: a decision is never recorded as
+            // SIGNED without a corresponding signature actually landing on the document.
             signAsClient(ceremony, partyRef)
         }
-        val now = Instant.now(clock)
-        val updated = ceremony.recordDecision(partyRef, decision, now)
         if (updated.status != CeremonyStatus.COMPLETED) {
             return ceremonyRepo.save(updated)
         }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumer.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumer.kt
@@ -55,9 +55,24 @@ class AccountCreatedConsumer(
             return
         }
 
-        onboardingUseCase.issueOnboardingDocument(
-            IssueOnboardingDocumentCommand(accountId = accountId, partyRef = partyId.toString(), productId = productId),
-        )
+        try {
+            onboardingUseCase.issueOnboardingDocument(
+                IssueOnboardingDocumentCommand(
+                    accountId = accountId,
+                    partyRef = partyId.toString(),
+                    productId = productId,
+                ),
+            )
+        } catch (e: Exception) {
+            // Poison-pill safety: onboarding is best-effort and off the money path (ADR-0086), so a
+            // deterministic downstream failure for ONE account (e.g. a documentTemplateCode with no
+            // PUBLISHED template) must not throw out of the stream and, under smallrye-kafka's default
+            // fail-strategy, wedge onboarding for EVERY subsequent account. Log and ack; a missed
+            // onboarding document is re-triggerable, not a money error. This deliberately trades
+            // at-least-once retry on a transient error for consumer liveness — a bounded retry / DLQ
+            // is a possible follow-up if transient-loss ever proves material.
+            log.errorf(e, "Onboarding-document issuance failed for account %s; skipping (event acked).", accountId)
+        }
     }
 
     private companion object {

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
@@ -133,6 +133,22 @@ class SignatureCeremonyServiceTest {
         coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
     }
 
+    @Test
+    fun `an out-of-order SIGNED decision is rejected before any client signature is applied`(): Unit = runBlocking {
+        // party-2 (order 2) tries to sign before party-1: the domain rejects it, and because
+        // validation now runs BEFORE signing, no phantom signature is written (nor is SCA even
+        // consulted). On the pre-fix ordering this same call signed the document, then threw.
+        val ceremony = ceremony(listOf(signer("party-1", order = 1), signer("party-2", order = 2)))
+        coEvery { ceremonyRepo.findById(ceremony.id) } returns ceremony
+
+        assertThatThrownBy {
+            runBlocking { service.recordDecision(ceremony.id, "party-2", SignerStatus.SIGNED, "evidence-2") }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { signerVerificationPort.verify(any(), any()) }
+    }
+
     private fun signer(partyRef: String, order: Int = 1) =
         Signer(partyRef = partyRef, order = order, status = SignerStatus.PENDING, signedAt = null)
 

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumerTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/kafka/AccountCreatedConsumerTest.kt
@@ -61,6 +61,21 @@ class AccountCreatedConsumerTest {
         coVerify(exactly = 0) { onboardingUseCase.issueOnboardingDocument(any()) }
     }
 
+    @Test
+    fun `swallows a downstream failure so one bad account never wedges the consumer`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val partyId = UUID.randomUUID()
+        val productId = UUID.randomUUID()
+        coEvery { onboardingUseCase.issueOnboardingDocument(any()) } throws
+            IllegalStateException("No published template for the product's documentTemplateCode")
+
+        // consume() must NOT propagate — a deterministic downstream failure for one account must not
+        // halt the stream (poison-pill safety). runBlocking would rethrow if consume() let it escape.
+        consumer.consume(accountCreatedPayload(accountId, partyId, productId))
+
+        coVerify(exactly = 1) { onboardingUseCase.issueOnboardingDocument(any()) }
+    }
+
     private fun accountCreatedPayload(accountId: UUID, partyId: UUID, productId: UUID) = """
         {"eventType":"AccountCreated","aggregateId":"$accountId","partyId":"$partyId","productId":"$productId","currency":"CZK"}
     """.trimIndent()


### PR DESCRIPTION
## Summary
Two robustness fixes to the e-signature/onboarding feature (#1102), from the #1112 review.

## Type of change
- [x] fix (bug fix)

## Linked issues
Refs #1112 (addresses 2 of the 3 items; idempotency-key work deliberately deferred — see below)

## Changes
- **Poison-pill** — `AccountCreatedConsumer` wraps the delegated `issueOnboardingDocument` call: a deterministic downstream failure for one account (e.g. a `documentTemplateCode` with no PUBLISHED template) is logged + acked instead of throwing out of the stream, where smallrye-kafka's default fail-strategy would halt the consumer and wedge onboarding for **every** subsequent account. Restores the poison-pill safety the KDoc already claimed.
- **Validate-before-sign** — `SignatureCeremonyService.recordDecision` runs the domain validation (signer order / not-already-decided / ceremony status) **before** applying the client signature. Previously `signAsClient` mutated the stored PDF before that check, so a rejected decision (wrong order, replayed duplicate, terminal ceremony) left a **phantom** client signature on the finalized document. Now an invalid decision throws before any object-store write; SCA + signing run only after the domain accepts it.

## Tests
- `AccountCreatedConsumerTest`: a throwing `issueOnboardingDocument` does not propagate out of `consume()`.
- `SignatureCeremonyServiceTest`: an out-of-order SIGNED decision is rejected before any client signature (or SCA) is invoked. Both fail on the pre-fix ordering.

## Deliberately deferred (Refs #1112)
- The object-store write is still not atomic with the ceremony persist → a persist failure **after** a valid sign can double-sign on retry (narrow transient window).
- Onboarding idempotency remains a check-then-act `listByParty` scan. A proper data-layer idempotency key needs a document-identity decision first: `case_ref` is a **general, non-onboarding-specific** column, so a blanket unique constraint would break other document flows. Left as a scoped follow-up rather than rushing a risky migration.

## Definition of Done
- [x] Hexagonal layering preserved.
- [x] Unit tests added.
- [x] `detekt ktlintCheck test quarkusBuild` pass locally (JDK 25): 63 tests, 0 failures.
- [ ] OpenAPI / Flyway / Avro — N/A (no API/DB/event change).

## Security checklist
- [x] No secrets/PII. `@Suppress("TooGenericExceptionCaught")` on the consumer is justified in-code (poison-pill). Auth/crypto-adjacent (signature ceremony) → please apply `security-review-required`.

## Rollout / Rollback
- Rolling; no schema/event/API change. Rollback: revert.