### PR TITLE
fix(infra): attest keycloak image SBOM to close kyverno gap

### DIFF
--- a/openbank-infra/scripts/build-push-keycloak.sh
+++ b/openbank-infra/scripts/build-push-keycloak.sh
@@ -37,63 +37,23 @@ aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS 
 docker buildx build --platform "$PLATFORM" -f "$DOCKERFILE" -t "$IMAGE" --push openbank-infra/docker/keycloak
 echo "==> pushed ${IMAGE}"
 
-# Sign with Cosign (ADR-0029/0030) — the kyverno verify-openbank-image-signatures
-# Enforce policy rejects unsigned 265175468565.../openbank-* images at admission.
+# Sign + attest with Cosign (ADR-0029/0030 D4). Kyverno runs two independent Enforce
+# policies at admission: verify-openbank-image-signatures rejects an unsigned image, and
+# verify-openbank-image-sbom-attestation rejects a signed-but-unattested one. This script
+# previously only signed, so every keycloak build produced an image that passed the first
+# gate and failed the second — latent until a pod rescheduled, which is what took admin-ui
+# login down on 2026-07-16.
 #
-# cosign v2 is pinned on purpose: kyverno 3.2.6 discovers signatures only via the
-# legacy `sha256-<digest>.sig` tag scheme. cosign v3 writes OCI 1.1 referrer
-# signatures kyverno cannot find. (Same pin/rationale as build-push-pyroscope-agent.sh.)
-COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
-COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
+# The shared helper owns the cosign-v2 pin, the mandatory trivy --platform, and the
+# post-attest verify. Provenance failures are FATAL there: a silently-unattested image is
+# an image that cannot be admitted.
+. "${REPO_ROOT}/openbank-infra/scripts/lib/cosign-attest.sh"
 
-resolve_cosign_v2() {
-  if command -v cosign >/dev/null 2>&1 && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; then
-    command -v cosign; return 0
-  fi
-  local os arch bin
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; x86_64|amd64) arch=amd64 ;; *) return 1 ;; esac
-  bin="${TMPDIR:-/tmp}/cosign-${COSIGN_VERSION}-${os}-${arch}"
-  if [ ! -x "$bin" ]; then
-    curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}" 2>/dev/null && chmod +x "$bin" || return 1
-  fi
-  printf '%s\n' "$bin"
-}
-
-COSIGN_BIN="$(resolve_cosign_v2 || true)"
-if [ -n "${COSIGN_BIN:-}" ]; then
-  echo "==> cosign sign ${IMAGE} (tag-based, $("$COSIGN_BIN" version 2>/dev/null | awk '/GitVersion/{print $2}'))"
-  if COSIGN_YES=true "$COSIGN_BIN" sign --key "${COSIGN_KEY}" "${IMAGE}"; then
-    echo "    signed (key=${COSIGN_KEY})"
-  else
-    echo "WARN: cosign sign failed — image pushed but UNSIGNED (kyverno will reject it under Enforce)." >&2
-    exit 1
-  fi
-  # Deploy-time provenance: attach a signed CycloneDX SBOM ATTESTATION to the image
-  # (ADR-0030 D4). Kyverno's verify-openbank-image-sbom-attestation policy checks
-  # this independently of the signature above — a signed-but-unattested image is
-  # rejected at pod admission the same as an unsigned one. trivy generates the
-  # image SBOM, cosign attest binds it with the same KMS key (matches
-  # build-push-admin-ui.sh's step).
-  if command -v trivy >/dev/null 2>&1; then
-    KEYCLOAK_SBOM="${TMPDIR:-/tmp}/openbank-keycloak.cdx.json"
-    if trivy image --platform "${PLATFORM}" --format cyclonedx --output "${KEYCLOAK_SBOM}" "${IMAGE}" 2>/dev/null; then
-      echo "==> cosign attest (cyclonedx) ${IMAGE}"
-      COSIGN_YES=true "$COSIGN_BIN" attest --key "${COSIGN_KEY}" --type cyclonedx \
-        --predicate "${KEYCLOAK_SBOM}" "${IMAGE}" \
-        && echo "    attested SBOM (key=${COSIGN_KEY})" \
-        || { echo "ERROR: cosign attest failed — image pushed but SBOM not attested (kyverno will reject it)." >&2; exit 1; }
-    else
-      echo "ERROR: trivy image SBOM generation failed — cannot attest (kyverno will reject the image)." >&2
-      exit 1
-    fi
-  else
-    echo "ERROR: trivy unavailable — cannot attest SBOM (kyverno will reject the image). Install trivy." >&2
-    exit 1
-  fi
-else
-  echo "WARN: cosign v2 unavailable — image pushed UNSIGNED. Install cosign v2.x or set COSIGN_VERSION (ADR-0029)." >&2
+cosign_sign_and_attest "$IMAGE" "$PLATFORM" || {
+  echo "ERROR: ${IMAGE} pushed but NOT fully attested — it is NOT deployable." >&2
+  echo "       keycloak is the cluster IdP: an unattested tag here breaks every login" >&2
+  echo "       the moment its pod reschedules. Fix the provenance failure above and re-run." >&2
   exit 1
-fi
+}
 
 echo "==> done."

--- a/openbank-infra/scripts/build-push-keycloak.sh
+++ b/openbank-infra/scripts/build-push-keycloak.sh
@@ -69,6 +69,28 @@ if [ -n "${COSIGN_BIN:-}" ]; then
     echo "WARN: cosign sign failed — image pushed but UNSIGNED (kyverno will reject it under Enforce)." >&2
     exit 1
   fi
+  # Deploy-time provenance: attach a signed CycloneDX SBOM ATTESTATION to the image
+  # (ADR-0030 D4). Kyverno's verify-openbank-image-sbom-attestation policy checks
+  # this independently of the signature above — a signed-but-unattested image is
+  # rejected at pod admission the same as an unsigned one. trivy generates the
+  # image SBOM, cosign attest binds it with the same KMS key (matches
+  # build-push-admin-ui.sh's step).
+  if command -v trivy >/dev/null 2>&1; then
+    KEYCLOAK_SBOM="${TMPDIR:-/tmp}/openbank-keycloak.cdx.json"
+    if trivy image --platform "${PLATFORM}" --format cyclonedx --output "${KEYCLOAK_SBOM}" "${IMAGE}" 2>/dev/null; then
+      echo "==> cosign attest (cyclonedx) ${IMAGE}"
+      COSIGN_YES=true "$COSIGN_BIN" attest --key "${COSIGN_KEY}" --type cyclonedx \
+        --predicate "${KEYCLOAK_SBOM}" "${IMAGE}" \
+        && echo "    attested SBOM (key=${COSIGN_KEY})" \
+        || { echo "ERROR: cosign attest failed — image pushed but SBOM not attested (kyverno will reject it)." >&2; exit 1; }
+    else
+      echo "ERROR: trivy image SBOM generation failed — cannot attest (kyverno will reject the image)." >&2
+      exit 1
+    fi
+  else
+    echo "ERROR: trivy unavailable — cannot attest SBOM (kyverno will reject the image). Install trivy." >&2
+    exit 1
+  fi
 else
   echo "WARN: cosign v2 unavailable — image pushed UNSIGNED. Install cosign v2.x or set COSIGN_VERSION (ADR-0029)." >&2
   exit 1


### PR DESCRIPTION
## Why

`build-push-keycloak.sh` only ran `cosign sign`. Kyverno runs **two independent Enforce policies** at admission — `verify-openbank-image-signatures` (rejects unsigned) and `verify-openbank-image-sbom-attestation` (rejects signed-but-unattested) — so every keycloak build produced an image that passed the first gate and failed the second.

Nothing broke at build time, or at deploy time, or for a month afterwards: Kyverno verifies at **admission**, and a running pod is never re-admitted. The image sat there, live and unattested, until its pod rescheduled on 2026-07-16 — at which point Keycloak could not come back, and **every admin-ui login broke**. The image had been pushed 2026-06-15.

`openbank-pyroscope-agent` had the same gap in its own script and took down `payments/sepa-payment` (money path) the same way, for four days.

## What changed

Sources the shared `openbank-infra/scripts/lib/cosign-attest.sh` helper introduced by #1177, which already moved every other producer onto it:

```sh
. "${REPO_ROOT}/openbank-infra/scripts/lib/cosign-attest.sh"
cosign_sign_and_attest "$IMAGE" "$PLATFORM" || { ...; exit 1; }
```

The helper owns the cosign-v2 pin (kyverno 3.2.6 discovers provenance only via the legacy `sha256-<digest>.sig`/`.att` tag scheme; v3 writes OCI 1.1 referrers it cannot find), the mandatory `trivy --platform`, and a post-attest `cosign verify-attestation` so that "`attest` exited 0" is never taken on trust. Provenance failure is **fatal** — a silently-unattested image is an image that cannot be admitted, and shipping one is what caused the outage.

**Net −40 lines.** An earlier revision of this PR carried an inline trivy+cosign block; that predated #1177. Keeping it would have left keycloak as the one producer re-implementing sign+attest by hand, with its own copy of the v2 pin to drift out of sync.

## Test plan

- [x] `bash -n` — syntax OK
- [x] `shellcheck -S warning` — clean
- [x] `REPO_ROOT` is defined (line 19) before the source line
- [x] Commits signed (`%G? = G`)
- [ ] Next real keycloak build exercises the helper end-to-end

The live fleet is already green — the 5 unattested images (keycloak included) were attested by hand during the incident, and #1177's `fleet-attestation` gate now reports `53 attested / 0 unattested / 54 total` on `main`. This PR is what stops the gap **reopening** on the next keycloak rebuild.

## Linked issues

Refs #310 — this is the tail of that issue's Enforce graduation: the criterion "the running fleet was fully redeployed with attested images" was asserted, not measured, and keycloak was one of the images it was wrong about.
