### PR TITLE
ci(opa): discover OPA bundle generators dynamically instead of hard-coding four

### DIFF
--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -50,13 +50,16 @@ jobs:
           PATTERN="${PATTERN}|^openbank-libs/governance/agents\.yaml$"
           PATTERN="${PATTERN}|^openbank-libs/governance/rules\.yaml$"
           PATTERN="${PATTERN}|^openbank-libs/governance/policies/"
-          PATTERN="${PATTERN}|^openbank-infra/gitops/components/agent/gen-opa-bundle-configmap\.sh$"
-          PATTERN="${PATTERN}|^openbank-infra/gitops/components/agent/agent-opa-bundle\.yaml$"
-          PATTERN="${PATTERN}|^openbank-infra/gitops/components/pid/"
-          PATTERN="${PATTERN}|^openbank-infra/gitops/components/copilot/"
-          PATTERN="${PATTERN}|^openbank-infra/gitops/components/customer-edge/"
-          PATTERN="${PATTERN}|^openbank-infra/gitops/components/notifications/"
           PATTERN="${PATTERN}|^\.github/workflows/opa-policy\.yml$"
+
+          # Every component directory that owns a bundle generator — discovered, never
+          # hard-coded (issue #1184). The old list named only agent/pid/copilot/
+          # customer-edge/notifications, so a hand-edit to any other service's committed
+          # bundle or pod-roll annotation did not even mark the PR policy-relevant, and
+          # `verify` never ran to catch it.
+          while IFS= read -r dir; do
+            PATTERN="${PATTERN}|^$(printf '%s' "$dir" | sed 's/\./\\./g')/"
+          done < <(find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' -exec dirname {} \; | sort -u)
 
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Event push -> always verify (post-merge; keeps the deployed-bundle check current)."
@@ -132,21 +135,51 @@ jobs:
         run: |
           # Each generator writes its ConfigMap AND stamps the matching Deployment/Rollout
           # pod-template annotation (openbank.tech/policy-checksum) — the annotation is what
-          # actually rolls the pods, since subPath mounts do not hot-reload. Regenerate all
-          # four and fail on any diff: a stale bundle OR a stale annotation blocks the merge.
-          ./openbank-infra/gitops/components/pid/gen-pid-opa-bundle.sh
-          ./openbank-infra/gitops/components/copilot/gen-copilot-opa-bundle.sh
-          ./openbank-infra/gitops/components/customer-edge/gen-customer-edge-opa-bundle.sh
-          ./openbank-infra/gitops/components/notifications/gen-notification-opa-bundle.sh
-          if ! git diff --exit-code -- \
-              openbank-infra/gitops/components/pid \
-              openbank-infra/gitops/components/copilot \
-              openbank-infra/gitops/components/customer-edge \
-              openbank-infra/gitops/components/notifications; then
-            echo "::error::A service OPA bundle ConfigMap or its pod-roll checksum annotation is stale — re-run the gen-*-opa-bundle.sh generators and commit the result."
+          # actually rolls the pods, since subPath mounts do not hot-reload. Regenerate every
+          # generator and fail on any diff: a stale bundle OR a stale annotation blocks the merge.
+          #
+          # Discovered, never hard-coded (issue #1184). This step used to name four generators
+          # while 25 of the 26 hash rules.yaml as a checksum input, so any shared-policy edit
+          # left ~21 services' committed bundles and pod-roll annotations stale with no CI
+          # signal. A hard-coded list opts every new service out of this gate by default.
+          # while-read, not `mapfile`: this job's Install OPA step still supports a darwin
+          # runner, and macOS ships bash 3.2 where mapfile does not exist (it would fail
+          # "command not found" and leave GENERATORS empty).
+          GENERATORS=()
+          while IFS= read -r g; do
+            GENERATORS+=("$g")
+          done < <(find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' | sort)
+
+          if [ "${#GENERATORS[@]}" -eq 0 ]; then
+            echo "::error::No OPA bundle generators discovered — the find pattern is wrong, not the repo. Refusing to pass a check that verifies nothing."
             exit 1
           fi
-          echo "All service OPA bundles + pod-roll annotations are in sync with the policy source."
+
+          echo "Discovered ${#GENERATORS[@]} bundle generators:"
+          printf '  %s\n' "${GENERATORS[@]}"
+
+          # A non-executable generator silently no-ops a `./…` loop, which would look
+          # identical to "in sync". gen-ledger-opa-bundle.sh shipped 100644 for exactly this
+          # reason and had never run. Fail loudly instead.
+          NON_EXEC=0
+          for g in "${GENERATORS[@]}"; do
+            if [ ! -x "$g" ]; then
+              echo "::error file=${g}::${g} is not executable — commit it mode 100755 (git update-index --chmod=+x)."
+              NON_EXEC=1
+            fi
+          done
+          [ "$NON_EXEC" -eq 0 ] || exit 1
+
+          for g in "${GENERATORS[@]}"; do
+            echo "--- $g"
+            "$g" >/dev/null
+          done
+
+          if ! git diff --exit-code -- openbank-infra/gitops/components; then
+            echo "::error::A service OPA bundle ConfigMap or its pod-roll checksum annotation is stale — re-run the gen-*opa-bundle*.sh generators shown above and commit the result."
+            exit 1
+          fi
+          echo "All ${#GENERATORS[@]} service OPA bundles + pod-roll annotations are in sync with the policy source."
 
   # Gate job — always runs, maps to the required check name (issue #799). Passes
   # when verify succeeded OR was skipped (no policy-relevant changes in this PR);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,15 +150,25 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   Verify with `cosign verify-attestation` after attesting; never trust `attest` exit 0 alone.
 
 ### OPA / Rego policies (ADR-0031/ADR-0034)
-- **Adding any new agent charter to `agents.yaml` ripples the OPA bundle checksum of unrelated
-  services.** `gen-pid-opa-bundle.sh` / `gen-copilot-opa-bundle.sh` /
-  `gen-customer-edge-opa-bundle.sh` / `gen-notification-opa-bundle.sh` each hash
-  `openbank-libs/governance/agents.yaml` as one of their checksum inputs — a new charter entry for
-  a completely unrelated agent (e.g. a new fleet-monitoring agent) still changes those four
-  services' `openbank.tech/policy-checksum` annotation. `opa-policy.yml`'s "build + verify bundle"
-  job regenerates and diffs all four on every OPA-relevant PR, so a PR that only adds an agent
-  charter fails there unless it also re-runs and commits all five `gen-*-opa-bundle*.sh` outputs
-  (`agent`, `pid`, `copilot`, `customer-edge`, `notifications`), not just its own service's bundle.
+- **Editing any shared policy source ripples the OPA bundle checksum of every service.** Each
+  `openbank-infra/gitops/components/**/gen-*opa-bundle*.sh` embeds `rest.rego`, `agents.rego`,
+  `agents.yaml` and (25 of the 26) `rules.yaml` verbatim into its ConfigMap and hashes them into
+  that service's `openbank.tech/policy-checksum` annotation. So a new charter entry for a
+  completely unrelated agent — or any `rules.yaml` edit — still changes *every* service's bundle
+  and annotation. `opa-policy.yml`'s "build + verify bundle" job discovers the generators with
+  `find` and regenerates **all** of them on every OPA-relevant PR, so your PR fails there unless it
+  re-runs and commits every generator's output, not just your own service's bundle. Regenerate with:
+  ```
+  find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' | sort | xargs -n1 bash
+  ```
+  Expect this to roll the pods of every service whose checksum moved — that is the point (subPath
+  mounts do not hot-reload). Do not hand-edit a bundle or an annotation to dodge the diff.
+- **The generator list is discovered, not hard-coded — keep it that way.** Until #1184 the gate
+  named four generators while 25 hashed `rules.yaml`, so ~21 services' committed bundles drifted
+  from the policy source for months with CI green: the deployed OPA data (`data.rules.*`,
+  `data.agents.*`) silently lagged what `rules.yaml` declared. If you add a generator, add nothing
+  to CI — but do commit it mode `100755`: a non-executable generator no-ops a `./…` loop and looks
+  exactly like "in sync" (`gen-ledger-opa-bundle.sh` shipped `100644` and had never once run).
 - **An `AI_AGENT` principal's id carries an `agent:` prefix on the REST path, but not on the
   MCP path.** `AuthorizeInterceptor.principalType()` classifies `AI_AGENT` from a JWT `sub`
   prefixed `agent:`, and `principal.id` is that sub verbatim — but `openbank-agent-service`


### PR DESCRIPTION
## What

Stage 3 of 3 for #1184. Replaces the hard-coded generator list in `opa-policy.yml` with dynamic
discovery, and corrects the stale `CLAUDE.md` note that said "all five `gen-*-opa-bundle*.sh`".

> [!IMPORTANT]
> **Merge last.** This guard is red until #1185 and #1186 land — that is the guard working. It is
> the first thing that has ever been able to see the existing drift.

## Why

The gate named 4 generators; **25 of the 26** hash `rules.yaml`. The four names were never wrong,
just incomplete — and nothing made the list grow, so every new service was opted out of the gate by
default. That is the defect being fixed, not the specific omissions.

Two hard-coded lists, both replaced:

1. **The `verify` step** regenerated 4 generators and diffed 4 directories.
2. **The `changes` job's path filter** — same 4 component dirs. So a hand-edit to, say,
   `components/ledger/ledger-opa-bundle.yaml` did not even mark the PR policy-relevant, and `verify`
   never ran. Fixing only the step would have left this hole.

Both now derive from `find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh'`.

## Also: fail loudly on a non-executable generator

A `100644` generator silently no-ops a `./…` loop — indistinguishable from "in sync". This is not
hypothetical: `gen-ledger-opa-bundle.sh` shipped that way and had never once run (fixed in #1185).
The check would be self-defeating without this.

## Implementation notes

- **`while read`, not `mapfile`.** The `Install OPA` step in this same job still branches on
  `darwin`, and macOS ships bash 3.2 where `mapfile` does not exist — it would fail
  `command not found`, leave the array empty, and pass a check that verified nothing. Exactly the
  failure mode this PR exists to remove.
- **Empty discovery is a hard error**, for the same reason.
- The agent-bundle step is left as-is: it runs first and gives a targeted message. The dynamic loop
  also covers `gen-opa-bundle-configmap.sh`; re-running it is idempotent.

## Verification

Ran the guard's exact logic locally against `main`:

- discovers **26** generators (19 unique component dirs; `payments` holds 8);
- exec-check correctly flags `gen-ledger-opa-bundle.sh`;
- after `chmod +x` and regenerating all 26, it reports **36 drifted files** — i.e. it catches
  precisely the drift the old gate could not see;
- `pid`, `copilot`, `customer-edge`, `notifications`, `agent` show **no** drift, confirming the old
  4-generator gate did keep its own scope honest.

Path filter, rebuilt dynamically:

| changed file | policy-relevant? |
|---|---|
| `components/ledger/ledger-opa-bundle.yaml` | YES (was **NO** before this PR) |
| `openbank-admin-ui/app/page.tsx` | NO |

Workflow YAML parses; the step's bash passes `bash -n`.

Refs #1184
