### PR TITLE
fix(transaction-service): add tests to clear the koverVerify 85% floor

### DIFF
--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/domain/event/TransactionEventsTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/domain/event/TransactionEventsTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.domain.event
+
+import com.openbank.libs.domain.payment.InstructionType
+import com.openbank.libs.domain.payment.PaymentRail
+import com.openbank.transaction.domain.model.TransactionType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/** Unit coverage for the domain events emitted around the transaction saga. */
+class TransactionEventsTest {
+
+    private val aggregateId = UUID.randomUUID()
+    private val now = Instant.parse("2026-07-14T12:00:00Z")
+
+    @Test
+    fun `TransactionInitiatedEvent carries the aggregate and payment fields, with default rail and instruction type`() {
+        val event = TransactionInitiatedEvent(
+            aggregateId = aggregateId,
+            version = 1L,
+            referenceNumber = "REF-1",
+            type = TransactionType.TRANSFER,
+            sourceAccountId = UUID.randomUUID(),
+            targetAccountId = UUID.randomUUID(),
+            amount = BigDecimal("100.50"),
+            currencyCode = "CZK",
+            occurredAt = now,
+        )
+
+        assertThat(event.aggregateId).isEqualTo(aggregateId)
+        assertThat(event.aggregateType).isEqualTo("Transaction")
+        assertThat(event.eventType).isEqualTo("TransactionInitiated")
+        assertThat(event.rail).isEqualTo(PaymentRail.UNKNOWN)
+        assertThat(event.instructionType).isEqualTo(InstructionType.UNKNOWN)
+        assertThat(event.initiatedByPartyId).isNull()
+        assertThat(event.eventId).isNotNull()
+    }
+
+    @Test
+    fun `TransactionInitiatedEvent honours explicit SCA and rail fields, and supports copy + equality`() {
+        val partyId = UUID.randomUUID()
+        val scaChallengeId = UUID.randomUUID()
+        val event = TransactionInitiatedEvent(
+            aggregateId = aggregateId,
+            version = 1L,
+            referenceNumber = "REF-2",
+            type = TransactionType.DEBIT,
+            sourceAccountId = null,
+            targetAccountId = null,
+            amount = BigDecimal("42.00"),
+            currencyCode = "EUR",
+            initiatedByPartyId = partyId,
+            scaChallengeId = scaChallengeId,
+            scaExemption = "LOW_VALUE",
+            rail = PaymentRail.SEPA_INST,
+            instructionType = InstructionType.STANDING_ORDER,
+            occurredAt = now,
+        )
+        val copy = event.copy(referenceNumber = "REF-2-COPY")
+
+        assertThat(event.initiatedByPartyId).isEqualTo(partyId)
+        assertThat(event.scaChallengeId).isEqualTo(scaChallengeId)
+        assertThat(event.scaExemption).isEqualTo("LOW_VALUE")
+        assertThat(event.rail).isEqualTo(PaymentRail.SEPA_INST)
+        assertThat(event).isEqualTo(event.copy())
+        assertThat(event).isNotEqualTo(copy)
+        assertThat(event.toString()).contains("REF-2")
+        assertThat(event.hashCode()).isEqualTo(event.copy().hashCode())
+    }
+
+    @Test
+    fun `TransactionCompletedEvent carries the aggregate and reference number`() {
+        val event = TransactionCompletedEvent(
+            aggregateId = aggregateId,
+            version = 2L,
+            referenceNumber = "REF-3",
+            occurredAt = now,
+        )
+
+        assertThat(event.aggregateType).isEqualTo("Transaction")
+        assertThat(event.eventType).isEqualTo("TransactionCompleted")
+        assertThat(event.referenceNumber).isEqualTo("REF-3")
+        assertThat(event).isEqualTo(event.copy())
+        assertThat(event.toString()).contains("REF-3")
+    }
+
+    @Test
+    fun `TransactionFailedEvent carries the failure reason`() {
+        val event = TransactionFailedEvent(
+            aggregateId = aggregateId,
+            version = 3L,
+            referenceNumber = "REF-4",
+            reason = "insufficient funds",
+            occurredAt = now,
+        )
+
+        assertThat(event.aggregateType).isEqualTo("Transaction")
+        assertThat(event.eventType).isEqualTo("TransactionFailed")
+        assertThat(event.reason).isEqualTo("insufficient funds")
+        assertThat(event).isEqualTo(event.copy())
+        assertThat(event.toString()).contains("insufficient funds")
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/domain/event/TransactionSettledEventTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/domain/event/TransactionSettledEventTest.kt
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.domain.event
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/** Unit coverage for [TransactionSettledEvent] (emitted at the end of the settlement saga). */
+class TransactionSettledEventTest {
+
+    @Test
+    fun `carries the journal and originating payment ids and the settlement dates`() {
+        val aggregateId = UUID.randomUUID()
+        val journalId = UUID.randomUUID()
+        val originatingPaymentId = UUID.randomUUID()
+        val settledAt = Instant.parse("2026-07-14T12:00:00Z")
+        val bookingDate = LocalDate.of(2026, 7, 14)
+
+        val event = TransactionSettledEvent(
+            aggregateId = aggregateId,
+            version = 4L,
+            referenceNumber = "REF-5",
+            journalId = journalId,
+            originatingPaymentId = originatingPaymentId,
+            bookingDate = bookingDate,
+            settledAt = settledAt,
+            occurredAt = settledAt,
+        )
+
+        assertThat(event.aggregateType).isEqualTo("Transaction")
+        assertThat(event.eventType).isEqualTo("TransactionSettled")
+        assertThat(event.journalId).isEqualTo(journalId)
+        assertThat(event.originatingPaymentId).isEqualTo(originatingPaymentId)
+        assertThat(event.bookingDate).isEqualTo(bookingDate)
+        assertThat(event.settledAt).isEqualTo(settledAt)
+        assertThat(event.eventId).isNotNull()
+    }
+
+    @Test
+    fun `originatingPaymentId is optional for internal transfers with no originating rail payment`() {
+        val event = TransactionSettledEvent(
+            aggregateId = UUID.randomUUID(),
+            version = 1L,
+            referenceNumber = "REF-6",
+            journalId = UUID.randomUUID(),
+            originatingPaymentId = null,
+            bookingDate = LocalDate.of(2026, 7, 14),
+            settledAt = Instant.parse("2026-07-14T12:00:00Z"),
+            occurredAt = Instant.parse("2026-07-14T12:00:00Z"),
+        )
+
+        assertThat(event.originatingPaymentId).isNull()
+        assertThat(event).isEqualTo(event.copy())
+        assertThat(event.toString()).contains("REF-6")
+        assertThat(event.hashCode()).isEqualTo(event.copy().hashCode())
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/client/BalanceCoverClientTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/client/BalanceCoverClientTest.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/** Unit coverage for [BalanceCoverClient] — delegation to [BalanceCoverRestClient]. */
+class BalanceCoverClientTest {
+
+    private val restClient: BalanceCoverRestClient = mockk()
+    private val client = BalanceCoverClient(restClient)
+
+    @Test
+    fun `placeHold builds the request body and returns the hold id`(): Unit = runBlocking {
+        val accountId = UUID.randomUUID()
+        val holdId = UUID.randomUUID()
+        every {
+            restClient.placeHold(
+                accountId,
+                PlaceHoldBody(BigDecimal("50.00"), "CZK", "sca-pending", "ref-1", 300L),
+            )
+        } returns Uni.createFrom().item(HoldResponse(holdId))
+
+        val result = client.placeHold(accountId, BigDecimal("50.00"), "CZK", "sca-pending", "ref-1", 300L)
+
+        assertThat(result).isEqualTo(holdId)
+    }
+
+    @Test
+    fun `releaseHold delegates to the rest client`(): Unit = runBlocking {
+        val holdId = UUID.randomUUID()
+        every { restClient.releaseHold(holdId) } returns Uni.createFrom().item(HoldResponse(holdId))
+
+        client.releaseHold(holdId)
+
+        verify(exactly = 1) { restClient.releaseHold(holdId) }
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/client/FxRateClientTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/client/FxRateClientTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.WebApplicationException
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+/** Unit coverage for [FxRateClient] — in particular the 404-means-no-rate mapping. */
+class FxRateClientTest {
+
+    private val restClient: FxServiceRestClient = mockk()
+    private val client = FxRateClient(restClient)
+
+    @Test
+    fun `getRate maps a successful response to an FxRateView`(): Unit = runBlocking {
+        every { restClient.getRate("CZK", "EUR") } returns
+            Uni.createFrom().item(FxRateResponse("CZK", "EUR", BigDecimal("0.040"), BigDecimal("0.041")))
+
+        val result = client.getRate("CZK", "EUR")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.baseCurrency).isEqualTo("CZK")
+        assertThat(result.quoteCurrency).isEqualTo("EUR")
+        assertThat(result.bidRate).isEqualTo(BigDecimal("0.040"))
+        assertThat(result.askRate).isEqualTo(BigDecimal("0.041"))
+    }
+
+    @Test
+    fun `getRate returns null when fx-service responds 404 (no rate for the pair)`(): Unit = runBlocking {
+        val notFound = WebApplicationException(Response.status(404).build())
+        every { restClient.getRate("CZK", "XXX") } returns Uni.createFrom().failure(notFound)
+
+        val result = client.getRate("CZK", "XXX")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `getRate rethrows on a non-404 failure`(): Unit = runBlocking {
+        val serverError = WebApplicationException(Response.status(503).build())
+        every { restClient.getRate("CZK", "USD") } returns Uni.createFrom().failure(serverError)
+
+        assertThatThrownBy {
+            runBlocking { client.getRate("CZK", "USD") }
+        }.isInstanceOf(WebApplicationException::class.java)
+    }
+}

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/client/LedgerCallGuardTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/client/LedgerCallGuardTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.client
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/** Unit coverage for [LedgerCallGuard] — the fault-tolerance-annotated delegation to [LedgerRestClient]. */
+class LedgerCallGuardTest {
+
+    private val ledgerClient: LedgerRestClient = mockk()
+    private val guard = LedgerCallGuard(ledgerClient)
+
+    @Test
+    fun `postJournal delegates to the ledger client and returns its response`() {
+        val transactionId = UUID.randomUUID()
+        val journalId = UUID.randomUUID()
+        val request = PostJournalRequest(
+            idempotencyKey = "key-1",
+            transactionId = transactionId,
+            entryDate = "2026-07-14",
+            valueDate = "2026-07-14",
+            description = "test journal",
+            lines = listOf(
+                JournalLineRequest(
+                    glAccountId = UUID.randomUUID(),
+                    side = "DEBIT",
+                    amount = BigDecimal("10.00"),
+                    currencyCode = "CZK",
+                    fxRate = null,
+                    baseAmount = BigDecimal("10.00"),
+                    baseCurrencyCode = "CZK",
+                ),
+            ),
+            createdBy = UUID.randomUUID(),
+        )
+        every { ledgerClient.postJournal(request) } returns
+            Uni.createFrom().item(JournalResponse(journalId, transactionId, "POSTED"))
+
+        val result = guard.postJournal(request).await().indefinitely()
+
+        assertThat(result.id).isEqualTo(journalId)
+        assertThat(result.status).isEqualTo("POSTED")
+        verify(exactly = 1) { ledgerClient.postJournal(request) }
+    }
+
+    @Test
+    fun `reverseJournal delegates to the ledger client with the journal id and reason`() {
+        val journalId = UUID.randomUUID()
+        val reversedBy = UUID.randomUUID()
+        val request = ReverseJournalRequest(reason = "duplicate", reversedBy = reversedBy)
+        every { ledgerClient.reverseJournal(journalId, request) } returns
+            Uni.createFrom().item(JournalResponse(journalId, UUID.randomUUID(), "REVERSED"))
+
+        val result = guard.reverseJournal(journalId, request).await().indefinitely()
+
+        assertThat(result.status).isEqualTo("REVERSED")
+        verify(exactly = 1) { ledgerClient.reverseJournal(journalId, request) }
+    }
+}


### PR DESCRIPTION
## Summary

`koverVerify` on `openbank-transaction-service` was failing in CI (84.77% line coverage, 85% floor) — blocking `all-green` (a required status check) for any unrelated PR that touches a shared file forcing a fleet-wide rebuild (surfaced via JiRaska/open-bank-oss#1119).

## Type of change

- [x] fix (bug fix — closes a coverage-ratchet violation)

## Linked issues

Closes #1131

## Changes

Added unit tests for genuinely pre-existing untested code (not the #931 four-eyes work — `infrastructure.approval`/`infrastructure.rest` were already at 100% line coverage locally):

- `domain/event/TransactionEventsTest.kt`, `TransactionSettledEventTest.kt` — construction, field values, `aggregateType`/`eventType`, `copy`/`equals`/`hashCode`/`toString` for all 4 domain events.
- `infrastructure/client/LedgerCallGuardTest.kt` — delegation to `LedgerRestClient` (postJournal/reverseJournal).
- `infrastructure/client/FxRateClientTest.kt` — including the 404-means-no-rate vs rethrow-on-other-errors branch, the one real piece of logic in that package.
- `infrastructure/client/BalanceCoverClientTest.kt` — delegation to `BalanceCoverRestClient` (placeHold/releaseHold).

No production code changed — this is real coverage of real (if thin) logic, not padding to hit a number.

## Verified

- Local line coverage: **85.7% → 90.5%** (891/985) — a real margin over the 85% floor, not a razor-thin pass. CI's own measurement of the identical code ran ~1pp lower than an identical local build (environment-dependent, not investigated further given the margin now covers it).
- `./gradlew :openbank-transaction-service:detekt :openbank-transaction-service:ktlintCheck :openbank-transaction-service:koverVerify :openbank-transaction-service:build` — all green locally.

## Definition of Done

- [x] Hexagonal layering preserved (test-only change).
- [x] Unit tests added (this PR IS the test addition).
- [ ] Integration/contract tests — N/A, no behavior change.
- [x] `./gradlew detekt ktlintCheck koverVerify build` passes.
- [ ] No `src/main/**` change → no version.txt bump (rule #2 scope).
- [ ] OpenAPI — N/A, no API change.

## Security checklist

- [x] No secrets/PII. No new dependency. No `@Suppress`.
- [ ] Not an auth/crypto/payment code change (test-only) → no `security-review-required` tag needed.

## Compliance impact

- [ ] None — test-only change, no behavior change.

## Rollout / Rollback

- Test-only; no runtime behavior change. Revert is trivial if ever needed.

## Reviewer notes

Unblocks JiRaska/open-bank-oss#1119 (customer-edge WebAuthn RP), whose `all-green` check is currently red solely because of this pre-existing, unrelated coverage gap.
