### PR TITLE
fix(gitops): repair Flyway checksum mismatch on pid-service V5-V9

### DIFF
--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -70,6 +70,19 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # Flyway checksum mismatch on V5-V9 (2026-07-16): the 2026-06-27 repo-wide
+            # MPL->Apache-2.0 relicense (60e0263f, #2276) flipped the SPDX header on every
+            # migration file. V5-V9 were applied 2026-06-16..06-22, i.e. BEFORE it, so their
+            # recorded checksums are the pre-relicense ones; V1-V4 carry no header and still
+            # match. pid-service hadn't been redeployed since, so the mismatch stayed latent
+            # until this rollout hit it — same root cause and fix as onboarding-service V1
+            # (#730). Verified before enabling this: the content at 60e0263f^ reproduces all
+            # five recorded checksums exactly, and the delta to the current files is the
+            # licence header lines only — no SQL executed differently. Remove once the live
+            # schema_history rows are repaired (one successful boot is enough; repair is a
+            # no-op after that).
+            - name: QUARKUS_FLYWAY_REPAIR_AT_START
+              value: "true"
             # Kafka broker for the outbox dispatcher (party-events-out → topic party.events,
             # pid-events-out → topic openbank.pid.events). Strimzi bootstrap, mTLS port (ADR-0137).
             - name: KAFKA_BOOTSTRAP_SERVERS


### PR DESCRIPTION
## Summary

`pid-service` has been in `CrashLoopBackOff` (~55 restarts, ~4h) with `FlywayValidateException: Migrations have failed validation` — checksum mismatch on **V5, V6, V7, V8 and V9**.

Same root cause and same fix as the onboarding-service V1 repair (#730): the 2026-06-27 repo-wide MPL→Apache-2.0 relicense (`60e0263f`, #2276) flipped the SPDX header on every migration file, changing its checksum. V5–V9 were applied to the live DB between 2026-06-16 and 2026-06-22 — **before** the relicense — so `flyway_schema_history` holds the pre-relicense checksums. V1–V4 carry no SPDX header at all and still validate, which is exactly why the mismatch starts at V5. pid-service hadn't been redeployed since the relicense, so the mismatch stayed latent until this rollout hit it.

This is the third instance of the same latent landmine (onboarding V1, now pid V5–V9). Any service not redeployed since 2026-06-27 whose migrations carry an SPDX header is still carrying it.

## Why repair is safe here — verified, not assumed

`flyway repair` rewrites recorded checksums to match the current files. That is only safe if the files' **SQL** is unchanged; if DDL had changed, repair would mark the new DDL as applied without executing it — silent schema drift, worse than the crashloop. So I proved the delta is comment-only:

1. Reimplemented Flyway's line-wise CRC32 and **calibrated it against V1–V4**, whose recorded checksums it reproduces exactly (4/4) — establishing the implementation is correct before trusting any result from it.
2. On that basis, the file content at `60e0263f^` reproduces **all five** recorded checksums for V5–V9 exactly (5/5):

   | migration | computed @ `60e0263f^` | recorded in DB |
   |---|---|---|
   | V5 | 1757871806 | 1757871806 |
   | V6 | -1224291578 | -1224291578 |
   | V7 | 1672618206 | 1672618206 |
   | V8 | -381902778 | -381902778 |
   | V9 | -1534089771 | -1534089771 |

3. Diffing that DB-proven content against the current files shows the delta is **only** the licence header lines:
   ```
   - -- SPDX-License-Identifier: MPL-2.0
   - -- Copyright (c) OpenBank contributors. Licensed under the Mozilla Public License 2.0.
   + -- SPDX-License-Identifier: Apache-2.0
   + -- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
   ```
   Zero DDL change across all five files. The live schema already matches what these files produce.

## Test plan

- [x] YAML parses; `QUARKUS_FLYWAY_REPAIR_AT_START` present; no duplicate env keys
- [x] `check-duplicate-yaml-keys.sh` — 50 files, no duplicates
- [x] `flyway_schema_history` read (read-only) to obtain the recorded checksums; all 9 rows `success = t`
- [ ] ArgoCD sync → pid-service boots, repair re-baselines V5–V9, pod goes Ready

## Follow-up

Remove the flag once the `schema_history` rows are repaired (one successful boot is enough; repair is a no-op afterwards). The same flag from #730 is still present in `onboarding-service.yaml` and can be removed in the same sweep.

Worth a separate issue: a guard that fails CI when a commit changes a migration file that is already applied in any environment — the relicense sweep should never have been able to touch `db/migration/**` silently. That is what turns this from "fix the third instance" into "close the class".

Refs #730