### PR TITLE
fix(admin-ui): render mermaid labels as SVG text so they survive sanitizing

### DIFF
--- a/openbank-admin-ui/src/components/docs/Mermaid.tsx
+++ b/openbank-admin-ui/src/components/docs/Mermaid.tsx
@@ -6,14 +6,10 @@
 
 import { useEffect, useRef, useState } from 'react'
 import mermaid from 'mermaid'
+import DOMPurify from 'dompurify'
+import { MERMAID_CONFIG } from '@/lib/docs/mermaidConfig'
 
-mermaid.initialize({
-  startOnLoad: false,
-  theme: 'neutral',
-  fontFamily: 'inherit',
-  flowchart: { useMaxWidth: true, htmlLabels: true },
-  sequence: { useMaxWidth: true },
-})
+mermaid.initialize(MERMAID_CONFIG)
 
 let seq = 0
 
@@ -32,7 +28,9 @@ export function Mermaid({ chart }: { chart: string }) {
       .render(id, chart)
       .then(({ svg }) => {
         if (!cancelled && ref.current) {
-          ref.current.innerHTML = svg
+          // Same sanitize contract as MermaidEnhancer — never innerHTML a
+          // rendered diagram straight into the page.
+          ref.current.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })
           setError(null)
         }
       })

--- a/openbank-admin-ui/src/components/docs/MermaidEnhancer.tsx
+++ b/openbank-admin-ui/src/components/docs/MermaidEnhancer.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useRef } from 'react'
 import DOMPurify from 'dompurify'
+import { MERMAID_CONFIG } from '@/lib/docs/mermaidConfig'
 
 // Tiny client-side enhancer. Wraps server-rendered markdown content and,
 // after mount, scans for the `<pre data-mermaid>` placeholders the
@@ -25,13 +26,7 @@ async function getMermaid(): Promise<MermaidApi> {
   if (mermaidInstance) return mermaidInstance
   const mod = await import('mermaid')
   const m = (mod.default ?? mod) as unknown as MermaidApi
-  m.initialize({
-    startOnLoad: false,
-    theme: 'neutral',
-    fontFamily: 'inherit',
-    flowchart: { useMaxWidth: true, htmlLabels: true },
-    sequence: { useMaxWidth: true },
-  })
+  m.initialize(MERMAID_CONFIG)
   mermaidInstance = m
   return m
 }
@@ -61,10 +56,10 @@ export function MermaidEnhancer({ children, contentKey }: { children: React.Reac
             const { svg } = await m.render(id, src)
             const wrap = document.createElement('div')
             wrap.className = 'mermaid-svg'
-            // Mermaid's flowchart htmlLabels:true lets diagram source embed raw
-            // HTML in node labels, which ends up in the rendered `svg` string —
-            // sanitize before innerHTML so a crafted diagram source can't smuggle
-            // a <script>/event-handler payload into the page.
+            // Defense in depth: MERMAID_CONFIG's htmlLabels:false already keeps
+            // diagram source out of the label markup, but sanitize before
+            // innerHTML anyway so a crafted diagram can't smuggle a
+            // <script>/event-handler payload into the page.
             wrap.innerHTML = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })
             block.replaceWith(wrap)
           } catch (err) {

--- a/openbank-admin-ui/src/lib/docs/mermaidConfig.ts
+++ b/openbank-admin-ui/src/lib/docs/mermaidConfig.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+/**
+ * The single mermaid config shared by every diagram renderer in the console
+ * (`MermaidEnhancer` for docs pages, `Mermaid` for ProcessView).
+ *
+ * `htmlLabels: false` is load-bearing, not cosmetic:
+ *
+ * - With html labels on, mermaid emits node labels inside a `<foreignObject>`
+ *   (XHTML). `foreignObject` is not in DOMPurify's `svg` profile allowlist, so
+ *   sanitizing the rendered SVG strips the whole label subtree — diagrams render
+ *   as empty boxes with correct connectors but no text.
+ * - With it off, mermaid emits native `<text>`/`<tspan>`, which survives the
+ *   profile. `<br/>` in a label still works (mermaid splits it into tspans).
+ * - It also removes the HTML-in-label injection vector at source: diagram text
+ *   can no longer become live markup.
+ *
+ * It must be set at the TOP LEVEL. `flowchart.htmlLabels` is deprecated as of
+ * mermaid 11 and does NOT control node labels — the renderer reads the
+ * top-level key (defaulting to `true`), so a `flowchart.htmlLabels: false` alone
+ * is silently a no-op.
+ */
+export const MERMAID_CONFIG = {
+  startOnLoad: false,
+  theme: 'neutral',
+  fontFamily: 'inherit',
+  htmlLabels: false,
+  flowchart: { useMaxWidth: true },
+  sequence: { useMaxWidth: true },
+} as const

--- a/openbank-admin-ui/src/test/mermaid-labels.test.ts
+++ b/openbank-admin-ui/src/test/mermaid-labels.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect, beforeAll } from 'vitest'
+import DOMPurify from 'dompurify'
+import mermaid from 'mermaid'
+import { MERMAID_CONFIG } from '@/lib/docs/mermaidConfig'
+
+// Regression guard for the "empty grey boxes" docs bug.
+//
+// The diagram renderers sanitize mermaid's SVG with DOMPurify's `svg` profile
+// before innerHTML. `foreignObject` is NOT in that profile's allowlist, so when
+// mermaid emits node labels as html labels the sanitizer strips the whole label
+// subtree: connectors survive, text vanishes.
+//
+// `htmlLabels: false` makes mermaid emit native <text>/<tspan>, which survives.
+// It must be set at the TOP LEVEL — `flowchart.htmlLabels` is deprecated in
+// mermaid 11 and does not control node labels, so setting only that is a no-op.
+// The `flowchart.htmlLabels`-only case is pinned below precisely because it
+// looks like a fix and isn't.
+
+// The exact sanitize config both renderers use.
+const SANITIZE_CONFIG = { USE_PROFILES: { svg: true, svgFilters: true } } as const
+
+// jsdom has no SVG layout engine, so the text-measurement APIs mermaid calls on
+// the SVG-label path (getBBox / getComputedTextLength) are missing. Stub them
+// with plausible dimensions; every assertion here is about which elements and
+// text survive sanitizing, never about geometry.
+const CHAR_WIDTH_PX = 8
+function stubSvgTextMetrics(): void {
+  const proto = (globalThis as unknown as { SVGElement: { prototype: Record<string, unknown> } }).SVGElement.prototype
+  if (typeof proto.getBBox !== 'function') {
+    proto.getBBox = function (this: Element) {
+      return { x: 0, y: 0, width: (this.textContent?.length ?? 0) * CHAR_WIDTH_PX, height: 16 }
+    }
+  }
+  if (typeof proto.getComputedTextLength !== 'function') {
+    proto.getComputedTextLength = function (this: Element) {
+      return (this.textContent?.length ?? 0) * CHAR_WIDTH_PX
+    }
+  }
+}
+
+const FLOWCHART = `flowchart TD
+  A[Customer Edge] --> B[Ledger Service]
+  B --> C[Outbox Dispatcher]`
+
+function sanitize(svg: string): string {
+  return DOMPurify.sanitize(svg, SANITIZE_CONFIG)
+}
+
+/** Visible text of the diagram's node labels, <style> excluded. */
+function nodeLabelText(svg: string): string {
+  const host = document.createElement('div')
+  host.innerHTML = svg
+  host.querySelectorAll('style').forEach(el => el.remove())
+  return [...host.querySelectorAll('.nodes .label')]
+    .map(n => (n.textContent ?? '').replace(/\s+/g, ' ').trim())
+    .join(' | ')
+}
+
+async function render(id: string, config: object): Promise<string> {
+  mermaid.initialize(config)
+  const { svg } = await mermaid.render(id, FLOWCHART)
+  return svg
+}
+
+describe('mermaid diagram labels survive DOMPurify', () => {
+  beforeAll(() => stubSvgTextMetrics())
+
+  it('renders node label text that survives sanitizing, with the shipped config', async () => {
+    const svg = await render('t-shipped', MERMAID_CONFIG)
+
+    // Mermaid used native <text>, not <foreignObject>.
+    expect(svg).not.toContain('foreignObject')
+    expect(svg).toContain('<text')
+
+    // The label text is still there after the sanitizer runs — the actual bug.
+    const clean = sanitize(svg)
+    expect(nodeLabelText(clean)).toContain('Customer Edge')
+    expect(nodeLabelText(clean)).toContain('Ledger Service')
+    expect(nodeLabelText(clean)).toContain('Outbox Dispatcher')
+  })
+
+  it('pins htmlLabels at the top level, where mermaid actually reads it', () => {
+    // flowchart.htmlLabels is deprecated in mermaid 11 and is NOT a substitute:
+    // the next test proves it silently fails to prevent the bug.
+    expect(MERMAID_CONFIG.htmlLabels).toBe(false)
+    expect(MERMAID_CONFIG.flowchart).not.toHaveProperty('htmlLabels')
+  })
+
+  it('would still lose every label if htmlLabels were only set under flowchart', async () => {
+    // The tempting one-line "fix". Mermaid's node renderer reads the top-level
+    // key (default true), so this config still emits foreignObject labels and
+    // the sanitizer still empties them. Guards against a well-meant revert.
+    const svg = await render('t-flowchart-only', {
+      ...MERMAID_CONFIG,
+      htmlLabels: undefined,
+      flowchart: { useMaxWidth: true, htmlLabels: false },
+    })
+
+    expect(svg).toContain('foreignObject')
+    expect(nodeLabelText(svg)).toContain('Customer Edge') // present in the raw SVG...
+    expect(nodeLabelText(sanitize(svg))).not.toContain('Customer Edge') // ...gone after sanitizing.
+  })
+
+  it('still strips a script smuggled through the diagram source', () => {
+    // Defense in depth: htmlLabels:false removes the HTML-in-label vector at
+    // source, but the sanitize call stays and must keep doing its job.
+    const clean = sanitize('<svg><text>ok</text><script>alert(1)</script></svg>')
+    expect(clean).not.toContain('<script')
+    expect(clean).toContain('ok')
+  })
+})


### PR DESCRIPTION
## Problem

Every C4/flowchart diagram in the service docs renders as **empty grey boxes** — correct connectors, no text. `sequenceDiagram` is unaffected (it emits native `<text>`).

Both diagram renderers sanitize mermaid's SVG with DOMPurify's `svg` profile before `innerHTML`. With html labels enabled, mermaid emits flowchart node labels inside a `<foreignObject>` (XHTML). `foreignObject` is **not** in DOMPurify's SVG allowlist, so the sanitizer strips the entire label subtree.

## The fix — and a trap worth flagging

Set `htmlLabels: false`, so mermaid emits native `<text>`/`<tspan>`, which survives the profile. `<br/>` in labels still works (mermaid splits it into tspans). This also removes the HTML-in-label injection vector at source. The `DOMPurify.sanitize` call stays as defense in depth.

**`htmlLabels` must be set at the TOP LEVEL, not under `flowchart`.** The obvious one-line fix — flipping `flowchart.htmlLabels` to `false` — is **silently a no-op** on mermaid 11.16.0. `flowchart.htmlLabels` is deprecated, and the node renderer (`labelHelper`) reads only the top-level key:

```js
// mermaid 11.16.0
return evaluate(config.htmlLabels ?? config.flowchart?.htmlLabels ?? true)
```

Since the top-level key defaults to `true`, `flowchart.htmlLabels: false` alone leaves `foreignObject` labels in place and the boxes stay empty. Measured, rendering through the real sanitize config:

| config | `foreignObject` | node labels after sanitize |
|---|---|---|
| `flowchart.htmlLabels: false` only | yes | **empty — still broken** |
| `htmlLabels: false` (top level) | no | `Customer Edge \| Ledger Service` ✅ |
| `flowchart.htmlLabels: true` (before) | yes | empty (the bug) |

A test pins the misleading case precisely because it looks like a fix and isn't — it guards against a well-meant "simplification" back to the deprecated key.

## Changes

- **New `src/lib/docs/mermaidConfig.ts`** — one shared `MERMAID_CONFIG` (`htmlLabels: false`, deprecated `flowchart.htmlLabels` dropped) so the two renderers can't drift apart again. The comment records why the setting is load-bearing.
- **`MermaidEnhancer.tsx`** — uses the shared config; stale comment describing the old `htmlLabels: true` behavior corrected.
- **`Mermaid.tsx`** — uses the shared config, **and** now sanitizes. It previously assigned rendered SVG to `innerHTML` with **no sanitizing at all**; it now uses the same contract as `MermaidEnhancer`, closing an unsanitized-`innerHTML` path in ProcessView.

## Verification

- New `src/test/mermaid-labels.test.ts` renders a real flowchart through the shipped config and the real DOMPurify config, asserting label text survives. Written as `.ts` — `vitest.config.ts` includes `src/test/**/*.{test,spec}.ts` only, so a `.tsx` test would be silently uncollected.
- **Confirmed the test fails on the buggy config and passes on the fix** (flipping `htmlLabels` back to `true` fails 2 of 4 tests).
- `npx vitest run` — 458 passed. The 4 failing tests are in `finops-*` and are **pre-existing on `origin/main`**, unrelated to this change (verified against a clean checkout).
- `npm run type-check` clean; `npx eslint` clean on all changed files.

Note: jsdom has no SVG layout engine, so the test stubs `getBBox`/`getComputedTextLength` — mermaid calls them to measure `<text>`. Assertions are about which elements and text survive sanitizing, never geometry.

No version files touched. `check-admin-ui-version-sync.sh` states the convention outright — *"a feature PR touches neither — release-please owns both"* — and admin-ui is registered in `release-please-config.json` as release-type `simple` with a `package.json` extra-files updater. An earlier revision of this PR hand-bumped to 0.48.1; that was wrong, and was dropped on rebase (it also raced #1168, which had claimed the same version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

N/A — found ad-hoc while auditing why service-docs diagrams rendered blank; no pre-existing issue covers it, and the fix is a two-line config change rather than a tracked workstream.
