### PR TITLE
fix(party-service): restore @PactBroker on provider verification (unblocks auto-deploy)

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/PartyCreatedMessagePactConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/PartyCreatedMessagePactConsumerTest.kt
@@ -27,7 +27,8 @@ import java.util.UUID
  * - PARTY_UPDATED / KYC_STATUS_CHANGED → reconcile account status via `status` field (P2 extension)
  *
  * party-service verifies all three via `PartyEventPactProviderVerificationTest`
- * (`@PactFolder("../pacts")` — always runs, no Pact Broker involved).
+ * (`@PactBroker` — CI-only, publishes/consumes results against the broker; skips locally
+ * without `pactbroker.url`).
  *
  * IMPORTANT — regenerate on change: if this test's `@Pact` methods change (new interaction,
  * different matcher, renamed field), re-run this test (`./gradlew :openbank-account-service:test

--- a/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/PartyEventMessagePactConsumerTest.kt
+++ b/openbank-kyc-service/src/test/kotlin/com/openbank/kyc/contract/PartyEventMessagePactConsumerTest.kt
@@ -34,9 +34,9 @@ import java.util.UUID
  * legitimately dropped a field kyc-service never needed.
  *
  * party-service verifies both via `PartyEventPactProviderVerificationTest`
- * (`@PactFolder("../pacts")` — always runs, no Pact Broker involved). PARTY_CREATED reuses that
- * class's existing `"a party has been created"` state; PARTY_ERASED needed a new one, added
- * alongside this contract.
+ * (`@PactBroker` — CI-only, publishes/consumes results against the broker; skips locally
+ * without `pactbroker.url`). PARTY_CREATED reuses that class's existing `"a party has been
+ * created"` state; PARTY_ERASED needed a new one, added alongside this contract.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(

--- a/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/contract/PartyServicePactConsumerTest.kt
+++ b/openbank-onboarding-service/src/test/kotlin/com/openbank/onboarding/contract/PartyServicePactConsumerTest.kt
@@ -62,9 +62,10 @@ import java.util.UUID
  * all (by design; it only tracks status-affecting transitions).
  *
  * party-service verifies via `PartyEventPactProviderVerificationTest`
- * (`@PactFolder("../pacts")`, extended with an HTTP target for the REST interaction alongside its
- * existing message-only ones). `"a party has been created"` and `"a party KYC status has
- * changed"` are its existing message states, reused as-is; `"a party has been erased"` is new
+ * (`@PactBroker`, extended with an HTTP target for the REST interaction alongside its
+ * existing message-only ones — CI-only, skips locally without `pactbroker.url`). `"a party has
+ * been created"` and `"a party KYC status has changed"` are its existing message states, reused
+ * as-is; `"a party has been erased"` is new
  * here (also being added independently by the kyc->party edge's PR — expect a trivial rebase
  * conflict on that one state block, not a semantic drift, whichever PR lands second).
  */

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
@@ -12,7 +12,7 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
-import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.party.application.port.out.PartyRepository
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 import java.time.Instant
 import java.util.UUID
@@ -46,29 +47,31 @@ import java.util.concurrent.TimeUnit
  * issue #468's onboarding->party/kyc/sca edge with the REST `PUT /{id}/kyc-status` interaction).
  * Boots Quarkus (needed for the HTTP interaction; the message ones don't use it) and picks a
  * per-interaction target the same way `TransactionPactProviderVerificationTest` does — a single
- * `@Provider` class must verify every pact the broker/folder returns, so splitting HTTP and
- * message into two classes collides (this repo's own "one @Provider test per provider" rule).
- * `@TestSecurity` matches the kyc-status endpoint's `@RolesAllowed("ROLE_ADMIN", "ROLE_KYC")`.
+ * `@Provider` class must verify every pact the broker returns, so splitting HTTP and message into
+ * two classes collides (this repo's own "one @Provider test per provider" rule). `@TestSecurity`
+ * matches the kyc-status endpoint's `@RolesAllowed("ROLE_ADMIN", "ROLE_KYC")`.
  *
- * Reads the consumer pact from the git-pact folder (`@PactFolder`, resolved relative to this
- * module's working directory at `../pacts` = the monorepo-root `pacts/` dir) and replays each
- * interaction. This always runs — no broker, no gate, no CI secret required (ADR-0063 chose
- * git-pact over a Pact Broker for exactly this reason: zero new infra dependency).
- *
- * IMPORTANT: if a consumer's `@Pact` method changes (new interaction, different matcher, renamed
- * field), regenerate that consumer's pact JSON and commit it in the same PR, or this test will
- * fail — or worse, pass against a stale contract that no longer matches what the consumer
- * actually expects.
- *
- * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact file a skip, not a
- * failure — relevant if the folder is ever emptied ahead of a broker migration.
+ * `@PactBroker` (not `@PactFolder`) — matches every other provider-verification test in this repo
+ * (`TransactionPactProviderVerificationTest`, `BalancePactProviderVerificationTest`, etc.).
+ * 2026-07-07 (#371) had switched this specific class to `@PactFolder("../pacts")` for local-dev
+ * ergonomics (ADR-0063: no broker secret needed to run it locally) — but that meant party-service
+ * CI never published a verification result to the broker again, for ANY consumer. kyc-service's
+ * and onboarding-service's consumer contracts (added 2026-07-12, five days later) therefore never
+ * got a single verification recorded — not stale, never-run — which silently wedged ADR-0092's
+ * `can-i-deploy` gate: party-service's sandbox auto-deploy hard-blocked for 4 days straight with
+ * no way to unblock from the consumer side (there's nothing to re-run there; they don't verify
+ * party-service, they only publish their own pacts). Reverting to `@PactBroker` restores the one
+ * thing `can-i-deploy` actually reads. `@EnabledIfSystemProperty` keeps it a no-op locally without
+ * a broker URL, same as every sibling class — verify a change with `compileTestKotlin` locally;
+ * the real verification only runs in CI (`pactbroker.url` set there).
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.party.it.PostgresRedpandaTestResource::class)
 @TestSecurity(user = "pact-verifier", roles = ["ROLE_KYC"])
 @Provider("openbank-party-service")
-@PactFolder("../pacts")
+@PactBroker(enablePendingPacts = "true")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class PartyEventPactProviderVerificationTest {
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")


### PR DESCRIPTION
## Summary
- `openbank-party-service`'s sandbox auto-deploy has been hard-blocked for 4 days (deployed image is 4 days stale) by ADR-0092's `can-i-deploy` gate: no verified pact between kyc-service/onboarding-service and the latest party-service. Found while investigating why tonight's #1157/#1161 (already merged) weren't actually going live.
- Root cause: [#371](https://github.com/JiRaska/open-bank-oss/pull/371) (2026-07-07) switched `PartyEventPactProviderVerificationTest` from `@PactBroker` to `@PactFolder("../pacts")` for local-dev ergonomics. Reasonable in isolation, but it meant party-service's CI stopped publishing ANY verification result to the broker, for any consumer, permanently. kyc-service's and onboarding-service's consumer contracts (added 2026-07-12, five days later) have literally never had a verification recorded — not stale, never-run. There's no consumer-side fix: they don't verify party-service, they only publish their own pacts.
- Fix: revert to `@PactBroker(enablePendingPacts = "true")` + `@EnabledIfSystemProperty(pactbroker.url)` — matches every other provider-verification test in this repo (Transaction/Balance/Account/etc.), none of which were ever switched to git-pact.
- Confirmed the contract itself is fine BEFORE touching anything: ran this test locally against the current `@PactFolder` fixtures — 9/9 interactions pass. This is purely a broker bookkeeping gap, not a real incompatibility.

## Linked issues
N/A — found ad-hoc tonight while chasing why merged consent PRs weren't live in sandbox; no tracking issue filed.

## Test plan
- [x] `compileTestKotlin` + `ktlintCheck` + `detekt` clean
- [x] Full `:openbank-party-service:test` green — the Pact test correctly SKIPS locally without `pactbroker.url`, same as every sibling class
- [ ] Real verification only runs in CI (`_service-ci.yml` sets `pactbroker.url` on push to `main`) — will publish a fresh result there, which should unblock the next `auto-deploy` run for party-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)