### PR TITLE
security(notification): never store rendered OTP or password-reset bodies

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -10,13 +10,13 @@ import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
 import com.openbank.notification.application.port.out.OversightWebhookPublisher
 import com.openbank.notification.application.port.out.PushMessage
-import jakarta.annotation.PostConstruct
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationStatus
 import com.openbank.notification.domain.model.NotificationTemplate
 import com.openbank.notification.domain.model.PushPlatform
+import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
@@ -24,6 +24,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.mailer.Mail
 import io.quarkus.mailer.reactive.ReactiveMailer
 import io.smallrye.mutiny.Uni
+import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import kotlinx.coroutines.runBlocking
@@ -115,7 +116,9 @@ class NotificationConsumer {
             it.template = req.template.name
             it.recipient = req.recipient
             it.subject = subject
-            it.body = body
+            // Secret-bearing templates persist a placeholder; `body` below still carries the
+            // rendered secret to the delivery adapters, so the customer receives it as usual.
+            it.body = TemplateSensitivity.bodyForStorage(req.template, body)
             it.status = "PENDING"
             it.createdAt = Instant.now(clock)
         }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/TemplateSensitivity.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/TemplateSensitivity.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+// ── Secret-bearing templates — the storage redaction core ────────────────────
+//
+// Some templates render a short-lived authentication secret into the message
+// body (the OTP code itself, a password-reset token). Delivering that secret to
+// the customer is the whole point of the message; *persisting* it is not.
+//
+// A stored OTP defeats SCA (ADR-0021): `notifications.body` is readable by any
+// ROLE_OPERATOR — both via @RolesAllowed on NotificationResource and via the
+// shared rest.rego `operator-read-any` rule, which grants `.read`/`.list` on any
+// resource to every operator. Staff who can read a customer's OTP can complete
+// that customer's strong authentication. It is also GDPR Art. 5(1)(c) data
+// minimisation: the secret has no purpose after dispatch, yet the row is kept
+// under the service's declared retention (governance.yaml).
+//
+// So: render the secret, deliver it, store a placeholder. This is a POSITIVE
+// allow-list of the templates that must never reach storage in rendered form —
+// the same shape as the ADR-0059 oversight allow-list, and TemplateSensitivityTest
+// forbids it drifting.
+//
+// NOTE: this is the storage sink only. The push-payload sink (sendPush feeds the
+// same rendered body into the APNs/FCM message, which ADR-0135 §3 forbids) is a
+// separate defect tracked on its own — fixing it needs the customer app's
+// fetch-on-tap path, which lives in another repository.
+
+/**
+ * Classifies [NotificationTemplate]s by whether their rendered body embeds an
+ * authentication secret, and supplies the value stored in place of one.
+ */
+object TemplateSensitivity {
+
+    /** Stored in `notifications.body` instead of a rendered secret. Not a valid message body. */
+    const val REDACTED_BODY: String =
+        "[REDACTED] Secret-bearing template: the rendered body is delivered to the customer " +
+            "but never stored (GDPR Art. 5(1)(c); a stored OTP would defeat SCA, ADR-0021)."
+
+    /**
+     * Templates whose rendered body contains a secret that authenticates the customer.
+     *
+     * Membership is decided by one question: *if a bank operator read this body, could
+     * they use it to act as the customer?* Add a template here the moment its rendered
+     * form carries a code, token, link with an embedded token, or password.
+     */
+    val SECRET_TEMPLATES: Set<NotificationTemplate> = setOf(
+        NotificationTemplate.OTP_CODE,
+        NotificationTemplate.PASSWORD_RESET,
+    )
+
+    /** True when [template]'s rendered body embeds an authentication secret. */
+    fun isSecret(template: NotificationTemplate): Boolean = template in SECRET_TEMPLATES
+
+    /**
+     * The body to persist for [template]: [renderedBody] for ordinary templates,
+     * [REDACTED_BODY] for secret-bearing ones. Callers must still deliver the
+     * rendered body — only the stored copy is redacted.
+     */
+    fun bodyForStorage(template: NotificationTemplate, renderedBody: String): String =
+        if (isSecret(template)) REDACTED_BODY else renderedBody
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
@@ -5,6 +5,8 @@
 package com.openbank.notification.infrastructure.rest
 
 import com.openbank.libs.authz.Authorize
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
@@ -82,7 +84,7 @@ class NotificationResource {
                 "template" to n.template,
                 "recipient" to n.recipient,
                 "subject" to n.subject,
-                "body" to n.body,
+                "body" to bodyForRead(n.template, n.body),
                 "status" to n.status,
                 "sentAt" to n.sentAt,
                 "readAt" to n.readAt,
@@ -124,5 +126,23 @@ class NotificationResource {
             .entity(mapOf("code" to "BAD_REQUEST", "message" to "partyId query parameter is required")).build()
         val flipped = repo.markAllRead(partyId)
         return Response.ok(mapOf("marked" to flipped)).build()
+    }
+
+    /**
+     * Second, independent control over the secret-template redaction (the first is
+     * NotificationConsumer, which never persists a rendered secret). Rows written before
+     * that fix — and any row whose write-path redaction failed — are redacted here on the
+     * way out, so two controls must both fail to leak an OTP to an operator. Same
+     * defense-in-depth shape as the ADR-0059 D3 scrubber.
+     *
+     * An unrecognised template returns [stored] verbatim rather than redacting. That is safe
+     * because the write path only ever persists a value that parsed into [NotificationTemplate]
+     * (a payload with any other template is rejected as poison), so an unknown value here means
+     * the enum shrank after the row was written — and any such row was already redacted by the
+     * write path or by V9. Fail-open keeps a legacy row readable instead of 500-ing on it.
+     */
+    private fun bodyForRead(template: String, stored: String): String {
+        val known = NotificationTemplate.entries.firstOrNull { it.name == template } ?: return stored
+        return if (TemplateSensitivity.isSecret(known)) TemplateSensitivity.REDACTED_BODY else stored
     }
 }

--- a/openbank-notification-service/src/main/resources/db/migration/V9__redact_secret_notification_bodies.sql
+++ b/openbank-notification-service/src/main/resources/db/migration/V9__redact_secret_notification_bodies.sql
@@ -1,0 +1,18 @@
+-- Retire rendered authentication secrets already sitting in notifications.body.
+--
+-- OTP_CODE and PASSWORD_RESET render the code/token straight into the body, which is
+-- readable by any ROLE_OPERATOR (NotificationResource + rest.rego `operator-read-any`).
+-- A stored OTP defeats SCA (ADR-0021) and outlives its purpose (GDPR Art. 5(1)(c)).
+-- NotificationConsumer no longer persists these rendered bodies; this clears the rows
+-- written before that change. Delivery is unaffected — the body is rendered in-flight.
+--
+-- Data-loss note: intentional and one-way. The redacted bodies are spent secrets with no
+-- business, audit or legal value; every other column (template, status, timestamps) is
+-- untouched, so the delivery record itself survives intact.
+--
+-- Rollback: none possible, and none wanted — the pre-image is the secret this removes.
+-- Reverting the code change alone is enough to restore the old (unsafe) write behaviour.
+UPDATE notifications
+SET body = '[REDACTED] Secret-bearing template: the rendered body is delivered to the customer '
+        || 'but never stored (GDPR Art. 5(1)(c); a stored OTP would defeat SCA, ADR-0021).'
+WHERE template IN ('OTP_CODE', 'PASSWORD_RESET');

--- a/openbank-notification-service/src/main/resources/docs/04-data.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/04-data.cs.md
@@ -18,6 +18,9 @@
 | V4 | `V4__dispatch_control_sequences.sql` | `dispatch_control_log_seq`, `dispatch_resume_proposal_seq` (oprava Hibernate sekvencí) |
 | V5 | `V5__notification_sequences.sql` | `notifications_seq`, `notification_outbox_seq` (oprava Hibernate sekvencí) |
 | V6 | `V6__create_device_tokens.sql` | tabulka `device_tokens` + unique `(platform, token)`, index `(party_id, status)`, `device_tokens_seq` |
+| V7 | `V7__device_token_lifecycle_columns.sql` | `registered_at`, `refreshed_at` na `device_tokens` (ADR-0135 §2, TTL tokenu) |
+| V8 | `V8__notification_read_state.sql` | `read_at` na `notifications` + částečný index `idx_notifications_party_unread` |
+| V9 | `V9__redact_secret_notification_bodies.sql` | jednorázová redakce uložených těl `OTP_CODE` / `PASSWORD_RESET` (viz *Šablony nesoucí tajemství* níže) |
 
 Každý soubor migrace nese inline **poznámku k rollbacku** (např. V6: `DROP TABLE device_tokens; DROP SEQUENCE device_tokens_seq;`). Nikdy nepřepisujte aplikovanou migraci (selhání startu kvůli checksum mismatch) — při driftu živé DB použijte `QUARKUS_FLYWAY_REPAIR_AT_START=true`.
 
@@ -34,11 +37,29 @@ Každý soubor migrace nese inline **poznámku k rollbacku** (např. V6: `DROP T
 | `template` | VARCHAR(50) | název enum šablony |
 | `recipient` | VARCHAR(255) | **PII** — e-mailová adresa / telefon / cíl zařízení |
 | `subject` | VARCHAR(500) | vyrenderovaný předmět (může obsahovat obsah) |
-| `body` | TEXT | vyrenderované tělo — **může obsahovat PII** (jména, maskované částky, OTP) |
+| `body` | TEXT | vyrenderované tělo — **může obsahovat PII** (jména, částky). Nikdy ne autentizační tajemství: viz *Šablony nesoucí tajemství* |
 | `status` | VARCHAR(10) | PENDING / SENT / FAILED / BOUNCED |
 | `metadata` | JSONB | volná forma, default `{}` |
 | `sent_at` | TIMESTAMPTZ | čas doručení |
 | `created_at` | TIMESTAMPTZ | default `NOW()` |
+
+#### Šablony nesoucí tajemství
+
+`OTP_CODE` a `PASSWORD_RESET` renderují do těla zprávy autentizační tajemství. To se doručí
+zákazníkovi, ale **nikdy se neukládá**: `NotificationConsumer` uloží místo něj
+`TemplateSensitivity.REDACTED_BODY` a `NotificationResource` redaguje ještě jednou při čtení
+(dvě nezávislé kontroly, stejný tvar jako ADR-0059 D3). V9 vyčistila řádky zapsané předtím.
+
+Proč: `body` může číst kterýkoli `ROLE_OPERATOR` — jak přes `@RolesAllowed`, tak přes sdílené
+pravidlo `operator-read-any` v `rest.rego`, které dává `.read`/`.list` na jakýkoli resource
+každému operátorovi. Zaměstnanec, který přečte zákazníkovo OTP, může dokončit jeho SCA
+(ADR-0021). Tajemství je navíc doručením spotřebované, takže jeho uchovávání porušuje
+minimalizaci údajů podle GDPR čl. 5 odst. 1 písm. c).
+
+Klasifikace je v `domain/model/TemplateSensitivity.kt` jako pozitivní allow-list, zapinovaný
+testem `TemplateSensitivityTest`, takže každá úprava setu je vědomá. Přidání šablony, jejíž
+render nese tajemství, **bez** klasifikace test nezachytí — `renderTemplate` a tento allow-list
+je potřeba revidovat společně.
 
 ### `notification_outbox`
 
@@ -73,7 +94,7 @@ Unique `(platform, token)` → opětovná registrace provede upsert; index `(par
 | Pole | Klasifikace | Kontrola |
 |---|---|---|
 | `notifications.recipient` | přímé PII (e-mail / telefon) | maskováno v logu (PiiMask); nevystaveno v oversight signálech |
-| `notifications.body` / `subject` | možné PII / tajemství (OTP) | OTP/tajné šablony nikdy neegrešují do oversightu |
+| `notifications.body` / `subject` | možné PII | šablony s tajemstvím (OTP_CODE, PASSWORD_RESET) se doručí, ale neukládají — redakce při zápisu i při čtení; do oversightu neegrešuje žádná šablona |
 | `notifications.party_id`, `device_tokens.party_id` | pseudonymní identifikátor | vazba na party-service |
 | `device_tokens.token` | PII-adjacentní token poskytovatele | jen pro zápis přes REST, maskovaný v logu |
 | `dispatch_control_log.actor` / `dispatch_resume_proposal.*_by` | identita operátora | audit-logováno, jen interní |

--- a/openbank-notification-service/src/main/resources/docs/04-data.en.md
+++ b/openbank-notification-service/src/main/resources/docs/04-data.en.md
@@ -18,6 +18,9 @@
 | V4 | `V4__dispatch_control_sequences.sql` | `dispatch_control_log_seq`, `dispatch_resume_proposal_seq` (Hibernate sequence fix) |
 | V5 | `V5__notification_sequences.sql` | `notifications_seq`, `notification_outbox_seq` (Hibernate sequence fix) |
 | V6 | `V6__create_device_tokens.sql` | `device_tokens` table + unique `(platform, token)`, `(party_id, status)` index, `device_tokens_seq` |
+| V7 | `V7__device_token_lifecycle_columns.sql` | `registered_at`, `refreshed_at` on `device_tokens` (ADR-0135 §2 token TTL) |
+| V8 | `V8__notification_read_state.sql` | `read_at` on `notifications` + partial index `idx_notifications_party_unread` |
+| V9 | `V9__redact_secret_notification_bodies.sql` | one-off redaction of stored `OTP_CODE` / `PASSWORD_RESET` bodies (see *Secret-bearing templates* below) |
 
 Each migration file carries an inline **rollback note** (e.g. V6: `DROP TABLE device_tokens; DROP SEQUENCE device_tokens_seq;`). Never rewrite an applied migration (checksum-mismatch startup failure) — use `QUARKUS_FLYWAY_REPAIR_AT_START=true` if a live DB drifts.
 
@@ -34,11 +37,28 @@ Each migration file carries an inline **rollback note** (e.g. V6: `DROP TABLE de
 | `template` | VARCHAR(50) | template enum name |
 | `recipient` | VARCHAR(255) | **PII** — email address / phone / device target |
 | `subject` | VARCHAR(500) | rendered subject (may contain content) |
-| `body` | TEXT | rendered body — **may contain PII** (names, masked amounts, OTP) |
+| `body` | TEXT | rendered body — **may contain PII** (names, amounts). Never an authentication secret: see *Secret-bearing templates* |
 | `status` | VARCHAR(10) | PENDING / SENT / FAILED / BOUNCED |
 | `metadata` | JSONB | free-form, default `{}` |
 | `sent_at` | TIMESTAMPTZ | delivery time |
 | `created_at` | TIMESTAMPTZ | default `NOW()` |
+
+#### Secret-bearing templates
+
+`OTP_CODE` and `PASSWORD_RESET` render an authentication secret into the message body. The
+secret is delivered to the customer but **never persisted**: `NotificationConsumer` stores
+`TemplateSensitivity.REDACTED_BODY` in its place, and `NotificationResource` redacts again on
+read (two independent controls, the ADR-0059 D3 shape). V9 cleared the rows written before this.
+
+Why: `body` is readable by any `ROLE_OPERATOR` — both via `@RolesAllowed` and via the shared
+`rest.rego` `operator-read-any` rule, which grants `.read`/`.list` on any resource to every
+operator. Staff able to read a customer's OTP can complete that customer's SCA (ADR-0021). The
+secret is also spent on delivery, so keeping it fails GDPR Art. 5(1)(c) data minimisation.
+
+Classification lives in `domain/model/TemplateSensitivity.kt` as a positive allow-list, pinned by
+`TemplateSensitivityTest` so any edit to the set is deliberate. Adding a template whose render
+embeds a secret **without** classifying it is not caught by a test — review `renderTemplate` and
+this allow-list together.
 
 ### `notification_outbox`
 
@@ -73,7 +93,7 @@ Unique `(platform, token)` → re-registration upserts; index `(party_id, status
 | Field | Classification | Control |
 |---|---|---|
 | `notifications.recipient` | direct PII (email / phone) | masked in logs (PiiMask); not exposed in oversight signals |
-| `notifications.body` / `subject` | possible PII / secret (OTP) | OTP/secret templates never egress to oversight |
+| `notifications.body` / `subject` | possible PII | secret-bearing templates (OTP_CODE, PASSWORD_RESET) are delivered but never stored — redacted on write and again on read; no template egresses to oversight |
 | `notifications.party_id`, `device_tokens.party_id` | pseudonymous identifier | links to party-service |
 | `device_tokens.token` | PII-adjacent provider token | write-only over REST, masked in logs |
 | `dispatch_control_log.actor` / `dispatch_resume_proposal.*_by` | operator identity | audit-logged, internal only |

--- a/openbank-notification-service/src/main/resources/docs/06-compliance.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/06-compliance.cs.md
@@ -87,6 +87,7 @@ Zastavení odchozích notifikací je bezpečný směr, takže **halt** je break-
 - ✅ AuthZ: `@RolesAllowed` per endpoint; aktér řízení výpravy z JWT subjektu (ne z těla)
 - ✅ Prevence IDOR: device `partyId` injektováno edgem ze zákaznického JWT
 - ✅ Důvěrnost tokenu: push token jen pro zápis přes REST, maskovaný v logu
+- ✅ Důvěrnost tajemství: těla OTP_CODE / PASSWORD_RESET se doručí, ale neukládají — redakce při zápisu i při čtení (GDPR čl. 5 odst. 1 písm. c); uložené OTP by operátorovi umožnilo dokončit zákazníkovo SCA, ADR-0021)
 - ✅ Minimalizace egresu: push + oversight ve výchozím stavu vypnuté; oversight bez PII z principu
 - ✅ Odolnost: outbox circuit-breaker/retry/bulkhead/timeout; break-glass halt
 - ✅ Bezpečnostní hlavičky: CSP, HSTS, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy, Permissions-Policy

--- a/openbank-notification-service/src/main/resources/docs/06-compliance.en.md
+++ b/openbank-notification-service/src/main/resources/docs/06-compliance.en.md
@@ -87,6 +87,7 @@ Stopping outbound notifications is the fail-safe direction, so **halt** is a sin
 - ✅ AuthZ: `@RolesAllowed` per endpoint; dispatch-control actor from JWT subject (not body)
 - ✅ IDOR prevention: device `partyId` injected by the edge from the customer JWT
 - ✅ Token confidentiality: push token write-only over REST, masked in logs
+- ✅ Secret confidentiality: OTP_CODE / PASSWORD_RESET bodies delivered but never stored — redacted on write and again on read (GDPR Art. 5(1)(c); a stored OTP would let an operator complete the customer's SCA, ADR-0021)
 - ✅ Egress minimisation: push + oversight off by default; oversight PII-free by construction
 - ✅ Resilience: outbox circuit-breaker/retry/bulkhead/timeout; break-glass halt
 - ✅ Security headers: CSP, HSTS, X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy, Permissions-Policy

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateSensitivityTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateSensitivityTest.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Executable form of the storage guarantee: a rendered authentication secret never
+ * reaches `notifications.body`, where any ROLE_OPERATOR could read it and complete the
+ * customer's SCA (ADR-0021). If someone renders a new secret into a body without
+ * classifying the template, these tests fail.
+ */
+class TemplateSensitivityTest {
+
+    @Test
+    fun `secret-bearing templates are classified (allow-list, not block-list)`() {
+        assertThat(TemplateSensitivity.isSecret(NotificationTemplate.OTP_CODE)).isTrue()
+        assertThat(TemplateSensitivity.isSecret(NotificationTemplate.PASSWORD_RESET)).isTrue()
+    }
+
+    @Test
+    fun `ordinary templates are not classified secret and store their rendered body`() {
+        val ordinary = NotificationTemplate.entries - TemplateSensitivity.SECRET_TEMPLATES
+        assertThat(ordinary).isNotEmpty()
+        for (t in ordinary) {
+            assertThat(TemplateSensitivity.isSecret(t)).isFalse()
+            assertThat(TemplateSensitivity.bodyForStorage(t, "<p>rendered</p>")).isEqualTo("<p>rendered</p>")
+        }
+    }
+
+    @Test
+    fun `the rendered secret is never the stored body`() {
+        val rendered = "<h2>Verification Code</h2><p>Your code is: <b>828913</b>. Valid for 5 minutes.</p>"
+        for (t in TemplateSensitivity.SECRET_TEMPLATES) {
+            val stored = TemplateSensitivity.bodyForStorage(t, rendered)
+            assertThat(stored).isEqualTo(TemplateSensitivity.REDACTED_BODY)
+            assertThat(stored).doesNotContain("828913")
+            assertThat(stored).isNotEqualTo(rendered)
+        }
+    }
+
+    @Test
+    fun `the placeholder says why, so an operator reading it is not left guessing`() {
+        assertThat(TemplateSensitivity.REDACTED_BODY).startsWith("[REDACTED]")
+        assertThat(TemplateSensitivity.REDACTED_BODY).contains("ADR-0021")
+        assertThat(TemplateSensitivity.REDACTED_BODY).contains("Art. 5(1)(c)")
+    }
+
+    @Test
+    fun `the classification set is pinned, so widening or narrowing it is deliberate`() {
+        // This pins the CURRENT set: it fails when someone edits SECRET_TEMPLATES, forcing that
+        // edit through review. It does NOT — and cannot — catch a new enum constant whose render
+        // embeds a secret but which nobody classified; the set is simply unchanged then. That gap
+        // is covered by review of renderTemplate, and is why the classification lives next to the
+        // enum rather than in the consumer.
+        assertThat(TemplateSensitivity.SECRET_TEMPLATES).containsExactlyInAnyOrder(
+            NotificationTemplate.OTP_CODE,
+            NotificationTemplate.PASSWORD_RESET,
+        )
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
 import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.mailer.MockMailbox
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import io.quarkus.test.junit.QuarkusTest
@@ -62,6 +64,9 @@ class NotificationConsumerIT {
     lateinit var objectMapper: ObjectMapper
 
     @Inject
+    lateinit var mailbox: MockMailbox
+
+    @Inject
     @Connector("smallrye-in-memory")
     lateinit var connector: InMemoryConnector
 
@@ -74,6 +79,27 @@ class NotificationConsumerIT {
     private fun statusFor(partyId: UUID): String? = VertxContextSupport.subscribeAndAwait {
         Panache.withSession { repository.find("partyId", partyId).firstResult() }
     }?.status
+
+    private fun bodyFor(partyId: UUID): String? = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { repository.find("partyId", partyId).firstResult() }
+    }?.body
+
+    /** Drive one request through the in-memory inbound channel and wait for the ack. */
+    private fun consumeAndAwait(request: NotificationRequest) {
+        val source: InMemorySource<Message<String>> = connector.source("notification-events-in")
+        source.runOnVertxContext(true)
+        val acked = CompletableFuture<Void>()
+        source.send(
+            Message.of(
+                objectMapper.writeValueAsString(request),
+                Supplier<CompletionStage<Void>> {
+                    acked.complete(null)
+                    CompletableFuture.completedFuture<Void>(null)
+                },
+            ),
+        )
+        acked.get(20, TimeUnit.SECONDS)
+    }
 
     @Test
     fun `consumed message is persisted and acked (drives the offset commit)`() {
@@ -112,5 +138,58 @@ class NotificationConsumerIT {
         // SENT (the %test profile mocks the mailer, so the email leg succeeds).
         assertThat(countFor(partyId)).isEqualTo(1L)
         assertThat(statusFor(partyId)).isEqualTo("SENT")
+    }
+
+    /**
+     * The redaction must bite at the storage boundary and nowhere earlier: the customer still
+     * receives the real OTP, the database never holds it. Asserting both halves in one test is
+     * the point — redacting at render time would also make the stored body safe, while silently
+     * mailing the customer a useless placeholder.
+     */
+    @Test
+    fun `OTP is delivered to the customer but never stored (ADR-0021, GDPR Art 5(1)(c))`() {
+        val partyId = UUID.randomUUID()
+        val code = "828913"
+        mailbox.clear()
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.EMAIL,
+                template = NotificationTemplate.OTP_CODE,
+                recipient = "otp-recipient@example.com",
+                variables = mapOf("code" to code),
+            ),
+        )
+
+        // Delivered: the mail that left the service carries the real code.
+        val sent = mailbox.getMailMessagesSentTo("otp-recipient@example.com")
+        assertThat(sent).hasSize(1)
+        assertThat(sent.first().html).contains(code)
+
+        // Stored: the row exists and is SENT, but its body is the placeholder — an operator
+        // reading it through NotificationResource cannot recover the code.
+        assertThat(countFor(partyId)).isEqualTo(1L)
+        assertThat(statusFor(partyId)).isEqualTo("SENT")
+        assertThat(bodyFor(partyId)).isEqualTo(TemplateSensitivity.REDACTED_BODY)
+        assertThat(bodyFor(partyId)).doesNotContain(code)
+    }
+
+    /** An ordinary template is untouched — redaction is an allow-list, not a blanket. */
+    @Test
+    fun `non-secret template still stores its rendered body`() {
+        val partyId = UUID.randomUUID()
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.EMAIL,
+                template = NotificationTemplate.WELCOME,
+                recipient = "welcome-recipient@example.com",
+                variables = mapOf("name" to "Alice"),
+            ),
+        )
+
+        assertThat(bodyFor(partyId)).contains("Alice")
+        assertThat(bodyFor(partyId)).isNotEqualTo(TemplateSensitivity.REDACTED_BODY)
     }
 }


### PR DESCRIPTION
Closes #1179

## What

`OTP_CODE` and `PASSWORD_RESET` render an authentication secret into `notifications.body`, and the consumer persisted it verbatim. That column is readable by any `ROLE_OPERATOR` — via `@RolesAllowed` on `NotificationResource` **and**, independently, via the shared `rest.rego` `operator-read-any` rule, which grants `.read`/`.list` on any resource to every operator. Staff able to read a customer OTP can complete that customer SCA (ADR-0021). The secret is spent on delivery, so retaining it also fails GDPR Art. 5(1)(c) minimisation.

**Latent, not live** — no producer publishes those templates today (`openbank-account-service` sends only `TRANSACTION_COMPLETED`). Fixing it now because a planned per-customer message-history tab in admin-ui would put stored bodies one click from an operator.

## How

- `domain/model/TemplateSensitivity.kt` — positive allow-list of secret-bearing templates, same shape as the ADR-0059 D2 oversight list. Domain layer, zero framework imports.
- `NotificationConsumer` persists `TemplateSensitivity.bodyForStorage(...)`; **delivery is untouched** — the rendered body still reaches the mail/push adapters.
- `NotificationResource` redacts again on read → two independent controls must both fail to leak (ADR-0059 D3 shape). Fail-open on an unrecognised template is deliberate and explained in the KDoc.
- `V9__redact_secret_notification_bodies.sql` — one-off cleanup of pre-existing rows. Rollback note included (none possible, and none wanted: the pre-image is the secret).
- In-module docs (en+cs) corrected — `04-data` literally documented `body` as "may contain … OTP" and listed the only control as "never egress to oversight", which missed this sink entirely.

## Verification

`detekt`, `ktlintCheck`, `test`, `quarkusBuild` all green locally.

The IT asserts **both halves in one test** — the mock mailbox holds the real code while the stored row holds the placeholder. That pairing is the point: redacting at render time would also make storage safe while silently mailing the customer a useless placeholder.

I verified the test is a real regression guard, not a tautology: reverting just the one-line consumer change turns `NotificationConsumerIT` red on exactly that test (`tests="3" failures="1"`), and green again with it restored.

## Not in scope

`sendPush` feeds the same rendered body into the APNs/FCM payload (`htmlToPlain(body)`), which **ADR-0135 §3 forbids** — and that one *is* live today: `TRANSACTION_COMPLETED` puts amount + currency into the payload, while the ADR-0135 delivery note claims payload minimisation is "✅ Complete". Needs its own issue + ADR follow-up; the correct fix is the §3 wake-signal + fetch-on-tap design, which depends on the customer app in the `openbank-app` repo.

## Contract / release

No API contract change — `body` stays present in the response, only its value is redacted, so `openapi.yaml` and `info.version` are untouched. `version.txt` left to release-please (`security` scope `notification`).