### PR TITLE
chore(gitops): auto-deploy services @ f4bd8b810a4e116d8315e8bd6c7ca699f253cc4f

### DIFF
--- a/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/control-liveness-sentinel.yaml
@@ -28,7 +28,7 @@ spec:
         - name: control-liveness-sentinel
           # Pending first CI build (ADR-0163 initial PR) — build-push-service.sh publishes the
           # real sandbox-<sha> tag on merge; ArgoCD will not sync a healthy pod until then.
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-control-liveness-sentinel:sandbox-a75d8878
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-control-liveness-sentinel:sandbox-f4bd8b81
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit f4bd8b810a4e116d8315e8bd6c7ca699f253cc4f.

**Changed services:** ["openbank-control-liveness-sentinel"]

Each image tag was updated to `sandbox-f4bd8b810a4e116d8315e8bd6c7ca699f253cc4f` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.