### PR TITLE
fix(control-liveness-sentinel): boot crash on unmapped config keys

### DIFF
--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/GitHubProposalAdapter.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/GitHubProposalAdapter.kt
@@ -32,7 +32,7 @@ import java.util.Base64
  * writes code to a service or merges (charter: write_proposal=github-pr; gh.pr.merge denied,
  * ADR-0031).
  *
- * Auth is a fine-grained token (openbank.liveness-sentinel.github.token ← LIVENESS_GITHUB_TOKEN)
+ * Auth is a fine-grained token (liveness.github.token ← LIVENESS_GITHUB_TOKEN)
  * read via an OPTIONAL lookup, so an un-seeded token degrades to a descriptive placeholder rather
  * than CrashLooping or breaking the workflow. Any API failure degrades the same way — the finding
  * itself is not lost, only the GitHub side-effect.
@@ -45,9 +45,14 @@ class GitHubProposalAdapter(private val config: LivenessSentinelConfig) : GitHub
 
     private val log = Logger.getLogger(GitHubProposalAdapter::class.java)
 
+    // Deliberately OUTSIDE the openbank.liveness-sentinel prefix LivenessSentinelConfig's strict
+    // @ConfigMapping owns — a key nested under that prefix with no matching interface property
+    // fails boot with SRCFG00050 ("does not map to any root"), which crash-looped this pod on
+    // first real deploy. "liveness.github.token" resolves via SmallRye's env-var relaxed matching
+    // straight from LIVENESS_GITHUB_TOKEN, no application.yaml entry needed.
     private val token: String
         get() = ConfigProvider.getConfig()
-            .getOptionalValue("openbank.liveness-sentinel.github.token", String::class.java).orElse("")
+            .getOptionalValue("liveness.github.token", String::class.java).orElse("")
 
     private val http: HttpClient by lazy {
         HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S)).build()
@@ -57,10 +62,10 @@ class GitHubProposalAdapter(private val config: LivenessSentinelConfig) : GitHub
     override suspend fun openTicket(finding: LivenessFinding, diagnosis: String): String {
         if (token.isBlank()) {
             log.warn(
-                "openbank.liveness-sentinel.github.token (env LIVENESS_GITHUB_TOKEN) not seeded — " +
+                "liveness.github.token (env LIVENESS_GITHUB_TOKEN) not seeded — " +
                     "no ticket opened (degraded)",
             )
-            return "not opened: openbank.liveness-sentinel.github.token not seeded"
+            return "not opened: liveness.github.token not seeded"
         }
         return try {
             withContext(Dispatchers.IO) {
@@ -85,10 +90,10 @@ class GitHubProposalAdapter(private val config: LivenessSentinelConfig) : GitHub
     override suspend fun openProposalPr(finding: LivenessFinding, fixDiff: String): String {
         if (token.isBlank()) {
             log.warn(
-                "openbank.liveness-sentinel.github.token (env LIVENESS_GITHUB_TOKEN) not seeded — " +
+                "liveness.github.token (env LIVENESS_GITHUB_TOKEN) not seeded — " +
                     "no proposal PR opened (degraded)",
             )
-            return "not opened: openbank.liveness-sentinel.github.token not seeded"
+            return "not opened: liveness.github.token not seeded"
         }
         val shortId = finding.id.take(SHORT_ID_LEN)
         val branch = "control-liveness-sentinel/proposal-$shortId"

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/adapter/LlmDiagnosisAdapter.kt
@@ -43,10 +43,15 @@ class LlmDiagnosisAdapter(private val config: LivenessSentinelConfig) : LlmDiagn
     private val log = Logger.getLogger(LlmDiagnosisAdapter::class.java)
 
     // OPTIONAL (not @ConfigProperty-injected): an un-seeded key must not fail config load at boot.
-    // Mirrors DevOpsConfig / OpenAiCompatibleModelProvider exactly (issue #1084 precedent).
+    // Deliberately OUTSIDE the openbank.liveness-sentinel prefix LivenessSentinelConfig's strict
+    // @ConfigMapping owns — a key nested under that prefix with no matching interface property
+    // fails boot with SRCFG00050 ("does not map to any root"), which crash-looped this pod on
+    // first real deploy. "liveness.model.api-key" resolves via SmallRye's env-var relaxed matching
+    // straight from LIVENESS_MODEL_API_KEY, no application.yaml entry needed — mirrors
+    // DevOpsConfig / OpenAiCompatibleModelProvider's short, unmapped lookup key exactly.
     private val apiKey: String
         get() = ConfigProvider.getConfig()
-            .getOptionalValue("openbank.liveness-sentinel.model.api-key", String::class.java).orElse("")
+            .getOptionalValue("liveness.model.api-key", String::class.java).orElse("")
 
     private val http: HttpClient by lazy {
         HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_S)).build()
@@ -56,7 +61,7 @@ class LlmDiagnosisAdapter(private val config: LivenessSentinelConfig) : LlmDiagn
     override suspend fun diagnose(finding: LivenessFinding, contextMetrics: Map<String, Double>): String {
         if (apiKey.isBlank()) {
             log.warn(
-                "openbank.liveness-sentinel.model.api-key not seeded — returning placeholder diagnosis (degraded)",
+                "liveness.model.api-key not seeded — returning placeholder diagnosis (degraded)",
             )
             return "Automated diagnosis unavailable (model API key not seeded). Finding: ${finding.title}. " +
                 "Affected control: ${finding.affectedControl}."

--- a/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LivenessSentinelConfig.kt
+++ b/openbank-control-liveness-sentinel/src/main/kotlin/com/openbank/liveness/infrastructure/config/LivenessSentinelConfig.kt
@@ -25,7 +25,7 @@ interface LivenessSentinelConfig {
      * NOT the "litellm.ai-platform" gateway every sibling agent's charter names: that in-cluster
      * gateway is aspirational (ADR-0031 D6) and is not actually deployed anywhere in this repo's
      * gitops (verified: no LiteLLM Deployment/Service manifest exists, only policy-comment mentions).
-     * The API key is read separately via an OPTIONAL lookup (openbank.liveness-sentinel.model.api-key)
+     * The API key is read separately via an OPTIONAL lookup (liveness.model.api-key)
      * so an un-seeded key degrades the diagnosis call instead of CrashLooping the pod at boot
      * (SmallRye SRCFG00040 on an empty String bind) — mirrors devops-agent's DevOpsConfig exactly.
      */
@@ -38,7 +38,7 @@ interface LivenessSentinelConfig {
 
     /**
      * GitHub for opening tracking tickets / rare mechanical-fix PRs. The token is read separately via
-     * an OPTIONAL lookup (openbank.liveness-sentinel.github.token) so an un-seeded token degrades to
+     * an OPTIONAL lookup (liveness.github.token) so an un-seeded token degrades to
      * "no ticket/PR opened" rather than CrashLooping — mirrors devops-agent's RemediationProposalAdapter.
      */
     @WithDefault("https://api.github.com")

--- a/openbank-control-liveness-sentinel/src/main/resources/application.yaml
+++ b/openbank-control-liveness-sentinel/src/main/resources/application.yaml
@@ -74,18 +74,13 @@ openbank:
     alertmanager-url: ${ALERTMANAGER_URL:http://alertmanager-operated.observability:9093}
     # OpenAI-compatible model backend — DeepInfra, the same provider devops-agent (ADR-0119) and
     # the customer copilot (ADR-0089) already run against; "litellm.ai-platform" is not deployed
-    # anywhere in this repo's gitops (ADR-0163 E2E-wiring note). model.api-key is read separately
-    # (OPTIONAL lookup) so an un-seeded key degrades diagnosis instead of CrashLooping.
+    # anywhere in this repo's gitops (ADR-0163 E2E-wiring note).
     model-endpoint: ${LIVENESS_MODEL_ENDPOINT:https://api.deepinfra.com/v1/openai}
     model-id: ${LIVENESS_MODEL_ID:deepseek-ai/DeepSeek-V3.2}
-    model:
-      api-key: ${LIVENESS_MODEL_API_KEY:}
     github-api-url: ${LIVENESS_GITHUB_API_URL:https://api.github.com}
     github-owner: ${LIVENESS_GITHUB_OWNER:JiRaska}
     github-repo: ${LIVENESS_GITHUB_REPO:open-bank-oss}
     github-proposal-dir: ${LIVENESS_GITHUB_PROPOSAL_DIR:docs/liveness-sentinel-proposals}
-    github:
-      token: ${LIVENESS_GITHUB_TOKEN:}
     # 2x expected interval == the same paging threshold ADR-0160 mechanism 3 defines, so this
     # agent's CRITICAL finding can never silently disagree with the Alertmanager rule.
     stale-heartbeat-multiplier: ${STALE_HEARTBEAT_MULTIPLIER:2.0}


### PR DESCRIPTION
## Summary

control-liveness-sentinel's first-ever real deploy (after PR #1087/#1091 and manual ECR/auto-deploy fleet fixes) crash-looped with:

```
SRCFG00050: openbank.liveness-sentinel.model.api-key ... does not map to any root
SRCFG00050: openbank.liveness-sentinel.github.token ... does not map to any root
```

`application.yaml` declared `model.api-key`/`github.token` under the same `openbank.liveness-sentinel` prefix `LivenessSentinelConfig`'s strict `@ConfigMapping` owns. SmallRye validates every YAML key under a mapped prefix against the interface's declared properties — neither key is declared there (both are intentionally read via a raw `ConfigProvider.getOptionalValue()` lookup, not `@ConfigMapping`, so an un-seeded value degrades instead of crashing at boot) — so the strict-unknown-keys check rejects the whole config at startup.

`quarkusBuild` did not catch this — it only surfaced running the actual packaged jar.

## Type of change

- [x] fix (bug fix)

## Linked issues

N/A — direct follow-up to PR #1087's first live deploy attempt; no tracking issue opened.

## Changes

- `LlmDiagnosisAdapter`/`GitHubProposalAdapter`: lookup key changed to `liveness.model.api-key` / `liveness.github.token` — outside the `openbank.liveness-sentinel` `@ConfigMapping` prefix, same short-unmapped-key pattern devops-agent's `DevOpsConfig` already uses.
- `application.yaml`: removed the now-unnecessary `model: {api-key: ...}` / `github: {token: ...}` entries — SmallRye's env-var relaxed matching resolves the new keys straight from `LIVENESS_MODEL_API_KEY` / `LIVENESS_GITHUB_TOKEN` (already wired in the Deployment/ExternalSecret from PR #1087) with no YAML declaration at all.
- Updated docstrings/log messages referencing the old key path.

## Definition of Done

- [x] `ktlintCheck` / `detekt` / `test` / `quarkusBuild` all pass
- [x] Verified by actually **running** the packaged jar (`java -jar quarkus-run.jar`), not just building it — boots clean in 1.4s, no SRCFG00050

Refs ADR-0163, PR #1087, PR #1091.