### PR TITLE
docs(adr): customer document access + onboarding e-signature (ADR-0169/0170)

### DIFF
--- a/docs/adr/0169-customer-document-access-and-sca-bound-signing.md
+++ b/docs/adr/0169-customer-document-access-and-sca-bound-signing.md
@@ -1,0 +1,163 @@
+# ADR-0169 — Customer document access & SCA-bound signing over customer-edge
+
+Date: 2026-07-15
+Decision-Status: Proposed
+Delivery-Status: Planned
+Author(s): jiri.raska
+
+## Context
+
+ADR-0162 shipped `openbank-document-service`: versioned templates, HTML→PDF rendering, WORM
+storage, and a signature ceremony that seals a document with the signer's own one-time PKI
+signature plus the bank's PAdES-B institutional seal (eIDAS **AdES**). D7 of that ADR even wires
+onboarding: on `account.created`, `OnboardingDocumentService` renders the product's bound contract
+and opens a single-signer ceremony for the account holder.
+
+But the capability is **not reachable by the customer**. Verified against `main` (2026-07-15):
+
+1. **Every document-service endpoint is `@RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR",
+   "ROLE_ADMIN")`** — `DocumentResource` and `SignatureCeremonyResource` alike. A customer JWT
+   (`ROLE_CUSTOMER`, `openbank-customers` realm) cannot fetch a rendered PDF, list its own
+   documents, or record a signature decision. `openbank-customer-edge` — the single internet-facing
+   surface for the app (ADR-0065) — exposes **no** document or signature routes at all.
+2. **The SCA binding is document-agnostic.** `ScaVerificationAdapter` (the `SignerVerificationPort`
+   over sca-service) treats `evidenceRef` as an SCA challenge id and accepts a SIGNED decision iff
+   that challenge is `COMPLETED`, belongs to the signer's party, and hasn't been consumed. It does
+   **not** check that the challenge was raised *for this document* — its own KDoc flags the gap:
+   "it does encode an assumption … that a future, purpose-built 'verify approval' endpoint could
+   make explicit." So today *any* completed challenge for the party would authorize signing *any*
+   document. For a payment, RTS Art. 5 **dynamic linking** binds the SCA approval to the specific
+   amount+payee; the equivalent binding for a *document* signature does not yet exist.
+3. **D7 renders in one fixed language.** `OnboardingDocumentService` resolves a single
+   `documentTemplateCode` from product-catalog and renders it with `data = emptyMap()`. Template
+   codes are locale-suffixed (`RAMCOVA_SMLOUVA_CS` / `_EN`, ADR-0162 seed), so a product binds
+   exactly one language; there is no path for the customer to receive the contract in the language
+   they actually read.
+
+This ADR defines the **customer-facing contract** for reading and signing documents: the edge API,
+the document-bound SCA linking that makes the signature legally sound, and language-correct
+rendering. The app-side UX that consumes it is ADR-0170. (The mock "Agreement" step in the app
+today — local-only consent that never reaches the backend — is replaced by ADR-0170 D1.)
+
+## Decision
+
+### D1 — Customer document & signature routes on customer-edge (ownership-scoped)
+
+The app never talks to document-service directly (ADR-0065 trust boundary). `customer-edge` gains
+`ROLE_CUSTOMER` routes that proxy to document-service with the edge's M2M service token, enforcing
+ownership on every call — `partyRef`/document/ceremony must resolve to the caller's `party_id`
+claim (the same `resolvePartyIdClaim` pattern the edge already uses; IDOR is the primary risk):
+
+| Edge route (`/customer/v1/…`) | Proxies to document-service | Ownership check |
+|---|---|---|
+| `POST /documents/agreements` (body: `{lang}`) | ensure-onboarding-agreement (D3) | party = token |
+| `GET /documents` | `GET /api/v1/documents?partyRef=<token party>` | forced partyRef = token |
+| `GET /documents/{id}/content` | `GET /api/v1/documents/{id}/content` | document.partyRef = token |
+| `GET /signature-ceremonies/{id}` | `GET /api/v1/signature-ceremonies/{id}` | ceremony's signer = token |
+| `POST /signature-ceremonies/{id}/decisions` | `POST …/{id}/decisions` | signer = token |
+
+The edge **never** trusts a client-supplied `partyRef`: it injects the token's party on reads and
+rejects a decision whose ceremony signer isn't the caller. PDF content streams back with
+document-service's own `Content-Type` (`application/pdf`), like the existing statement-render proxy.
+
+### D2 — Document-bound SCA: dynamic linking for a signature act (RTS Art. 5, applied to documents)
+
+The signer's biometric SCA approval MUST be bound to the exact document, closing the gap in §2. We
+extend the SCA contract with a **document-signing purpose** whose dynamic-linking data *is* the
+document identity, mirroring how a payment challenge binds amount+payee:
+
+- The app opens an SCA challenge with `purpose = DOCUMENT_SIGNING` and dynamic-linking data
+  `{ ceremonyId, documentId, documentSha256 }` — the SHA-256 of the exact rendered PDF the customer
+  is viewing (document-service already content-addresses documents by SHA-256, ADR-0161).
+- The on-device key (ADR-0021 `ScaDeviceKey`, Secure Enclave / AndroidKeyStore, biometric-gated)
+  signs a payload that **includes that document hash**, so the hardware signature covers *which
+  document* is being authorized — not a bare "approve".
+- `SignerVerificationPort.verify` is strengthened: a `DOCUMENT_SIGNING` challenge is accepted as
+  evidence only if its linked `documentSha256`/`ceremonyId` match the document/ceremony the decision
+  is being recorded against. A completed challenge raised for document A can no longer authorize
+  document B. Single-use `consume` (already present) stays — replay-proof per RTS Art. 5.
+
+This makes "what the customer saw is what the customer authorized is what got sealed" a verified
+property, not an assumption. It is the document analogue of payment dynamic linking, using the same
+SCA rails — no new authentication mechanism.
+
+### D3 — Language-correct, idempotent onboarding-agreement provisioning (app-driven)
+
+Because D7 renders one fixed language server-side, the **app drives** the render language. The edge
+`POST /documents/agreements {lang}` calls an idempotent document-service operation
+`ensureOnboardingAgreement(partyRef, lang)`:
+
+- If the party has **no** pending (unsigned) onboarding ceremony → render the locale-resolved
+  template (`RAMCOVA_SMLOUVA` + `lang` → `RAMCOVA_SMLOUVA_CS`/`_EN`) and open a single-signer
+  ceremony; return `{ ceremonyId, documents:[…] }`.
+- If a pending ceremony **already exists in the requested language** → return it unchanged
+  (idempotent — safe against retries and D7 having pre-rendered it).
+- If a pending ceremony exists in a **different** language (e.g. D7 pre-rendered the product's
+  default while the customer reads the other) → because the document is still **unsigned**, retire
+  it and render+open in the requested language. Once **signed**, the `(templateCode,
+  templateVersion)` snapshot is immutable (ADR-0162 D2) and language can never change under a
+  customer.
+
+D7's `account.created` auto-render is kept as a pre-warm / server-of-record default; the
+app-triggered ensure is the authoritative, language-correct path and reconciles with it. This needs
+**no** party-schema change and keeps language a pure presentation concern.
+
+### D4 — The signed artifact is the exact rendered PDF, never a client re-render
+
+The customer views, and signs, the **same** content-addressed PDF that gets sealed — fetched via
+`GET /documents/{id}/content`. The app MUST NOT reconstruct or re-format the legal text locally for
+display-and-sign (a re-formatted client view would make "what was shown" ≠ "what was sealed", the
+classic e-signature integrity hole). Native PDF rendering of the server artifact is ADR-0170 D2.
+
+## Alternatives considered
+
+- **Expose document-service directly to the app.** Rejected: it would move the customer trust
+  boundary off customer-edge (ADR-0065) and force `ROLE_CUSTOMER` + ownership logic into a
+  non-edge service. The edge is exactly where per-customer ownership belongs.
+- **Keep SCA document-agnostic (any completed challenge is evidence).** Rejected: it fails the
+  legal core — the signature would not be provably bound to the document, so "the customer
+  authorized *this contract*" could not be evidenced. D2 is the whole point.
+- **Render the contract client-side from a template + data, sign that.** Rejected: signed ≠ shown,
+  and it duplicates the legal-text source of truth on-device where it can drift from the published
+  template.
+- **Bind language to the party record + rely solely on D7.** Rejected for Phase 1: a party-schema
+  + event change for what D3 solves as a presentation concern, and it still races (party language
+  unknown at `account.created` for a fresh self-registration). Revisit if language must persist for
+  later re-issued documents.
+
+## Consequences
+
+**Positive**
+- Closes the last gap between "document-service can sign" and "a customer can sign", reusing the
+  edge's proven ownership model and the SCA rails — no new auth mechanism, no new customer-facing
+  service.
+- D2 upgrades the signature from *an* AdES to one whose signer-intent is cryptographically bound to
+  the specific document, materially strengthening the evidential value (and the audit-chain record).
+
+**Negative**
+- A small, security-sensitive change to sca-service / `ScaVerificationAdapter` (document-bound
+  verification). It touches the SCA path, so it carries a threat-model update on document-service
+  (already trust-boundary-flagged by ADR-0162) and a security review.
+
+**Neutral**
+- Edge gains a new proxy surface; standard coverage/openapi-contract obligations apply. Non-money-
+  path (ADR-0162): a document-service outage degrades signing availability, never a payment.
+
+## Compliance impact
+
+- **eIDAS** (Reg. (EU) 910/2014): Phase-1 signatures are AdES (ADR-0162 D4); D2 binds signer intent
+  to the document, supporting the "sole control" and "detectable subsequent change" AdES criteria.
+- **PSD2 / RTS Art. 5**: reuses SCA (ADR-0021); D2 is dynamic linking applied to a document
+  signature act (single-use, bound to what is authorized).
+- **GDPR**: no new personal data at the edge; documents carry the party ref only. Retention/erasure
+  overrides for signed contracts stay in document-service (ADR-0162 D5 / ADR-0118).
+- **CNB**: records retention via WORM (ADR-0161) + audit hash-chain (ADR-0086/0133), unchanged.
+
+## References
+
+- ADR-0162 — Document management, templating & e-signature (the service this exposes)
+- ADR-0021 — SCA decoupled device approval (signer binding); RTS Art. 5 dynamic linking
+- ADR-0065 — customer-edge as the single customer trust boundary
+- ADR-0161 — Object-storage standard (content-addressed documents)
+- ADR-0086 / ADR-0133 — non-repudiation & tamper-evident audit hash-chain
+- ADR-0069 — customer onboarding journey; ADR-0170 — the app-side signing UX that consumes this

--- a/docs/adr/0170-onboarding-e-signature-flow-in-the-customer-app.md
+++ b/docs/adr/0170-onboarding-e-signature-flow-in-the-customer-app.md
@@ -1,0 +1,142 @@
+# ADR-0170 — Onboarding e-signature flow in the customer app
+
+Date: 2026-07-15
+Decision-Status: Proposed
+Delivery-Status: Planned
+Author(s): jiri.raska
+
+## Context
+
+The customer app (`openbank-app`, KMP/Compose) has an onboarding wizard whose step 3 —
+`StepAgreement` — *looks* like contract signing: a document list ("Rámcová smlouva o platebních
+službách", "Obchodní podmínky a ceník"), GDPR/marketing consent rows, and a hold-to-sign
+fingerprint gesture. It is **entirely a mock**, verified against `main` (2026-07-15):
+
+- The "documents" are hard-coded Czech/English sample strings rendered as plain Compose `Text`
+  (`DocViewerOverlay`) — not fetched, not the published template, not a PDF.
+- The consent booleans are written to an on-device key-value store and folded into `OnboardRequest`,
+  but `HttpOnboardingApi.register` / `registerAuthenticated` **omit them from the JSON body** — so
+  consent never reaches the edge. Nothing is signed; no legal record is produced.
+
+Three more facts shape the design:
+- **No PDF/WebView rendering exists anywhere in the app** — every "document" today is monospace
+  Compose `Text`. There is no native PDF viewer.
+- **Language is a manual in-app CS/EN toggle** (`lang` state, defaults `"cs"`); `systemLanguage()`
+  exists but is unused. `lang` is available in every screen scope.
+- **SCA signing already works** for payments: `ScaDeviceKey.sign()` (biometric-gated hardware
+  ECDSA) over a payment-bound payload → `POST sca/challenges/{id}/decision`. A document ceremony
+  mirrors this exactly.
+- **Ordering**: the mock agreement sits at step 3, *before* the party even exists (registration
+  happens at step 4). But the real ceremony (ADR-0162 D7) is created *after* `account.created`,
+  i.e. after registration. The real signature therefore cannot live where the mock does.
+
+ADR-0169 defines the edge API + document-bound SCA this consumes. This ADR is the app-side
+decision: what the customer sees and does, and where it sits in onboarding.
+
+## Decision
+
+### D1 — Split the mock: pre-contractual consent stays early, cryptographic signature moves after account provisioning
+
+- **Before registration** (former step 3, kept): show the customer the pre-contractual information
+  and capture the **GDPR consent** they must give up front. This consent now travels to the edge
+  with registration (fixing the drop noted above) — it is a legal fact, not on-device state.
+- **After registration + account provisioning** (new step): the customer reads and **cryptographically
+  signs the framework agreement**. This is where the real ceremony (ADR-0162 D7, ADR-0169 D3) lives,
+  because that is when the document/ceremony exist. The former hold-to-sign fingerprint mock is
+  replaced by a real SCA biometric signature (D3 below).
+
+Onboarding becomes: `Welcome → KYC → Email → Consent (pre-contractual) → Passkey (register →
+account opens → ceremony) → 📄 Sign framework agreement → HOME`.
+
+### D2 — Native PDF rendering of the exact server artifact
+
+The app gains its first real PDF viewer via `expect`/`actual`: **iOS `PDFKit.PDFView`**, **Android
+`PdfRenderer`**, surfaced as a Compose component. It renders the exact bytes streamed from
+`GET /customer/v1/documents/{id}/content` (ADR-0169 D1/D4) — never a re-formatted local view, so
+what the customer scrolls is byte-identical to what gets sealed. VOP and ceník are shown through the
+same viewer.
+
+### D3 — Real SCA biometric signature over the document (reusing the payment rails)
+
+Signing reuses the existing possession+inherence ceremony, re-pointed from a payment to a document:
+`ScaApi.initiateChallenge(purpose = DOCUMENT_SIGNING, dynamicLinkingData = { ceremonyId, documentId,
+documentSha256 })` → `ScaDeviceKey.sign(payload-including-doc-hash)` fires Face ID / biometric →
+`POST /customer/v1/signature-ceremonies/{id}/decisions { decision: SIGNED, evidenceRef: challengeId }`.
+The document hash the app signs is computed over the fetched PDF bytes (ADR-0169 D2). No new signing
+UI paradigm — the customer experiences the same biometric confirmation they already use for
+payments, over the contract instead of a transfer.
+
+### D4 — App-side gating until signed
+
+The account is opened before the framework agreement is signed (ADR-0162 D7 keeps document-service
+off the money-path). The app therefore **gates HOME/transacting on the signed ceremony**: after
+registration it queries for a pending onboarding ceremony (`ensureOnboardingAgreement`, ADR-0169
+D3); an unsigned one forces the signing step, and only a `SIGNED`/`COMPLETED` ceremony lets the
+customer reach a fully-active HOME. A returning customer who somehow bypassed it (e.g. app killed
+mid-flow) is re-gated on next launch. This is a UX/product gate, not a money-path block — it keeps
+the "you must sign the framework contract before using the account" invariant without violating
+ADR-0086.
+
+### D5 — Language drives the render; framework agreement is signed, VOP/ceník acknowledged
+
+- The in-app `lang` (CS/EN) is passed to `POST /customer/v1/documents/agreements {lang}` (ADR-0169
+  D3) so the customer signs the contract in the language they read. Signed ⇒ language frozen.
+- **Signed** (one ceremony, SCA): the **framework agreement** (`RAMCOVA_SMLOUVA`), which incorporates
+  the account contract terms. **Acknowledged** (viewable + a confirm tap, incorporated by reference):
+  **VOP** and **ceník**. Phase 1 keeps a single signed document to keep the ceremony simple; a
+  multi-document ceremony (separately signing the account contract) is a later refinement, not a
+  Phase-1 requirement.
+
+### D6 — Phasing & cleanup
+
+- **Phase 1 (this ADR):** AdES signature (ADR-0162 D4 phase 1), CS/EN, single signed framework
+  agreement, app gate. Delivers a legally-valid onboarding contract end to end.
+- **Phase 2 (later):** QES/HSM (ADR-0007), a visual signature appearance, an in-app "My contracts"
+  surface for documents beyond onboarding, and device-locale-driven default language.
+- The on-device consent KV store and the hard-coded sample legal text are **removed** — consent
+  becomes part of the signed/edge record, and legal text has exactly one source of truth (the
+  published template).
+
+## Alternatives considered
+
+- **Keep signing at step 3 (before registration).** Rejected: the document/ceremony don't exist
+  until after `account.created`; signing before the party exists would require inventing a parallel
+  pre-party document flow, contradicting ADR-0162 D7.
+- **Render legal text as styled Compose text (no PDF viewer).** Rejected: signed ≠ shown (ADR-0169
+  D4), and it keeps a second copy of legal text on-device that drifts from the published template.
+- **Hard-gate account opening on the signature (block money-path).** Rejected: violates ADR-0086
+  money-path decoupling. D4's app-side gate achieves the product invariant without it.
+- **Auto-pick language from device locale now.** Deferred to Phase 2: the app already has an
+  explicit CS/EN toggle that the customer controls; wiring `systemLanguage()` as a *default* is a
+  small, separable follow-up.
+
+## Consequences
+
+**Positive**
+- Onboarding becomes genuinely complete and legally sound: a customer signs a real, versioned,
+  sealed framework agreement in their language, evidenced by a document-bound SCA signature.
+- Removes a latent liability — a mock step that presents as "signed" but produces no legal record.
+- The new native PDF viewer is reusable for statements and any future document surface.
+
+**Negative**
+- First native PDF integration (per-platform `actual`s) and an onboarding-flow change with a new
+  gated state to test on device.
+
+**Neutral**
+- No new backend service; all backend capability exists (ADR-0162) or is added at the edge (ADR-0169).
+
+## Compliance impact
+
+- **eIDAS / PSD2**: as ADR-0169 (AdES; document-bound SCA). The app is the presentation + SCA
+  trigger; the legal artifact is produced server-side.
+- **GDPR**: GDPR consent now reaches the edge as a first-class fact rather than dying on-device.
+- **Accessibility/consumer law**: the customer reads the actual contract PDF in their language
+  before signing — a stronger informed-consent posture than the mock.
+
+## References
+
+- ADR-0169 — Customer document access & SCA-bound signing over customer-edge (the API this consumes)
+- ADR-0162 — Document service, templating & e-signature (D7 onboarding integration)
+- ADR-0021 — SCA device approval (biometric signature); ADR-0066 — customer app auth
+- ADR-0069 — customer onboarding journey; ADR-0086 — money-path decoupling
+- ADR-0065 — customer-edge trust boundary

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -171,6 +171,8 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0166](0166-docs-truth-agent-ai-agent.md) | docs-truth-agent AI agent | Accepted | Partial | — |
 | [0167](0167-authz-policy-auditor-ai-agent.md) | authz-policy-auditor AI agent | Accepted | Partial | — |
 | [0168](0168-flaky-test-hunter-ai-agent.md) | flaky-test-hunter AI agent | Accepted | Partial | — |
+| [0169](0169-customer-document-access-and-sca-bound-signing.md) | Customer document access & SCA-bound signing over customer-edge | Proposed | Planned | — |
+| [0170](0170-onboarding-e-signature-flow-in-the-customer-app.md) | Onboarding e-signature flow in the customer app | Proposed | Planned | — |
 
 ---
 


### PR DESCRIPTION
## Summary

Two ADRs for completing onboarding with legally-valid contract signing, building on the existing `openbank-document-service` (ADR-0162, already live: templates, HTML→PDF, WORM, AdES ceremony, D7 auto-render on `account.created`).

- **ADR-0169 — Customer document access & SCA-bound signing over customer-edge.** The backend can sign but the customer can't reach it (every document-service route is `ROLE_SERVICE/OPERATOR/ADMIN`; customer-edge has no document routes). Adds ownership-scoped `ROLE_CUSTOMER` edge routes, and — the security core — **document-bound SCA**: today `ScaVerificationAdapter` accepts any `COMPLETED` challenge for the party as signing evidence without checking *which document* (its own KDoc flags this). D2 binds the SCA challenge to the document SHA-256 + ceremony (RTS Art. 5 dynamic linking applied to a signature act), so "what was authorized = what was sealed" becomes verified, not assumed. Plus language-correct idempotent rendering (D7 renders one fixed language).
- **ADR-0170 — Onboarding e-signature flow in the customer app.** The app's `StepAgreement` is a mock (hard-coded text, consent stored on-device and never sent, fake hold-to-sign). Replaces it with: GDPR consent that actually reaches the edge; a real native PDF viewer (iOS PDFKit / Android PdfRenderer) showing the exact server artifact; a real biometric-SCA signature of the framework agreement moved after account provisioning (where the ceremony exists); app-side gating until signed; CS/EN.

Both are Phase 1 = eIDAS **AdES** (QES/HSM is Phase 2, ADR-0007). Decision-Status: Proposed.

## Type of change

- [x] docs (ADR only — no code)

## Linked issues

N/A — architecture decisions; implementation lands as follow-up PRs (edge + app).

## Definition of Done

- [x] Two ADRs added following TEMPLATE.md two-axis front-matter.
- [x] `docs/adr/README.md` regenerated via `gen-index.sh` (derived; not hand-edited).
- [ ] Code — N/A, docs-only PR.

## Reviewer notes

These are the app-integration follow-up to ADR-0162. Please sanity-check especially: ADR-0169 D2 (document-bound SCA — the legal core) and ADR-0170 D4 (app-side gate vs. ADR-0086 money-path decoupling — the account opens before signing; the gate is UX, not a money-path block). Decisions A–D from the design review are baked in as recommended (app-driven language, app-side gate, framework-agreement-signed / VOP-acknowledged, AdES now).
