### PR TITLE
chore(infra): revert arc_max_runners 12 -> 6

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/variables.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/variables.tf
@@ -113,9 +113,18 @@ variable "arc_max_runners" {
   # individual openbank-build-labeled jobs (96 Services CI runs x their per-service
   # matrix), not ~97 — at 8 runners that's still a ~1-2h drain. 12 is the same value
   # already validated safe on 2026-06-04 (bounded by the runners NodePool cpu limit of
-  # 64: 12 build + 0 batch runners, well within limit now that batch is at 0). Revert
-  # to 6 once the backlog clears; this is not meant to be a permanent bump.
-  default = 12
+  # 64: 12 build + 0 batch runners, well within limit now that batch is at 0).
+  # Reverted 12 -> 6 (2026-07-15, same incident, hours later): a separate GitHub Actions
+  # Runner Scale Set bug surfaced mid-drain — the backend keeps redelivering stale
+  # "job available" offers for matrix slots that were fail-fast-cancelled before ever
+  # being created, so a large fraction of runner slots sit idle holding a phantom claim
+  # instead of doing real work. Confirmed this survives pod delete, listener restart,
+  # controller restart, and a full EphemeralRunner purge — it is NOT fixable from this
+  # side (GitHub-side queue state), and a bigger pool does not mitigate it: more slots
+  # just means more concurrent phantom holds, not more real throughput. Root cause
+  # #1149 already stops new inert-push waste at the source, so paying for 12 idle-
+  # capable spot runners no longer buys a proportional drain-speed benefit. Back to 6.
+  default = 6
 }
 
 variable "arc_batch_max_runners" {


### PR DESCRIPTION
## Summary
Separate GHA Runner Scale Set bug surfaced mid-drain: GitHub keeps redelivering stale "job available" offers for matrix slots that were fail-fast-cancelled before ever being created — confirmed to survive pod delete, listener restart, controller restart, and a full EphemeralRunner purge. It's GitHub-side queue state, not fixable here, and a bigger pool doesn't mitigate it (more slots = more concurrent phantom holds, not more real throughput). Root cause #1149 already stops new waste at the source, so 12 idle-capable spot runners no longer buy a proportional benefit over 6.

## Type of change
- [x] Infra/CI change, revert of #1146/#1147

## Already applied
Applied directly (`tofu apply -target=helm_release.arc_build`) and verified live (`kubectl get autoscalingrunnerset` → MAXIMUM RUNNERS: 6) before this PR.