### PR TITLE
chore(gitops): auto-deploy services @ aeb6e2021b2329ba689a7e6127f8657499d4ca3d

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-baf6a154
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-aeb6e202
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit aeb6e2021b2329ba689a7e6127f8657499d4ca3d.

**Changed services:** ["openbank-document-service"]

Each image tag was updated to `sandbox-aeb6e2021b2329ba689a7e6127f8657499d4ca3d` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.