### PR TITLE
fix(gitops): record the OPA bundle sync invariant in rules.yaml

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "bb72b989557726e0"
+    openbank.tech/policy-checksum: "fb2a0068c011f1fa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1975,6 +1975,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bb72b989557726e0"
+        openbank.tech/policy-checksum: "fb2a0068c011f1fa"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "62904ba3625f5e0b"
+    openbank.tech/policy-checksum: "0b08fa88bf34a7ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1918,6 +1918,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "62904ba3625f5e0b"
+        openbank.tech/policy-checksum: "0b08fa88bf34a7ef"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "e8e340b1e397ff43"
+    openbank.tech/policy-checksum: "df6c9feff1ee9d3a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2019,6 +2019,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e8e340b1e397ff43"
+        openbank.tech/policy-checksum: "df6c9feff1ee9d3a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "74916470465201f9"
+    openbank.tech/policy-checksum: "6df2e9d4922a583b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1924,6 +1924,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "74916470465201f9"
+        openbank.tech/policy-checksum: "6df2e9d4922a583b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "8b501cba0ef8ade6"
+    openbank.tech/policy-checksum: "a8b6c1ec74f3f021"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1956,6 +1956,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b501cba0ef8ade6"
+        openbank.tech/policy-checksum: "a8b6c1ec74f3f021"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "ebef0ec9f5ede7c3"
+    openbank.tech/policy-checksum: "404f60cdb07db510"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2007,6 +2007,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ebef0ec9f5ede7c3"
+        openbank.tech/policy-checksum: "404f60cdb07db510"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "565a265c64ebf01e"
+    openbank.tech/policy-checksum: "0afd8614d31dcdfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1229,6 +1229,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "565a265c64ebf01e"
+        openbank.tech/policy-checksum: "0afd8614d31dcdfd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "565a265c64ebf01e"
+    openbank.tech/policy-checksum: "0afd8614d31dcdfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1229,6 +1229,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "565a265c64ebf01e"
+        openbank.tech/policy-checksum: "0afd8614d31dcdfd"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "972fc440fd22bf3e"
+    openbank.tech/policy-checksum: "49b90032b484d72e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1935,6 +1935,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "972fc440fd22bf3e"
+        openbank.tech/policy-checksum: "49b90032b484d72e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "3ed8d25f6d89f706"
+    openbank.tech/policy-checksum: "d98a7fd4020bc700"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1986,6 +1986,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ed8d25f6d89f706"
+        openbank.tech/policy-checksum: "d98a7fd4020bc700"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "fda83c5361d4b403"
+    openbank.tech/policy-checksum: "0a1cb2bc83065773"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1920,6 +1920,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fda83c5361d4b403"
+        openbank.tech/policy-checksum: "0a1cb2bc83065773"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "e0c26208f36582b0"
+    openbank.tech/policy-checksum: "eed5fef635dce3cd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2033,6 +2033,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e0c26208f36582b0"
+        openbank.tech/policy-checksum: "eed5fef635dce3cd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "f38ee38bb37bf31a"
+    openbank.tech/policy-checksum: "07c16005ac0e12bb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1988,6 +1988,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f38ee38bb37bf31a"
+        openbank.tech/policy-checksum: "07c16005ac0e12bb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "565a265c64ebf01e"
+    openbank.tech/policy-checksum: "0afd8614d31dcdfd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1229,6 +1229,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "565a265c64ebf01e"
+        openbank.tech/policy-checksum: "0afd8614d31dcdfd"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e3dce67b493a949b"
+    openbank.tech/policy-checksum: "6739fbfe0e32d2dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1933,6 +1933,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "17cdfbeec244f7b9"
+    openbank.tech/policy-checksum: "c7f004d00728fe50"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1978,6 +1978,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bbc16943c061d36b"
+    openbank.tech/policy-checksum: "99ff67eb542101f5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1963,6 +1963,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ede2ab9321883360" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "0a019598ff399588" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -374,7 +374,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "984e270ab478b6e3"
+        openbank.tech/policy-checksum: "603c35591a7da177"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -727,7 +727,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "bbc16943c061d36b" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "99ff67eb542101f5" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1050,7 +1050,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5544437b6a726ea3"
+        openbank.tech/policy-checksum: "06aea36380be8ea6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1365,7 +1365,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "17cdfbeec244f7b9" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "c7f004d00728fe50" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1780,7 +1780,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e3dce67b493a949b"
+        openbank.tech/policy-checksum: "6739fbfe0e32d2dd"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2036,7 +2036,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6dec2a2561ed89a1" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "cea0651223541ced" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2436,7 +2436,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6fda27efb6698697"
+        openbank.tech/policy-checksum: "cedd6d2d29dd013c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5544437b6a726ea3"
+    openbank.tech/policy-checksum: "06aea36380be8ea6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1936,6 +1936,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "984e270ab478b6e3"
+    openbank.tech/policy-checksum: "603c35591a7da177"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1957,6 +1957,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6dec2a2561ed89a1"
+    openbank.tech/policy-checksum: "cea0651223541ced"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1937,6 +1937,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6fda27efb6698697"
+    openbank.tech/policy-checksum: "cedd6d2d29dd013c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1940,6 +1940,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ede2ab9321883360"
+    openbank.tech/policy-checksum: "0a019598ff399588"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1993,6 +1993,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "8ed7d3bc263469c1"
+    openbank.tech/policy-checksum: "2e2ece7915267d6f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1946,6 +1946,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8ed7d3bc263469c1"
+        openbank.tech/policy-checksum: "2e2ece7915267d6f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "f9c0af32933be1ef"
+    openbank.tech/policy-checksum: "6187d37a5d649637"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1924,6 +1924,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9c0af32933be1ef"
+        openbank.tech/policy-checksum: "6187d37a5d649637"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "6fcdc8b7fd766283"
+    openbank.tech/policy-checksum: "482bd2facd6d814c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1960,6 +1960,27 @@ data:
       # (shares the domain package string for its JPA converters but IS the framework
       # side of the ADR-0122 split).
       ci_producer: ".github/scripts/check-domain-purity.sh"
+
+    # ---------------------------------------------------------------------------------------
+    # OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+    # bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    opa_bundle_sync:
+      # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+      # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+      # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+      # data.rules.* / data.agents.* for months with CI green.
+      generators_discovered_not_listed: true
+      generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+      # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+      # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+      generators_must_be_executable: true
+      # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+      # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+      # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+      checksum_annotation: "openbank.tech/policy-checksum"
+      enforced: enforce
+      ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
 
     # ---------------------------------------------------------------------------------------
     # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6fcdc8b7fd766283"
+        openbank.tech/policy-checksum: "482bd2facd6d814c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -763,6 +763,27 @@ architecture:
   ci_producer: ".github/scripts/check-domain-purity.sh"
 
 # ---------------------------------------------------------------------------------------
+# OPA bundle sync (issue #1184). Keep terse: this file is embedded verbatim into every
+# bundle it describes, so editing it rolls every checksum below. Rationale in ci_producer.
+# ---------------------------------------------------------------------------------------
+opa_bundle_sync:
+  # The gate must DISCOVER the generators, never name them. A hard-coded list opts each
+  # new service out by default: until #1187 it named 4 of the 26 gen-*opa-bundle*.sh
+  # scripts while 25 embed this file, so ~21 services' committed bundles served stale
+  # data.rules.* / data.agents.* for months with CI green.
+  generators_discovered_not_listed: true
+  generator_glob: "openbank-infra/gitops/components/**/gen-*opa-bundle*.sh"
+  # A 100644 generator no-ops a ./... loop and is indistinguishable from "in sync" —
+  # gen-ledger-opa-bundle.sh shipped that way and had never once run.
+  generators_must_be_executable: true
+  # Each generator hashes its embedded sources into openbank.tech/policy-checksum, which
+  # must match in BOTH the ConfigMap and the service's Rollout/Deployment: subPath mounts
+  # do not hot-reload, so the annotation is what actually rolls the pod onto new policy.
+  checksum_annotation: "openbank.tech/policy-checksum"
+  enforced: enforce
+  ci_producer: ".github/workflows/opa-policy.yml"   # `verify` job
+
+# ---------------------------------------------------------------------------------------
 # REST/MCP authorization policy invariants (ADR-0034 Phase 5, issue #266). rest.rego is
 # the shared OPA policy mounted in every enforcing service's bundle.
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds an `opa_bundle_sync` section to `openbank-libs/governance/rules.yaml`, the last open item from the #1184 bundle-drift thread.

#1185 / #1186 regenerated every stale bundle and #1187 rebuilt the gate to discover its generators with `find`. But the invariant itself was only ever written down as CLAUDE.md prose. Per the repo's own convention (`rules.yaml` is authoritative; CLAUDE.md is the human-readable summary; when they disagree, `rules.yaml` wins), the rule belongs here:

- `generators_discovered_not_listed` — a hard-coded list opts each new service out of the gate by default. That was the actual defect behind #1184: 4 of 26 generators named, 25 embedding `rules.yaml`.
- `generators_must_be_executable` — a `100644` script no-ops a `./…` loop and looks exactly like "in sync" (`gen-ledger-opa-bundle.sh` had never run).
- `checksum_annotation` — must match in **both** the ConfigMap and the Rollout/Deployment; subPath mounts do not hot-reload, so the annotation is what actually rolls the pod.

`ci_producer` points at `opa-policy.yml`'s `verify` job, which already enforces all three as of #1187.

## Why 26 ConfigMaps move

Mechanical consequence, not a second change. `rules.yaml` is embedded verbatim as `rules-data.yaml` into every bundle it describes, so documenting the checksum rule necessarily rolls every checksum. The recursion is noted in the section's own header comment.

## Verification

- `git diff --name-only` outside `openbank-infra/gitops/components/` is **`rules.yaml` alone** — no hand edits to any generated artifact.
- Every regenerated bundle's `openbank.tech/policy-checksum` appears in both its ConfigMap and its workload manifest with the same value (checked mechanically across all 26).
- No rego logic bytes moved — only the embedded data documents and checksums.
- All 26 generators are already `100755`; regeneration is idempotent (a second full run produces an empty diff).
- `rules.yaml` parses; `opa_bundle_sync.enforced == enforce`.

Expect this to roll the pods of every service whose checksum moved — that is the intent.

Refs #1184