### PR TITLE
feat(party-service,customer-edge): revocable marketing consent (Profile screen)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -744,10 +744,10 @@ class CustomerEdgeResource(
     // --- Profile (the caller's own party) ---
 
     /**
-     * The caller's own customer profile (name, contact, KYC status, member-since). Party-scoped by the
-     * JWT party — never a client-supplied id — so a customer only ever reads their own (no IDOR). The
-     * party-service response is already customer-safe: it carries no AML status, national id or risk
-     * fields (see Party.toResponse — legalName/email/phone/kycStatus/status/address/createdAt only).
+     * The caller's own customer profile (name, contact, KYC status, member-since, consent state).
+     * Party-scoped by the JWT party — never a client-supplied id — so a customer only ever reads
+     * their own (no IDOR). The party-service response is already customer-safe: it carries no AML
+     * status, national id or risk fields (see Party.toResponse).
      */
     @GET
     @Path("/profile")
@@ -756,6 +756,30 @@ class CustomerEdgeResource(
     fun getProfile(): Response {
         val customer = customer()
         return upstream.get("$partyServiceUrl/api/v1/parties/${customer.partyId}", customer.partyId.toString())
+    }
+
+    /**
+     * Revoke/re-grant marketing consent (mobile app Profile screen). Party-scoped by the JWT party
+     * (the M2M call to party-service always carries the CALLER's own id from the token, never a
+     * client-supplied one), so a customer can only ever change their own consent — no IDOR. Only
+     * `marketingConsent` is accepted here: the onboarding-time `consentGdpr` snapshot has no update
+     * path (it isn't revocable GDPR consent in the first place — see party-service's
+     * UpdateMarketingConsentCommand kdoc).
+     */
+    @PATCH
+    @Path("/profile/consent")
+    @Authorize(action = "customer.profile.consent.update")
+    @Blocking
+    fun updateConsent(body: String): Response {
+        val customer = customer()
+        val marketingConsent = extractBooleanField(objectMapper, body, "marketingConsent")
+            ?: return badRequest("marketingConsent (boolean) is required")
+        val out = """{"marketingConsent":$marketingConsent}"""
+        return upstream.patch(
+            "$partyServiceUrl/api/v1/parties/${customer.partyId}/consent",
+            customer.partyId.toString(),
+            out,
+        )
     }
 
     // --- Transactions ---

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -253,6 +253,24 @@ class UpstreamClient {
             .type(MediaType.APPLICATION_JSON).build()
     }
 
+    /** PATCH with a JSON body + M2M token + party header — e.g. update marketing consent. */
+    fun patch(url: String, partyId: String, body: String): Response = try {
+        val request = HttpRequest.newBuilder()
+            .uri(validatedUri(url))
+            .header("Authorization", "Bearer ${serviceToken()}")
+            .header(PARTY_HEADER, partyId)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .timeout(Duration.ofMillis(requestTimeoutMs))
+            .method("PATCH", HttpRequest.BodyPublishers.ofString(body)).build()
+        val r = http.send(request, HttpResponse.BodyHandlers.ofString())
+        Response.status(r.statusCode()).entity(r.body()).type(MediaType.APPLICATION_JSON).build()
+    } catch (e: Exception) {
+        Log.error("upstream call to $url failed: ${e::class.qualifiedName}: ${e.message}", e)
+        Response.status(502).entity("""{"error":"upstream unavailable"}""")
+            .type(MediaType.APPLICATION_JSON).build()
+    }
+
     /** PUT with a JSON body + M2M token + party header — e.g. set a savings goal (ADR-0153). */
     fun put(url: String, partyId: String, body: String): Response = try {
         val request = HttpRequest.newBuilder()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceConsentTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerEdgeResourceConsentTest.kt
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.CustomerEdgeResource
+import com.openbank.customeredge.infrastructure.rest.PaymentSessionStore
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.util.UUID
+
+/**
+ * Post-onboarding marketing-consent revocation (mobile app Profile screen). Split into its own
+ * class rather than appended to the already-large [CustomerEdgeResourceTest].
+ */
+class CustomerEdgeResourceConsentTest {
+
+    private fun newResource(sub: UUID, upstream: UpstreamClient): CustomerEdgeResource = CustomerEdgeResource(
+        upstream,
+        mockk(relaxed = true),
+        PaymentSessionStore(),
+        mockk(relaxed = true),
+        Clock.systemUTC(),
+    ).apply {
+        jwt = mockk {
+            every { getClaim<String>("party_id") } returns null
+            every { subject } returns sub.toString()
+        }
+        objectMapper = ObjectMapper()
+        partyServiceUrl = "http://party"
+    }
+
+    @Test
+    fun `updateConsent PATCHes marketingConsent scoped to the caller's own party id`() {
+        val sub = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val bodySlot = slot<String>()
+        every {
+            upstream.patch(match { it.contains("/api/v1/parties/$sub/consent") }, sub.toString(), capture(bodySlot))
+        } returns Response.ok("""{"id":"$sub","consentMarketing":false}""").build()
+        val resource = newResource(sub, upstream)
+
+        val resp = resource.updateConsent("""{"marketingConsent":false}""")
+
+        assertThat(resp.status).isEqualTo(200)
+        assertThat(bodySlot.captured).isEqualTo("""{"marketingConsent":false}""")
+        verify(exactly = 1) { upstream.patch(any(), sub.toString(), any()) }
+    }
+
+    @Test
+    fun `updateConsent rejects a body missing marketingConsent without calling upstream`() {
+        val sub = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val resource = newResource(sub, upstream)
+
+        val resp = resource.updateConsent("{}")
+
+        assertThat(resp.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.patch(any(), any(), any()) }
+    }
+
+    @Test
+    fun `updateConsent rejects a non-boolean marketingConsent value`() {
+        val sub = UUID.randomUUID()
+        val upstream = mockk<UpstreamClient>()
+        val resource = newResource(sub, upstream)
+
+        val resp = resource.updateConsent("""{"marketingConsent":"yes"}""")
+
+        assertThat(resp.status).isEqualTo(400)
+        verify(exactly = 0) { upstream.patch(any(), any(), any()) }
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -64,6 +64,15 @@ data class UpdatePartyCommand(
     val tradingName: String?,
 )
 
+/**
+ * Revoke/re-grant marketing consent post-onboarding (mobile app Profile screen). Deliberately
+ * NOT a general "update consent" command: `consentGdpr` is an immutable onboarding-time record
+ * (data processing needed to run the account is a contract/legal-obligation basis, not GDPR
+ * Art 6(1)(a) consent, so it isn't something to "revoke" while keeping the account open) —
+ * only the marketing opt-in is genuinely revocable consent under Art 6(1)(a)/ePrivacy.
+ */
+data class UpdateMarketingConsentCommand(val id: UUID, val marketingConsent: Boolean)
+
 data class AddDocumentCommand(
     val partyId: UUID,
     val documentType: DocumentType,
@@ -82,6 +91,9 @@ interface PartyUseCase {
     suspend fun createParty(cmd: CreatePartyCommand): Party
     suspend fun getParty(id: UUID): Party
     suspend fun updateParty(cmd: UpdatePartyCommand): Party
+
+    /** Post-onboarding marketing-consent toggle (mobile app Profile screen, revocable). */
+    suspend fun updateMarketingConsent(cmd: UpdateMarketingConsentCommand): Party
     suspend fun addDocument(cmd: AddDocumentCommand): PartyDocument
     suspend fun listDocuments(partyId: UUID): List<PartyDocument>
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -96,6 +96,18 @@ class PartyService : PartyUseCase {
         return saved
     }
 
+    override suspend fun updateMarketingConsent(cmd: UpdateMarketingConsentCommand): Party {
+        val party = partyRepo.findById(cmd.id) ?: throw PartyNotFoundException(cmd.id)
+        val updated = party.copy(
+            consentMarketing = cmd.marketingConsent,
+            consentMarketingUpdatedAt = Instant.now(clock),
+            updatedAt = Instant.now(clock),
+        )
+        val saved = partyRepo.update(updated)
+        eventPublisher.publishPartyUpdated(saved)
+        return saved
+    }
+
     /** Computes the RČ blind index when the pepper is configured and [taxId] is a valid Czech RČ. */
     private fun computeRcBlindIndex(taxId: String?): Pair<String?, Int?> {
         if (taxId == null) return null to null

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -42,6 +42,12 @@ data class Party(
     val consentGdpr: Boolean? = null,
     val consentMarketing: Boolean? = null,
     val consentCapturedAt: Instant? = null,
+    /**
+     * Stamped whenever [consentMarketing] changes AFTER onboarding (Profile screen toggle).
+     * Null until the customer changes it post-onboarding — [consentCapturedAt] alone covers
+     * the original onboarding-time value.
+     */
+    val consentMarketingUpdatedAt: Instant? = null,
 )
 
 data class Address(

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
@@ -92,6 +92,9 @@ class PartyEntity : PanacheEntity() {
 
     @Column(name = "consent_captured_at")
     var consentCapturedAt: Instant? = null
+
+    @Column(name = "consent_marketing_updated_at")
+    var consentMarketingUpdatedAt: Instant? = null
 }
 
 @Entity

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -154,6 +154,7 @@ class PartyRepositoryImpl :
         it.consentGdpr = consentGdpr
         it.consentMarketing = consentMarketing
         it.consentCapturedAt = consentCapturedAt
+        it.consentMarketingUpdatedAt = consentMarketingUpdatedAt
     }
 
     private fun PartyEntity.toDomain() = Party(
@@ -182,6 +183,7 @@ class PartyRepositoryImpl :
         consentGdpr = consentGdpr,
         consentMarketing = consentMarketing,
         consentCapturedAt = consentCapturedAt,
+        consentMarketingUpdatedAt = consentMarketingUpdatedAt,
     )
 }
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -161,16 +161,27 @@ class PartyResource {
     @Authorize(action = "party.consent.update", resource = "#id")
     @Operation(summary = "Update the party's post-onboarding marketing consent")
     suspend fun updateConsent(@PathParam("id") id: UUID, req: UpdateConsentRequest): Response {
+        // Old value for the Art 30 audit trail below — read before the write so it reflects the
+        // state actually being changed FROM, not a stale/racing re-read after.
+        val before = partyUseCase.getParty(id).consentMarketing
         val party = partyUseCase.updateMarketingConsent(UpdateMarketingConsentCommand(id, req.marketingConsent))
         auditPublisher.publish(
             AuditEvent(
+                // The caller here is ALWAYS the customer-edge's M2M service identity (ROLE_OPERATOR
+                // client-credentials token), never the customer directly — same trust boundary as
+                // every other edge->party-service call (registerParty, updateParty, …). actorType
+                // reflects that; the customer whose consent changed is resourceId (= the party id),
+                // not the actor.
                 actorId = jwt?.subject ?: jwt?.name ?: "unknown",
-                actorType = "HUMAN",
+                actorType = "SERVICE",
                 operation = "party.consent.marketing-updated",
                 resourceType = "party",
                 resourceId = id.toString(),
                 result = AuditResult.SUCCESS,
-                payload = mapOf("marketingConsent" to req.marketingConsent.toString()),
+                payload = mapOf(
+                    "marketingConsentBefore" to (before?.toString() ?: "null"),
+                    "marketingConsentAfter" to req.marketingConsent.toString(),
+                ),
             ),
         )
         return Response.ok(party.toResponse()).build()
@@ -532,6 +543,13 @@ fun PartyGdprExport.toResponse() = mapOf(
         "amlStatus" to party.amlStatus,
         "createdAt" to party.createdAt,
         "updatedAt" to party.updatedAt,
+        // Consent state is PII the subject agreed to/withheld — belongs in an Art 15 access
+        // export same as everything else here. Gap pre-dates this PR (never wired in when
+        // consentGdpr/consentMarketing were added) — closing it now since it's adjacent.
+        "consentGdpr" to party.consentGdpr,
+        "consentCapturedAt" to party.consentCapturedAt,
+        "consentMarketing" to party.consentMarketing,
+        "consentMarketingUpdatedAt" to party.consentMarketingUpdatedAt,
     ),
     "documents" to documents.map {
         mapOf(

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -18,6 +18,7 @@ import com.openbank.party.application.port.`in`.PartyUseCase
 import com.openbank.party.application.port.`in`.ResolvePartyByRcCommand
 import com.openbank.party.application.port.`in`.SearchPartiesQuery
 import com.openbank.party.application.port.`in`.SelfRegisterPartyCommand
+import com.openbank.party.application.port.`in`.UpdateMarketingConsentCommand
 import com.openbank.party.application.port.`in`.UpdatePartyCommand
 import com.openbank.party.application.port.`in`.UploadDocumentCommand
 import com.openbank.party.domain.model.Address
@@ -143,6 +144,34 @@ class PartyResource {
     suspend fun updateParty(@PathParam("id") id: UUID, req: UpdatePartyRequest): Response {
         val party = partyUseCase.updateParty(
             UpdatePartyCommand(id, req.email, req.phone, req.address?.toDomain(), req.tradingName),
+        )
+        return Response.ok(party.toResponse()).build()
+    }
+
+    /**
+     * Post-onboarding marketing-consent toggle (mobile app Profile screen). Deliberately its own
+     * endpoint rather than folded into [updateParty]: `consentGdpr` is NOT exposed here — it's an
+     * immutable onboarding-time record, not a live togglable consent (see [UpdateMarketingConsentCommand]
+     * kdoc). Audited (ADR-0086): a consent-state change is a compliance-relevant event same as the
+     * GDPR export/erase operations below, even though it isn't itself a GDPR-article action.
+     */
+    @PATCH
+    @Path("/{id}/consent")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "party.consent.update", resource = "#id")
+    @Operation(summary = "Update the party's post-onboarding marketing consent")
+    suspend fun updateConsent(@PathParam("id") id: UUID, req: UpdateConsentRequest): Response {
+        val party = partyUseCase.updateMarketingConsent(UpdateMarketingConsentCommand(id, req.marketingConsent))
+        auditPublisher.publish(
+            AuditEvent(
+                actorId = jwt?.subject ?: jwt?.name ?: "unknown",
+                actorType = "HUMAN",
+                operation = "party.consent.marketing-updated",
+                resourceType = "party",
+                resourceId = id.toString(),
+                result = AuditResult.SUCCESS,
+                payload = mapOf("marketingConsent" to req.marketingConsent.toString()),
+            ),
         )
         return Response.ok(party.toResponse()).build()
     }
@@ -446,6 +475,7 @@ data class UpdatePartyRequest(
     val tradingName: String?,
     val address: AddressRequest?,
 )
+data class UpdateConsentRequest(val marketingConsent: Boolean)
 data class AddDocumentRequest(
     val documentType: String,
     val documentNumber: String,
@@ -478,6 +508,10 @@ fun Party.toResponse() = mapOf(
     "id" to id, "partyType" to partyType, "status" to status, "legalName" to legalName,
     "tradingName" to tradingName, "email" to email, "phone" to phone,
     "kycStatus" to kycStatus, "address" to address, "createdAt" to createdAt, "updatedAt" to updatedAt,
+    // Onboarding-time consent snapshot (consentGdpr is informational/non-revocable — see
+    // UpdateMarketingConsentCommand kdoc) + the live, revocable marketing preference.
+    "consentGdpr" to consentGdpr, "consentCapturedAt" to consentCapturedAt,
+    "consentMarketing" to consentMarketing, "consentMarketingUpdatedAt" to consentMarketingUpdatedAt,
 )
 
 fun PartyGdprExport.toResponse() = mapOf(

--- a/openbank-party-service/src/main/resources/db/migration/V13__marketing_consent_updated_at.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V13__marketing_consent_updated_at.sql
@@ -1,0 +1,15 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- Post-onboarding marketing-consent revocation (mobile app Profile screen). consent_marketing
+-- (V12) already holds the current value and is updated in place; this column records WHEN it
+-- last changed after onboarding, separate from consent_captured_at (V12), which stays the
+-- immutable onboarding-time record and is never touched again.
+--
+-- consent_gdpr is deliberately NOT made revocable here: it isn't GDPR Art 6(1)(a) consent in
+-- the first place (account operation runs on contract/legal-obligation basis), so there is no
+-- "current value" to track for it.
+--
+-- Rollback note: DROP COLUMN is instant in Postgres (no-rewrite, logical catalog change).
+ALTER TABLE parties
+    ADD COLUMN consent_marketing_updated_at TIMESTAMPTZ;

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -130,6 +130,25 @@ paths:
         '200':
           description: Updated
 
+  /api/v1/parties/{id}/consent:
+    patch:
+      tags: [Parties]
+      summary: Update the party's post-onboarding marketing consent (revocable; consentGdpr is not — see UpdateConsentRequest)
+      operationId: updateConsent
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateConsentRequest'
+      responses:
+        '200':
+          description: Updated
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/parties/{id}/documents:
     post:
       tags: [Parties]
@@ -390,6 +409,17 @@ components:
           type: string
         address:
           $ref: '#/components/schemas/AddressDto'
+
+    UpdateConsentRequest:
+      type: object
+      required: [marketingConsent]
+      properties:
+        marketingConsent:
+          type: boolean
+          description: >-
+            Live, revocable marketing-communications preference (mobile app Profile screen).
+            Not the onboarding-time consentGdpr snapshot — that isn't Art 6(1)(a) consent and
+            has no update path.
 
     AddDocumentRequest:
       type: object

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMarketingConsentTest.kt
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.`in`.UpdateMarketingConsentCommand
+import com.openbank.party.domain.model.Address
+import com.openbank.party.domain.model.AmlStatus
+import com.openbank.party.domain.model.KycStatus
+import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyStatus
+import com.openbank.party.domain.model.PartyType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+
+/**
+ * Post-onboarding marketing-consent revocation (mobile app Profile screen). Split into its own
+ * class to keep [PartyServiceTest] under detekt's LargeClass threshold.
+ */
+class PartyServiceMarketingConsentTest {
+
+    private val now = Instant.parse("2026-03-01T12:00:00Z")
+    private val partyId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+
+    private fun newService() = PartyService().apply {
+        partyRepo = mockk()
+        documentRepo = mockk()
+        documentFileRepo = mockk()
+        eventPublisher = mockk(relaxed = true)
+        metrics = mockk(relaxed = true)
+        gdprAggregation = mockk(relaxed = true)
+        rcPepper = Optional.empty()
+        clock = Clock.fixed(now, ZoneOffset.UTC)
+    }
+
+    private fun existingParty(consentMarketing: Boolean?, consentMarketingUpdatedAt: Instant? = null) = Party(
+        id = partyId,
+        partyType = PartyType.INDIVIDUAL,
+        status = PartyStatus.ACTIVE,
+        legalName = "Test Party",
+        tradingName = null,
+        dateOfBirth = null,
+        nationality = null,
+        taxId = null,
+        registrationNumber = null,
+        email = "test@example.com",
+        phone = null,
+        address = null as Address?,
+        kycStatus = KycStatus.APPROVED,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        amlStatus = AmlStatus.CLEARED,
+        consentGdpr = true,
+        consentCapturedAt = Instant.parse("2026-01-01T00:00:00Z"),
+        consentMarketing = consentMarketing,
+        consentMarketingUpdatedAt = consentMarketingUpdatedAt,
+    )
+
+    @Test
+    fun `updateMarketingConsent flips the value and stamps consentMarketingUpdatedAt`(): Unit = runBlocking {
+        val service = newService()
+        coEvery { service.partyRepo.findById(partyId) } returns existingParty(consentMarketing = true)
+        coEvery { service.partyRepo.update(any()) } answers { firstArg() }
+
+        val result = service.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, marketingConsent = false))
+
+        assertThat(result.consentMarketing).isFalse()
+        assertThat(result.consentMarketingUpdatedAt).isEqualTo(now)
+        // The immutable onboarding snapshot must not be touched by a later revoke.
+        assertThat(result.consentGdpr).isTrue()
+        assertThat(result.consentCapturedAt).isEqualTo(Instant.parse("2026-01-01T00:00:00Z"))
+        coVerify { service.eventPublisher.publishPartyUpdated(result) }
+    }
+
+    @Test
+    fun `updateMarketingConsent throws PartyNotFoundException for an unknown id`(): Unit = runBlocking {
+        val service = newService()
+        coEvery { service.partyRepo.findById(partyId) } returns null
+
+        assertThatThrownBy {
+            runBlocking { service.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, true)) }
+        }.isInstanceOf(PartyNotFoundException::class.java)
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/rest/PartyResourceAuditTest.kt
@@ -8,6 +8,7 @@ import com.openbank.libs.audit.AuditEvent
 import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
 import com.openbank.party.application.port.`in`.ErasePartyCommand
+import com.openbank.party.application.port.`in`.UpdateMarketingConsentCommand
 import com.openbank.party.domain.model.KycStatus
 import com.openbank.party.domain.model.Party
 import com.openbank.party.domain.model.PartyGdprExport
@@ -126,5 +127,41 @@ class PartyResourceAuditTest {
         runCatching { res.exportPartyGdpr(partyId) }
 
         assertThat(events).isEmpty()
+    }
+
+    @Test
+    fun `updateConsent emits an event with both the before and after marketing-consent values`(): Unit = runBlocking {
+        val events = mutableListOf<AuditEvent>()
+        val res = resource(events)
+        coEvery { res.partyUseCase.getParty(partyId) } returns sampleParty().copy(consentMarketing = true)
+        coEvery { res.partyUseCase.updateMarketingConsent(UpdateMarketingConsentCommand(partyId, false)) } returns
+            sampleParty().copy(consentMarketing = false, consentMarketingUpdatedAt = now)
+
+        res.updateConsent(partyId, UpdateConsentRequest(marketingConsent = false))
+
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.operation).isEqualTo("party.consent.marketing-updated")
+            assertThat(e.actorId).isEqualTo(actorSub)
+            // The actor here is always the customer-edge M2M identity, never the customer directly.
+            assertThat(e.actorType).isEqualTo("SERVICE")
+            assertThat(e.resourceType).isEqualTo("party")
+            assertThat(e.resourceId).isEqualTo(partyId.toString())
+            assertThat(e.result).isEqualTo(AuditResult.SUCCESS)
+            assertThat(e.payload["marketingConsentBefore"]).isEqualTo("true")
+            assertThat(e.payload["marketingConsentAfter"]).isEqualTo("false")
+        })
+    }
+
+    @Test
+    fun `updateConsent records a null before-value when marketing consent was never set`(): Unit = runBlocking {
+        val events = mutableListOf<AuditEvent>()
+        val res = resource(events)
+        coEvery { res.partyUseCase.getParty(partyId) } returns sampleParty()
+        coEvery { res.partyUseCase.updateMarketingConsent(any()) } returns
+            sampleParty().copy(consentMarketing = true, consentMarketingUpdatedAt = now)
+
+        res.updateConsent(partyId, UpdateConsentRequest(marketingConsent = true))
+
+        assertThat(events.single().payload["marketingConsentBefore"]).isEqualTo("null")
     }
 }


### PR DESCRIPTION
## Summary
- Backend half of a mobile Profile-screen feature: a live "unsubscribe from marketing" toggle. Follow-up to #1157.
- `consentGdpr`/`consentMarketing` (from #1157) were onboarding-time-only. Deliberately did NOT make `consentGdpr` revocable — it isn't GDPR Art 6(1)(a) consent in the first place (running the account is contract/legal-obligation basis, not consent), so there's nothing to withdraw while keeping the account open. Marketing consent IS Art 6(1)(a)/ePrivacy consent and must be as easy to withdraw as to give — this PR adds that path.
- `party-service`: `consentMarketing` becomes the live/current value going forward (same column from #1157, just now updatable — it was never exposed or writable before this). New `consentMarketingUpdatedAt` column (`V13`), stamped only on a post-onboarding change, kept separate from `consentCapturedAt` (#1157) which stays the immutable onboarding record. New `PATCH /api/v1/parties/{id}/consent` (`ROLE_OPERATOR`/`ROLE_ADMIN`, mirrors `updateParty`) emits an ADR-0086 audit event per change. `toResponse()` now exposes all four consent fields.
- `customer-edge`: new `PATCH /customer/v1/profile/consent` (`ROLE_CUSTOMER`), party-scoped from the JWT only (no client-supplied id — no IDOR). New `UpstreamClient.patch(url, partyId, body)` overload. `GET /profile` needed no change — it already proxies the full party-service response.
- `openapi.yaml` updated.

## Linked issues
N/A — direct follow-up to #1157, no separate tracking issue filed.

## Test plan
- [x] `compileKotlin` + `ktlintCheck` + `detekt` clean on both services
- [x] New: `PartyServiceMarketingConsentTest` (flip + stamp timestamp, 404 on unknown id, onboarding snapshot untouched), `CustomerEdgeResourceConsentTest` (forwards scoped to caller's own party id, rejects missing/non-boolean body without calling upstream)
- [x] Full suite otherwise green; one Pact provider test flaked once locally on a port collision with a concurrent build on this dev machine — reproduced as environmental, passes in isolation, unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)