### PR TITLE
chore(infra): temporarily raise arc_max_runners 6 -> 8

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/variables.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/variables.tf
@@ -103,7 +103,14 @@ variable "arc_max_runners" {
   # ~2 batches vs ~3, shaving ~10 min off merge-to-green. Cap at 6 (not 12): each warm
   # runner keeps the on-demand node from consolidating; more than 6 would spill onto many
   # spot nodes and negate the warm-pool benefit.
-  default = 6
+  # TEMP raised 6 -> 8 (2026-07-15): ~55 concurrent agent branches drove a ~97-run,
+  # 21h+-old backlog on `openbank-build` — services-ci.yml intentionally never cancels
+  # a push-to-main lane (per-SHA concurrency group, issue #846), so none of that queue
+  # is stale/cancellable, it's genuine backlog. NAT is no longer the constraint (see
+  # 2026-06-13 note above) and minRunners stays 0, so this doesn't add idle cost — it
+  # only shortens how long the existing backlog takes to drain. Revert to 6 once the
+  # backlog clears; this is not meant to be a permanent bump.
+  default = 8
 }
 
 variable "arc_batch_max_runners" {


### PR DESCRIPTION
## Summary
~55 concurrent agent branches drove a ~97-run, 21h+-old backlog on the `openbank-build` ARC scale set. `services-ci.yml` intentionally never cancels a push-to-main CI lane (per-SHA concurrency group, issue #846), so none of that queue was stale/cancellable — it's genuine backlog competing for 6 runner slots.

## Type of change
- [x] Infra/CI change, temporary

## Linked issues
N/A — direct operational response to observed queue depth, not a tracked backlog item

## Changes
- `openbank-infra/aws/envs/sandbox-platform/variables.tf`: `arc_max_runners` default 6 → 8, with inline rationale matching the file's existing history-comment convention.

## Already applied
Applied directly (`tofu apply -target=helm_release.arc_build`, sandbox-substrate has no CI apply pipeline) and verified live via `kubectl get autoscalingrunnerset -n arc-runners` (MAXIMUM RUNNERS: 8) before this PR was opened. This PR is the required bookkeeping merge so `main` isn't unaware of live infra state (see repo's own "apply directly, laptop-only" lesson).

## FinOps note
NAT is no longer the constraint that motivated 12 → 6 on 2026-06-13 (CodeArtifact IRSA now routes deps in-VPC via S3 Gateway endpoint, no NAT charge). `minRunners` stays 0 (scale-to-zero), so this doesn't add idle cost — it only shortens how long the existing backlog takes to drain, not the total compute-seconds billed.

## Reviewer notes
This is meant to be **temporary**. Revert to 6 once the backlog clears — tracked informally, not via issue, since it's a quick FinOps-conscious operational toggle rather than a permanent capacity decision.