### PR TITLE
fix(infra): deliver critical alerts outside the cluster and alert on blocked admission

### DIFF
--- a/.github/scripts/check-critical-alert-egress.py
+++ b/.github/scripts/check-critical-alert-egress.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Critical-alert egress gate (rules.yaml: alerting).
+
+Enforces the invariant: at least one Alertmanager route matching
+`severity = "critical"` must terminate at a receiver that can actually reach a
+human OUTSIDE the cluster.
+
+WHY THIS EXISTS: this is the "severity inversion" — the failure it guards against
+is invisible by inspection, because the config looks *more* careful for critical
+than for warning. Critical alerts were routed to GoAlert (paging, escalation,
+ack, dedup) and to HolmesGPT for RCA enrichment, while warning got a plain Slack
+webhook. But GoAlert, the ntfy it fans out to, and the Holmes relay are all
+cluster-internal Services with no Ingress (ADR-0056), so every critical delivery
+path dead-ended inside the perimeter: reaching one required a kubectl
+port-forward by someone who already suspected a problem. Warning escaped to
+Slack. Net effect: the more severe the alert, the less likely a human saw it —
+and a money-path service stayed down for days with nobody paged.
+
+The subtlety this encodes: "has a paging receiver configured" is NOT the same
+property as "a human is reachable". Only the second one matters at 03:00, and
+only the second one is checked here.
+
+A receiver counts as egress-capable if it configures a known external
+integration (slack/pagerduty/opsgenie/email/...). A `webhook_configs` receiver
+counts ONLY if its URL is demonstrably external: an in-cluster URL
+(*.svc, *.cluster.local, localhost) does not count, and a `url_file` does not
+count either — the URL is a mounted secret this script cannot resolve, so it
+cannot be proven to leave the cluster (this is exactly the GoAlert case).
+That is deliberately conservative: an unprovable path is treated as no path.
+
+This gate does NOT argue against in-perimeter paging (ADR-0088's intent stands).
+It only requires that it is not the ONLY leg.
+
+Requires pyyaml (installed by the ci.yml step that precedes it). ENFORCED.
+Usage: check-critical-alert-egress.py [kube-prometheus-stack.yaml path]
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = REPO / "openbank-infra" / "gitops" / "apps" / "kube-prometheus-stack.yaml"
+
+# Receiver config keys that, by construction, deliver to an external system.
+EXTERNAL_INTEGRATION_KEYS = frozenset(
+    {
+        "slack_configs",
+        "pagerduty_configs",
+        "opsgenie_configs",
+        "email_configs",
+        "victorops_configs",
+        "pushover_configs",
+        "telegram_configs",
+        "webex_configs",
+        "discord_configs",
+        "msteams_configs",
+        "msteamsv2_configs",
+        "sns_configs",
+        "rocketchat_configs",
+        "jira_configs",
+    }
+)
+
+# Hostname suffixes/values that are unambiguously inside the cluster.
+INTERNAL_HOST_MARKERS = (".svc", ".cluster.local", "localhost", "127.0.0.1")
+
+
+def _webhook_url_is_external(webhook: dict) -> bool:
+    """A webhook proves egress only if it has a literal, non-cluster-internal URL."""
+    url = webhook.get("url")
+    if not isinstance(url, str) or not url.strip():
+        # url_file (or nothing): a secret-mounted URL we cannot resolve -> unprovable.
+        return False
+    host = url.split("://", 1)[-1].split("/", 1)[0].split(":", 1)[0].lower()
+    return not any(marker in host for marker in INTERNAL_HOST_MARKERS)
+
+
+def receiver_is_egress_capable(receiver: dict) -> bool:
+    if any(receiver.get(key) for key in EXTERNAL_INTEGRATION_KEYS):
+        return True
+    return any(
+        isinstance(w, dict) and _webhook_url_is_external(w)
+        for w in receiver.get("webhook_configs") or []
+    )
+
+
+def _matchers_select_critical(route: dict) -> bool:
+    """True if this route's matchers select severity=critical.
+
+    Handles the `matchers: ['severity = "critical"']` form used by this repo as
+    well as the legacy `match: {severity: critical}` map form.
+    """
+    match_map = route.get("match") or {}
+    if isinstance(match_map, dict) and match_map.get("severity") == "critical":
+        return True
+    for matcher in route.get("matchers") or []:
+        if not isinstance(matcher, str):
+            continue
+        normalized = matcher.replace('"', "").replace("'", "").replace(" ", "")
+        if normalized in ("severity=critical", "severity=~critical"):
+            return True
+    return False
+
+
+def _walk_routes(route: dict, receivers_hit: list[str]) -> None:
+    for child in route.get("routes") or []:
+        if not isinstance(child, dict):
+            continue
+        if _matchers_select_critical(child) and child.get("receiver"):
+            receivers_hit.append(child["receiver"])
+        _walk_routes(child, receivers_hit)
+
+
+def main() -> int:
+    manifest = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_MANIFEST
+    if not manifest.is_file():
+        print(f"::error::check-critical-alert-egress: {manifest} not found")
+        return 1
+
+    doc = yaml.safe_load(manifest.read_text())
+    values = (((doc or {}).get("spec") or {}).get("source") or {}).get("helm") or {}
+    alertmanager = (values.get("valuesObject") or {}).get("alertmanager") or {}
+
+    if not alertmanager.get("enabled", False):
+        print("check-critical-alert-egress: alertmanager disabled — nothing to check.")
+        return 0
+
+    config = alertmanager.get("config") or {}
+    root = config.get("route") or {}
+    receivers = {
+        r["name"]: r for r in (config.get("receivers") or []) if isinstance(r, dict) and r.get("name")
+    }
+
+    critical_receivers: list[str] = []
+    if _matchers_select_critical(root) and root.get("receiver"):
+        critical_receivers.append(root["receiver"])
+    _walk_routes(root, critical_receivers)
+
+    if not critical_receivers:
+        print(
+            "::error::check-critical-alert-egress: no Alertmanager route matches "
+            'severity = "critical" — critical alerts fall through to the default '
+            "receiver and page nobody. Add a critical route to an egress-capable receiver."
+        )
+        return 1
+
+    egressing = [n for n in critical_receivers if receiver_is_egress_capable(receivers.get(n, {}))]
+
+    if not egressing:
+        dead_ends = ", ".join(sorted(set(critical_receivers)))
+        print(
+            "::error::check-critical-alert-egress: SEVERITY INVERSION — every "
+            f"severity=critical route dead-ends inside the cluster (receivers: {dead_ends}). "
+            "None configures an external integration or a webhook with a literal "
+            "non-cluster URL, so a critical alert cannot reach a human who is not already "
+            "port-forwarding into the cluster. Route critical to a receiver that egresses "
+            "(in-perimeter paging may stay alongside it, but not as the only leg). "
+            "See rules.yaml: alerting.critical_alerts_must_egress."
+        )
+        return 1
+
+    print(
+        "check-critical-alert-egress: OK — severity=critical reaches egress-capable "
+        f"receiver(s): {', '.join(sorted(set(egressing)))}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,15 @@ jobs:
       - name: SLO registry consistency (issue #669, rules.yaml: slo)
         run: python3 .github/scripts/check-slo-registry.py
 
+      # rules.yaml: alerting.critical_alerts_must_egress. A severity=critical alert must
+      # reach a receiver that leaves the cluster. Guards the "severity inversion": critical
+      # routed only to GoAlert/ntfy/Holmes — all cluster-internal with no Ingress
+      # (ADR-0056) — while warning escaped to Slack, so the most severe alerts were the
+      # least likely to be seen. Config-inspection alone hides this (the critical path
+      # looks MORE careful), which is why it is a gate. ENFORCED.
+      - name: "critical-alert egress (rules.yaml: alerting, enforced)"
+        run: python3 .github/scripts/check-critical-alert-egress.py
+
       # ADR-0160 mechanism 1 / rules.yaml: change_requirements.event_consumer_liveness.
       # Fleet-wide scan (not diff-scoped): every Kafka topic a service publishes must have a
       # real @Incoming consumer somewhere in the fleet, or a one-line-reasoned allowlist entry.

--- a/openbank-infra/gitops/apps/blackbox-exporter.yaml
+++ b/openbank-infra/gitops/apps/blackbox-exporter.yaml
@@ -56,6 +56,29 @@ spec:
                 valid_status_codes: [200, 301, 302, 401, 403, 404]
                 follow_redirects: true
                 preferred_ip_protocol: ip4
+            # STRICT OIDC-discovery module. `http_app` above accepts 404, so probing
+            # Keycloak's apex with it proves only "nginx answered" — it stayed GREEN
+            # through a total Keycloak outage that broke all admin-ui login, because a
+            # dead IdP behind a live ingress still yields a 404. This module asserts the
+            # realm is actually SERVING OIDC: a hard 200 only, no redirect following (a
+            # bounce to an error page must fail, not be followed to a 200), and the body
+            # must contain the discovery document's own endpoint claims — so an ingress
+            # default-backend or a Keycloak that boots without the realm both fail.
+            # Keep this strict; loosening it re-creates the outage-invisible probe.
+            http_oidc_discovery:
+              prober: http
+              timeout: 10s
+              http:
+                method: GET
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: [200]
+                follow_redirects: false
+                preferred_ip_protocol: ip4
+                fail_if_body_not_matches_regexp:
+                  - '"issuer"'
+                  - '"token_endpoint"'
+                  - '"authorization_endpoint"'
+                  - '"jwks_uri"'
         resources:
           requests:
             cpu: 25m

--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -1,5 +1,5 @@
-# Metrics plane: Prometheus + Grafana + kube-state-metrics + node-exporter
-# (alertmanager disabled — no routing configured in the sandbox). Lean FinOps
+# Metrics plane: Prometheus + Grafana + kube-state-metrics + node-exporter +
+# alertmanager (enabled, with the routing tree configured below). Lean FinOps
 # sizing per ADR-0027: single Prometheus replica, 12h retention, gp3 PVC.
 # serviceMonitorSelectorNilUsesHelmValues=false so app ServiceMonitors are
 # picked up regardless of release labels. Grafana has no Ingress — the edge NLB
@@ -21,10 +21,9 @@ spec:
     helm:
       valuesObject:
         # Alerting plane (ADR-0082 / ADR-0077 Phase 4). Enabled with a lean
-        # single replica. The sandbox routes everything to a no-op receiver so
-        # alerts are visible in the Alertmanager UI + Grafana alert list without
-        # needing creds; prod wires Slack/PagerDuty via ESO (a slack_configs
-        # block referencing a Vault-sourced webhook secret).
+        # single replica. Unmatched alerts fall through to a no-op receiver and
+        # stay visible in the Alertmanager UI + Grafana alert list; `warning`
+        # and `critical` both egress to Slack (see the routing tree below).
         alertmanager:
           enabled: true
           # Single replica -> minAvailable:1 blocks ANY voluntary eviction (Karpenter
@@ -71,21 +70,35 @@ spec:
               routes:
                 # Davis-lite (ADR-0088): auto root-cause enrichment via HolmesGPT.
                 # `continue: true` so the SAME critical alert ALSO falls through to the
-                # GoAlert paging route below — Holmes enriches, it never pages.
+                # delivery routes below — Holmes enriches, it never pages.
                 - matchers:
                     - severity = "critical"
                   receiver: 'holmes-rca'
                   continue: true
                   group_interval: 10m
                   repeat_interval: 12h   # re-investigate a still-firing alert at most twice a day
+                # WHY critical ALSO goes to Slack, not just GoAlert:
+                # both GoAlert and the ntfy it fans out to are cluster-internal with no
+                # Ingress (ADR-0056) — reaching either needs a kubectl port-forward. So a
+                # `critical` alert had NO path to a human who was not already looking at
+                # the cluster, while `warning` egressed to Slack: the more severe the
+                # alert, the less likely anyone saw it. That inversion let a money-path
+                # outage run for days unnoticed. Slack is the delivery leg that actually
+                # works today; `continue: true` keeps the GoAlert leg below intact so the
+                # ADR-0088 "paging inside the perimeter" design still runs (and remains
+                # the eventual goal — this is delivery insurance, not a replacement).
+                - matchers:
+                    - severity = "critical"
+                  receiver: 'slack-alerts'
+                  continue: true
+                  repeat_interval: 1h   # a still-unacked critical re-pings hourly (vs 4h default)
                 - matchers:
                     - severity = "critical"
                   receiver: 'goalert'   # ADR-0088 §D1: page on-call via GoAlert — escalation,
-                  # ack and dedup — which fans out to ntfy. Critical pages, never just Slack.
+                  # ack and dedup — which fans out to ntfy. In-perimeter paging.
                 - matchers:
                     - severity = "warning"
-                  receiver: 'slack-warning'   # ADR-0077 Phase 4: non-paging visibility.
-                  # warning -> Slack only (no on-call page); critical stays on GoAlert above.
+                  receiver: 'slack-alerts'   # ADR-0077 Phase 4: non-paging visibility.
             receivers:
               - name: 'null'
               - name: 'holmes-rca'
@@ -103,12 +116,15 @@ spec:
                   # mounted Secret (url_file) — never committed to git.
                   - url_file: /etc/alertmanager/secrets/goalert-webhook-url/url
                     send_resolved: true
-              - name: 'slack-warning'
+              - name: 'slack-alerts'
                 slack_configs:
-                  # Non-paging warning feed. The incoming-webhook URL is the secret and
-                  # carries its own target channel, so it is read from the mounted Secret
-                  # (api_url_file) — never committed to git. `channel` is required by the
-                  # schema but the incoming webhook posts to its own bound channel.
+                  # Delivery leg for BOTH warning and critical (see routing above) — the
+                  # only receiver that reaches a human outside the cluster perimeter. The
+                  # incoming-webhook URL is the secret and carries its own target channel,
+                  # so it is read from the mounted Secret (api_url_file) — never committed
+                  # to git. `channel` is required by the schema but the incoming webhook
+                  # posts to its own bound channel. The title renders the severity, so a
+                  # critical is distinguishable in the same channel.
                   - api_url_file: /etc/alertmanager/secrets/alertmanager-slack/SLACK_WEBHOOK
                     channel: '#openbank-alerts'
                     send_resolved: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "9ad4f0341bff8cb8"
+    openbank.tech/policy-checksum: "c1fd07b50d801187"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1667,6 +1667,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ad4f0341bff8cb8"
+        openbank.tech/policy-checksum: "c1fd07b50d801187"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "5a283a52d4713e6f"
+    openbank.tech/policy-checksum: "61fc22473f673876"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -889,6 +889,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5a283a52d4713e6f"
+        openbank.tech/policy-checksum: "61fc22473f673876"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "5a283a52d4713e6f"
+    openbank.tech/policy-checksum: "61fc22473f673876"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -889,6 +889,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "5a283a52d4713e6f"
+        openbank.tech/policy-checksum: "61fc22473f673876"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/observability/probes-synthetic.yaml
+++ b/openbank-infra/gitops/components/observability/probes-synthetic.yaml
@@ -17,6 +17,10 @@ spec:
   scrapeTimeout: 12s
   # Strict 2xx — admin-ui serves a real 200 at "/", so a non-2xx here is a
   # genuine regression worth paging on.
+  # SCOPE (do not over-trust this probe): "/" is the unauthenticated landing page and
+  # returns 200 whether or not Keycloak is alive, so this stays GREEN through a total
+  # login outage. It proves the admin-ui pod + ingress + cert only. The OIDC path is
+  # covered by the synthetic-oidc-discovery probe below — that is the login signal.
   module: http_2xx
   prober:
     url: blackbox-exporter:9115
@@ -76,3 +80,37 @@ spec:
         - https://api.open-bank.tech
       labels:
         tier: api
+---
+# The login signal. Every other edge probe is blind to a dead IdP: admin.open-bank.tech
+# serves its landing page 200 without Keycloak, and kc.open-bank.tech is probed with the
+# lenient http_app module, which accepts the 404 a dead Keycloak behind a live ingress
+# returns. Result: a Keycloak outage that broke ALL admin-ui login left every synthetic
+# probe green. This probe exercises the OIDC discovery document itself with the strict
+# http_oidc_discovery module (hard 200 + the discovery claims must be in the body), so
+# the realm must genuinely be serving OIDC for it to pass.
+#
+# Both realms are covered because they fail independently and have different blast radii:
+#   openbank            -> admin-ui staff login (KEYCLOAK_REALM in components/admin-ui)
+#   openbank-customers  -> customer-facing / mobile login
+# Discovery is a public, unauthenticated endpoint — no credential is involved in probing it.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: synthetic-oidc-discovery
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  jobName: synthetic-oidc-discovery
+  interval: 60s
+  scrapeTimeout: 12s
+  module: http_oidc_discovery
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      static:
+        - https://kc.open-bank.tech/realms/openbank/.well-known/openid-configuration
+        - https://kc.open-bank.tech/realms/openbank-customers/.well-known/openid-configuration
+      labels:
+        tier: iam

--- a/openbank-infra/gitops/components/observability/prometheus-rules-kyverno.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-kyverno.yaml
@@ -1,0 +1,106 @@
+# Kyverno admission-control alert rules (ADR-0030 D4 / ADR-0082).
+#
+# WHY THIS EXISTS: servicemonitor-kyverno.yaml has scraped Kyverno's metrics since
+# the SOC dashboard needed them, but NOTHING alerted on them — the metrics were
+# dashboard-only. A ClusterPolicy graduating Audit -> Enforce with resources still
+# failing it therefore blocks admission silently: running pods are unaffected (they
+# are not re-admitted), so nothing looks wrong until a pod happens to reschedule and
+# then can never come back. The failure is spread over days and is invisible to
+# every existing signal. These rules make a blocked admission page.
+#
+# Metric names/labels verified against Kyverno v1.12.5 (chart 3.2.6, apps/kyverno.yaml):
+#   kyverno_admission_requests_total  — pkg/webhooks/handlers/metrics.go: labels
+#     resource_kind, resource_namespace, resource_request_operation, request_allowed.
+#     `request_allowed="false"` is the DIRECT "this request was blocked" signal.
+#   kyverno_policy_results_total      — pkg/engine/metrics.go: labels policy_name,
+#     policy_namespace, policy_type, policy_validation_mode ("enforce"|"audit"),
+#     policy_background_mode, resource_kind, resource_namespace,
+#     resource_request_operation, rule_name, rule_result ("pass"|"fail"|"warn"|
+#     "error"|"skip"), rule_type, rule_execution_cause.
+#   (Both are OTel Int64Counters named without `_total`; the Prometheus exporter
+#   appends `_total` — which is why the SOC dashboard queries the `_total` form.)
+#
+# Picked up automatically (ruleSelectorNilUsesHelmValues=false).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-kyverno-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.kyverno.admission
+      rules:
+        # THE alert the SBOM-attestation enforcement incident needed. Any denied
+        # admission request is a workload that cannot start — by the time this fires
+        # a pod is already being turned away. Not scoped to a policy or namespace on
+        # purpose: an Enforce-mode policy denying ANYTHING is a cluster-wide risk,
+        # since the blast radius is "every pod that happens to reschedule".
+        - alert: KyvernoAdmissionDenied
+          expr: |
+            sum by (resource_kind, resource_namespace, resource_request_operation) (
+              increase(kyverno_admission_requests_total{request_allowed="false"}[10m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Kyverno is BLOCKING admission of {{ $labels.resource_kind }} in {{ $labels.resource_namespace }}"
+            description: >-
+              Kyverno denied {{ $value | printf "%.0f" }} {{ $labels.resource_request_operation }}
+              admission request(s) for {{ $labels.resource_kind }} in namespace
+              {{ $labels.resource_namespace }} over the last 10m, sustained for >5m. The workload
+              CANNOT start and will stay down until the policy passes or is relaxed — already-running
+              pods are NOT re-admitted, so this may be silent until a pod reschedules. Find the policy
+              with the KyvernoEnforcePolicyBlocking alert, or:
+              kubectl -n {{ $labels.resource_namespace }} describe <kind> / kubectl logs -n kyverno -l app.kubernetes.io/component=admission-controller
+        # Same event, attributed to the policy + rule that did the blocking. Split from
+        # the alert above because kyverno_admission_requests_total carries no policy_name
+        # (the webhook handler does not know which policy denied) and
+        # kyverno_policy_results_total carries no allow/deny outcome — you need both to
+        # know that something was blocked AND what blocked it.
+        - alert: KyvernoEnforcePolicyBlocking
+          expr: |
+            sum by (policy_name, rule_name, resource_kind, resource_namespace) (
+              increase(kyverno_policy_results_total{
+                policy_validation_mode="enforce",
+                rule_result="fail",
+                policy_background_mode!="true"
+              }[10m])
+            ) > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Enforce-mode policy {{ $labels.policy_name }}/{{ $labels.rule_name }} is failing {{ $labels.resource_kind }}"
+            description: >-
+              Kyverno ClusterPolicy {{ $labels.policy_name }} (rule {{ $labels.rule_name }}) is in
+              ENFORCE mode and failed {{ $labels.resource_kind }} in namespace
+              {{ $labels.resource_namespace }} — admission is being denied. Either fix the resource
+              so it satisfies the policy, or drop the policy back to Audit
+              (validationFailureAction: Audit) to unblock while you do.
+        # PREVENTIVE — the signal that would have caught the incident BEFORE it happened.
+        # An Audit-mode policy that is already failing resources is a loaded gun: the day
+        # it graduates to Enforce, every one of those failures becomes a denied admission.
+        # Warning (not critical) because nothing is broken *yet* — Audit blocks nothing.
+        # Treat a firing instance as a blocker on the Audit -> Enforce graduation.
+        - alert: KyvernoAuditPolicyFailingBeforeEnforce
+          expr: |
+            sum by (policy_name, rule_name, resource_kind, resource_namespace) (
+              increase(kyverno_policy_results_total{
+                policy_validation_mode="audit",
+                rule_result="fail"
+              }[1h])
+            ) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Audit-mode policy {{ $labels.policy_name }} would block {{ $labels.resource_kind }} if enforced"
+            description: >-
+              ClusterPolicy {{ $labels.policy_name }} (rule {{ $labels.rule_name }}) is failing
+              {{ $labels.resource_kind }} in {{ $labels.resource_namespace }} while in AUDIT mode —
+              nothing is blocked today, but graduating this policy to Enforce would deny these
+              admissions. Clear the failures BEFORE flipping validationFailureAction to Enforce
+              (ADR-0144 gate graduation).

--- a/openbank-infra/gitops/components/observability/prometheus-rules-synthetic.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-synthetic.yaml
@@ -12,14 +12,37 @@ spec:
   groups:
     - name: openbank.synthetic
       rules:
+        # Generic edge-probe failure. The OIDC-discovery job is excluded here and handled
+        # by OIDCDiscoveryDown below — same condition, but that alert can name the actual
+        # blast radius (login is broken) and the right remediation, and excluding it keeps
+        # one outage from paging twice under two alertnames.
         - alert: SyntheticProbeDown
-          expr: probe_success == 0
+          expr: probe_success{job!="synthetic-oidc-discovery"} == 0
           for: 3m
           labels:
             severity: critical
           annotations:
             summary: "Synthetic probe failing: {{ $labels.instance }}"
             description: "Blackbox probe to {{ $labels.instance }} has failed for >3m — the public endpoint is down or unreachable from in-cluster."
+        # The login alert (probes-synthetic.yaml: synthetic-oidc-discovery). Fires when a
+        # Keycloak realm stops serving its OIDC discovery document — i.e. nobody can log
+        # in. This is deliberately its own alert because no other signal sees it: the
+        # admin-ui probe returns 200 from the landing page without Keycloak, and the
+        # lenient http_app edge probe accepts the 404 a dead Keycloak still returns.
+        - alert: OIDCDiscoveryDown
+          expr: probe_success{job="synthetic-oidc-discovery"} == 0
+          for: 3m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Keycloak OIDC discovery failing: {{ $labels.instance }}"
+            description: >-
+              The OIDC discovery document at {{ $labels.instance }} has not served a valid 200 for
+              >3m — the realm is not serving OIDC, so LOGIN IS BROKEN for everything that depends on
+              it (realm `openbank` = admin-ui staff login; realm `openbank-customers` = customer /
+              mobile login). Note the admin-ui and edge probes can stay GREEN through this.
+              Check: kubectl -n iam get pods -l app=keycloak — and if the pod is absent rather than
+              unhealthy, check whether admission was denied (KyvernoAdmissionDenied).
         - alert: SyntheticProbeSlow
           expr: probe_duration_seconds > 5
           for: 10m

--- a/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-tier1.yaml
@@ -81,6 +81,10 @@ spec:
         # failed: error-rate ≥5% or p95 latency ≥1s). Rollout auto-reverts to
         # stable, but operators need to know so they can investigate the root
         # cause before the next deploy attempt (ADR-0098).
+        # NOTE: the argo-rollouts controller labels rollout_phase with `namespace` + `name`
+        # (controller/metrics/prommetrics.go: namespaceNameLabels), NOT `rollout` — the
+        # original `{{ $labels.rollout }}` here rendered EMPTY, so the page never said which
+        # rollout aborted. Use $labels.name.
         - alert: RolloutAnalysisAborted
           expr: |
             rollout_phase{phase="Aborted"} == 1
@@ -88,9 +92,9 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "Rollout {{ $labels.rollout }} aborted in {{ $labels.namespace }}"
+            summary: "Rollout {{ $labels.name }} aborted in {{ $labels.namespace }}"
             description: >-
-              Canary analysis failed for {{ $labels.rollout }} (namespace {{ $labels.namespace }}).
+              Canary analysis failed for {{ $labels.name }} (namespace {{ $labels.namespace }}).
               Traffic has been reverted to stable. Check AnalysisRun for failing metric
               (error-rate or p95-latency). Next deploy will restart the canary cycle.
         # Fires when a Rollout is stuck degraded — pod failed to become healthy
@@ -104,9 +108,9 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "Rollout {{ $labels.rollout }} degraded in {{ $labels.namespace }}"
+            summary: "Rollout {{ $labels.name }} degraded in {{ $labels.namespace }}"
             description: >-
-              Rollout {{ $labels.rollout }} (namespace {{ $labels.namespace }}) exceeded
+              Rollout {{ $labels.name }} (namespace {{ $labels.namespace }}) exceeded
               the 10-minute progress deadline — canary pods did not become healthy.
               Likely cause: OOMKilled, CrashLoopBackOff, missing secret/configmap, or
               image pull error. Traffic reverted to stable.

--- a/openbank-infra/gitops/components/observability/prometheus-rules-workload-availability.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-workload-availability.yaml
@@ -1,0 +1,106 @@
+# Workload total-unavailability alert rules (ADR-0082).
+#
+# WHY THIS EXISTS: kube-prometheus-stack's `defaultRules` are never overridden, so the
+# only workload-stuck signals were the chart defaults — KubeDeploymentReplicasMismatch /
+# KubePodNotReady — which are `severity: warning`. Warning routes to Slack as a low-signal
+# feed nobody treats as an outage, and, crucially, the chart defaults cover Deployments and
+# StatefulSets ONLY: they do not know what an Argo Rollout is. Much of the fleet
+# (sepa-payment, party-service, ledger, ...) runs as argoproj.io/v1alpha1 Rollouts, so a
+# Rollout stuck at zero available replicas produced NO alert of any severity.
+#
+# These rules say the one thing that is unambiguously an outage — "this workload has no
+# running pods at all, and it is supposed to" — at `critical`, across all three kinds.
+#
+# THE SCALE-TO-ZERO GUARD (`desired > 0`) IS LOAD-BEARING: finops-scaledown's CronJobs
+# (ADR-0057) and the per-service KEDA ScaledObjects deliberately scale workloads —
+# including money-path ones — to zero overnight and at weekends, via the `scale`
+# subresource. That sets spec/desired replicas to 0, so an intentionally parked workload
+# never matches. Without this guard these alerts would fire across the fleet every night
+# at 22:00 Europe/Prague and be muted within a week.
+#
+# Metric names/labels verified:
+#   kube_deployment_status_replicas_available{deployment,namespace}
+#   kube_deployment_spec_replicas{deployment,namespace}
+#   kube_statefulset_status_replicas_ready{statefulset,namespace}
+#   kube_statefulset_replicas{statefulset,namespace}
+#     — kube-state-metrics (bundled in kube-prometheus-stack 87.0.0); the same metrics the
+#       chart's own rules-1.14/kubernetes-apps.yaml default rules query.
+#   rollout_info_replicas_available{namespace,name}
+#   rollout_info_replicas_desired{namespace,name}
+#     — argo-rollouts controller/metrics/prommetrics.go @ v1.9.0 (chart 2.41.0,
+#       apps/argo-rollouts.yaml). NOTE the label is `name`, NOT `rollout`.
+#
+# Each expression aggregates with `max by (...)` BEFORE the `and on (...)` join, rather
+# than comparing the raw series. That is not cosmetic: both exporters run a single replica
+# today, but argo-rollouts is documented right in apps/argo-rollouts.yaml as "scale to 2
+# for HA in prod", and a second controller replica would export a second series per
+# rollout. Joining raw series would then abort with "found duplicate series for the match
+# group" and the alert would silently stop evaluating — the exact failure mode these rules
+# exist to catch. Aggregating first is correct at 1 replica and stays correct at N.
+#
+# Picked up automatically (ruleSelectorNilUsesHelmValues=false).
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-workload-availability-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.workload.availability
+      rules:
+        # Argo Rollouts — the gap the chart defaults leave completely open.
+        - alert: RolloutNoAvailableReplicas
+          expr: |
+            max by (namespace, name) (rollout_info_replicas_available) == 0
+              and on (namespace, name)
+            max by (namespace, name) (rollout_info_replicas_desired) > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Rollout {{ $labels.name }} has ZERO available replicas ({{ $labels.namespace }})"
+            description: >-
+              Rollout {{ $labels.name }} in namespace {{ $labels.namespace }} has had no available
+              replicas for >15m while still desiring at least one — the service is DOWN (this is not
+              an off-hours scale-down; those set desired replicas to 0 and are excluded). Likely
+              causes: admission denied by a Kyverno policy (see KyvernoAdmissionDenied),
+              ImagePullBackOff, CrashLoopBackOff, OOMKilled, missing secret/configmap, or no node
+              with capacity. Check: kubectl -n {{ $labels.namespace }} get pods,
+              kubectl argo rollouts get rollout {{ $labels.name }} -n {{ $labels.namespace }}
+        # Deployments — chart default exists but is warning-only. keycloak (iam) and
+        # admin-ui are Deployments; keycloak at zero replicas takes down ALL admin-ui login.
+        - alert: DeploymentNoAvailableReplicas
+          expr: |
+            max by (namespace, deployment) (kube_deployment_status_replicas_available) == 0
+              and on (namespace, deployment)
+            max by (namespace, deployment) (kube_deployment_spec_replicas) > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Deployment {{ $labels.deployment }} has ZERO available replicas ({{ $labels.namespace }})"
+            description: >-
+              Deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} has had no
+              available replicas for >15m while spec.replicas > 0 — the service is DOWN (off-hours
+              scale-down sets spec.replicas to 0 and is excluded). Likely causes: admission denied by
+              a Kyverno policy (see KyvernoAdmissionDenied), ImagePullBackOff, CrashLoopBackOff,
+              OOMKilled, missing secret/configmap, or unschedulable.
+              Check: kubectl -n {{ $labels.namespace }} describe deploy {{ $labels.deployment }}
+        # StatefulSets — postgres/kafka and friends. Same class of gap.
+        - alert: StatefulSetNoReadyReplicas
+          expr: |
+            max by (namespace, statefulset) (kube_statefulset_status_replicas_ready) == 0
+              and on (namespace, statefulset)
+            max by (namespace, statefulset) (kube_statefulset_replicas) > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "StatefulSet {{ $labels.statefulset }} has ZERO ready replicas ({{ $labels.namespace }})"
+            description: >-
+              StatefulSet {{ $labels.statefulset }} in namespace {{ $labels.namespace }} has had no
+              ready replicas for >15m while desiring at least one — likely a datastore outage, which
+              takes its dependent services down with it. Check:
+              kubectl -n {{ $labels.namespace }} describe sts {{ $labels.statefulset }}

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "e50655a0a98ac421"
+    openbank.tech/policy-checksum: "ccb19defeaeb463b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1606,6 +1606,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e50655a0a98ac421"
+        openbank.tech/policy-checksum: "ccb19defeaeb463b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -421,6 +421,23 @@ slo:
   # the SLO burn-rate should page before the blunter absolute-latency alert does.
   latency_threshold_seconds: 1
   latency_window: 30d
+
+# ---------------------------------------------------------------------------------------
+# Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+# verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+# ---------------------------------------------------------------------------------------
+alerting:
+  # At least one Alertmanager route matching severity=critical must end at a receiver that
+  # egresses the cluster (external integration, or a webhook with a literal non-cluster
+  # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+  # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+  # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+  # reached Slack, so the most severe alerts were the least likely to be seen.
+  critical_alerts_must_egress: true
+  enforced: enforce
+  ci_producer: ".github/scripts/check-critical-alert-egress.py"
+  checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
 review:
   default_approvals: 1
   money_path_approvals: 2               # CONTRIBUTING.md + branch protection


### PR DESCRIPTION
## The finding: a severity inversion

Critical alerts could not physically reach a human.

Alertmanager routed `severity: critical` to **GoAlert** (paging, escalation, ack, dedup) and
**HolmesGPT** (auto-RCA), and `severity: warning` to **Slack**. But GoAlert, the ntfy it fans out
to, and the Holmes relay are all cluster-internal Services with **no Ingress** (ADR-0056) —
`grep -c "kind: Ingress"` on `ntfy.yaml` and `goalert.yaml` both return `0`. So every `critical`
delivery path dead-ended inside the perimeter and could only be reached by someone already
port-forwarding into the cluster, while `warning` escaped to Slack.

**Net effect: the more severe the alert, the less likely a human saw it.**

This survived review because the critical path looked *more* carefully built than the warning path.
"A paging receiver is configured" and "a human is reachable" are different properties, and only
reading the receiver's downstream Ingress manifests tells them apart.

## What changed

**1. Critical now egresses (the decided fix).** `critical` routes to the same Slack receiver
`warning` already used, with `continue: true` so the Holmes enrichment and GoAlert legs are
untouched. ntfy/GoAlert are **not** exposed via Ingress — ADR-0088's "paging inside the perimeter"
stays the documented eventual goal; this is delivery insurance, not a replacement. The receiver is
renamed `slack-warning` → `slack-alerts` since it now carries both severities (the title template
already renders severity). Critical gets `repeat_interval: 1h` vs the 4h default.

**2. Kyverno admission-denial alerting (new).** `servicemonitor-kyverno.yaml` scraped Kyverno for
dashboards only; nothing alerted. New `prometheus-rules-kyverno.yaml`:
- `KyvernoAdmissionDenied` (**critical**) — on `kyverno_admission_requests_total{request_allowed="false"}`.
  This is the *direct* "this request was blocked" signal, and is better than `rule_result="fail"`,
  which also fires for Audit-mode policies that block nothing.
- `KyvernoEnforcePolicyBlocking` (**critical**) — attributes the denial to a policy/rule.
  Split from the above because the two metrics carry disjoint information: the admission counter has
  no `policy_name`, and `policy_results_total` has no allow/deny outcome. You need both.
- `KyvernoAuditPolicyFailingBeforeEnforce` (**warning**) — preventive. An Audit-mode policy that is
  already failing resources is a loaded gun: the day it graduates to Enforce, every one of those
  failures becomes a denied admission. This is the signal that would have fired *before* the
  Audit→Enforce graduation rather than after.

**3. Workload-stuck alerts (new).** `defaultRules` is never overridden, so the only signals were the
chart defaults (`KubeDeploymentReplicasMismatch` / `KubePodNotReady`) — **warning-only**, and they
cover Deployments/StatefulSets only. They do not know what an Argo Rollout is. Much of the fleet
(sepa-payment, party-service, ledger, …) runs as `argoproj.io/v1alpha1` Rollouts, so **a Rollout at
zero replicas produced no alert of any severity**. New `prometheus-rules-workload-availability.yaml`
adds critical rules for Rollouts, Deployments and StatefulSets.

> The `desired > 0` guard on each rule is load-bearing: `finops-scaledown`'s CronJobs (ADR-0057) and
> the KEDA ScaledObjects deliberately scale workloads — including money-path ones — to zero
> overnight via the `scale` subresource, which sets desired replicas to 0. Without the guard these
> would fire fleet-wide every night at 22:00 and be muted within a week.

Each expression aggregates with `max by (...)` *before* the `and on (...)` join. Both exporters run
one replica today, but `apps/argo-rollouts.yaml` documents "scale to 2 for HA in prod" — a second
controller replica would export a duplicate series per rollout, and joining raw series would abort
with "found duplicate series for the match group", silently stopping evaluation. That is the exact
failure mode these rules exist to catch.

**4. The login probe was a lie.** `admin.open-bank.tech` returns 200 from its unauthenticated
landing page whether or not Keycloak is alive, and `kc.open-bank.tech` was probed with `http_app`,
whose `valid_status_codes` includes 404 — so a dead Keycloak behind a live ingress still passed.
Both probes stayed green through a total login outage. Added a **strict** `http_oidc_discovery`
blackbox module (hard 200 only, no redirect following, and the discovery document's own claims must
appear in the body) and a `synthetic-oidc-discovery` Probe against both realms'
`.well-known/openid-configuration` — `openbank` (admin-ui staff login) and `openbank-customers`
(customer/mobile), which fail independently. Wired to a critical `OIDCDiscoveryDown`; the generic
`SyntheticProbeDown` is scoped off that job so one outage doesn't page twice. Discovery is a public
unauthenticated endpoint — no credential is involved.

**5. Stale header comment** at `kube-prometheus-stack.yaml:2` ("alertmanager disabled — no routing
configured") corrected; it contradicted `enabled: true` and the routing block directly below it.

**6. Governance (`rules.yaml: alerting`).** Encoded the invariant as an enforced gate: at least one
`severity=critical` route must end at a receiver that egresses the cluster. A `url_file` webhook
counts as **unprovable**, not as egress — deliberately conservative. New
`.github/scripts/check-critical-alert-egress.py`, wired into the `validate` job next to the other
pyyaml guards.

## Verification

- **The new gate reproduces the bug.** Run against the pre-fix config from `origin/main` it fails
  with `SEVERITY INVERSION — every severity=critical route dead-ends inside the cluster (receivers:
  goalert, holmes-rca)`; against this branch it passes. Edge cases checked: alertmanager disabled →
  skip; no critical route → fail; external literal webhook URL → pass; `url_file` → fail.
- **Every metric name and label was verified against the deployed versions**, not assumed:

| Metric | Labels | Verified against |
|---|---|---|
| `kyverno_admission_requests_total` | `resource_kind`, `resource_namespace`, `resource_request_operation`, `request_allowed` | Kyverno **v1.12.5** `pkg/webhooks/handlers/metrics.go` (chart 3.2.6 → appVersion v1.12.5) |
| `kyverno_policy_results_total` | `policy_name`, `rule_name`, `rule_result` (`pass`/`fail`/`warn`/`error`/`skip`), `policy_validation_mode` (`enforce`/`audit`), `policy_background_mode`, `resource_kind`, `resource_namespace`, … | Kyverno v1.12.5 `pkg/engine/metrics.go`; also already queried by the SOC dashboard |
| `rollout_info_replicas_available` / `_desired` | `namespace`, `name` | argo-rollouts **v1.9.0** `controller/metrics/prommetrics.go` (chart 2.41.0 → appVersion v1.9.0) |
| `kube_deployment_status_replicas_available` / `kube_deployment_spec_replicas` | `namespace`, `deployment` | kube-state-metrics docs **and** kube-prometheus-stack 87.0.0's own `rules-1.14/kubernetes-apps.yaml` |
| `kube_statefulset_status_replicas_ready` / `kube_statefulset_replicas` | `namespace`, `statefulset` | same as above |
| `fail_if_body_not_matches_regexp`, `valid_status_codes`, `follow_redirects` | — | blackbox_exporter **v0.28.0** `config/config.go` (chart 11.12.0); `follow_redirects` is inlined from `prometheus/common` `HTTPClientConfig` |
| `job` label from `spec.jobName` | — | prometheus-operator `promcfg.go` Probe relabeling |

  Both OTel counters are registered *without* the `_total` suffix; the Prometheus exporter appends
  it — which is why the existing SOC dashboard queries the `_total` form. **No metric name was left
  unverified.**
- CI-scoped `yamllint` (`openbank-infra .github`, CI's exact config) passes with zero errors; all
  changed YAML parses; the OPA bundle build + decision assertions pass; generators are idempotent.
- `promtool` was not available locally and I did not download a binary, so the PromQL is
  syntax-reviewed by hand rather than machine-checked — CI/Prometheus will be the first mechanical
  check on the expressions.

## Drive-by

The argo-rollouts controller labels rollout metrics `namespace` + `name`, **not** `rollout`
(`namespaceNameLabels` in `prommetrics.go`). The existing `RolloutAnalysisAborted` /
`RolloutProgressDeadlineExceeded` annotations used `{{ $labels.rollout }}`, which rendered **empty** —
the alert never said which rollout aborted. Fixed to `$labels.name`.

## Note on the OPA bundle churn

`pid` / `copilot` / `customer-edge` / `notifications` bundles are regenerated. Their generators hash
the **whole of `rules.yaml`** into the bundle checksum and embed it verbatim, so any `rules.yaml`
edit restales them and the OPA gate (which regenerates and diffs exactly these four) would fail.
The diffs are checksum + the embedded `rules.yaml` text only — no policy change. For the same reason
the new `alerting:` section is kept terse: it is copied into every OPA sidecar ConfigMap.

## Follow-ups (deliberately not folded in)

- **21 of the 25 `gen-*-opa-bundle.sh` generators hash `rules.yaml` but are not verified by CI** —
  the OPA gate only diffs 4. Regenerating `ledger` locally produced a large diff of *unrelated*
  policy-source changes, i.e. those bundles are **already stale on `main`**, independent of this PR.
  Reverted and left alone: it is a pre-existing drift problem, it would bury this change, and it
  touches money-path bundles (2 approvals + threat model). Worth its own issue.
- No issue number is linked — I did not find an existing one for this and did not open one. Happy to
  add a `Closes #<n>` if you create one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
