### PR TITLE
chore(repo): route project contact points to open-bank.tech mailboxes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,12 +18,20 @@ Only the `main` branch and the latest tagged release receive security fixes duri
 
 ### Channel
 
-Report privately via:
+Report privately via one of:
 
-**GitHub Security Advisories** (preferred):
-https://github.com/JiRaska/open-bank-oss/security/advisories/new
+1. **GitHub Security Advisories** (preferred):
+   https://github.com/JiRaska/open-bank-oss/security/advisories/new
 
-GitHub Security Advisories provide a private collaboration space where maintainers and reporters can discuss, develop, and publish coordinated fixes.
+   GitHub Security Advisories provide a private collaboration space where maintainers and reporters can discuss, develop, and publish coordinated fixes.
+
+2. **Email** (no GitHub account needed):
+   security@open-bank.tech
+
+   This mailbox is unencrypted by default. If your report involves live exploit details you consider highly sensitive, say so in your first message and we'll agree on a secure delivery method before you send them.
+
+Machine-readable contact metadata is published per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) at
+[`open-bank.tech/.well-known/security.txt`](https://open-bank.tech/.well-known/security.txt).
 
 ### What to include
 

--- a/openbank-infra/gitops/components/platform/clusterissuer.yaml
+++ b/openbank-infra/gitops/components/platform/clusterissuer.yaml
@@ -61,7 +61,7 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: jiri@iraska.cz
+    email: jiri@open-bank.tech
     privateKeySecretRef:
       name: letsencrypt-staging-account
     solvers:
@@ -76,7 +76,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: jiri@iraska.cz
+    email: jiri@open-bank.tech
     privateKeySecretRef:
       name: letsencrypt-prod-account
     solvers:

--- a/openbank-infra/web/landing/index.html
+++ b/openbank-infra/web/landing/index.html
@@ -233,7 +233,7 @@
       <h2>Let's build the bank everyone can stand on.</h2>
       <p>The Open Bank Foundation doesn't exist yet. This is the call to start it. If you build, run, audit or regulate banking software, and you believe the common core belongs in the open, I'd love to talk about co-founding it together.</p>
       <div class="join-cta">
-        <a class="btn btn-primary" href="mailto:jiri@iraska.cz?subject=Open%20Bank%20Foundation%20%E2%80%94%20count%20me%20in">Reach out</a>
+        <a class="btn btn-primary" href="mailto:hello@open-bank.tech?subject=Open%20Bank%20Foundation%20%E2%80%94%20count%20me%20in">Reach out</a>
         <a class="btn btn-ghost" href="https://www.linkedin.com/in/jiriraska" target="_blank" rel="noopener">Follow on LinkedIn</a>
       </div>
     </div>

--- a/openbank-infra/web/landing/llms.txt
+++ b/openbank-infra/web/landing/llms.txt
@@ -11,5 +11,5 @@ AI-native governance with policy-gated agents and human-in-the-loop controls, an
 - [Platform](https://open-bank.tech/platform.html): Live governance (DORA/PSD2/GDPR), FinOps, BCP, AI governance, cloud architecture
 
 ## Contact
-- Email: jiri@iraska.cz
+- Email: hello@open-bank.tech
 - LinkedIn: https://www.linkedin.com/in/jiriraska


### PR DESCRIPTION
## Summary
- `SECURITY.md`: adds `security@open-bank.tech` as a fallback reporting channel alongside GitHub Security Advisories, and links the RFC 9116 `security.txt` — closes the gap where README already promised an email option that SECURITY.md never listed, and where `security.txt`'s `Contact:` had no working mailbox behind it until now (Zoho Mail now live on the domain, MX/SPF/DKIM configured).
- Landing page (`index.html`), `llms.txt`, and the cert-manager ACME contact (`clusterissuer.yaml`) move off the maintainer's personal address (`jiri@iraska.cz`) now that project-branded mailboxes exist: `hello@open-bank.tech` (alias) for public/marketing contact, `jiri@open-bank.tech` for the ACME/Let's Encrypt registration contact.
- No functional/deploy behavior change beyond the contact addresses themselves.

## Test plan
- [x] `.github/scripts/public-readiness-audit.sh` — 15/15 passed (SECURITY.md claims still backed by real workflows, no new gaps)
- [x] Verified no remaining `iraska.cz` references in tracked docs/config
- [x] Confirmed `security@open-bank.tech` / `hello@open-bank.tech` / `jiri@open-bank.tech` are live mailboxes (Zoho, MX+SPF+DKIM verified in Route53)
- [ ] Confirm cert-manager picks up the new ACME contact email on next reconciliation (informational only — doesn't affect issuance)

Linked issues: N/A — housekeeping / contact hygiene, not tied to a tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)