### PR TITLE
fix(document-service): data-level idempotency + resumability for onboarding issuance

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/in/DocumentUseCases.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/in/DocumentUseCases.kt
@@ -39,6 +39,9 @@ data class RenderDocumentCommand(
     val caseRef: String?,
     val productRef: String?,
     val retainUntil: LocalDate?,
+    // Onboarding sets this ("onboarding:<accountId>") to make issuance idempotent under at-least-once
+    // redelivery (ADR-0162 D7); ad-hoc REST renders leave it null. See [Document.idempotencyKey].
+    val idempotencyKey: String? = null,
 )
 
 data class OpenCeremonyCommand(
@@ -80,11 +83,17 @@ interface DocumentQueryUseCase {
 
     /** Documents for a party/case — lets the compliance/legal persona browse, not just look up by id. */
     suspend fun listByParty(partyRef: String): List<Document>
+
+    /** The document previously issued under [key] (e.g. onboarding idempotency key), or null. */
+    suspend fun findByIdempotencyKey(key: String): Document?
 }
 
 /** Opens signing ceremonies and records signer decisions. */
 interface SignatureCeremonyUseCase {
     suspend fun openCeremony(cmd: OpenCeremonyCommand): SignatureCeremony
+
+    /** The ceremony over [documentId] if one exists (resumable onboarding: open one only if absent). */
+    suspend fun findByDocumentId(documentId: UUID): SignatureCeremony?
 
     /**
      * [evidenceRef] is the SCA challenge/approval reference (ADR-0021) proving the signer's

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
@@ -18,6 +18,22 @@ import java.util.UUID
  */
 class TemplatePublishConflictException(message: String) : RuntimeException(message)
 
+/**
+ * A document with the same idempotency key already exists — a concurrent onboarding delivery lost
+ * the insert race (Postgres unique-violation on `uq_documents_idempotency_key`, translated at the
+ * persistence boundary so the application layer never depends on a framework/SQL exception type,
+ * ADR-0002). Extends [IllegalStateException] so the shared runtime maps an *uncaught* one to 422;
+ * onboarding catches it and resolves to the winning document (idempotent).
+ */
+class DuplicateDocumentException(message: String) : IllegalStateException(message)
+
+/**
+ * A non-terminal ceremony already exists for the document — a concurrent open lost the race
+ * (unique-violation on `uq_signature_ceremonies_active_document`). Same boundary-translation and
+ * 422-mapping rationale as [DuplicateDocumentException].
+ */
+class DuplicateCeremonyException(message: String) : IllegalStateException(message)
+
 /** Persistence port for the [DocumentTemplate] aggregate. */
 interface TemplateRepositoryPort {
     suspend fun save(template: DocumentTemplate): DocumentTemplate
@@ -57,16 +73,32 @@ interface TemplateRepositoryPort {
 /** Persistence port for the [Document] aggregate, including transactional-outbox co-persistence. */
 interface DocumentRepositoryPort {
     suspend fun save(document: Document): Document
+
+    /**
+     * Persists [document] with its outbox event in one transaction. Throws [DuplicateDocumentException]
+     * if [Document.idempotencyKey] collides with an existing row (a lost onboarding-redelivery race).
+     */
     suspend fun saveWithOutbox(document: Document, outboxMessage: OutboxMessage): Document
     suspend fun findById(id: UUID): Document?
     suspend fun findByParty(partyRef: String): List<Document>
+
+    /** The document persisted under [idempotencyKey], or null — an O(1) index lookup, not a scan. */
+    suspend fun findByIdempotencyKey(idempotencyKey: String): Document?
 }
 
 /** Persistence port for the [SignatureCeremony] aggregate. */
 interface CeremonyRepositoryPort {
+    /**
+     * Inserts a new ceremony or updates an existing one (optimistic-locked). Throws
+     * [DuplicateCeremonyException] if a non-terminal ceremony already exists for the same document
+     * (a lost open race), and [IllegalStateException] on an optimistic-lock conflict.
+     */
     suspend fun save(ceremony: SignatureCeremony): SignatureCeremony
     suspend fun saveWithOutbox(ceremony: SignatureCeremony, outboxMessage: OutboxMessage): SignatureCeremony
     suspend fun findById(id: UUID): SignatureCeremony?
+
+    /** The (non-terminal-or-not) ceremony over [documentId], or null. */
+    suspend fun findByDocumentId(documentId: UUID): SignatureCeremony?
 }
 
 /**

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentQueryService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentQueryService.kt
@@ -40,4 +40,6 @@ class DocumentQueryService(
     }
 
     override suspend fun listByParty(partyRef: String): List<Document> = documentRepo.findByParty(partyRef)
+
+    override suspend fun findByIdempotencyKey(key: String): Document? = documentRepo.findByIdempotencyKey(key)
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentRenderService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/DocumentRenderService.kt
@@ -79,6 +79,7 @@ class DocumentRenderService(
             productRef = cmd.productRef,
             retainUntil = cmd.retainUntil,
             createdAt = now,
+            idempotencyKey = cmd.idempotencyKey,
         )
 
         val outboxMessage = OutboxMessage(

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
@@ -11,16 +11,31 @@ import com.openbank.document.application.port.`in`.OnboardingDocumentUseCase
 import com.openbank.document.application.port.`in`.OpenCeremonyCommand
 import com.openbank.document.application.port.`in`.RenderDocumentCommand
 import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
+import com.openbank.document.application.port.out.DuplicateCeremonyException
+import com.openbank.document.application.port.out.DuplicateDocumentException
 import com.openbank.document.application.port.out.ProductCatalogPort
+import com.openbank.document.domain.model.Document
 import com.openbank.document.domain.model.SignatureLevel
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.util.UUID
 
 /**
- * Wires templating + e-signature into account onboarding (ADR-0162 D7): consuming
- * `account.created` is what actually exercises the version-resolution policy
- * (`RenderDocumentCommand.templateVersion = null` — always the current PUBLISHED version) and
- * product-catalog's `documentTemplateCode` reference end to end, for the first time.
+ * Wires templating + e-signature into account onboarding (ADR-0162 D7): consuming `account.created`
+ * exercises the version-resolution policy (`RenderDocumentCommand.templateVersion = null` — always
+ * the current PUBLISHED version) and product-catalog's `documentTemplateCode` reference end to end.
+ *
+ * **Idempotent and resumable** under at-least-once Kafka delivery. The operation has two persisted
+ * effects — render the document, then open its ceremony — and neither may be duplicated nor half-
+ * applied by a replay:
+ *  - the document carries an [Document.idempotencyKey] backed by a partial unique index, so a
+ *    concurrent double-delivery renders at most one onboarding contract per account (the loser
+ *    catches [DuplicateDocumentException] and reuses the winner's document);
+ *  - the ceremony is opened only if one does not already exist for the document, and a partial
+ *    unique index on the document's active ceremony makes a concurrent open a caught
+ *    [DuplicateCeremonyException]. Because step 2 keys on the document (not on step 1 having just
+ *    run), a crash *between* render and open-ceremony self-heals on the next delivery: the document
+ *    is found, and its missing ceremony is opened.
  */
 @ApplicationScoped
 class OnboardingDocumentService(
@@ -33,15 +48,26 @@ class OnboardingDocumentService(
     private val log = Logger.getLogger(OnboardingDocumentService::class.java)
 
     override suspend fun issueOnboardingDocument(cmd: IssueOnboardingDocumentCommand) {
-        val caseRef = cmd.accountId.toString()
-        // Idempotent: at-least-once Kafka delivery / a replayed event must not render (and open a
-        // ceremony for) the same account's onboarding contract twice.
-        val alreadyIssued = documentQueryUseCase.listByParty(cmd.partyRef).any { it.caseRef == caseRef }
-        if (alreadyIssued) {
-            log.infof("Onboarding document already issued for account %s — skipping.", cmd.accountId)
-            return
-        }
+        val idempotencyKey = onboardingKey(cmd.accountId)
 
+        // 1. Resolve the onboarding document idempotently: reuse the one already issued for this
+        //    account on replay (an O(1) index lookup), otherwise render a new one.
+        val document = documentQueryUseCase.findByIdempotencyKey(idempotencyKey)
+            ?: renderOnboardingDocument(cmd, idempotencyKey)
+            ?: return
+
+        // 2. Ensure exactly one ceremony exists for the document (resumable + race-safe).
+        ensureCeremony(cmd, document.id)
+    }
+
+    // SwallowedException: the DuplicateDocumentException type itself IS the "a concurrent delivery
+    // already rendered this" signal — caught to resolve to the winning document (idempotent), not an
+    // error to rethrow.
+    @Suppress("SwallowedException")
+    private suspend fun renderOnboardingDocument(
+        cmd: IssueOnboardingDocumentCommand,
+        idempotencyKey: String,
+    ): Document? {
         val templateCode = productCatalogPort.findDocumentTemplateCode(cmd.productId)
         if (templateCode == null) {
             log.infof(
@@ -49,34 +75,55 @@ class OnboardingDocumentService(
                 cmd.productId,
                 cmd.accountId,
             )
-            return
+            return null
         }
+        return try {
+            renderUseCase.render(
+                RenderDocumentCommand(
+                    templateCode = templateCode,
+                    templateVersion = null,
+                    data = emptyMap(),
+                    contentType = "application/pdf",
+                    partyRef = cmd.partyRef,
+                    caseRef = cmd.accountId.toString(),
+                    productRef = cmd.productId.toString(),
+                    retainUntil = null,
+                    idempotencyKey = idempotencyKey,
+                ),
+            )
+        } catch (e: DuplicateDocumentException) {
+            // A concurrent delivery won the insert race — reuse its document (idempotent).
+            log.infof(
+                "Onboarding document already issued for account %s (concurrent delivery) — reusing.",
+                cmd.accountId,
+            )
+            documentQueryUseCase.findByIdempotencyKey(idempotencyKey)
+        }
+    }
 
-        val document = renderUseCase.render(
-            RenderDocumentCommand(
-                templateCode = templateCode,
-                templateVersion = null,
-                data = emptyMap(),
-                contentType = "application/pdf",
-                partyRef = cmd.partyRef,
-                caseRef = caseRef,
-                productRef = cmd.productId.toString(),
-                retainUntil = null,
-            ),
-        )
+    // SwallowedException: the DuplicateCeremonyException type itself IS the "a concurrent delivery
+    // already opened the ceremony" signal — idempotent no-op, not an error to rethrow.
+    @Suppress("SwallowedException")
+    private suspend fun ensureCeremony(cmd: IssueOnboardingDocumentCommand, documentId: UUID) {
+        if (ceremonyUseCase.findByDocumentId(documentId) != null) return
+        try {
+            ceremonyUseCase.openCeremony(
+                OpenCeremonyCommand(
+                    documentId = documentId,
+                    signerPartyRefs = listOf(cmd.partyRef),
+                    signatureLevel = SignatureLevel.ADVANCED,
+                ),
+            )
+            log.infof("Issued onboarding document %s + ceremony for account %s.", documentId, cmd.accountId)
+        } catch (e: DuplicateCeremonyException) {
+            // A concurrent replay opened the ceremony first — idempotent, nothing to do.
+            log.infof("Onboarding ceremony already open for account %s (concurrent delivery).", cmd.accountId)
+        }
+    }
 
-        ceremonyUseCase.openCeremony(
-            OpenCeremonyCommand(
-                documentId = document.id,
-                signerPartyRefs = listOf(cmd.partyRef),
-                signatureLevel = SignatureLevel.ADVANCED,
-            ),
-        )
-        log.infof(
-            "Issued onboarding document %s + ceremony for account %s (template %s)",
-            document.id,
-            cmd.accountId,
-            templateCode,
-        )
+    private fun onboardingKey(accountId: UUID) = "$ONBOARDING_KEY_PREFIX$accountId"
+
+    private companion object {
+        const val ONBOARDING_KEY_PREFIX = "onboarding:"
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
@@ -110,6 +110,9 @@ class SignatureCeremonyService(
 
     override suspend fun getCeremony(id: UUID): SignatureCeremony? = ceremonyRepo.findById(id)
 
+    override suspend fun findByDocumentId(documentId: UUID): SignatureCeremony? =
+        ceremonyRepo.findByDocumentId(documentId)
+
     private suspend fun signAsClient(ceremony: SignatureCeremony, partyRef: String) {
         val document = documentRepo.findById(ceremony.documentId)
             ?: error("Cannot sign ceremony ${ceremony.id}: document ${ceremony.documentId} not found")

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/domain/model/Document.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/domain/model/Document.kt
@@ -32,6 +32,10 @@ data class Document(
     val productRef: String?,
     val retainUntil: LocalDate?,
     val createdAt: Instant,
+    // Onboarding-specific idempotency key ("onboarding:<accountId>"), null for every other document
+    // type. Backed by a partial unique index (V6) so at-least-once event redelivery cannot render a
+    // second onboarding contract for the same account (ADR-0162 D7). Not part of the content address.
+    val idempotencyKey: String? = null,
 ) {
     fun markPendingSignature(): Document {
         require(status == DocumentStatus.GENERATED) { "Only GENERATED documents can enter signing" }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/DocumentEntity.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/entity/DocumentEntity.kt
@@ -54,6 +54,9 @@ class DocumentEntity {
     @field:Column(name = "product_ref")
     var productRef: String? = null
 
+    @field:Column(name = "idempotency_key")
+    var idempotencyKey: String? = null
+
     @field:Column(name = "retain_until")
     var retainUntil: LocalDate? = null
 

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/mapper/DocumentMappers.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/mapper/DocumentMappers.kt
@@ -59,6 +59,7 @@ fun DocumentEntity.toDomain(mapper: ObjectMapper) = Document(
     productRef = productRef,
     retainUntil = retainUntil,
     createdAt = createdAt,
+    idempotencyKey = idempotencyKey,
 )
 
 fun Document.toEntity(mapper: ObjectMapper) = DocumentEntity().also {
@@ -74,6 +75,7 @@ fun Document.toEntity(mapper: ObjectMapper) = DocumentEntity().also {
     it.partyRef = partyRef
     it.caseRef = caseRef
     it.productRef = productRef
+    it.idempotencyKey = idempotencyKey
     it.retainUntil = retainUntil
     it.createdAt = createdAt
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/CeremonyRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/CeremonyRepositoryImpl.kt
@@ -6,7 +6,9 @@ package com.openbank.document.infrastructure.persistence.repository
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.document.application.port.out.CeremonyRepositoryPort
+import com.openbank.document.application.port.out.DuplicateCeremonyException
 import com.openbank.document.domain.model.SignatureCeremony
+import com.openbank.document.infrastructure.persistence.PostgresConflicts
 import com.openbank.document.infrastructure.persistence.entity.SignatureCeremonyEntity
 import com.openbank.document.infrastructure.persistence.mapper.toDomain
 import com.openbank.document.infrastructure.persistence.mapper.toEntity
@@ -41,11 +43,26 @@ class CeremonyRepositoryImpl :
     override suspend fun save(ceremony: SignatureCeremony): SignatureCeremony = Panache.withTransaction {
         getSession().flatMap { s -> s.merge(ceremony.toEntity(objectMapper)) }
     }.onFailure(OptimisticLockException::class.java).transform { conflictException(ceremony.id) }
+        .onFailure().transform { e ->
+            // A second non-terminal ceremony for the same document lost the insert race
+            // (uq_signature_ceremonies_active_document). Translate at the boundary so the
+            // application layer catches a typed DuplicateCeremonyException (ADR-0002); any other
+            // failure — including the optimistic-lock IllegalStateException above — passes through.
+            if (PostgresConflicts.isUniqueViolation(e)) {
+                DuplicateCeremonyException("A non-terminal ceremony already exists for document ${ceremony.documentId}")
+            } else {
+                e
+            }
+        }
         .map { it.toDomain(objectMapper) }
         .awaitSuspending()
 
     override suspend fun findById(id: UUID): SignatureCeremony? =
         Panache.withSession { find("id", id).firstResult() }.awaitSuspending()?.toDomain(objectMapper)
+
+    override suspend fun findByDocumentId(documentId: UUID): SignatureCeremony? =
+        Panache.withSession { find("documentId", documentId).firstResult() }
+            .awaitSuspending()?.toDomain(objectMapper)
 
     override suspend fun saveWithOutbox(ceremony: SignatureCeremony, outboxMessage: OutboxMessage): SignatureCeremony =
         Panache.withTransaction {

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
@@ -6,7 +6,9 @@ package com.openbank.document.infrastructure.persistence.repository
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.document.application.port.out.DocumentRepositoryPort
+import com.openbank.document.application.port.out.DuplicateDocumentException
 import com.openbank.document.domain.model.Document
+import com.openbank.document.infrastructure.persistence.PostgresConflicts
 import com.openbank.document.infrastructure.persistence.entity.DocumentEntity
 import com.openbank.document.infrastructure.persistence.mapper.toDomain
 import com.openbank.document.infrastructure.persistence.mapper.toEntity
@@ -42,6 +44,10 @@ class DocumentRepositoryImpl :
         Panache.withSession { find("partyRef", partyRef).list() }
             .awaitSuspending().map { it.toDomain(objectMapper) }
 
+    override suspend fun findByIdempotencyKey(idempotencyKey: String): Document? =
+        Panache.withSession { find("idempotencyKey", idempotencyKey).firstResult() }
+            .awaitSuspending()?.toDomain(objectMapper)
+
     override suspend fun saveWithOutbox(document: Document, outboxMessage: OutboxMessage): Document =
         Panache.withTransaction {
             find("id", document.id).firstResult().flatMap { existing ->
@@ -53,6 +59,15 @@ class DocumentRepositoryImpl :
                         .chain { _ -> outboxRepo.persistInTransaction(outboxMessage) }
                         .replaceWith(document)
                 }
+            }
+        }.onFailure().transform { e ->
+            // Translate the idempotency-key unique-violation at the persistence boundary so the
+            // application layer catches a typed DuplicateDocumentException, never a raw SQL/Hibernate
+            // exception (ADR-0002). Any other failure passes through unchanged.
+            if (PostgresConflicts.isUniqueViolation(e)) {
+                DuplicateDocumentException("A document already exists for idempotency key ${document.idempotencyKey}")
+            } else {
+                e
             }
         }.awaitSuspending()
 

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
@@ -85,8 +85,14 @@ class OpenBaoClientSignatureAdapter(
         .build()
 
     override suspend fun signAsClient(pdf: ByteArray, partyRef: String): ByteArray = withContext(Dispatchers.IO) {
-        val identity = issueOneTimeIdentity(partyRef)
-        PadesSigning.applySignature(pdf, identity, partyRef, SIGNATURE_REASON)
+        // Idempotent: a retry after a persistence failure must not layer a second signature for a
+        // signer who has already signed this document.
+        if (PadesSigning.hasSignatureNamed(pdf, partyRef)) {
+            pdf
+        } else {
+            val identity = issueOneTimeIdentity(partyRef)
+            PadesSigning.applySignature(pdf, identity, partyRef, SIGNATURE_REASON)
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
@@ -99,6 +99,14 @@ object PadesSigning {
         )
     }
 
+    /**
+     * True if [pdf] already carries a PAdES signature whose `Name` is [name]. Lets a signing act be
+     * idempotent: a retry after a persistence failure must not layer a second identical signature for
+     * a signer (or the seal) that already signed this document (ADR-0162 D7 robustness).
+     */
+    fun hasSignatureNamed(pdf: ByteArray, name: String): Boolean =
+        Loader.loadPDF(pdf).use { document -> document.signatureDictionaries.any { it.name == name } }
+
     /** Appends one more PAdES signature (an incremental PDF update) using [identity]. */
     fun applySignature(pdf: ByteArray, identity: SigningIdentity, name: String, reason: String): ByteArray =
         Loader.loadPDF(pdf).use { document ->

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
@@ -91,7 +91,13 @@ class PdfBoxPadesSealAdapter(
 
     override suspend fun sealPades(pdf: ByteArray, ceremony: SignatureCeremony): ByteArray =
         withContext(Dispatchers.IO) {
-            PadesSigning.applySignature(pdf, identity, ORGANIZATION_NAME, SEAL_REASON)
+            // Idempotent: don't re-apply the institutional seal if a retry re-enters after the seal
+            // was already written but the ceremony's completion failed to persist.
+            if (PadesSigning.hasSignatureNamed(pdf, ORGANIZATION_NAME)) {
+                pdf
+            } else {
+                PadesSigning.applySignature(pdf, identity, ORGANIZATION_NAME, SEAL_REASON)
+            }
         }
 
     private fun loadFromKeystore(path: String, password: String): SigningIdentity {

--- a/openbank-document-service/src/main/resources/db/migration/V6__onboarding_idempotency.sql
+++ b/openbank-document-service/src/main/resources/db/migration/V6__onboarding_idempotency.sql
@@ -1,0 +1,27 @@
+-- ADR-0162 D7: make onboarding-document issuance idempotent + resumable at the data layer, so
+-- at-least-once Kafka redelivery (or a crash between rendering the document and opening its
+-- ceremony) can never produce a duplicate onboarding contract / duplicate ceremony, nor strand an
+-- account with a document but no signature ceremony. Replaces the previous check-then-act
+-- application scan (a TOCTOU race) with a real DB guarantee.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS uq_signature_ceremonies_active_document;
+--   DROP INDEX IF EXISTS uq_documents_idempotency_key;
+--   ALTER TABLE documents DROP COLUMN IF EXISTS idempotency_key;
+
+-- Onboarding-specific idempotency key ("onboarding:<accountId>"). NULL for every other document
+-- type (ad-hoc renders via the REST API), so the partial unique index below constrains ONLY
+-- onboarding documents and never the general case_ref column (which legitimately repeats across
+-- document types for one case).
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS idempotency_key VARCHAR(128);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_documents_idempotency_key
+    ON documents (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+-- At most one NON-TERMINAL ceremony per document: prevents two concurrent deliveries opening two
+-- ceremonies for the same onboarding document, while still allowing a fresh ceremony to be opened
+-- after a previous one reached a terminal DECLINED/EXPIRED state (a legitimate re-attempt).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_signature_ceremonies_active_document
+    ON signature_ceremonies (document_id)
+    WHERE status NOT IN ('DECLINED', 'EXPIRED');

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/OnboardingDocumentServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/OnboardingDocumentServiceTest.kt
@@ -10,6 +10,8 @@ import com.openbank.document.application.port.`in`.IssueOnboardingDocumentComman
 import com.openbank.document.application.port.`in`.OpenCeremonyCommand
 import com.openbank.document.application.port.`in`.RenderDocumentCommand
 import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
+import com.openbank.document.application.port.out.DuplicateCeremonyException
+import com.openbank.document.application.port.out.DuplicateDocumentException
 import com.openbank.document.application.port.out.ProductCatalogPort
 import com.openbank.document.domain.model.Document
 import com.openbank.document.domain.model.DocumentStatus
@@ -23,10 +25,10 @@ import java.time.Instant
 import java.util.UUID
 
 /**
- * ADR-0162 D7: the onboarding wiring exercises product-catalog's `documentTemplateCode` reference
- * and the render use-case's version-resolution policy (`templateVersion = null`) end to end for
- * the first time — this test pins that contract, plus the idempotency guarantee a Kafka consumer
- * calling this under at-least-once delivery relies on.
+ * ADR-0162 D7 onboarding wiring: idempotent + resumable under at-least-once Kafka delivery. The
+ * idempotency key is keyed on the account, the document is rendered at most once for it, and the
+ * ceremony is opened only if the document doesn't already have one (so a crash between the two
+ * effects self-heals on replay).
  */
 class OnboardingDocumentServiceTest {
 
@@ -40,13 +42,15 @@ class OnboardingDocumentServiceTest {
     private val accountId: UUID = UUID.randomUUID()
     private val productId: UUID = UUID.randomUUID()
     private val partyRef = "party-1"
+    private val idempotencyKey = "onboarding:$accountId"
 
     @Test
     fun `renders the product's bound template with no pinned version and opens a ceremony`(): Unit = runBlocking {
-        coEvery { documentQueryUseCase.listByParty(partyRef) } returns emptyList()
+        coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null
         coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
         val document = document()
         coEvery { renderUseCase.render(any()) } returns document
+        coEvery { ceremonyUseCase.findByDocumentId(document.id) } returns null
         coEvery { ceremonyUseCase.openCeremony(any()) } returns mockk()
 
         service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
@@ -62,6 +66,7 @@ class OnboardingDocumentServiceTest {
                     caseRef = accountId.toString(),
                     productRef = productId.toString(),
                     retainUntil = null,
+                    idempotencyKey = idempotencyKey,
                 ),
             )
         }
@@ -77,9 +82,37 @@ class OnboardingDocumentServiceTest {
     }
 
     @Test
-    fun `skips when this account already has an issued document (idempotent replay)`(): Unit = runBlocking {
-        val existing = document().copy(caseRef = accountId.toString())
-        coEvery { documentQueryUseCase.listByParty(partyRef) } returns listOf(existing)
+    fun `skips render and ceremony when this account is already fully onboarded (idempotent replay)`(): Unit =
+        runBlocking {
+            val existing = document()
+            coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns existing
+            coEvery { ceremonyUseCase.findByDocumentId(existing.id) } returns mockk()
+
+            service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
+
+            coVerify(exactly = 0) { renderUseCase.render(any()) }
+            coVerify(exactly = 0) { ceremonyUseCase.openCeremony(any()) }
+        }
+
+    @Test
+    fun `resumes by opening the ceremony when the document exists but has no ceremony yet`(): Unit = runBlocking {
+        // A crash landed the document but not its ceremony; the replay must NOT re-render, but MUST
+        // open the missing ceremony.
+        val existing = document()
+        coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns existing
+        coEvery { ceremonyUseCase.findByDocumentId(existing.id) } returns null
+        coEvery { ceremonyUseCase.openCeremony(any()) } returns mockk()
+
+        service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
+
+        coVerify(exactly = 0) { renderUseCase.render(any()) }
+        coVerify(exactly = 1) { ceremonyUseCase.openCeremony(any()) }
+    }
+
+    @Test
+    fun `does nothing when the product has no documentTemplateCode bound`(): Unit = runBlocking {
+        coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null
+        coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns null
 
         service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
 
@@ -88,14 +121,35 @@ class OnboardingDocumentServiceTest {
     }
 
     @Test
-    fun `does nothing when the product has no documentTemplateCode bound`(): Unit = runBlocking {
-        coEvery { documentQueryUseCase.listByParty(partyRef) } returns emptyList()
-        coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns null
+    fun `reuses the winning document when a concurrent delivery lost the render race`(): Unit = runBlocking {
+        val winner = document()
+        // First lookup misses; render loses the unique-key race; the retry lookup finds the winner.
+        coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null andThen winner
+        coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
+        coEvery { renderUseCase.render(any()) } throws DuplicateDocumentException("lost the race")
+        coEvery { ceremonyUseCase.findByDocumentId(winner.id) } returns null
+        coEvery { ceremonyUseCase.openCeremony(any()) } returns mockk()
 
         service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
 
-        coVerify(exactly = 0) { renderUseCase.render(any()) }
-        coVerify(exactly = 0) { ceremonyUseCase.openCeremony(any()) }
+        coVerify(exactly = 1) {
+            ceremonyUseCase.openCeremony(match { it.documentId == winner.id })
+        }
+    }
+
+    @Test
+    fun `tolerates a concurrent ceremony open (idempotent, no error propagates)`(): Unit = runBlocking {
+        val document = document()
+        coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null
+        coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
+        coEvery { renderUseCase.render(any()) } returns document
+        coEvery { ceremonyUseCase.findByDocumentId(document.id) } returns null
+        coEvery { ceremonyUseCase.openCeremony(any()) } throws DuplicateCeremonyException("lost the race")
+
+        // Must not throw — the concurrent winner already opened the ceremony.
+        service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
+
+        coVerify(exactly = 1) { ceremonyUseCase.openCeremony(any()) }
     }
 
     private fun document() = Document(
@@ -109,9 +163,10 @@ class OnboardingDocumentServiceTest {
         status = DocumentStatus.GENERATED,
         metadata = emptyMap(),
         partyRef = partyRef,
-        caseRef = null,
+        caseRef = accountId.toString(),
         productRef = productId.toString(),
         retainUntil = null,
         createdAt = Instant.parse("2026-01-15T10:15:30Z"),
+        idempotencyKey = idempotencyKey,
     )
 }

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/CeremonyRepositoryImplIT.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/CeremonyRepositoryImplIT.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.document.infrastructure.persistence.repository
 
+import com.openbank.document.application.port.out.DuplicateCeremonyException
 import com.openbank.document.domain.model.CeremonyStatus
 import com.openbank.document.domain.model.SignatureCeremony
 import com.openbank.document.domain.model.SignatureLevel
@@ -102,4 +103,27 @@ class CeremonyRepositoryImplIT {
         assertThat(reloaded).isNotNull
         assertThat(reloaded!!.signers).isEqualTo(ceremony.signers)
     }
+
+    @Test
+    fun `at most one active ceremony per document, but a new one is allowed after the prior goes terminal`(): Unit =
+        onVertxContext {
+            val documentId = UUID.randomUUID()
+            val first = repo.save(newCeremony().copy(documentId = documentId))
+
+            // A second ACTIVE ceremony for the same document is rejected by the partial unique index.
+            val rejected = try {
+                repo.save(newCeremony().copy(documentId = documentId))
+                null
+            } catch (e: DuplicateCeremonyException) {
+                e
+            }
+            assertThat(rejected).isNotNull
+            assertThat(repo.findByDocumentId(documentId)!!.id).isEqualTo(first.id)
+
+            // Once the first ceremony reaches a terminal DECLINED state it leaves the active index,
+            // so a fresh ceremony for the same document IS allowed (a legitimate re-attempt).
+            repo.save(repo.findById(first.id)!!.copy(status = CeremonyStatus.DECLINED))
+            val retry = repo.save(newCeremony().copy(documentId = documentId))
+            assertThat(retry.id).isNotEqualTo(first.id)
+        }
 }

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImplIT.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImplIT.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.persistence.repository
+
+import com.openbank.document.application.port.out.DuplicateDocumentException
+import com.openbank.document.domain.model.Document
+import com.openbank.document.domain.model.DocumentStatus
+import com.openbank.document.it.PostgresRedisTestResource
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Data-level idempotency for onboarding-document issuance (ADR-0162 D7): the partial unique index on
+ * `documents.idempotency_key` (V6) is the backstop that turns a concurrent/at-least-once double
+ * delivery into a caught [DuplicateDocumentException] instead of a duplicate contract — behaviour a
+ * mocked repository cannot exercise, so this needs a real Postgres (Testcontainers).
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class DocumentRepositoryImplIT {
+
+    @Inject
+    lateinit var repo: DocumentRepositoryImpl
+
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    private fun onboardingDoc(idempotencyKey: String, id: UUID = Ids.newId()) = Document(
+        id = id,
+        templateCode = "UCET_SMLOUVA_CS",
+        templateVersion = "1.0.0",
+        sha256 = "a".repeat(64),
+        storageKey = "documents/$id",
+        contentType = "application/pdf",
+        sizeBytes = 10,
+        status = DocumentStatus.GENERATED,
+        metadata = emptyMap(),
+        partyRef = "party-1",
+        caseRef = "acc-1",
+        productRef = "prod-1",
+        retainUntil = null,
+        createdAt = Instant.now(),
+        idempotencyKey = idempotencyKey,
+    )
+
+    private fun outbox(aggregateId: UUID) =
+        OutboxMessage(aggregateId = aggregateId, eventType = "document.generated.v1", payload = "{}")
+
+    @Test
+    fun `findByIdempotencyKey returns the document persisted under that key`(): Unit = onVertxContext {
+        val doc = onboardingDoc("onboarding:${UUID.randomUUID()}")
+        repo.saveWithOutbox(doc, outbox(doc.id))
+
+        val found = repo.findByIdempotencyKey(doc.idempotencyKey!!)
+
+        assertThat(found).isNotNull
+        assertThat(found!!.id).isEqualTo(doc.id)
+        assertThat(repo.findByIdempotencyKey("onboarding:${UUID.randomUUID()}")).isNull()
+    }
+
+    @Test
+    fun `a second document with the same idempotency key is rejected, not duplicated`(): Unit = onVertxContext {
+        val key = "onboarding:${UUID.randomUUID()}"
+        repo.saveWithOutbox(onboardingDoc(key), outbox(UUID.randomUUID()))
+
+        // A different document id, same idempotency key (a replayed/concurrent onboarding delivery).
+        val duplicate = onboardingDoc(key)
+        val rejected = try {
+            repo.saveWithOutbox(duplicate, outbox(duplicate.id))
+            null
+        } catch (e: DuplicateDocumentException) {
+            e
+        }
+
+        assertThat(rejected).isNotNull
+        // The original row is the only one under that key.
+        assertThat(repo.findByIdempotencyKey(key)!!.id).isNotEqualTo(duplicate.id)
+    }
+}

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
@@ -52,6 +52,16 @@ class OpenBaoClientSignatureAdapterTest {
             .hasMessageContaining("require-trusted-issuer")
     }
 
+    @Test
+    fun `re-signing for the same party is idempotent — no second signature is layered`(): Unit = runBlocking {
+        val once = adapter().signAsClient(blankPdf(), "party-42")
+        val twice = adapter().signAsClient(once, "party-42")
+
+        val signatures = Loader.loadPDF(twice).use { it.signatureDictionaries }
+        assertThat(signatures).hasSize(1)
+        assertThat(signatures[0].name).isEqualTo("party-42")
+    }
+
     private fun blankPdf(): ByteArray {
         PDDocument().use { document ->
             document.addPage(PDPage())

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PadesSigningTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PadesSigningTest.kt
@@ -56,6 +56,16 @@ class PadesSigningTest {
         }
     }
 
+    @Test
+    fun `hasSignatureNamed detects a present signature and ignores absent names and unsigned pdfs`() {
+        val pdf = blankPdf()
+        val signed = PadesSigning.applySignature(pdf, PadesSigning.generateEphemeralIdentity("party-1"), "party-1", "s")
+
+        assertThat(PadesSigning.hasSignatureNamed(signed, "party-1")).isTrue()
+        assertThat(PadesSigning.hasSignatureNamed(signed, "party-2")).isFalse()
+        assertThat(PadesSigning.hasSignatureNamed(pdf, "party-1")).isFalse()
+    }
+
     /** Verifies a detached CMS/PKCS7 signature against the certificate embedded in it. */
     @Suppress("UNCHECKED_CAST")
     private fun verifies(cmsBytes: ByteArray, signedContent: ByteArray): Boolean {


### PR DESCRIPTION
## Summary
Closes the last #1112 robustness gap. Onboarding-document issuance was a check-then-act `listByParty` scan (a TOCTOU race under at-least-once redelivery); the render → open-ceremony sequence wasn't resumable (a crash between them stranded a document with no ceremony that replay then skipped forever); and a persist failure after signing could double-sign on retry.

## Type of change
- [x] fix (correctness / robustness)

## Linked issues
Closes #1112 (final item; poison-pill + phantom-signature landed in #1123)

## Changes
- **V6 migration** — `documents.idempotency_key` (+ **partial** unique index, onboarding-only, so the general `case_ref` column that repeats across document types is untouched) and a **partial** unique index on `signature_ceremonies(document_id) WHERE status NOT IN ('DECLINED','EXPIRED')`: at most one *active* ceremony per document, while still allowing a fresh one after a terminal DECLINED/EXPIRED (a legitimate re-attempt).
- **`OnboardingDocumentService`** — resolve-or-create the document by idempotency key (O(1) index lookup, not a full-party scan), then open a ceremony only if the document has none, so a crash *between* the two effects self-heals on the next delivery. Concurrent losers catch the typed `DuplicateDocumentException` / `DuplicateCeremonyException` (translated at the persistence boundary, ADR-0002) and resolve idempotently to the winner.
- **Idempotent signing** — `OpenBaoClientSignatureAdapter` / `PdfBoxPadesSealAdapter` skip re-applying a signature/seal whose `Name` is already present (`PadesSigning.hasSignatureNamed`), so a retry after a failed persist never layers a duplicate signature.

## Tests
- `OnboardingDocumentServiceTest`: happy path, idempotent replay, **resumable** (doc exists, ceremony missing → opens it), no-template fail-open, concurrent document-race reuse, concurrent ceremony-race tolerance.
- `DocumentRepositoryImplIT` (new) + `CeremonyRepositoryImplIT`: the partial unique indexes against **real Postgres** (Testcontainers) — duplicate idempotency key rejected; at most one active ceremony, a new one allowed after DECLINED.
- `PadesSigningTest` / `OpenBaoClientSignatureAdapterTest`: `hasSignatureNamed`; re-signing the same party is a no-op.

## Definition of Done
- [x] Hexagonal layering preserved (domain framework-free; conflicts translated to typed exceptions at the adapter boundary).
- [x] Unit + integration tests added.
- [x] `detekt ktlintCheck test quarkusBuild` pass locally (JDK 25): 71 tests, 0 failures.
- [x] Flyway migration added + rollback note (in V6 header). DB change is additive (nullable column + partial indexes) — backward-compatible.
- [ ] OpenAPI / Avro — N/A.

## Security checklist
- [x] No secrets/PII. `@Suppress("SwallowedException")` on the two idempotent catches is justified in-code (the exception type IS the 'already exists' signal). Crypto-adjacent (signing) → please apply `security-review-required`.

## Rollout / Rollback
- Rolling; V6 is additive/backward-compatible (an old pod tolerates the new nullable column). Rollback: revert + the DROP statements in the V6 header.
- A brief note for reviewers: the new active-ceremony unique index also makes the `POST /signature-ceremonies` REST path reject opening a second active ceremony for a document (422) — a correct invariant, not just an onboarding concern.