### PR TITLE
fix(infra): close fleet-wide SBOM attestation gap; gate Enforce graduation

### DIFF
--- a/.github/scripts/check-fleet-attestations.sh
+++ b/.github/scripts/check-fleet-attestations.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------------------
+# Fleet SBOM-attestation gate (ADR-0030 D4, rules.yaml provenance.enforce_criteria).
+#
+# Enumerates EVERY openbank-* image referenced anywhere under openbank-infra/gitops/ and
+# verifies each one carries a cosign-signed CycloneDX SBOM attestation that kyverno's
+# verify-openbank-image-sbom-attestation ClusterPolicy would accept.
+#
+# WHY THIS IS THE GATE:
+#   kyverno verifies at ADMISSION, not continuously. An unattested image whose pod is
+#   already running keeps running — the policy never re-evaluates it. The violation is
+#   LATENT until something reschedules that pod (node roll, eviction, scale-up), at which
+#   point the pod is denied and can never restart. So "the fleet looks healthy" proves
+#   nothing about whether the fleet is attested, and a PolicyReport with 0 fail only
+#   describes pods that happen to exist right now.
+#
+#   This check reads the DECLARED images in gitops instead — the set of images the cluster
+#   would admit — so a gap is caught while it is still latent, before a reschedule turns it
+#   into an outage.
+#
+#   No Audit -> Enforce graduation of an image-provenance policy may proceed unless this
+#   check passes. That precondition is encoded in rules.yaml provenance.enforce_criteria.
+#
+# COVERAGE: every openbank-* ECR reference in gitops — app containers, initContainers AND
+# sidecars alike. The image regex is intentionally position-blind (it does not care which
+# YAML key an image hangs off) precisely so a sidecar or initContainer cannot slip through.
+#
+# TWO FAILURE CLASSES, kept distinct on purpose:
+#   UNATTESTED — the image IS in the registry but carries no valid attestation. This is the
+#                outage class: pods run now, die forever on the next reschedule. Always fatal.
+#   ABSENT     — the image is not in the registry at all (a first-registration placeholder
+#                tag that was never built). Also broken, but a different bug with a different
+#                fix, and it is NOT an attestation regression. Fatal unless the image is
+#                listed in the placeholder allowlist below.
+# Conflating the two would make this gate permanently red on a known placeholder — and a
+# permanently-red check is one nobody reads. That is exactly how sbom-drift-scanner's
+# `sepa-payment: no-pod-found` sat unactioned on the morning of the outage.
+#
+# Usage:
+#   .github/scripts/check-fleet-attestations.sh              # verify the whole fleet
+#   COSIGN_BIN=/path/to/cosign-v2 ... check-fleet-attestations.sh
+#   FLEET_ATTEST_JSON=out.json ...                           # also emit a JSON report
+#
+# Requires: AWS credentials with ECR read access, cosign v2.x, jq (report only).
+# Read-only: never pushes, retags, signs, or mutates any image.
+# ---------------------------------------------------------------------------------------
+set -uo pipefail
+
+GITOPS_DIR="${GITOPS_DIR:-openbank-infra/gitops}"
+PLACEHOLDER_FILE="${PLACEHOLDER_FILE:-.github/scripts/fleet-attestation-placeholders.txt}"
+COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
+COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
+ECR_REGISTRY="${ECR_REGISTRY:-265175468565.dkr.ecr.eu-north-1.amazonaws.com}"
+FLEET_ATTEST_JSON="${FLEET_ATTEST_JSON:-}"
+
+# cosign v2 is pinned on purpose: kyverno 3.2.6 discovers attestations only via the legacy
+# `sha256-<digest>.att` tag scheme; cosign v3 writes OCI 1.1 referrers it cannot read. This
+# check MUST verify the same way kyverno does, or it would pass images kyverno rejects.
+resolve_cosign_v2() {
+  if [ -n "${COSIGN_BIN:-}" ] && [ -x "${COSIGN_BIN}" ]; then
+    printf '%s\n' "${COSIGN_BIN}"
+    return 0
+  fi
+  if command -v cosign >/dev/null 2>&1 \
+     && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; then
+    command -v cosign
+    return 0
+  fi
+  local os arch bin
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$(uname -m)" in
+    aarch64 | arm64) arch=arm64 ;;
+    x86_64 | amd64) arch=amd64 ;;
+    *) return 1 ;;
+  esac
+  bin="${TMPDIR:-/tmp}/cosign-${COSIGN_VERSION}-${os}-${arch}"
+  if [ ! -x "$bin" ]; then
+    curl -fsSL -o "$bin" \
+      "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}" \
+      2>/dev/null && chmod +x "$bin" || return 1
+  fi
+  printf '%s\n' "$bin"
+}
+
+if [ ! -d "$GITOPS_DIR" ]; then
+  echo "ERROR: gitops dir not found: ${GITOPS_DIR} (run from the repo root)." >&2
+  exit 1
+fi
+
+COSIGN_BIN_RESOLVED="$(resolve_cosign_v2 || true)"
+if [ -z "$COSIGN_BIN_RESOLVED" ]; then
+  echo "ERROR: cosign v2 unavailable — cannot verify fleet attestations." >&2
+  echo "       Install cosign v2.x, set COSIGN_BIN, or set COSIGN_VERSION." >&2
+  exit 1
+fi
+
+echo "==> Enumerating openbank-* images declared in ${GITOPS_DIR}"
+echo "    cosign:   $("$COSIGN_BIN_RESOLVED" version 2>/dev/null | awk '/GitVersion/{print $2}')"
+echo "    key:      ${COSIGN_KEY}"
+echo
+
+# Position-blind on purpose: matches `image:` under containers, initContainers, sidecars,
+# ephemeralContainers, and any Helm/kustomize value that names a full openbank-* ref.
+IMAGE_RE="${ECR_REGISTRY//./\\.}/openbank-[A-Za-z0-9._/-]+:[A-Za-z0-9._-]+"
+
+# Read into an array without `mapfile` — this script must also run on macOS's bash 3.2
+# (an operator verifying the gate by hand before authorizing a graduation).
+IMAGES=()
+while IFS= read -r _img; do
+  [ -n "$_img" ] && IMAGES+=("$_img")
+done < <(grep -rhoE "$IMAGE_RE" "$GITOPS_DIR" 2>/dev/null | sort -u)
+
+if [ "${#IMAGES[@]}" -eq 0 ]; then
+  echo "ERROR: no openbank-* images found under ${GITOPS_DIR} — the enumerator is broken." >&2
+  echo "       (Failing closed: an empty fleet would otherwise 'pass' vacuously.)" >&2
+  exit 1
+fi
+
+echo "==> ${#IMAGES[@]} distinct openbank-* image(s) declared"
+echo
+
+is_allowed_placeholder() {
+  [ -f "$PLACEHOLDER_FILE" ] || return 1
+  grep -vE '^[[:space:]]*(#|$)' "$PLACEHOLDER_FILE" | grep -qxF "$1"
+}
+
+PASS=0
+UNATTESTED=0
+ABSENT=0
+ALLOWED=0
+UNATTESTED_IMAGES=()
+ABSENT_IMAGES=()
+
+for image in "${IMAGES[@]}"; do
+  short="${image#"${ECR_REGISTRY}"/}"
+  if err="$(COSIGN_YES=true "$COSIGN_BIN_RESOLVED" verify-attestation \
+              --key "$COSIGN_KEY" --type cyclonedx "$image" 2>&1)"; then
+    printf '  OK          %s\n' "$short"
+    PASS=$((PASS + 1))
+    continue
+  fi
+
+  # Distinguish "not in the registry" from "in the registry, not attested". cosign surfaces
+  # the former as a registry NAME_UNKNOWN / MANIFEST_UNKNOWN / 404 from the manifest GET.
+  if printf '%s' "$err" | grep -qE 'NAME_UNKNOWN|MANIFEST_UNKNOWN|does not exist|not found|404'; then
+    if is_allowed_placeholder "$image"; then
+      printf '  PLACEHOLDER %s  (allowlisted: never built, cannot be admitted)\n' "$short"
+      ALLOWED=$((ALLOWED + 1))
+    else
+      printf '  ABSENT      %s  <-- declared in gitops but NOT in the registry\n' "$short"
+      ABSENT=$((ABSENT + 1))
+      ABSENT_IMAGES+=("$image")
+    fi
+    continue
+  fi
+
+  printf '  UNATTESTED  %s  <-- no valid CycloneDX SBOM attestation\n' "$short"
+  UNATTESTED=$((UNATTESTED + 1))
+  UNATTESTED_IMAGES+=("$image")
+done
+
+FAIL=$((UNATTESTED + ABSENT))
+
+echo
+echo "==> Fleet summary: ${PASS} attested / ${UNATTESTED} unattested / ${ABSENT} absent / ${ALLOWED} allowlisted placeholder / ${#IMAGES[@]} total"
+
+if [ -n "$FLEET_ATTEST_JSON" ] && command -v jq >/dev/null 2>&1; then
+  # `${arr[@]+"${arr[@]}"}` guards bash 3.2's unbound-variable error on an empty array
+  # under `set -u` — the all-attested case, which must still emit a valid report.
+  _json_arr() {
+    # `${arr[@]+"${arr[@]}"}` guards bash 3.2's unbound-variable error on an empty array
+    # under `set -u` — the all-attested case, which must still emit a valid report.
+    printf '%s\n' ${1+"$@"} | jq -R . | jq -s 'map(select(length > 0))'
+  }
+  jq -n \
+    --argjson total "${#IMAGES[@]}" \
+    --argjson attested "$PASS" \
+    --argjson unattested "$UNATTESTED" \
+    --argjson absent "$ABSENT" \
+    --argjson placeholders "$ALLOWED" \
+    --argjson unattestedImages "$(_json_arr ${UNATTESTED_IMAGES[@]+"${UNATTESTED_IMAGES[@]}"})" \
+    --argjson absentImages "$(_json_arr ${ABSENT_IMAGES[@]+"${ABSENT_IMAGES[@]}"})" \
+    --arg scannedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg gateResult "$([ "$FAIL" -gt 0 ] && echo FAIL || echo PASS)" \
+    '{scannedAt: $scannedAt, gateResult: $gateResult, total: $total, attested: $attested,
+      unattested: $unattested, absent: $absent, allowlistedPlaceholders: $placeholders,
+      unattestedImages: $unattestedImages, absentImages: $absentImages}' \
+    > "$FLEET_ATTEST_JSON"
+  echo "    JSON report: ${FLEET_ATTEST_JSON}"
+fi
+
+if [ "$UNATTESTED" -gt 0 ]; then
+  echo
+  echo "UNATTESTED (${UNATTESTED}) — pushed, signed, but NO SBOM attestation:"
+  for image in "${UNATTESTED_IMAGES[@]}"; do
+    echo "  - ${image}"
+  done
+  echo
+  echo "  Each is a LATENT OUTAGE. Its pods run until something reschedules them; then"
+  echo "  kyverno (verify-openbank-image-sbom-attestation, Enforce) denies admission and"
+  echo "  they can never restart. Rebuild + attest each one BEFORE it reschedules:"
+  echo "    openbank-infra/scripts/build-push-service.sh <svc>   # attests via lib/cosign-attest.sh"
+fi
+
+if [ "$ABSENT" -gt 0 ]; then
+  echo
+  echo "ABSENT (${ABSENT}) — declared in gitops but not present in the registry:"
+  for image in "${ABSENT_IMAGES[@]}"; do
+    echo "  - ${image}"
+  done
+  echo
+  echo "  Not an attestation regression: these can never be admitted at all. Either build+push"
+  echo "  the image, or — if this is a deliberate first-registration placeholder — document it"
+  echo "  in ${PLACEHOLDER_FILE}."
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "FLEET ATTESTATION GATE: FAIL — ${FAIL} of ${#IMAGES[@]} declared image(s) not deployable."
+  echo
+  echo "No image-provenance policy may graduate Audit -> Enforce while this gate fails"
+  echo "(rules.yaml: provenance.enforce_criteria)."
+  exit 1
+fi
+
+echo
+echo "FLEET ATTESTATION GATE: PASS — every declared openbank-* image is attested."
+[ "$ALLOWED" -gt 0 ] && echo "  (${ALLOWED} allowlisted placeholder(s) skipped — see ${PLACEHOLDER_FILE})"
+exit 0

--- a/.github/scripts/fleet-attestation-placeholders.txt
+++ b/.github/scripts/fleet-attestation-placeholders.txt
@@ -1,0 +1,23 @@
+# Placeholder image allowlist for .github/scripts/check-fleet-attestations.sh
+#
+# Images declared in openbank-infra/gitops/ that are deliberate FIRST-REGISTRATION
+# placeholders: the tag has never been built or pushed, so the image is absent from ECR
+# entirely. These cannot be admitted to the cluster at all (Kyverno blocks even ArgoCD's
+# dry-run diff for a nonexistent tag, so the app sits at sync status Unknown rather than
+# ImagePullBackOff), and they are NOT an attestation regression — a nonexistent image
+# cannot be an unattested one.
+#
+# This allowlist exists so the gate can reach GREEN and therefore stay credible. A check
+# that is permanently red because of a known placeholder is a check people learn to ignore.
+#
+# STRICT SCOPE — this file may ONLY list images absent from the registry. It can never
+# suppress an UNATTESTED image (present in ECR, no attestation); that class is always fatal
+# and has no allowlist, because that is precisely the class that caused the 2026-07-12
+# admission failures.
+#
+# Remove an entry the moment the service is genuinely built + pushed. One image ref per
+# line, exact match, full registry path.
+
+# finrep-service: first ArgoCD registration (ADR-0097); never built via build-push-service.sh.
+# See the header note in openbank-infra/gitops/components/finrep/finrep-service.yaml.
+265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-init

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -479,14 +479,21 @@ jobs:
       # image (ADR-0030 D4), complementing the release-time bundle (release-please.yml) and
       # the image SIGNATURE above. trivy generates the image SBOM (OS layer + jars, which a
       # source scan misses); cosign attest binds it to the image digest with the same KMS key.
-      # Non-fatal: kyverno enforces the signature, not (yet) the attestation, so an attest
-      # hiccup must never block a deploy.
+      #
+      # FATAL as of 2026-07-16. The two comments this step used to carry — "kyverno enforces
+      # the signature, not (yet) the attestation" and "an attest hiccup must never block a
+      # deploy" — were both false once verify-openbank-image-sbom-attestation graduated to
+      # Enforce on 2026-07-12. They were the entire bug: `trivy image` was missing --platform
+      # (it defaults to linux/amd64 on REMOTE scans; these images are arm64-only), so the scan
+      # failed with "no child with platform linux/amd64 in index" on EVERY image, the failure
+      # became a ::warning, continue-on-error swallowed it, and the deploy proceeded green with
+      # an unattested image. Nothing noticed until a pod rescheduled days later and could not
+      # be re-admitted.
+      #
+      # An unattested image cannot be admitted, so a deploy that "succeeds" while producing one
+      # is not a successful deploy — it is a time bomb with a green check. Fail here instead.
       - name: Attest image SBOMs (cosign + KMS)
         timeout-minutes: 15
-        # Strictly non-fatal: kyverno enforces the image signature, not (yet) the
-        # attestation, so nothing here — not even a failed cosign download — may block a
-        # deploy. continue-on-error guarantees the deploy proceeds regardless.
-        continue-on-error: true
         run: |
           set -uo pipefail
           SERVICES='${{ needs.changes.outputs.services }}'
@@ -501,17 +508,33 @@ jobs:
             curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
             chmod +x "$bin"
           fi
+          rc=0
           for svc in $(echo "$SERVICES" | jq -r '.[]'); do
             [ -f "${svc}/build/quarkus-app/quarkus-run.jar" ] || continue
             image="${ECR_REGISTRY}/${svc}:${TAG}"
             sbom="${RUNNER_TEMP}/${svc}.cdx.json"
-            if ! trivy image --format cyclonedx --output "$sbom" "$image" 2>/dev/null; then
-              echo "::warning::[${svc}] trivy image SBOM generation failed — skipping attestation"; continue
+            # --platform is REQUIRED: images are built linux/arm64 (line ~364) and trivy
+            # defaults to linux/amd64 for remote scans. Omitting it fails 100% of the time.
+            # Stderr is NOT swallowed (`2>/dev/null` was hiding the platform error for weeks).
+            echo "==> [${svc}] trivy image --platform linux/arm64 (cyclonedx) ${image}"
+            if ! trivy image --platform linux/arm64 --format cyclonedx --output "$sbom" "$image"; then
+              echo "::error::[${svc}] trivy image SBOM generation failed — image would be UNATTESTED and undeployable"; rc=1; continue
             fi
             echo "==> cosign attest (cyclonedx) ${image}"
-            COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type cyclonedx --predicate "$sbom" "$image" \
-              || echo "::warning::[${svc}] cosign attest failed"
+            if ! COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type cyclonedx --predicate "$sbom" "$image"; then
+              echo "::error::[${svc}] cosign attest failed — image UNATTESTED and undeployable"; rc=1; continue
+            fi
+            # Never trust `attest` exit 0 alone — verify the attestation is discoverable the
+            # same way kyverno discovers it at admission (legacy .att tag scheme, cosign v2).
+            if ! COSIGN_YES=true "$bin" verify-attestation --key "$COSIGN_KEY" --type cyclonedx "$image" >/dev/null 2>&1; then
+              echo "::error::[${svc}] cosign verify-attestation failed — the attestation did not land"; rc=1; continue
+            fi
+            echo "    [${svc}] attested + verified"
           done
+          [ "$rc" -eq 0 ] || {
+            echo "::error::One or more images are UNATTESTED. kyverno (verify-openbank-image-sbom-attestation, Enforce) will DENY their pods on the next reschedule."
+            exit 1
+          }
 
       - name: Collect image tags
         id: collect

--- a/.github/workflows/fleet-attestation.yml
+++ b/.github/workflows/fleet-attestation.yml
@@ -1,0 +1,147 @@
+# Fleet SBOM-attestation gate (ADR-0030 D4, rules.yaml provenance.enforce_criteria).
+#
+# Verifies that EVERY openbank-* image declared anywhere under openbank-infra/gitops/ —
+# app containers, initContainers and sidecars alike — carries a cosign-signed CycloneDX
+# SBOM attestation that kyverno's verify-openbank-image-sbom-attestation ClusterPolicy
+# (Enforce) would accept.
+#
+# WHY ON A SCHEDULE, not just on PRs:
+#   kyverno verifies at ADMISSION, not continuously. An unattested image whose pod is
+#   already running keeps running — the gap is LATENT and invisible until something
+#   reschedules that pod (node roll, eviction, scale-up), at which point the pod is denied
+#   and can never restart. A green fleet proves nothing. The daily run is what turns a
+#   latent gap into a ticket BEFORE a reschedule turns it into an outage.
+#
+# WHY ON gitops/producer PRs:
+#   catches an image bumped into gitops that was never attested, at review time.
+name: Fleet attestation
+
+on:
+  schedule:
+    # 02:40 UTC daily — ahead of sbom-drift-scanner's 03:10 in-cluster slot, so a fleet
+    # provenance gap is already known by the time the sync-drift report lands.
+    - cron: "40 2 * * *"
+  pull_request:
+    paths:
+      - "openbank-infra/gitops/**"
+      - "openbank-infra/scripts/build-push-*.sh"
+      - "openbank-infra/scripts/lib/cosign-attest.sh"
+      - ".github/scripts/check-fleet-attestations.sh"
+      - ".github/scripts/fleet-attestation-placeholders.txt"
+      - ".github/workflows/fleet-attestation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fleet-attestation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint gate script
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # ci.yml's shellcheck only globs openbank-infra/scripts — this script lives under
+      # .github/scripts, so it would otherwise never be linted.
+      - name: shellcheck
+        run: shellcheck -S warning .github/scripts/check-fleet-attestations.sh
+
+  verify:
+    name: Verify fleet attestations
+    runs-on: ubuntu-latest
+    # Needs the AWS OIDC role to read ECR. Fork PRs cannot assume it, so skip rather than
+    # fail red on a contribution that could never have run this.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      id-token: write # AWS OIDC
+    env:
+      AWS_REGION: eu-north-1
+      ECR_REGISTRY: "265175468565.dkr.ecr.eu-north-1.amazonaws.com"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        with:
+          role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+
+      - name: Verify every declared openbank-* image is attested
+        id: gate
+        env:
+          FLEET_ATTEST_JSON: ${{ runner.temp }}/fleet-attest.json
+        run: |
+          .github/scripts/check-fleet-attestations.sh | tee "${RUNNER_TEMP}/gate.log"
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Fleet SBOM-attestation gate"
+            echo
+            echo '```'
+            tail -40 "${RUNNER_TEMP}/gate.log" 2>/dev/null || echo "(gate produced no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fleet-attestation-report
+          path: ${{ runner.temp }}/fleet-attest.json
+          if-no-files-found: ignore
+          retention-days: 30
+
+  # A latent provenance gap must page someone, not just turn a scheduled run red — an
+  # unread red schedule is how sbom-drift-scanner's `no-pod-found` sat unactioned. On the
+  # scheduled run only (a PR failure is already visible to its author), file/refresh an
+  # issue so the gap has an owner and a paper trail.
+  raise-issue:
+    name: Raise issue on gap
+    needs: verify
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Open or refresh the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Fleet attestation gap detected (latent admission failure)"
+          # Heredoc body is deliberately flush-left: `run: |` strips only the common YAML
+          # indent, so an indented body would carry leading spaces into the issue markdown.
+          BODY=$(cat <<EOF
+          The daily fleet-attestation gate FAILED: at least one openbank-* image declared in
+          \`openbank-infra/gitops/\` has no valid CycloneDX SBOM attestation.
+
+          **This is latent, not cosmetic.** Affected pods keep running until something
+          reschedules them (node roll, eviction, scale-up) — then kyverno
+          (\`verify-openbank-image-sbom-attestation\`, Enforce) denies admission and they can
+          never restart. Fix before a reschedule, not after.
+
+          Run: ${RUN_URL} — the job summary and the \`fleet-attestation-report\` artifact list
+          the exact images.
+
+          Rebuild + attest each affected image via its producer script; provenance hard-fails at
+          push (\`openbank-infra/scripts/lib/cosign-attest.sh\`).
+          EOF
+          )
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label fleet-health --label "severity:high"
+          fi

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -120,7 +120,11 @@ jobs:
           COSIGN_YES=true cosign sign --key "$COSIGN_KEY" "$IMAGE_DIGEST_REF" \
             || { echo "::warning::cosign sign failed"; exit 1; }
           sbom="${RUNNER_TEMP}/ci-runner.cdx.json"
-          trivy image --format cyclonedx --output "$sbom" "$IMAGE_DIGEST_REF" \
+          # --platform is REQUIRED: this image is built linux/arm64 (see the buildx step) and
+          # trivy defaults to linux/amd64 for REMOTE scans regardless of host arch — without it
+          # the scan fails with "no child with platform linux/amd64 in index" and the image is
+          # left unattested. Same bug that left several fleet images unattested (2026-07-12).
+          trivy image --platform linux/arm64 --format cyclonedx --output "$sbom" "$IMAGE_DIGEST_REF" \
             || { echo "::warning::trivy SBOM generation failed"; exit 1; }
           echo "==> cosign attest (cyclonedx) ${IMAGE_DIGEST_REF}"
           COSIGN_YES=true cosign attest --key "$COSIGN_KEY" --type cyclonedx --predicate "$sbom" "$IMAGE_DIGEST_REF" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,21 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   platform linux/amd64 in index` — silently, if the caller only checks the exit code. Pass
   `--platform` explicitly, matching the arch the image was actually built for. A skipped SBOM
   attestation here means Kyverno's `verify-openbank-image-sbom-attestation` policy blocks every pod
-  admission for that image (admin-ui outage, 2026-07-09).
+  admission for that image (admin-ui outage, 2026-07-09). Producers must call the shared
+  `openbank-infra/scripts/lib/cosign-attest.sh` (which passes `--platform` and hard-fails), never
+  hand-roll `trivy`+`cosign attest` again.
+- **Kyverno verifies at ADMISSION, not continuously — a running pod is NOT evidence its image is
+  attested.** An unattested image keeps running; it is denied only on the next reschedule (node
+  roll, eviction, scale-up) and then can never restart, one pod at a time. So "the fleet is
+  healthy" / "PolicyReport shows 0 fail" only describes pods that happen to exist right now, and
+  never justifies an Audit→Enforce flip. Run `.github/scripts/check-fleet-attestations.sh` (daily
+  via `fleet-attestation.yml`) — it checks every image *declared* in gitops, incl. initContainers
+  and sidecars, so a gap is caught while still latent. Green gate before any Enforce graduation
+  (`rules.yaml: provenance.fleet_attestation_gate`).
+- **A provenance failure must fail the build that caused it.** `continue-on-error` /
+  `|| echo "::warning::"` on a sign/attest step buys a green deploy that produces an
+  undeployable image — the damage lands days later on whoever is on call, not on the author.
+  Verify with `cosign verify-attestation` after attesting; never trust `attest` exit 0 alone.
 
 ### OPA / Rego policies (ADR-0031/ADR-0034)
 - **Adding any new agent charter to `agents.yaml` ripples the OPA bundle checksum of unrelated

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "c1fd07b50d801187"
+    openbank.tech/policy-checksum: "ebef0ec9f5ede7c3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1895,9 +1895,48 @@ data:
       blocked_on: "all four enforce_criteria below must hold; see that list for the specific gap"
       enforce_criteria:
         - "every deployable service's latest release carries a verify-release-evidence-green bundle (admin-ui excepted until it has a non-Gradle SBOM source)"
-        - "the running fleet has been redeployed so every live image carries the cosign SBOM attestation"
-        - "kyverno SBOM-attestation rule flips Audit -> Enforce (Audit is LIVE: verify-sbom-attestation-policy.yaml; the flip is one line once criteria 1-2 hold)"
+        - "the fleet-attestation gate passes: .github/scripts/check-fleet-attestations.sh is GREEN against origin/main (see fleet_attestation_gate below) -- this is a HARD precondition, not a judgement call"
+        - "kyverno SBOM-attestation rule flips Audit -> Enforce (verify-sbom-attestation-policy.yaml; one line once criteria 1-2 hold)"
         - "the advisory gate has run clean for an observation window (no false-positive blocks)"
+
+      # -------------------------------------------------------------------------------------
+      # The fleet-attestation gate: the checkable precondition for ANY image-provenance policy
+      # graduating Audit -> Enforce. Encoded here because the 2026-07-12 graduation was
+      # authorized on a claim ("the running fleet was fully redeployed with attested images")
+      # that was FALSE and that nothing could have falsified -- there was no check to run.
+      # There is now. Run it; do not assert it.
+      # -------------------------------------------------------------------------------------
+      fleet_attestation_gate:
+        script: .github/scripts/check-fleet-attestations.sh
+        workflow: .github/workflows/fleet-attestation.yml   # daily schedule + gitops/producer PRs
+        placeholder_allowlist: .github/scripts/fleet-attestation-placeholders.txt
+        # WHAT IT CHECKS: every openbank-* image referenced anywhere under openbank-infra/gitops/
+        # -- app containers, initContainers AND sidecars -- carries a cosign-signed CycloneDX SBOM
+        # attestation verifiable with the same key + tag scheme kyverno uses at admission.
+        scope: every openbank-* image declared in openbank-infra/gitops (incl. initContainers + sidecars)
+        # WHY DECLARED, NOT RUNNING: kyverno verifies at ADMISSION, never continuously. An
+        # unattested image whose pod already runs keeps running; the violation is LATENT until a
+        # reschedule (node roll, eviction, scale-up) denies the pod permanently, one at a time.
+        # So "PolicyReport shows 0 fail" and "the fleet is healthy" are NOT evidence of coverage
+        # -- they only describe pods that happen to exist right now. NEVER infer "it is running,
+        # therefore it was verified".
+        basis: declared_images_not_running_pods
+        enforcement_rule: >-
+          No image-provenance policy (verify-openbank-image-signatures,
+          verify-openbank-image-sbom-attestation, or any successor) may be set to
+          validationFailureAction: Enforce while this gate fails. A graduation PR must cite a
+          green run of it. An unattested image is never rejected at the moment it is created --
+          only later, at a reschedule nobody scheduled -- so a passing gate is the ONLY evidence
+          that a flip to Enforce is safe.
+        # Producers must make an unattested image impossible rather than merely unlikely:
+        # every openbank-* image producer signs AND attests via the shared helper, and any
+        # provenance failure HARD-FAILS the push (a warning-only path is what created the gap).
+        producer_helper: openbank-infra/scripts/lib/cosign-attest.sh
+        producer_failure_mode: hard_fail   # never warn-and-continue on a provenance failure
+        # trivy defaults to --platform linux/amd64 for REMOTE scans regardless of host arch;
+        # fleet images are arm64-only, so an unqualified `trivy image` fails 100% of the time
+        # and silently yields an unattested image if only the exit code is checked.
+        trivy_platform_required: true
 
     # ---------------------------------------------------------------------------------------
     # Dependency policy (CONTRIBUTING.md security checklist).

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c1fd07b50d801187"
+        openbank.tech/policy-checksum: "ebef0ec9f5ede7c3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "61fc22473f673876"
+    openbank.tech/policy-checksum: "565a265c64ebf01e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1117,9 +1117,48 @@ data:
       blocked_on: "all four enforce_criteria below must hold; see that list for the specific gap"
       enforce_criteria:
         - "every deployable service's latest release carries a verify-release-evidence-green bundle (admin-ui excepted until it has a non-Gradle SBOM source)"
-        - "the running fleet has been redeployed so every live image carries the cosign SBOM attestation"
-        - "kyverno SBOM-attestation rule flips Audit -> Enforce (Audit is LIVE: verify-sbom-attestation-policy.yaml; the flip is one line once criteria 1-2 hold)"
+        - "the fleet-attestation gate passes: .github/scripts/check-fleet-attestations.sh is GREEN against origin/main (see fleet_attestation_gate below) -- this is a HARD precondition, not a judgement call"
+        - "kyverno SBOM-attestation rule flips Audit -> Enforce (verify-sbom-attestation-policy.yaml; one line once criteria 1-2 hold)"
         - "the advisory gate has run clean for an observation window (no false-positive blocks)"
+
+      # -------------------------------------------------------------------------------------
+      # The fleet-attestation gate: the checkable precondition for ANY image-provenance policy
+      # graduating Audit -> Enforce. Encoded here because the 2026-07-12 graduation was
+      # authorized on a claim ("the running fleet was fully redeployed with attested images")
+      # that was FALSE and that nothing could have falsified -- there was no check to run.
+      # There is now. Run it; do not assert it.
+      # -------------------------------------------------------------------------------------
+      fleet_attestation_gate:
+        script: .github/scripts/check-fleet-attestations.sh
+        workflow: .github/workflows/fleet-attestation.yml   # daily schedule + gitops/producer PRs
+        placeholder_allowlist: .github/scripts/fleet-attestation-placeholders.txt
+        # WHAT IT CHECKS: every openbank-* image referenced anywhere under openbank-infra/gitops/
+        # -- app containers, initContainers AND sidecars -- carries a cosign-signed CycloneDX SBOM
+        # attestation verifiable with the same key + tag scheme kyverno uses at admission.
+        scope: every openbank-* image declared in openbank-infra/gitops (incl. initContainers + sidecars)
+        # WHY DECLARED, NOT RUNNING: kyverno verifies at ADMISSION, never continuously. An
+        # unattested image whose pod already runs keeps running; the violation is LATENT until a
+        # reschedule (node roll, eviction, scale-up) denies the pod permanently, one at a time.
+        # So "PolicyReport shows 0 fail" and "the fleet is healthy" are NOT evidence of coverage
+        # -- they only describe pods that happen to exist right now. NEVER infer "it is running,
+        # therefore it was verified".
+        basis: declared_images_not_running_pods
+        enforcement_rule: >-
+          No image-provenance policy (verify-openbank-image-signatures,
+          verify-openbank-image-sbom-attestation, or any successor) may be set to
+          validationFailureAction: Enforce while this gate fails. A graduation PR must cite a
+          green run of it. An unattested image is never rejected at the moment it is created --
+          only later, at a reschedule nobody scheduled -- so a passing gate is the ONLY evidence
+          that a flip to Enforce is safe.
+        # Producers must make an unattested image impossible rather than merely unlikely:
+        # every openbank-* image producer signs AND attests via the shared helper, and any
+        # provenance failure HARD-FAILS the push (a warning-only path is what created the gap).
+        producer_helper: openbank-infra/scripts/lib/cosign-attest.sh
+        producer_failure_mode: hard_fail   # never warn-and-continue on a provenance failure
+        # trivy defaults to --platform linux/amd64 for REMOTE scans regardless of host arch;
+        # fleet images are arm64-only, so an unqualified `trivy image` fails 100% of the time
+        # and silently yields an unattested image if only the exit code is checked.
+        trivy_platform_required: true
 
     # ---------------------------------------------------------------------------------------
     # Dependency policy (CONTRIBUTING.md security checklist).

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "61fc22473f673876"
+        openbank.tech/policy-checksum: "565a265c64ebf01e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "61fc22473f673876"
+    openbank.tech/policy-checksum: "565a265c64ebf01e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1117,9 +1117,48 @@ data:
       blocked_on: "all four enforce_criteria below must hold; see that list for the specific gap"
       enforce_criteria:
         - "every deployable service's latest release carries a verify-release-evidence-green bundle (admin-ui excepted until it has a non-Gradle SBOM source)"
-        - "the running fleet has been redeployed so every live image carries the cosign SBOM attestation"
-        - "kyverno SBOM-attestation rule flips Audit -> Enforce (Audit is LIVE: verify-sbom-attestation-policy.yaml; the flip is one line once criteria 1-2 hold)"
+        - "the fleet-attestation gate passes: .github/scripts/check-fleet-attestations.sh is GREEN against origin/main (see fleet_attestation_gate below) -- this is a HARD precondition, not a judgement call"
+        - "kyverno SBOM-attestation rule flips Audit -> Enforce (verify-sbom-attestation-policy.yaml; one line once criteria 1-2 hold)"
         - "the advisory gate has run clean for an observation window (no false-positive blocks)"
+
+      # -------------------------------------------------------------------------------------
+      # The fleet-attestation gate: the checkable precondition for ANY image-provenance policy
+      # graduating Audit -> Enforce. Encoded here because the 2026-07-12 graduation was
+      # authorized on a claim ("the running fleet was fully redeployed with attested images")
+      # that was FALSE and that nothing could have falsified -- there was no check to run.
+      # There is now. Run it; do not assert it.
+      # -------------------------------------------------------------------------------------
+      fleet_attestation_gate:
+        script: .github/scripts/check-fleet-attestations.sh
+        workflow: .github/workflows/fleet-attestation.yml   # daily schedule + gitops/producer PRs
+        placeholder_allowlist: .github/scripts/fleet-attestation-placeholders.txt
+        # WHAT IT CHECKS: every openbank-* image referenced anywhere under openbank-infra/gitops/
+        # -- app containers, initContainers AND sidecars -- carries a cosign-signed CycloneDX SBOM
+        # attestation verifiable with the same key + tag scheme kyverno uses at admission.
+        scope: every openbank-* image declared in openbank-infra/gitops (incl. initContainers + sidecars)
+        # WHY DECLARED, NOT RUNNING: kyverno verifies at ADMISSION, never continuously. An
+        # unattested image whose pod already runs keeps running; the violation is LATENT until a
+        # reschedule (node roll, eviction, scale-up) denies the pod permanently, one at a time.
+        # So "PolicyReport shows 0 fail" and "the fleet is healthy" are NOT evidence of coverage
+        # -- they only describe pods that happen to exist right now. NEVER infer "it is running,
+        # therefore it was verified".
+        basis: declared_images_not_running_pods
+        enforcement_rule: >-
+          No image-provenance policy (verify-openbank-image-signatures,
+          verify-openbank-image-sbom-attestation, or any successor) may be set to
+          validationFailureAction: Enforce while this gate fails. A graduation PR must cite a
+          green run of it. An unattested image is never rejected at the moment it is created --
+          only later, at a reschedule nobody scheduled -- so a passing gate is the ONLY evidence
+          that a flip to Enforce is safe.
+        # Producers must make an unattested image impossible rather than merely unlikely:
+        # every openbank-* image producer signs AND attests via the shared helper, and any
+        # provenance failure HARD-FAILS the push (a warning-only path is what created the gap).
+        producer_helper: openbank-infra/scripts/lib/cosign-attest.sh
+        producer_failure_mode: hard_fail   # never warn-and-continue on a provenance failure
+        # trivy defaults to --platform linux/amd64 for REMOTE scans regardless of host arch;
+        # fleet images are arm64-only, so an unqualified `trivy image` fails 100% of the time
+        # and silently yields an unattested image if only the exit code is checked.
+        trivy_platform_required: true
 
     # ---------------------------------------------------------------------------------------
     # Dependency policy (CONTRIBUTING.md security checklist).

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "61fc22473f673876"
+        openbank.tech/policy-checksum: "565a265c64ebf01e"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "ccb19defeaeb463b"
+    openbank.tech/policy-checksum: "8ed7d3bc263469c1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1834,9 +1834,48 @@ data:
       blocked_on: "all four enforce_criteria below must hold; see that list for the specific gap"
       enforce_criteria:
         - "every deployable service's latest release carries a verify-release-evidence-green bundle (admin-ui excepted until it has a non-Gradle SBOM source)"
-        - "the running fleet has been redeployed so every live image carries the cosign SBOM attestation"
-        - "kyverno SBOM-attestation rule flips Audit -> Enforce (Audit is LIVE: verify-sbom-attestation-policy.yaml; the flip is one line once criteria 1-2 hold)"
+        - "the fleet-attestation gate passes: .github/scripts/check-fleet-attestations.sh is GREEN against origin/main (see fleet_attestation_gate below) -- this is a HARD precondition, not a judgement call"
+        - "kyverno SBOM-attestation rule flips Audit -> Enforce (verify-sbom-attestation-policy.yaml; one line once criteria 1-2 hold)"
         - "the advisory gate has run clean for an observation window (no false-positive blocks)"
+
+      # -------------------------------------------------------------------------------------
+      # The fleet-attestation gate: the checkable precondition for ANY image-provenance policy
+      # graduating Audit -> Enforce. Encoded here because the 2026-07-12 graduation was
+      # authorized on a claim ("the running fleet was fully redeployed with attested images")
+      # that was FALSE and that nothing could have falsified -- there was no check to run.
+      # There is now. Run it; do not assert it.
+      # -------------------------------------------------------------------------------------
+      fleet_attestation_gate:
+        script: .github/scripts/check-fleet-attestations.sh
+        workflow: .github/workflows/fleet-attestation.yml   # daily schedule + gitops/producer PRs
+        placeholder_allowlist: .github/scripts/fleet-attestation-placeholders.txt
+        # WHAT IT CHECKS: every openbank-* image referenced anywhere under openbank-infra/gitops/
+        # -- app containers, initContainers AND sidecars -- carries a cosign-signed CycloneDX SBOM
+        # attestation verifiable with the same key + tag scheme kyverno uses at admission.
+        scope: every openbank-* image declared in openbank-infra/gitops (incl. initContainers + sidecars)
+        # WHY DECLARED, NOT RUNNING: kyverno verifies at ADMISSION, never continuously. An
+        # unattested image whose pod already runs keeps running; the violation is LATENT until a
+        # reschedule (node roll, eviction, scale-up) denies the pod permanently, one at a time.
+        # So "PolicyReport shows 0 fail" and "the fleet is healthy" are NOT evidence of coverage
+        # -- they only describe pods that happen to exist right now. NEVER infer "it is running,
+        # therefore it was verified".
+        basis: declared_images_not_running_pods
+        enforcement_rule: >-
+          No image-provenance policy (verify-openbank-image-signatures,
+          verify-openbank-image-sbom-attestation, or any successor) may be set to
+          validationFailureAction: Enforce while this gate fails. A graduation PR must cite a
+          green run of it. An unattested image is never rejected at the moment it is created --
+          only later, at a reschedule nobody scheduled -- so a passing gate is the ONLY evidence
+          that a flip to Enforce is safe.
+        # Producers must make an unattested image impossible rather than merely unlikely:
+        # every openbank-* image producer signs AND attests via the shared helper, and any
+        # provenance failure HARD-FAILS the push (a warning-only path is what created the gap).
+        producer_helper: openbank-infra/scripts/lib/cosign-attest.sh
+        producer_failure_mode: hard_fail   # never warn-and-continue on a provenance failure
+        # trivy defaults to --platform linux/amd64 for REMOTE scans regardless of host arch;
+        # fleet images are arm64-only, so an unqualified `trivy image` fails 100% of the time
+        # and silently yields an unattested image if only the exit code is checked.
+        trivy_platform_required: true
 
     # ---------------------------------------------------------------------------------------
     # Dependency policy (CONTRIBUTING.md security checklist).

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ccb19defeaeb463b"
+        openbank.tech/policy-checksum: "8ed7d3bc263469c1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sbom-drift-scanner/prometheus-rules.yaml
+++ b/openbank-infra/gitops/components/sbom-drift-scanner/prometheus-rules.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Alerts for the sbom-drift-scanner CronJob (ADR-0030 D5 phase 1).
+#
+# WHY THIS FILE EXISTS: the scanner used to write its findings to a ConfigMap and exit 0 —
+# always. On 2026-07-12 it reported `sepa-payment: no-pod-found` while sepa-payment was in
+# fact down and un-admittable, and nothing escalated: no pod, no alert, no owner. A finding
+# that only lands in a ConfigMap is a finding nobody acts on. The scanner now fails its Job
+# on any actionable finding; these rules turn that failure into an actual page.
+#
+# Prometheus selects PrometheusRules cluster-wide (ruleSelectorNilUsesHelmValues: false in
+# kube-prometheus-stack.yaml), so no selector labels are required for discovery.
+#
+# SEVERITY MUST BE `critical` OR `warning` — nothing else. Alertmanager routes only those two
+# (kube-prometheus-stack.yaml); the top-level route's default receiver is `null`, so any other
+# value (`high`, `medium`, `info`, …) is silently BLACK-HOLED. An alert that routes nowhere is
+# indistinguishable from no alert at all — the exact class of bug this component exists to
+# catch. Do not "normalise" these labels to a severity scale that Alertmanager does not match.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-sbom-drift-scanner-alerts
+  namespace: admin-ui
+  labels:
+    app.kubernetes.io/part-of: openbank
+    app.kubernetes.io/name: sbom-drift-scanner
+spec:
+  groups:
+    - name: openbank.supplychain.driftscanner
+      rules:
+        # Fires when the scanner found real drift (running image != declared image) or a
+        # money-path service with no running pod at all.
+        - alert: SbomDriftScannerFailing
+          expr: kube_job_failed{namespace="admin-ui", job_name=~"sbom-drift-scanner-.*"} > 0
+          for: 5m
+          labels:
+            severity: critical
+            component: supply-chain
+          annotations:
+            summary: "sbom-drift-scanner reported actionable findings"
+            description: >-
+              The daily gitops-image-sync scan failed: at least one money-path service is
+              running an image other than the one origin/main declares, or has NO running pod
+              at all. `no-pod-found` on a money-path service is not benign — it can mean the
+              service cannot be admitted (e.g. an unattested image under the Kyverno Enforce
+              policy) and is simply down. Read the `sbom-drift` ConfigMap in the admin-ui
+              namespace for the per-service detail.
+              NOTE: this scan does NOT verify SBOM attestations — that is the
+              fleet-attestation CI gate (.github/workflows/fleet-attestation.yml).
+
+        # A scanner that silently stops running is indistinguishable from a clean fleet —
+        # exactly the failure mode this whole component exists to avoid. Alert on staleness.
+        - alert: SbomDriftScannerStale
+          # 26h: the schedule is daily (03:10 UTC); allow one missed run plus slack.
+          expr: >-
+            time() - kube_cronjob_status_last_successful_time{namespace="admin-ui",
+            cronjob="sbom-drift-scanner"} > 93600
+          for: 30m
+          labels:
+            severity: warning
+            component: supply-chain
+          annotations:
+            summary: "sbom-drift-scanner has not completed successfully in >26h"
+            description: >-
+              The gitops-image-sync scan has not had a successful run in over 26 hours. Its
+              last report is stale — an absent signal reads exactly like a clean one, so treat
+              this as unknown fleet state rather than a healthy one.

--- a/openbank-infra/gitops/components/sbom-drift-scanner/sbom-drift-scanner.yaml
+++ b/openbank-infra/gitops/components/sbom-drift-scanner/sbom-drift-scanner.yaml
@@ -9,25 +9,39 @@
 # phase 3 (true in-container filesystem drift) are deliberately out of scope
 # here — see the ADR-0030 D5 design note.
 #
+# ⚠ NAME WARNING — this CronJob does NOT verify SBOMs or attestations.
+# Despite "sbom" in its name it answers exactly one question: is the pod
+# currently RUNNING the image GitOps (origin/main) currently DECLARES? The
+# authoritative SBOM-attestation check is the CI gate
+# .github/scripts/check-fleet-attestations.sh (workflow: fleet-attestation.yml),
+# which covers the WHOLE fleet, not just the money-path list below.
+# The name is retained only because the `sbom-drift` ConfigMap is a published
+# contract consumed by the admin-ui BFF (SBOM_DRIFT_PATH); renaming is tracked
+# as a follow-up rather than bundled into a supply-chain fix.
+#
 # Design note — why this checks GitOps sync, not the cosign attestation
-# itself: the original design intended to re-verify each running pod's
-# CycloneDX attestation directly (cosign verify-attestation against ECR).
-# Live testing during implementation found that's both unreachable and
-# redundant:
-#   - Unreachable: cosign's registry client (and the AWS CLI's ECR auth
-#     token exchange) needs actual AWS credentials, not just "the node has
+# itself. The original design intended to re-verify each running pod's
+# CycloneDX attestation directly. One of the two reasons recorded for dropping
+# that was WRONG, and the correction is the whole point of this component:
+#   - Unreachable (still true): cosign's registry client (and the AWS CLI's ECR
+#     auth token exchange) needs actual AWS credentials, not just "the node has
 #     ecr:* permissions" — this cluster's EKS nodes set the IMDS hop-limit to
 #     block non-host-network pods from reaching instance-profile credentials
 #     (a deliberate hardening), so a plain pod gets "Unable to locate
-#     credentials" / registry 401s with no IRSA. Standing up a new IAM role +
-#     OIDC trust policy for this is a real infra change, not a k8s-manifest
-#     one — out of scope for this pass; flagged as a possible follow-up if a
-#     genuine need for live attestation re-verification emerges.
-#   - Redundant: Kyverno's verify-openbank-image-sbom-attestation ClusterPolicy
-#     is Enforce (issue #310) — every pod that is currently RUNNING already
-#     passed cosign attestation verification at admission time, by definition.
-#     Re-checking it here would at best restate what admission already
-#     guaranteed, for the cost of the IAM work above.
+#     credentials" / registry 401s with no IRSA. That is why the attestation
+#     check lives in CI, which already holds a GitHub-OIDC role with ECR read —
+#     no new IAM, and it runs daily on a schedule.
+#   - "Redundant" (FALSE — this reasoning caused an outage): the claim was that
+#     Kyverno's verify-openbank-image-sbom-attestation is Enforce, so every
+#     RUNNING pod already passed attestation verification by definition.
+#     Kyverno verifies at ADMISSION, not continuously. A pod admitted while the
+#     policy was still Audit — i.e. most of the fleet — proves nothing at all,
+#     and keeps running indefinitely because nothing re-evaluates it. The
+#     violation is LATENT until the pod reschedules, and only then does it fail,
+#     permanently and one pod at a time. On 2026-07-12 exactly that happened:
+#     several images had no attestation, the running fleet looked healthy, and
+#     the gap surfaced only as pods rescheduled. "It is running, therefore it
+#     was verified" is not a valid inference — never re-derive it.
 # What's left — "is the running pod what GitOps currently says should be
 # deployed" — is exactly the ArgoCD-sync-drift signal issue #846 this session
 # spent most of its time on (money-path services silently stuck on day-zero
@@ -510,12 +524,48 @@ spec:
                           "inSync": in_sync,
                       }
 
+                  # Findings that must not sit silently in a ConfigMap.
+                  #
+                  # `no-pod-found` for a money-path service is NOT a benign skip: a service
+                  # with zero running pods is either scaled to zero or unable to start at all
+                  # (e.g. denied at admission). sepa-payment reported `no-pod-found` on the
+                  # morning of 2026-07-12 while it was in fact down and un-admittable, and
+                  # because this job exited 0 and only wrote a ConfigMap, nothing escalated.
+                  # Anything actionable now FAILS the Job, which surfaces via the
+                  # SbomDriftScannerFailing / kube_job_failed alert (prometheus-rules.yaml).
+                  drifted = [s for s, r in results.items()
+                             if r.get("status") == "checked" and not r.get("inSync")]
+                  missing = [s for s, r in results.items()
+                             if r.get("status") == "no-pod-found"]
+
+                  summary = {
+                      # State plainly what this report does and does NOT cover, so a reader
+                      # of the ConfigMap cannot mistake it for an SBOM/attestation check.
+                      "checkScope": "gitops-image-tag-sync-only",
+                      "doesNotVerify": "SBOM attestations — see CI gate fleet-attestation.yml",
+                      "coverage": "money-path services only (not the full openbank-* fleet)",
+                      "scannedAt": None,
+                      "services": results,
+                      "driftedServices": drifted,
+                      "noPodServices": missing,
+                      "ok": not drifted and not missing,
+                  }
                   with open("/work/final.json", "w") as f:
-                      json.dump({"scannedAt": None, "services": results}, f)
+                      json.dump(summary, f)
                   print(f"Written /work/final.json: {len(results)} services", flush=True)
+
+                  if drifted or missing:
+                      print(f"FAIL drifted={drifted} noPod={missing}", flush=True)
+                      # Exit AFTER writing the report: the publish container still needs it,
+                      # so the ConfigMap reflects the failure rather than going stale.
+                      raise SystemExit(1)
+                  print("OK: every money-path service runs its declared image.", flush=True)
                   PYEOF
 
-                  python3 /tmp/compare.py
+                  # `|| true`: a findings-exit must still let the publish container run and
+                  # surface the report. The Job is failed explicitly by the publish container
+                  # once it has published, so the alert fires WITH a readable report attached.
+                  python3 /tmp/compare.py || echo "findings" > /work/findings
               volumeMounts:
                 - name: work
                   mountPath: /work
@@ -536,6 +586,7 @@ spec:
                   value: /tmp
               args:
                 - |
+                  set -eu
                   NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                   sed "s/\"scannedAt\": null/\"scannedAt\": \"${NOW}\"/" /work/final.json > /tmp/final.json
 
@@ -545,6 +596,16 @@ spec:
                     --namespace admin-ui \
                     --from-file=sbom-drift.json=/tmp/final.json \
                     --dry-run=client -o yaml | kubectl apply -f -
+                  echo "Published."
+
+                  # Publish FIRST, then fail — so the alert fires with the report already
+                  # readable in the ConfigMap. A finding that only ever lands in a ConfigMap
+                  # is a finding nobody acts on; this Job failing is what raises the alarm
+                  # (SbomDriftScannerFailing in prometheus-rules.yaml).
+                  if [ -f /work/findings ]; then
+                    echo "ERROR: drift or missing pods detected — see the report above." >&2
+                    exit 1
+                  fi
                   echo "Done."
               volumeMounts:
                 - name: work

--- a/openbank-infra/scripts/build-push-admin-ui.sh
+++ b/openbank-infra/scripts/build-push-admin-ui.sh
@@ -329,62 +329,22 @@ docker buildx build \
 
 echo "==> pushed ${IMAGE}"
 
-# Sign with Cosign (ADR-0029/0030 supply-chain). KMS trust root alias/openbank-cosign-signing;
-# kyverno verifies against the matching public key + Rekor tlog.
+# Sign + attest via the shared helper (ADR-0029/0030 supply-chain), so admin-ui does
+# provenance identically to every other producer. KMS trust root
+# alias/openbank-cosign-signing. This block used to be the only correct copy of the attest
+# logic in the tree; it is now the shared implementation (lib/cosign-attest.sh) — which is
+# also where the cosign-v2 pin and its rationale (kyverno 3.2.6 / issue #770) now live.
 #
-# IMPORTANT — cosign v2 is pinned on purpose. kyverno 3.2.6 discovers signatures only via the
-# legacy `sha256-<digest>.sig` tag scheme. cosign v3 writes OCI 1.1 *referrer* signatures on ECR
-# (no .sig tag) which kyverno cannot find ("no signatures found") — under Enforce that rejects
-# every image. cosign v2 writes tag-based signatures kyverno reads. Revisit once kyverno can
-# verify referrers (then cosign v3 is the target). See ADR-0029 / issue #770.
-COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
-COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
+# Now FATAL rather than best-effort. The old "never blocks the push" behaviour is exactly
+# what let unattested images reach gitops: kyverno's SBOM-attestation policy is Enforce, so
+# a warning here buys a push that cannot be admitted on its next reschedule.
+. "${REPO_ROOT}/openbank-infra/scripts/lib/cosign-attest.sh"
 
-# Echo a cosign v2.x binary path: reuse one on PATH if it is v2, else fetch the pinned release
-# to a cache path. Returns non-zero (empty) if no v2 binary can be obtained.
-resolve_cosign_v2() {
-  if command -v cosign >/dev/null 2>&1 && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; then
-    command -v cosign; return 0
-  fi
-  local os arch bin
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; x86_64|amd64) arch=amd64 ;; *) return 1 ;; esac
-  bin="${TMPDIR:-/tmp}/cosign-${COSIGN_VERSION}-${os}-${arch}"
-  if [ ! -x "$bin" ]; then
-    curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}" 2>/dev/null && chmod +x "$bin" || return 1
-  fi
-  printf '%s\n' "$bin"
+cosign_sign_and_attest "$IMAGE" "$PLATFORM" || {
+  echo "ERROR: ${IMAGE} pushed but NOT fully attested — it is NOT deployable." >&2
+  echo "       Fix the provenance failure above and re-run; do not bump gitops to this tag." >&2
+  exit 1
 }
-
-COSIGN_BIN="$(resolve_cosign_v2 || true)"
-if [ -n "${COSIGN_BIN:-}" ]; then
-  echo "==> cosign sign ${IMAGE} (tag-based, $("$COSIGN_BIN" version 2>/dev/null | awk '/GitVersion/{print $2}'))"
-  if COSIGN_YES=true "$COSIGN_BIN" sign --key "${COSIGN_KEY}" "${IMAGE}"; then
-    echo "    signed (key=${COSIGN_KEY})"
-  else
-    echo "WARN: cosign sign failed — image pushed but UNSIGNED (kyverno will Audit-flag it)." >&2
-  fi
-  # Deploy-time provenance: attach a signed CycloneDX SBOM ATTESTATION to the image
-  # (ADR-0030 D4), matching the per-service images in auto-deploy.yml so admin-ui is not
-  # the lone gap when the provenance gate moves Audit->Enforce. Best-effort (never blocks
-  # the push): trivy generates the image SBOM, cosign attest binds it with the same KMS key.
-  if command -v trivy >/dev/null 2>&1; then
-    AUI_SBOM="${TMPDIR:-/tmp}/openbank-admin-ui.cdx.json"
-    if trivy image --platform "${PLATFORM}" --format cyclonedx --output "${AUI_SBOM}" "${IMAGE}" 2>/dev/null; then
-      echo "==> cosign attest (cyclonedx) ${IMAGE}"
-      COSIGN_YES=true "$COSIGN_BIN" attest --key "${COSIGN_KEY}" --type cyclonedx \
-        --predicate "${AUI_SBOM}" "${IMAGE}" \
-        && echo "    attested SBOM (key=${COSIGN_KEY})" \
-        || echo "WARN: cosign attest failed — image SBOM not attested." >&2
-    else
-      echo "WARN: trivy image SBOM generation failed — skipping SBOM attestation." >&2
-    fi
-  else
-    echo "WARN: trivy unavailable — skipping image SBOM attestation." >&2
-  fi
-else
-  echo "WARN: cosign v2 unavailable — image pushed UNSIGNED. Install cosign v2.x or set COSIGN_VERSION (ADR-0029)." >&2
-fi
 
 if [ "${BUMP_MANIFEST}" -eq 1 ]; then
   echo "==> bump ${MANIFEST} -> ${TAG}"

--- a/openbank-infra/scripts/build-push-pyroscope-agent.sh
+++ b/openbank-infra/scripts/build-push-pyroscope-agent.sh
@@ -40,43 +40,23 @@ aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS 
 docker buildx build --platform "$PLATFORM" -f "$DOCKERFILE" -t "$IMAGE" --push openbank-infra/docker/pyroscope-agent
 echo "==> pushed ${IMAGE}"
 
-# Sign with Cosign (ADR-0029/0030 supply-chain) — same trust root as the service images.
+# Sign + attest with Cosign (ADR-0029/0030 supply-chain) — same trust root and same shared
+# helper as every other producer.
 #
-# IMPORTANT — cosign v2 is pinned on purpose. kyverno 3.2.6 discovers signatures only via the
-# legacy `sha256-<digest>.sig` tag scheme. cosign v3 writes OCI 1.1 *referrer* signatures on ECR
-# (no .sig tag) which kyverno cannot find ("no signatures found") — under the verify-images
-# Enforce policy that rejects the image at admission. cosign v2 writes tag-based signatures
-# kyverno reads. (This carrier image was once signed with v3 and blocked sepa-payment at
-# admission — that is the bug this pin prevents.) Revisit once kyverno can verify referrers.
-COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
-COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
+# This carrier image is an INIT CONTAINER on money-path pods, which makes its provenance
+# load-bearing far beyond its own footprint: a pod whose init container is denied at
+# admission never starts, no matter how well-attested the app container is. This image
+# having no SBOM attestation is what took sepa-payment down on 2026-07-12 — an
+# unattested init container fails the pod, silently, on the next reschedule. It was
+# previously also the v3-signature bug's victim (see the cosign v2 pin in
+# lib/cosign-attest.sh). Provenance failures here are FATAL for that reason.
+. "${REPO_ROOT}/openbank-infra/scripts/lib/cosign-attest.sh"
 
-# Echo a cosign v2.x binary path: reuse one on PATH if it is v2, else fetch the pinned release
-# to a cache path. Returns non-zero (empty) if no v2 binary can be obtained.
-resolve_cosign_v2() {
-  if command -v cosign >/dev/null 2>&1 && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; then
-    command -v cosign; return 0
-  fi
-  local os arch bin
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; x86_64|amd64) arch=amd64 ;; *) return 1 ;; esac
-  bin="${TMPDIR:-/tmp}/cosign-${COSIGN_VERSION}-${os}-${arch}"
-  if [ ! -x "$bin" ]; then
-    curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}" 2>/dev/null && chmod +x "$bin" || return 1
-  fi
-  printf '%s\n' "$bin"
+cosign_sign_and_attest "$IMAGE" "$PLATFORM" || {
+  echo "ERROR: ${IMAGE} pushed but NOT fully attested — it is NOT deployable." >&2
+  echo "       This image is an init container on money-path pods: an unattested tag here" >&2
+  echo "       fails the WHOLE pod at admission. Fix the provenance failure above and re-run." >&2
+  exit 1
 }
-
-COSIGN_BIN="$(resolve_cosign_v2 || true)"
-if [ -n "${COSIGN_BIN:-}" ]; then
-  echo "==> cosign sign ${IMAGE} (tag-based, $("$COSIGN_BIN" version 2>/dev/null | awk '/GitVersion/{print $2}'))"
-  if COSIGN_YES=true "$COSIGN_BIN" sign --key "${COSIGN_KEY}" "${IMAGE}"; then
-    echo "    signed (key=${COSIGN_KEY})"
-  else
-    echo "WARN: cosign sign failed — image pushed but UNSIGNED (kyverno will reject it under Enforce)." >&2
-  fi
-else
-  echo "WARN: cosign v2 unavailable — image pushed UNSIGNED. Install cosign v2.x or set COSIGN_VERSION (ADR-0029)." >&2
-fi
 
 echo "==> done."

--- a/openbank-infra/scripts/build-push-service.sh
+++ b/openbank-infra/scripts/build-push-service.sh
@@ -99,45 +99,21 @@ aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS 
 docker buildx build --platform "$PLATFORM" -t "$IMAGE" --push "$CTX"
 echo "==> pushed ${IMAGE}"
 
-# 2b. Sign the image with Cosign (ADR-0029/0030 supply-chain). Trust root = AWS KMS key
-# alias/openbank-cosign-signing; kyverno verifies against the matching public key + Rekor tlog.
+# 2b. Sign the image AND attest its SBOM (ADR-0029/0030 supply-chain), via the shared helper
+# so every producer does provenance identically. Trust root = AWS KMS key
+# alias/openbank-cosign-signing; kyverno verifies against the matching public key.
 #
-# IMPORTANT — cosign v2 is pinned on purpose. kyverno 3.2.6 discovers signatures only via the
-# legacy `sha256-<digest>.sig` tag scheme. cosign v3 writes OCI 1.1 *referrer* signatures on
-# ECR (no .sig tag), which kyverno cannot find ("no signatures found") — under Enforce that
-# rejects every image. cosign v2 writes tag-based signatures kyverno reads. Revisit once kyverno
-# can verify referrers (then cosign v3 is the target). See ADR-0029 / issue #770.
-# Best-effort: warn (don't fail the build) if cosign/KMS are unavailable — CI/operators have both.
-COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
-COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
+# HARD FAILS on any provenance failure. Both kyverno policies (signature + SBOM attestation)
+# are Enforce, so an image missing either is undeployable — its pods run until the next
+# reschedule, then are denied admission forever. Failing the push that produced it is the
+# only way an operator finds out at a time when it is still cheap to fix.
+. "${REPO_ROOT}/openbank-infra/scripts/lib/cosign-attest.sh"
 
-# Echo a cosign v2.x binary path: reuse one on PATH if it is v2, else fetch the pinned release
-# to a cache path. Returns non-zero (empty) if no v2 binary can be obtained.
-resolve_cosign_v2() {
-  if command -v cosign >/dev/null 2>&1 && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; then
-    command -v cosign; return 0
-  fi
-  local os arch bin
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; x86_64|amd64) arch=amd64 ;; *) return 1 ;; esac
-  bin="${TMPDIR:-/tmp}/cosign-${COSIGN_VERSION}-${os}-${arch}"
-  if [ ! -x "$bin" ]; then
-    curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}" 2>/dev/null && chmod +x "$bin" || return 1
-  fi
-  printf '%s\n' "$bin"
+cosign_sign_and_attest "$IMAGE" "$PLATFORM" || {
+  echo "ERROR: ${IMAGE} pushed but NOT fully attested — it is NOT deployable." >&2
+  echo "       Fix the provenance failure above and re-run; do not bump gitops to this tag." >&2
+  exit 1
 }
-
-COSIGN_BIN="$(resolve_cosign_v2 || true)"
-if [ -n "${COSIGN_BIN:-}" ]; then
-  echo "==> cosign sign ${IMAGE} (tag-based, $("$COSIGN_BIN" version 2>/dev/null | awk '/GitVersion/{print $2}'))"
-  if COSIGN_YES=true "$COSIGN_BIN" sign --key "$COSIGN_KEY" "$IMAGE"; then
-    echo "    signed (key=${COSIGN_KEY})"
-  else
-    echo "WARN: cosign sign failed — image pushed but UNSIGNED (kyverno will Audit-flag it)." >&2
-  fi
-else
-  echo "WARN: cosign v2 unavailable — image pushed UNSIGNED. Install cosign v2.x or set COSIGN_VERSION (ADR-0029)." >&2
-fi
 
 # 3. Optionally bump the gitops image tag.
 if [ "$BUMP" -eq 1 ]; then

--- a/openbank-infra/scripts/lib/cosign-attest.sh
+++ b/openbank-infra/scripts/lib/cosign-attest.sh
@@ -1,0 +1,142 @@
+# shellcheck shell=bash
+# ---------------------------------------------------------------------------------------
+# Shared cosign SBOM-attestation helper (ADR-0029 / ADR-0030 D4).
+#
+# Source this from any script that pushes an openbank-* image to ECR:
+#
+#     . "$(dirname "$0")/lib/cosign-attest.sh"
+#     cosign_sign_and_attest "$IMAGE" "$PLATFORM"
+#
+# Why this exists: the attest logic was copy-pasted into some producers and simply
+# absent from others, so several fleet images were pushed SIGNED but UNATTESTED.
+# kyverno's verify-openbank-image-sbom-attestation ClusterPolicy is Enforce — an
+# unattested image is admitted never, so the gap only surfaces when a pod happens to
+# reschedule, long after the push that caused it.
+#
+# Two invariants this helper exists to hold:
+#
+#   1. --platform is ALWAYS passed to `trivy image`. trivy defaults to linux/amd64 for
+#      REMOTE (registry) scans regardless of host arch. Fleet images are built
+#      linux/arm64 (Graviton nodes), so an unqualified `trivy image` fails with
+#      "no child with platform linux/amd64 in index" — and every caller that only
+#      checked the exit code turned that into a skipped attestation.
+#   2. A failed attestation is FATAL (return 1). The image is verified with
+#      `cosign verify-attestation` after the fact, so "attest exited 0" is not taken
+#      on trust. A silently-unattested image is an image that cannot be deployed.
+#
+# cosign v2 is pinned ON PURPOSE: kyverno 3.2.6 discovers signatures/attestations only
+# via the legacy `sha256-<digest>.sig` / `.att` tag scheme. cosign v3 writes OCI 1.1
+# referrers kyverno cannot find, so a v3-signed image fails an Enforce policy. Revisit
+# once kyverno can verify referrers (ADR-0029, issue #770).
+# ---------------------------------------------------------------------------------------
+
+COSIGN_KEY="${COSIGN_KEY:-awskms:///alias/openbank-cosign-signing}"
+COSIGN_VERSION="${COSIGN_VERSION:-v2.4.3}"
+
+# Echo a cosign v2.x binary path: reuse one on PATH if it is v2, else fetch the pinned
+# release to a cache path. Returns non-zero (and echoes nothing) if no v2 binary can be
+# obtained.
+resolve_cosign_v2() {
+  if command -v cosign >/dev/null 2>&1 \
+     && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; then
+    command -v cosign
+    return 0
+  fi
+  local os arch bin
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$(uname -m)" in
+    aarch64 | arm64) arch=arm64 ;;
+    x86_64 | amd64) arch=amd64 ;;
+    *) return 1 ;;
+  esac
+  bin="${TMPDIR:-/tmp}/cosign-${COSIGN_VERSION}-${os}-${arch}"
+  if [ ! -x "$bin" ]; then
+    curl -fsSL -o "$bin" \
+      "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}" \
+      2>/dev/null && chmod +x "$bin" || return 1
+  fi
+  printf '%s\n' "$bin"
+}
+
+# cosign_attest_sbom <image-ref> <platform> [cosign-bin]
+#
+# Generate a CycloneDX SBOM for the image with trivy, bind it to the image digest with
+# `cosign attest`, then PROVE it landed with `cosign verify-attestation`. Returns 0 only
+# if the attestation is verifiable afterwards; returns 1 on any failure.
+cosign_attest_sbom() {
+  local image="$1" platform="$2" bin="${3:-}"
+  local sbom
+
+  if [ -z "$image" ] || [ -z "$platform" ]; then
+    echo "ERROR: cosign_attest_sbom requires <image> <platform>." >&2
+    return 1
+  fi
+
+  if [ -z "$bin" ]; then
+    bin="$(resolve_cosign_v2 || true)"
+  fi
+  if [ -z "$bin" ]; then
+    echo "ERROR: cosign v2 unavailable — cannot attest ${image}." >&2
+    return 1
+  fi
+  if ! command -v trivy >/dev/null 2>&1; then
+    echo "ERROR: trivy unavailable — cannot generate the SBOM for ${image}." >&2
+    return 1
+  fi
+
+  sbom="${TMPDIR:-/tmp}/$(echo "$image" | tr '/:@' '___').cdx.json"
+
+  # --platform is REQUIRED here — see the header note. Do not "simplify" it away.
+  echo "==> trivy image --platform ${platform} (cyclonedx) ${image}"
+  if ! trivy image --platform "$platform" --format cyclonedx --output "$sbom" "$image"; then
+    echo "ERROR: trivy SBOM generation failed for ${image} (platform=${platform})." >&2
+    return 1
+  fi
+
+  echo "==> cosign attest (cyclonedx) ${image}"
+  if ! COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type cyclonedx \
+       --predicate "$sbom" "$image"; then
+    echo "ERROR: cosign attest failed for ${image}." >&2
+    return 1
+  fi
+
+  # Never trust `attest` exit 0 alone: verify the attestation is actually discoverable
+  # the same way kyverno will discover it at admission.
+  echo "==> cosign verify-attestation ${image}"
+  if ! COSIGN_YES=true "$bin" verify-attestation --key "$COSIGN_KEY" --type cyclonedx \
+       "$image" >/dev/null 2>&1; then
+    echo "ERROR: cosign verify-attestation failed for ${image} — the attestation did not land." >&2
+    return 1
+  fi
+
+  echo "    attested + verified SBOM (key=${COSIGN_KEY})"
+  return 0
+}
+
+# cosign_sign_and_attest <image-ref> <platform>
+#
+# The full provenance pass a producer needs: sign the image, then attest its SBOM.
+# HARD FAILS (return 1) if either step does not land — kyverno's signature policy AND
+# its SBOM-attestation policy are both Enforce, so an image missing either is
+# undeployable and must fail the build that produced it, loudly, at push time.
+cosign_sign_and_attest() {
+  local image="$1" platform="$2"
+  local bin
+
+  bin="$(resolve_cosign_v2 || true)"
+  if [ -z "$bin" ]; then
+    echo "ERROR: cosign v2 unavailable — ${image} would be pushed UNSIGNED + UNATTESTED" >&2
+    echo "       and rejected at admission. Install cosign v2.x or set COSIGN_VERSION." >&2
+    return 1
+  fi
+
+  echo "==> cosign sign ${image} (tag-based, $("$bin" version 2>/dev/null | awk '/GitVersion/{print $2}'))"
+  if ! COSIGN_YES=true "$bin" sign --key "$COSIGN_KEY" "$image"; then
+    echo "ERROR: cosign sign failed for ${image}." >&2
+    return 1
+  fi
+  echo "    signed (key=${COSIGN_KEY})"
+
+  cosign_attest_sbom "$image" "$platform" "$bin" || return 1
+  return 0
+}

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -649,9 +649,48 @@ provenance:
   blocked_on: "all four enforce_criteria below must hold; see that list for the specific gap"
   enforce_criteria:
     - "every deployable service's latest release carries a verify-release-evidence-green bundle (admin-ui excepted until it has a non-Gradle SBOM source)"
-    - "the running fleet has been redeployed so every live image carries the cosign SBOM attestation"
-    - "kyverno SBOM-attestation rule flips Audit -> Enforce (Audit is LIVE: verify-sbom-attestation-policy.yaml; the flip is one line once criteria 1-2 hold)"
+    - "the fleet-attestation gate passes: .github/scripts/check-fleet-attestations.sh is GREEN against origin/main (see fleet_attestation_gate below) -- this is a HARD precondition, not a judgement call"
+    - "kyverno SBOM-attestation rule flips Audit -> Enforce (verify-sbom-attestation-policy.yaml; one line once criteria 1-2 hold)"
     - "the advisory gate has run clean for an observation window (no false-positive blocks)"
+
+  # -------------------------------------------------------------------------------------
+  # The fleet-attestation gate: the checkable precondition for ANY image-provenance policy
+  # graduating Audit -> Enforce. Encoded here because the 2026-07-12 graduation was
+  # authorized on a claim ("the running fleet was fully redeployed with attested images")
+  # that was FALSE and that nothing could have falsified -- there was no check to run.
+  # There is now. Run it; do not assert it.
+  # -------------------------------------------------------------------------------------
+  fleet_attestation_gate:
+    script: .github/scripts/check-fleet-attestations.sh
+    workflow: .github/workflows/fleet-attestation.yml   # daily schedule + gitops/producer PRs
+    placeholder_allowlist: .github/scripts/fleet-attestation-placeholders.txt
+    # WHAT IT CHECKS: every openbank-* image referenced anywhere under openbank-infra/gitops/
+    # -- app containers, initContainers AND sidecars -- carries a cosign-signed CycloneDX SBOM
+    # attestation verifiable with the same key + tag scheme kyverno uses at admission.
+    scope: every openbank-* image declared in openbank-infra/gitops (incl. initContainers + sidecars)
+    # WHY DECLARED, NOT RUNNING: kyverno verifies at ADMISSION, never continuously. An
+    # unattested image whose pod already runs keeps running; the violation is LATENT until a
+    # reschedule (node roll, eviction, scale-up) denies the pod permanently, one at a time.
+    # So "PolicyReport shows 0 fail" and "the fleet is healthy" are NOT evidence of coverage
+    # -- they only describe pods that happen to exist right now. NEVER infer "it is running,
+    # therefore it was verified".
+    basis: declared_images_not_running_pods
+    enforcement_rule: >-
+      No image-provenance policy (verify-openbank-image-signatures,
+      verify-openbank-image-sbom-attestation, or any successor) may be set to
+      validationFailureAction: Enforce while this gate fails. A graduation PR must cite a
+      green run of it. An unattested image is never rejected at the moment it is created --
+      only later, at a reschedule nobody scheduled -- so a passing gate is the ONLY evidence
+      that a flip to Enforce is safe.
+    # Producers must make an unattested image impossible rather than merely unlikely:
+    # every openbank-* image producer signs AND attests via the shared helper, and any
+    # provenance failure HARD-FAILS the push (a warning-only path is what created the gap).
+    producer_helper: openbank-infra/scripts/lib/cosign-attest.sh
+    producer_failure_mode: hard_fail   # never warn-and-continue on a provenance failure
+    # trivy defaults to --platform linux/amd64 for REMOTE scans regardless of host arch;
+    # fleet images are arm64-only, so an unqualified `trivy image` fails 100% of the time
+    # and silently yields an unattested image if only the exit code is checked.
+    trivy_platform_required: true
 
 # ---------------------------------------------------------------------------------------
 # Dependency policy (CONTRIBUTING.md security checklist).


### PR DESCRIPTION
## Why

Kyverno `verify-openbank-image-sbom-attestation` (Enforce since 2026-07-12) denied pods for images that carried no SBOM attestation. Its own description claimed it graduated *"after the running fleet was fully redeployed with attested images"*. **That claim was false — and nothing could have falsified it, because there was no check to run.** Running pods survived (admission is never re-evaluated); they were denied one at a time as they rescheduled. `payments/sepa-payment` (money path) was down 4 days; `iam/keycloak` took out admin-ui login.

Two mistakes made this possible, and this PR targets both:

1. **Infra image producers never attested at all.** `build-push-keycloak.sh` and
   `build-push-pyroscope-agent.sh` only ran `cosign sign`. Those two images are precisely what broke:
   the unattested `openbank-pyroscope-agent:2.5.4` is an **init container** in `sepa-payment`, and
   `openbank-keycloak` took out admin-ui login. The `~34`-service path
   (`build-push-service.sh` / `auto-deploy.yml`) was **not** the problem — measured against ECR,
   23 of 24 recent `sandbox-*` images across 6 repos carry a verifying `.att`. The gap was in the
   producers nobody thought of as "services".
2. **An invalid inference.** "The policy is Enforce, therefore every running pod passed
   verification." Kyverno verifies at **admission**, not continuously. A pod admitted while the
   policy was still Audit proves nothing and keeps running forever. This exact reasoning is written
   into `sbom-drift-scanner`'s design note as justification for *not* checking attestations.

### A root cause this PR previously claimed, now retracted

An earlier revision of this description blamed the `trivy image --platform` footgun documented in
`CLAUDE.md`, asserting the SBOM scan in `auto-deploy.yml` "failed on every image" and that deploys
"went green while producing undeployable images". **That was wrong, and is retracted.** ECR shows
23/24 recent images attested, and the images are pushed as a **single manifest**
(`application/vnd.docker.distribution.manifest.v2+json`), not a multi-arch index — the footgun can
only fire on an **index**, where trivy must select a child by platform and errors with
`no child with platform linux/amd64 in index`. With a single manifest there is nothing to select
between, so the omission is inert. The footgun is real for `docker buildx --platform ... --push`
scripts, which do publish an index; that is the actual 2026-07-09 admin-ui case.

The code smell in `auto-deploy.yml:508` is genuine and still worth fixing — a missing `--platform`
plus `2>/dev/null` plus `continue-on-error` is a provenance failure that cannot be seen — but it is
a **latent fragility, not the cause of this outage**. The `--platform` additions here are defensive.

## Producer audit

Every producer that can push an `openbank-*` image to ECR (the registry Kyverno matches):

| Producer | Signed | Attested (before) | After |
|---|---|---|---|
| `scripts/build-push-service.sh` (~34 services) | yes | **no** | shared helper, hard-fail |
| `scripts/build-push-pyroscope-agent.sh` (**init container**) | yes | **no** | shared helper, hard-fail |
| `scripts/build-push-admin-ui.sh` | yes | yes — best-effort, warn-only | shared helper, hard-fail |
| `scripts/build-push-keycloak.sh` | yes | **no** | **untouched — owned by #1160** |
| `.github/workflows/auto-deploy.yml` | yes | yes — works in practice (single-manifest images); but silent on failure: no `--platform`, stderr swallowed, `continue-on-error` | `--platform`, verified, **fails the job** |
| `.github/workflows/runner-image.yml` (`openbank-ci-runner`) | yes | no `--platform` (inert today) | `--platform` added defensively |
| `.github/workflows/admin-ui-deploy.yml` | delegates to `build-push-admin-ui.sh` | — | inherits fix |
| `.github/workflows/ghcr-publish.yml` | ghcr.io + Sigstore provenance | n/a | **out of scope** — not ECR, not Kyverno-matched |
| `.github/workflows/_service-ci.yml` | ECR *pull-through cache only*, no push | n/a | no change |

The images actually found unattested came from the **dedicated scripts** (`openbank-keycloak`, `openbank-pyroscope-agent`) plus stale/manually-tagged builds predating current attestation coverage (`party-service:sandbox-571cbd2e` from June, `developer-portal:sandbox-sec1`, `clearing-simulator:sandbox-0af2ee215`). One intermittent `auto-deploy` miss also exists (`sepa-payment:sandbox-7f281cab`, 2026-07-12) — which is exactly why the helper now verifies and hard-fails rather than trusting `attest` exit 0.

## What's here

1. **`openbank-infra/scripts/lib/cosign-attest.sh`** — shared sign+attest helper. Always passes `--platform`; proves the result with `cosign verify-attestation` (never trusts `attest` exit 0); **hard-fails**. Keeps the cosign-v2 pin (kyverno 3.2.6 reads only the legacy `.sig`/`.att` tag scheme, not OCI 1.1 referrers) with the rationale now in one place.
2. **`.github/scripts/check-fleet-attestations.sh` + `fleet-attestation.yml`** — the precondition gate. Enumerates every `openbank-*` image **declared** in `openbank-infra/gitops/` and verifies each attestation.
   - **Declared, not running** — kyverno verifies at admission only, so a healthy fleet is not evidence of coverage. This catches a gap while it is still **latent**, before a reschedule turns it into an outage.
   - **initContainers + sidecars included** — the image regex is position-blind on purpose. `pyroscope-agent` is an init container, and an init container denied at admission fails the whole pod no matter how well-attested the app container is. That is what killed sepa-payment.
   - Daily schedule + gitops/producer PRs; **files/refreshes an issue** on the scheduled run.
   - Distinguishes **UNATTESTED** (present but unattested — always fatal, no allowlist) from **ABSENT** (never-built placeholder — allowlisted), so the gate can reach green. *A permanently-red check is one nobody reads — which is exactly how this morning's `no-pod-found` was ignored.*
3. **`sbom-drift-scanner`** — corrected the false "redundant" note; findings now **fail the Job and alert** (`PrometheusRule`) instead of sitting in a ConfigMap; the report declares its own scope.
4. **`rules.yaml: provenance.fleet_attestation_gate`** — no image-provenance policy may be `Enforce` while the gate fails; a graduation PR must cite a green run. Replaces the unfalsifiable criterion #2 with a checkable one. Plus two `CLAUDE.md` footguns (admission ≠ continuous; provenance failures must fail the build).

### On #4: why not rename the scanner or move attestation checks into it?

- **Kept the name.** `sbom-drift` is a published contract — the ConfigMap, the admin-ui BFF's `SBOM_DRIFT_PATH`, the volume mount, RBAC `resourceNames`, and the ArgoCD app all key off it. Renaming means changing `openbank-admin-ui` (a separately released component) inside a supply-chain fix. Instead the manifest carries a name warning, and the JSON output states `checkScope: gitops-image-tag-sync-only` + `doesNotVerify: SBOM attestations`, so the limitation is machine-visible. **Rename tracked as a follow-up.**
- **Attestation check went to CI, not the CronJob.** The scanner's own note documents why in-cluster verification is unreachable: the IMDS hop-limit blocks non-host-network pods from instance-profile credentials, so this needs a new IAM role + OIDC trust — real infra work. CI **already** holds a GitHub-OIDC role with ECR read. Same coverage, no new IAM, and it gates PRs too. The note's *other* reason ("redundant") was simply wrong and is corrected.

## Verification

- `bash -n` + `shellcheck -S warning` clean on all scripts (CI's shellcheck only globs `openbank-infra/scripts`, so the new gate lints itself in its own workflow). `actionlint` + CI-config `yamllint` clean. `rules.yaml` parses; embedded CronJob Python compiles.
- Simulated the exact `sepa-payment: no-pod-found` case: report publishes **then** the Job fails → `kube_job_failed` → `SbomDriftScannerFailing`. Previously: exit 0, silence.
- **Ran the gate read-only against the live fleet** (no image pushed, retagged or modified):

```
==> Fleet summary: 53 attested / 0 unattested / 0 absent / 1 allowlisted placeholder / 54 total
FLEET ATTESTATION GATE: PASS
```

The gate **found a real gap on its first run**: `openbank-finrep-service:sandbox-init` — a 54th image in neither the 5 hand-fixed today nor the scanner's 17. Its ECR repo does not exist at all (a documented ADR-0097 first-registration placeholder, `replicas: 1`), so it is allowlisted rather than reported as an attestation regression. Post-fix state is genuinely clean, which is itself the point: **today the fleet is green because someone fixed 5 images by hand and nothing would have told them if they had missed one.** Now something does.

## Risk

Producers now hard-fail on provenance errors — an intentional trade: a failed build instead of an image that cannot be admitted. `build-push-keycloak.sh` is deliberately untouched; it should be rebased onto the shared helper once #1160 lands.

## Two things found while validating this PR

- **My alerts would have been black-holed.** I first labelled them `severity: high` / `medium`. Alertmanager (`kube-prometheus-stack.yaml`) matches **only** `critical` and `warning`; the top-level route's default receiver is `null`. `high`/`medium` route **nowhere** — an alert that fires into a black hole, i.e. the exact bug this PR exists to fix, reintroduced by me. Now `critical` (findings) / `warning` (staleness), with a comment on the file so nobody "normalises" them back onto a severity scale Alertmanager does not match.
- **The `rules.yaml` OPA ripple.** The pid/copilot/customer-edge/notification OPA bundles embed `rules.yaml` wholesale, so a governance-only edit changes four unrelated services' bundle checksums and pod-roll annotations. Regenerated all five generators per `CLAUDE.md`; the four bundle diffs and the `openbank.tech/policy-checksum` bumps are that ripple, not hand edits. (Rebased onto `origin/main` first — CI computes these on the merge ref, so a stale base yields a checksum that can never match.)

*Aside, not fixed here:* 25 of 26 `gen-*-opa-bundle.sh` generators hash `rules.yaml`, but `opa-policy.yml` only regenerates and diffs 4 of them. The other 21 services' committed bundles are therefore stale w.r.t. this change and CI cannot see it. Out of scope; worth its own issue.

Refs #310

