### PR TITLE
fix(party-service,customer-edge): forward + persist onboarding consent

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -1440,6 +1440,10 @@ class CustomerEdgeResource(
         extractTextField(objectMapper, body, "phone")?.let { out.put("phone", it) }
         extractTextField(objectMapper, body, "dateOfBirth")?.let { out.put("dateOfBirth", it) }
         extractTextField(objectMapper, body, "nationality")?.let { out.put("nationality", it) }
+        // Onboarding consent capture (mobile app "Agreement" step) — previously accepted by the
+        // app's request model but silently dropped here before reaching party-service.
+        extractBooleanField(objectMapper, body, "consentGdpr")?.let { out.put("consentGdpr", it) }
+        extractBooleanField(objectMapper, body, "consentMarketing")?.let { out.put("consentMarketing", it) }
 
         // Identity-resolution dedup gate (ADR-0072 §6 / ADR-0094): short-circuits to an existing
         // party (reuse) or a neutral pending state when pid resolves this applicant; null = proceed.
@@ -2035,6 +2039,14 @@ class CustomerEdgeResource(
             (mapper.readTree(json) as? ObjectNode)?.get(field)?.takeIf {
                 it.isTextual
             }?.asText()?.takeIf { it.isNotBlank() }
+        }.getOrNull()
+
+        /**
+         * Pull a single boolean field from a JSON object body, or null if absent/wrong type.
+         * Package-visible for tests.
+         */
+        internal fun extractBooleanField(mapper: ObjectMapper, json: String, field: String): Boolean? = runCatching {
+            (mapper.readTree(json) as? ObjectNode)?.get(field)?.takeIf { it.isBoolean }?.asBoolean()
         }.getOrNull()
 
         /**

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceTest.kt
@@ -962,6 +962,73 @@ class CustomerEdgeResourceTest {
     }
 
     @Test
+    fun `registerParty forwards consentGdpr and consentMarketing to party-service`() {
+        val sub = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        var forwarded: String? = null
+        every { upstream.post(match { it.contains("/api/v1/parties") }, any(), any(), any()) } answers {
+            forwarded = thirdArg()
+            Response.status(201)
+                .entity("""{"id":"$sub","status":"PENDING_KYC"}""").build()
+        }
+        val resource = CustomerEdgeResource(
+            upstream,
+            mockk(relaxed = true),
+            PaymentSessionStore(),
+            mockk(relaxed = true),
+            Clock.systemUTC(),
+        ).apply {
+            jwt = mockk {
+                every { getClaim<String>("party_id") } returns null
+                every { subject } returns sub.toString()
+            }
+            objectMapper = ObjectMapper()
+            partyServiceUrl = "http://party"
+        }
+
+        val resp = resource.registerParty(
+            """{"legalName":"Jan Novák","email":"jan@example.cz","consentGdpr":true,"consentMarketing":false}""",
+        )
+
+        assertThat(resp.status).isEqualTo(201)
+        val node = mapper.readTree(forwarded!!)
+        assertThat(node.get("consentGdpr").asBoolean()).isTrue()
+        assertThat(node.get("consentMarketing").asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `registerParty omits consent fields entirely when the body doesn't send them`() {
+        val sub = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        var forwarded: String? = null
+        every { upstream.post(match { it.contains("/api/v1/parties") }, any(), any(), any()) } answers {
+            forwarded = thirdArg()
+            Response.status(201)
+                .entity("""{"id":"$sub","status":"PENDING_KYC"}""").build()
+        }
+        val resource = CustomerEdgeResource(
+            upstream,
+            mockk(relaxed = true),
+            PaymentSessionStore(),
+            mockk(relaxed = true),
+            Clock.systemUTC(),
+        ).apply {
+            jwt = mockk {
+                every { getClaim<String>("party_id") } returns null
+                every { subject } returns sub.toString()
+            }
+            objectMapper = ObjectMapper()
+            partyServiceUrl = "http://party"
+        }
+
+        resource.registerParty("""{"legalName":"Jan Novák","email":"jan@example.cz"}""")
+
+        val node = mapper.readTree(forwarded!!)
+        assertThat(node.has("consentGdpr")).isFalse()
+        assertThat(node.has("consentMarketing")).isFalse()
+    }
+
+    @Test
     fun `registerParty falls back to the token name and email claims when the body omits them`() {
         val sub = UUID.randomUUID()
         val upstream = mockk<UpstreamClient>()

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -51,6 +51,9 @@ data class CreatePartyCommand(
     val address: Address?,
     /** Explicit party id (ADR-0069 §B1: id == Keycloak sub for self-service onboarding). */
     val id: UUID? = null,
+    /** Onboarding consent capture (mobile app "Agreement" step). Null = not asked/answered. */
+    val consentGdpr: Boolean? = null,
+    val consentMarketing: Boolean? = null,
 )
 
 data class UpdatePartyCommand(

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -60,6 +60,11 @@ class PartyService : PartyUseCase {
             partyRepo.findById(requested)?.let { return it }
         }
         val (rcIndex, rcKeyVer) = computeRcBlindIndex(cmd.taxId)
+        val consentCapturedAt = if (cmd.consentGdpr != null || cmd.consentMarketing != null) {
+            Instant.now(clock)
+        } else {
+            null
+        }
         val party = Party(
             id = cmd.id ?: UUID.randomUUID(),
             // B1 invariant for self-service onboarding: id == Keycloak sub. Mirror it into
@@ -81,6 +86,9 @@ class PartyService : PartyUseCase {
             updatedAt = Instant.now(clock),
             rcBlindIndex = rcIndex,
             rcIndexKeyVersion = rcKeyVer,
+            consentGdpr = cmd.consentGdpr,
+            consentMarketing = cmd.consentMarketing,
+            consentCapturedAt = consentCapturedAt,
         )
         val saved = partyRepo.save(party)
         eventPublisher.publishPartyCreated(saved)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -33,6 +33,15 @@ data class Party(
     /** ADR-0072: HMAC-SHA256(pepper, canonical_rc) blind index — null if no RČ or non-Czech. */
     val rcBlindIndex: String? = null,
     val rcIndexKeyVersion: Int? = null,
+    /**
+     * Onboarding consent capture (mobile app "Agreement" step). Null = not asked / not answered
+     * (e.g. operator-created parties). `consentCapturedAt` is stamped whenever either value is
+     * present, giving a minimal "when was this consent given" audit trail — it does NOT version
+     * the consent text itself; that's a follow-up if the wording needs to change over time.
+     */
+    val consentGdpr: Boolean? = null,
+    val consentMarketing: Boolean? = null,
+    val consentCapturedAt: Instant? = null,
 )
 
 data class Address(

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
@@ -82,6 +82,16 @@ class PartyEntity : PanacheEntity() {
     /** Which pepper key version produced [rcBlindIndex]; used during pepper rotation. */
     @Column(name = "rc_index_key_version")
     var rcIndexKeyVersion: Int? = null
+
+    /** Onboarding consent capture (mobile app "Agreement" step) — null = not asked/answered. */
+    @Column(name = "consent_gdpr")
+    var consentGdpr: Boolean? = null
+
+    @Column(name = "consent_marketing")
+    var consentMarketing: Boolean? = null
+
+    @Column(name = "consent_captured_at")
+    var consentCapturedAt: Instant? = null
 }
 
 @Entity

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -151,6 +151,9 @@ class PartyRepositoryImpl :
         it.keycloakSub = keycloakSub
         it.rcBlindIndex = rcBlindIndex
         it.rcIndexKeyVersion = rcIndexKeyVersion
+        it.consentGdpr = consentGdpr
+        it.consentMarketing = consentMarketing
+        it.consentCapturedAt = consentCapturedAt
     }
 
     private fun PartyEntity.toDomain() = Party(
@@ -176,6 +179,9 @@ class PartyRepositoryImpl :
         amlStatus = AmlStatus.valueOf(amlStatus),
         rcBlindIndex = rcBlindIndex,
         rcIndexKeyVersion = rcIndexKeyVersion,
+        consentGdpr = consentGdpr,
+        consentMarketing = consentMarketing,
+        consentCapturedAt = consentCapturedAt,
     )
 }
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -423,6 +423,10 @@ data class CreatePartyRequest(
     // here so party id == sub and the principal binding holds without a KC admin client.
     // The endpoint is operator-realm-only, so customers cannot mint arbitrary ids.
     val id: String? = null,
+    // Onboarding consent capture (mobile app "Agreement" step, ADR-0069). Null = not
+    // asked/answered — operator-created parties never send these.
+    val consentGdpr: Boolean? = null,
+    val consentMarketing: Boolean? = null,
 ) {
     fun toCommand(key: String): CreatePartyCommand {
         require(!email.isNullOrBlank()) { "email is required" }
@@ -430,6 +434,8 @@ data class CreatePartyRequest(
             key, PartyType.valueOf(partyType), legalName, tradingName,
             dateOfBirth, nationality, taxId, registrationNumber, email, phone, address?.toDomain(),
             id?.takeIf { it.isNotBlank() }?.let { UUID.fromString(it) },
+            consentGdpr = consentGdpr,
+            consentMarketing = consentMarketing,
         )
     }
 }

--- a/openbank-party-service/src/main/resources/db/migration/V12__consent_capture.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V12__consent_capture.sql
@@ -1,0 +1,18 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- Onboarding consent capture (mobile app "Agreement" step, ADR-0069). The app has collected
+-- a GDPR (required) and marketing (optional) checkbox since the onboarding UI shipped, but the
+-- edge never forwarded them and party-service had nowhere to store them — both flags were
+-- silently dropped. This does not retro-fix past onboardings: existing rows get NULL
+-- (not asked/answered), which is the correct honest value, not FALSE.
+--
+-- consent_captured_at is stamped only when at least one flag is present, giving a minimal
+-- "when was consent given" audit trail. This does NOT version the consent text itself — if the
+-- wording changes materially, that needs a follow-up (e.g. a consent_version column).
+--
+-- Rollback note: DROP COLUMN is instant in Postgres (no-rewrite, logical catalog change).
+ALTER TABLE parties
+    ADD COLUMN consent_gdpr        BOOLEAN,
+    ADD COLUMN consent_marketing   BOOLEAN,
+    ADD COLUMN consent_captured_at TIMESTAMPTZ;

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -372,6 +372,14 @@ components:
           type: string
         address:
           $ref: '#/components/schemas/AddressDto'
+        consentGdpr:
+          type: boolean
+          description: >-
+            Onboarding consent capture (mobile app "Agreement" step, ADR-0069). Omitted for
+            operator-created parties. When present, the service stamps a capture timestamp.
+        consentMarketing:
+          type: boolean
+          description: Optional marketing-communications consent from the same onboarding step.
 
     UpdatePartyRequest:
       type: object

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceConsentTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceConsentTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.`in`.CreatePartyCommand
+import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyType
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Optional
+
+/**
+ * Onboarding consent capture (mobile app "Agreement" step, ADR-0069). Split out of
+ * [PartyServiceTest] to keep that class under detekt's LargeClass threshold.
+ */
+class PartyServiceConsentTest {
+
+    private val now = Instant.parse("2025-01-01T00:00:00Z")
+
+    private fun newService() = PartyService().apply {
+        partyRepo = mockk()
+        documentRepo = mockk()
+        documentFileRepo = mockk()
+        eventPublisher = mockk(relaxed = true)
+        metrics = mockk(relaxed = true)
+        gdprAggregation = mockk(relaxed = true)
+        rcPepper = Optional.empty()
+        clock = Clock.fixed(now, ZoneOffset.UTC)
+    }
+
+    @Test
+    fun `createParty stores consent flags and stamps consentCapturedAt when either is present`(): Unit = runBlocking {
+        val service = newService()
+        val savedSlot = slot<Party>()
+        coEvery { service.partyRepo.findByEmail(any()) } returns null
+        coEvery { service.partyRepo.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        service.createParty(
+            CreatePartyCommand(
+                idempotencyKey = "key3",
+                partyType = PartyType.INDIVIDUAL,
+                legalName = "Test3",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "t3@example.com",
+                phone = null,
+                address = null,
+                consentGdpr = true,
+                consentMarketing = false,
+            ),
+        )
+
+        assertThat(savedSlot.captured.consentGdpr).isTrue()
+        assertThat(savedSlot.captured.consentMarketing).isFalse()
+        assertThat(savedSlot.captured.consentCapturedAt).isEqualTo(now)
+    }
+
+    @Test
+    fun `createParty leaves consent fields and consentCapturedAt null when neither is sent`(): Unit = runBlocking {
+        val service = newService()
+        val savedSlot = slot<Party>()
+        coEvery { service.partyRepo.findByEmail(any()) } returns null
+        coEvery { service.partyRepo.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        service.createParty(
+            CreatePartyCommand(
+                idempotencyKey = "key4",
+                partyType = PartyType.INDIVIDUAL,
+                legalName = "Test4",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "t4@example.com",
+                phone = null,
+                address = null,
+            ),
+        )
+
+        assertThat(savedSlot.captured.consentGdpr).isNull()
+        assertThat(savedSlot.captured.consentMarketing).isNull()
+        assertThat(savedSlot.captured.consentCapturedAt).isNull()
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
@@ -709,64 +709,6 @@ class PartyServiceTest {
         assertThat(savedSlot.captured.rcIndexKeyVersion).isNull()
     }
 
-    @Test
-    fun `createParty stores consent flags and stamps consentCapturedAt when either is present`(): Unit = runBlocking {
-        val service = newService()
-        val savedSlot = slot<Party>()
-        coEvery { service.partyRepo.findByEmail(any()) } returns null
-        coEvery { service.partyRepo.save(capture(savedSlot)) } answers { savedSlot.captured }
-
-        service.createParty(
-            CreatePartyCommand(
-                idempotencyKey = "key3",
-                partyType = PartyType.INDIVIDUAL,
-                legalName = "Test3",
-                tradingName = null,
-                dateOfBirth = null,
-                nationality = null,
-                taxId = null,
-                registrationNumber = null,
-                email = "t3@example.com",
-                phone = null,
-                address = null,
-                consentGdpr = true,
-                consentMarketing = false,
-            ),
-        )
-
-        assertThat(savedSlot.captured.consentGdpr).isTrue()
-        assertThat(savedSlot.captured.consentMarketing).isFalse()
-        assertThat(savedSlot.captured.consentCapturedAt).isEqualTo(now)
-    }
-
-    @Test
-    fun `createParty leaves consent fields and consentCapturedAt null when neither is sent`(): Unit = runBlocking {
-        val service = newService()
-        val savedSlot = slot<Party>()
-        coEvery { service.partyRepo.findByEmail(any()) } returns null
-        coEvery { service.partyRepo.save(capture(savedSlot)) } answers { savedSlot.captured }
-
-        service.createParty(
-            CreatePartyCommand(
-                idempotencyKey = "key4",
-                partyType = PartyType.INDIVIDUAL,
-                legalName = "Test4",
-                tradingName = null,
-                dateOfBirth = null,
-                nationality = null,
-                taxId = null,
-                registrationNumber = null,
-                email = "t4@example.com",
-                phone = null,
-                address = null,
-            ),
-        )
-
-        assertThat(savedSlot.captured.consentGdpr).isNull()
-        assertThat(savedSlot.captured.consentMarketing).isNull()
-        assertThat(savedSlot.captured.consentCapturedAt).isNull()
-    }
-
     private fun newService() = PartyService().apply {
         partyRepo = mockk()
         documentRepo = mockk()

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceTest.kt
@@ -709,6 +709,64 @@ class PartyServiceTest {
         assertThat(savedSlot.captured.rcIndexKeyVersion).isNull()
     }
 
+    @Test
+    fun `createParty stores consent flags and stamps consentCapturedAt when either is present`(): Unit = runBlocking {
+        val service = newService()
+        val savedSlot = slot<Party>()
+        coEvery { service.partyRepo.findByEmail(any()) } returns null
+        coEvery { service.partyRepo.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        service.createParty(
+            CreatePartyCommand(
+                idempotencyKey = "key3",
+                partyType = PartyType.INDIVIDUAL,
+                legalName = "Test3",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "t3@example.com",
+                phone = null,
+                address = null,
+                consentGdpr = true,
+                consentMarketing = false,
+            ),
+        )
+
+        assertThat(savedSlot.captured.consentGdpr).isTrue()
+        assertThat(savedSlot.captured.consentMarketing).isFalse()
+        assertThat(savedSlot.captured.consentCapturedAt).isEqualTo(now)
+    }
+
+    @Test
+    fun `createParty leaves consent fields and consentCapturedAt null when neither is sent`(): Unit = runBlocking {
+        val service = newService()
+        val savedSlot = slot<Party>()
+        coEvery { service.partyRepo.findByEmail(any()) } returns null
+        coEvery { service.partyRepo.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+        service.createParty(
+            CreatePartyCommand(
+                idempotencyKey = "key4",
+                partyType = PartyType.INDIVIDUAL,
+                legalName = "Test4",
+                tradingName = null,
+                dateOfBirth = null,
+                nationality = null,
+                taxId = null,
+                registrationNumber = null,
+                email = "t4@example.com",
+                phone = null,
+                address = null,
+            ),
+        )
+
+        assertThat(savedSlot.captured.consentGdpr).isNull()
+        assertThat(savedSlot.captured.consentMarketing).isNull()
+        assertThat(savedSlot.captured.consentCapturedAt).isNull()
+    }
+
     private fun newService() = PartyService().apply {
         partyRepo = mockk()
         documentRepo = mockk()


### PR DESCRIPTION
## Summary
- The mobile app's onboarding "Agreement" step captures a GDPR (required) + marketing (optional) consent checkbox, but it never reached the backend: `customer-edge`'s `/onboarding/register` handler rebuilds the outgoing JSON field-by-field and silently dropped both flags, and `party-service` had no field/column to store them anyway.
- `party-service`: threaded `consentGdpr`/`consentMarketing` through `CreatePartyRequest → CreatePartyCommand → Party → PartyEntity`, plus a `consentCapturedAt` timestamp stamped only when either flag is present (minimal "when was this given" audit trail — does not version the consent text itself). New nullable columns via `V12__consent_capture.sql`; existing rows get `NULL` (not asked), not `FALSE`.
- `customer-edge`: `registerParty()` now forwards both flags (new `extractBooleanField` helper, mirrors the existing `extractTextField`). The unauthenticated `/onboarding/start` path already forwards the raw body verbatim, so it picks these up for free once `party-service` accepts them.
- `openapi.yaml`: documented the two new optional `CreatePartyRequest` fields.

## Linked issues
N/A — found ad-hoc while auditing the mobile app's onboarding/consent flow tonight; no tracking issue was filed before the fix.

## Test plan
- [x] `:openbank-party-service:compileKotlin` / `:openbank-customer-edge:compileKotlin` clean
- [x] `ktlintCheck` + `detekt` clean on both services
- [x] New tests: consent forwarded when present, omitted entirely when absent (`CustomerEdgeResourceTest`); consent stored + `consentCapturedAt` stamped vs. left null (`PartyServiceConsentTest`)
- [x] Existing `CustomerEdgeResourceTest`, `PartyServiceTest`, `CreatePartyRequestTest` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
