### PR TITLE
fix(copilot,product-catalog): enable the Quarkus management interface so probes hit a real port

### DIFF
--- a/openbank-copilot-service/src/main/resources/application.yaml
+++ b/openbank-copilot-service/src/main/resources/application.yaml
@@ -25,6 +25,14 @@ quarkus:
       Strict-Transport-Security:
         value: "max-age=31536000; includeSubDomains"
 
+  # Health/metrics on a separate management port, matching the fleet convention and the
+  # Deployment's `management` containerPort that startup/liveness/readiness probes target.
+  management:
+    enabled: true
+    port: 8085
+    host: 0.0.0.0
+    root-path: /q
+
   # Customer session JWT arrives via the customer edge (ADR-0065).
   redis:
     hosts: ${REDIS_URL:redis://localhost:6379}

--- a/openbank-product-catalog/src/main/resources/application.yaml
+++ b/openbank-product-catalog/src/main/resources/application.yaml
@@ -24,6 +24,14 @@ quarkus:
       Strict-Transport-Security:
         value: "max-age=31536000; includeSubDomains"
 
+  # Health/metrics on a separate management port, matching the fleet convention and the
+  # Deployment's `management` containerPort that startup/liveness/readiness probes target.
+  management:
+    enabled: true
+    port: 8085
+    host: 0.0.0.0
+    root-path: /q
+
   datasource:
     db-kind: postgresql
     username: ${POSTGRES_USER:openbank}


### PR DESCRIPTION
Fixes `platform/copilot-service`, which has been in CrashLoopBackOff (~140 restarts, ~11h), and the same latent bug found in `product-catalog`.

## copilot-service — the live outage

The application starts perfectly, then kubelet kills it:

```
openbank-copilot-service 0.5.2 ... started in 7.442s. Listening on: http://0.0.0.0:8131
Startup probe failed: Get "http://10.80.139.73:8085/q/health/started": dial tcp ...: connection refused
Container copilot-service failed startup probe, will be restarted
```

The Deployment declares containerPorts `[8131, 8085]` and points startup/liveness/readiness at the port named `management` (8085), but `application.yaml` had **no `quarkus.management` section**, so the management interface was never enabled and the health endpoints stayed on the main port 8131. The probe target simply did not exist.

### Why enable management (option a) rather than repoint probes at 8131 (option b)

The fleet has already standardised on a separate management port — this is copilot diverging, not copilot being special:

| services with a manifest probing `management` | declare `quarkus.management` |
|---|---|
| 48 | **46** |

The only two that did not were `copilot-service` and `product-catalog` — both fixed here. The copilot manifest also already sets `QUARKUS_MANAGEMENT_HOST=0.0.0.0`, which is inert without the block and is clear evidence of the intended design. Repointing the probes at 8131 would have exposed `/q/health` on the public HTTP port and made copilot the fleet outlier. **No manifest or probe was changed.**

## product-catalog — the same bug, currently masked

`product-catalog` only ever set `quarkus.management.enabled: false` under the `%test` profile and never enabled it for the runtime profile, while its Deployment probes `management` for all three probes. It is not crashlooping today only because it sits at **0/0 replicas** — the first scale-up would have reproduced copilot exactly. Fixed in the same PR as requested. The `%test` override is retained (and is now meaningful).

## finrep-service — no code change; needs a decision

The reported diagnosis does not match git. Reporting rather than guessing:

- **The bare image ref is already fixed in git.** `openbank-infra/gitops/components/finrep/finrep-service.yaml:36` already carries the full ECR ref (`265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-init`), fixed by #557. The live Deployment still shows the bare `openbank-finrep-service:0.1.0` — that is **cluster drift**, not a git bug.
- **The image has never existed.** The ECR repository `openbank-finrep-service` does not exist at all (`RepositoryNotFoundException`) — so there is no tag to point at, and the SBOM-attestation check is moot.
- **CI never builds it.** `openbank-finrep-service` is absent from `ALL_SERVICES` in `.github/workflows/auto-deploy.yml`, so nothing ever built or pushed it. The manifest tag `sandbox-init` is a documented first-registration placeholder (ADR-0097), and the file comment says so.

Per the brief, the manifest was **not** repointed at a tag that does not exist. Getting finrep up is a separate piece of work: wire it into `auto-deploy.yml`, build+push+attest a real `sandbox-<sha>` image, then update the tag. Worth its own issue.

Note the drift is odd and may deserve a follow-up: ArgoCD reports `Synced` / `successfully synced (all tasks run)` at `84a67516` with `selfHeal: true`, yet the live Deployment does not match that revision.

## Verification

- `./gradlew :openbank-copilot-service:build :openbank-copilot-service:quarkusBuild :openbank-product-catalog:build :openbank-product-catalog:quarkusBuild` — **BUILD SUCCESSFUL** (`quarkusBuild` included so CDI/ArC wiring is actually validated).
- `.github/scripts/check-duplicate-yaml-keys.sh` — 50 files checked, no duplicate keys.
- Both files re-parsed with a duplicate-key-rejecting YAML loader; `quarkus.management` resolves as intended and `http.port` is unchanged (8131 / 8104).
- Nothing applied to the cluster — ArgoCD syncs from git.

Refs #1153