### PR TITLE
fix(infra): upgrade ARC gha-runner-scale-set 0.9.3 -> 0.14.2

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/variables.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/variables.tf
@@ -34,7 +34,17 @@ variable "cnpg_version" {
 variable "arc_controller_version" {
   description = "gha-runner-scale-set-controller Helm chart version."
   type        = string
-  default     = "0.9.3"
+  # Raised 0.9.3 -> 0.14.2 (2026-07-15): 0.9.3 (2024-06-25) predates a real upstream bug
+  # (actions/actions-runner-controller#4091, "EphemeralRunner stuck in failed state if the
+  # job it was allocated to is cancelled") fixed by #4239/#4260, first shipped in 0.13.0
+  # (2025-10-16). Live-confirmed on this cluster: when a matrix job's assignment was
+  # cancelled/superseded, the controller recreated a NEW pod bound to the SAME stale
+  # EphemeralRunner CR/job claim rather than releasing it — surviving `kubectl delete pod`,
+  # a listener restart, and a controller restart; only deleting the EphemeralRunner CR
+  # itself (with a finalizer strip when it hung) actually cleared it. Took the latest
+  # stable (0.14.2, 2026-05-22) rather than stopping at the minimum fix version — no
+  # BREAKING/migration/CRD-manual-step notes in 0.13.1-0.14.2's release notes.
+  default = "0.14.2"
 }
 
 variable "keda_version" {


### PR DESCRIPTION
## Summary
0.9.3 (2024-06-25) predates a real upstream bug (actions/actions-runner-controller#4091, "EphemeralRunner stuck in failed state if the job it was allocated to is cancelled") fixed by #4239/#4260, first shipped in 0.13.0 (2025-10-16). Live-confirmed on this cluster during a 2026-07-15 CI backlog incident — see #1152 for full symptom writeup.

## Type of change
- [x] Infra fix

## Linked issues
Closes #1152

## Changes
- `openbank-infra/aws/envs/sandbox-platform/variables.tf`: `arc_controller_version` 0.9.3 → 0.14.2 (shared by all 4 `helm_release` resources: `arc_controller`, `arc_build`, `arc_batch`, `arc_deploy`).

## Safety
Took the latest stable (0.14.2) rather than stopping at the minimum fix version (0.13.0) — no BREAKING/migration/CRD-manual-step notes found in 0.13.1 through 0.14.2's release notes.

Deliberately did NOT touch `arc-runner-reaper.tf`'s `IDLE_THRESHOLD_SECONDS` (considered, then ruled out): the reaper's selection guard requires `jobRequestId==0`; a phantom runner from this bug has a non-zero `jobRequestId`, so the reaper structurally cannot reach this class of stuck runner regardless of threshold.

## Already applied
Applied directly (targeted `tofu apply` on all 4 `helm_release` resources). `openbank-build`'s `AutoscalingRunnerSet` briefly vanished mid-upgrade (Helm reported "deployed" but the K8s object never recreated, because the old object — blocked by a still-finalizing phantom runner — hadn't finished terminating when the new manifest applied; Terraform didn't detect this since `helm_release` only tracks release metadata, not the underlying object). Fixed via `tofu taint` + re-apply to force recreation. Verified live: new listener + scale set came up on 0.14.2, and a real job from an in-flight run got assigned to a fresh runner immediately after.

## Reviewer notes
This is the durable root-cause fix for #1152, distinct from and following the same-day operational bumps in #1146/#1147/#1151 (temporary `arc_max_runners` capacity changes for an unrelated CI-scoping issue, #1149).