### PR TITLE
fix(statement): paginate booked-entry reads; heal oldest owed months first

### DIFF
--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/domain/close/CloseCalendar.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/domain/close/CloseCalendar.kt
@@ -29,7 +29,11 @@ object CloseCalendar {
      *   brand-new pocket starts its legal sequence at the current cadence; pre-registration history
      *   is deliberately not back-invented.
      * - Capped at [maxLookbackMonths] windows as a safety bound, so a long-dormant pocket can never
-     *   enqueue an unbounded backlog in a single run (the next run continues healing).
+     *   enqueue an unbounded backlog in a single run. The cap keeps the OLDEST owed months: the close
+     *   only ever advances `latestClosedPeriodTo` forward, so keeping the newest would permanently
+     *   drop the older months and break the legal sequence. Keeping the oldest also means the newest
+     *   months simply wait for a later run — correct, since balance chaining needs each prior period
+     *   closed first.
      *
      * Returns empty when the pocket is already current (last close == the through month).
      */
@@ -49,8 +53,10 @@ object CloseCalendar {
             windows.add(cursor to monthEnd(cursor))
             cursor = cursor.plusMonths(1)
         }
-        // Keep only the most recent [maxLookbackMonths] when a large gap exists.
-        return if (windows.size > maxLookbackMonths) windows.takeLast(maxLookbackMonths) else windows
+        // Keep only the OLDEST [maxLookbackMonths] when a large gap exists — healing progresses
+        // oldest-first so subsequent runs eventually reach the newest months (takeLast would strand
+        // the dropped older months forever, since the close cursor only moves forward).
+        return if (windows.size > maxLookbackMonths) windows.take(maxLookbackMonths) else windows
     }
 
     private fun monthEnd(firstOfMonth: LocalDate): LocalDate = firstOfMonth.withDayOfMonth(firstOfMonth.lengthOfMonth())

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/RestClients.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/RestClients.kt
@@ -44,6 +44,9 @@ data class TransactionSearchResponse(val data: List<TransactionDto> = emptyList(
 interface TransactionRestClient {
     // No Kotlin default-valued parameter here: a default on an interface method compiles to a
     // synthetic JVM default method, which the Quarkus REST Client rejects.
+    // limit/offset MUST always be passed explicitly: transaction-service defaults limit to 50 and
+    // silently truncates, which capped statements at 50 entries per month (fix: paginate in the
+    // adapter). The upstream coerces limit into 1..200.
     @GET
     @Path("/api/v1/transactions/search")
     fun searchByAccount(
@@ -51,6 +54,8 @@ interface TransactionRestClient {
         @QueryParam("dateFrom") dateFrom: String,
         @QueryParam("dateTo") dateTo: String,
         @QueryParam("status") status: String,
+        @QueryParam("limit") limit: Int,
+        @QueryParam("offset") offset: Int,
     ): Uni<TransactionSearchResponse>
 }
 

--- a/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/RestPortAdapters.kt
+++ b/openbank-statement-service/src/main/kotlin/com/openbank/statement/infrastructure/client/RestPortAdapters.kt
@@ -35,11 +35,46 @@ class BookedEntryRestAdapter @Inject constructor(@RestClient private val client:
         to: LocalDate,
     ): Uni<List<StatementEntry>> =
         // transaction-service search returns a {"data":[...]} envelope of entries touching the account
-        // (no currency filter param), so filter to this pocket's currency client-side.
-        client.searchByAccount(accountId, from.toString(), to.toString(), "COMPLETED").map { resp ->
-            resp.data.filter { it.currencyCode == null || it.currencyCode == currency }
+        // (no currency filter param), so filter to this pocket's currency client-side. The endpoint is
+        // paged (limit defaults to 50, coerced to max 200) — page through the whole window, or a busy
+        // pocket's statement would be silently truncated and could never pass reconciliation.
+        fetchAllPages(accountId, from.toString(), to.toString(), offset = 0, acc = emptyList()).map { dtos ->
+            dtos.filter { it.currencyCode == null || it.currencyCode == currency }
                 .map { it.toEntry(accountId, currency) }
         }
+
+    // Accumulates pages in upstream order (transaction-service sorts by initiatedAt desc; concatenating
+    // consecutive offsets preserves that ordering) until a short page signals the end. Fail-closed: if
+    // the window somehow exceeds MAX_ENTRIES the Uni fails loudly — a truncated statement must never be
+    // minted silently (the close records the pocket as failed and a later run retries).
+    private fun fetchAllPages(
+        accountId: UUID,
+        from: String,
+        to: String,
+        offset: Int,
+        acc: List<TransactionDto>,
+    ): Uni<List<TransactionDto>> =
+        client.searchByAccount(accountId, from, to, "COMPLETED", PAGE_SIZE, offset).flatMap { resp ->
+            val all = acc + resp.data
+            when {
+                resp.data.size < PAGE_SIZE -> Uni.createFrom().item(all)
+                all.size >= MAX_ENTRIES -> Uni.createFrom().failure(
+                    IllegalStateException(
+                        "booked-entry pagination exceeded $MAX_ENTRIES entries for account $accountId " +
+                            "($from..$to) — refusing to mint a possibly-truncated statement",
+                    ),
+                )
+                else -> fetchAllPages(accountId, from, to, offset + PAGE_SIZE, all)
+            }
+        }
+
+    private companion object {
+        /** transaction-service coerces `limit` into 1..200 — ask for the max to minimize round-trips. */
+        const val PAGE_SIZE = 200
+
+        /** Hard cap (100 pages) guarding against a non-terminating upstream; far beyond any real month. */
+        const val MAX_ENTRIES = 20_000
+    }
 
     private fun TransactionDto.toEntry(accountId: UUID, pocketCurrency: String): StatementEntry {
         val raw = amount ?: BigDecimal.ZERO

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/domain/close/CloseCalendarTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/domain/close/CloseCalendarTest.kt
@@ -66,15 +66,37 @@ class CloseCalendarTest {
     }
 
     @Test
-    fun `a large gap is capped at the lookback bound, keeping the most recent months`() {
-        // Last closed Jan 2024; through Mar 2026 (26 months owed) capped to 12 newest.
+    fun `a large gap is capped at the lookback bound, keeping the OLDEST months`() {
+        // Last closed Jan 2024; through Mar 2026 (26 months owed) capped to the 12 oldest. Keeping
+        // the oldest is what lets successive runs heal the whole gap: the close cursor only moves
+        // forward, so months dropped from the newest end would just wait for the next run, whereas
+        // months dropped from the oldest end would be stranded forever.
         val windows = CloseCalendar.monthsToClose(
             LocalDate.parse("2024-01-31"),
             LocalDate.parse("2026-03-31"),
             maxLookbackMonths = 12,
         )
         assertThat(windows).hasSize(12)
-        assertThat(windows.first()).isEqualTo(LocalDate.parse("2025-04-01") to LocalDate.parse("2025-04-30"))
-        assertThat(windows.last()).isEqualTo(LocalDate.parse("2026-03-01") to LocalDate.parse("2026-03-31"))
+        assertThat(windows.first()).isEqualTo(LocalDate.parse("2024-02-01") to LocalDate.parse("2024-02-29"))
+        assertThat(windows.last()).isEqualTo(LocalDate.parse("2025-01-01") to LocalDate.parse("2025-01-31"))
+    }
+
+    @Test
+    fun `successive capped runs converge on the full gap`() {
+        // Simulate the healing loop: after the first capped run closes through Jan 2025, the next
+        // run enumerates from there and reaches the months the cap deferred.
+        val first = CloseCalendar.monthsToClose(
+            LocalDate.parse("2024-01-31"),
+            LocalDate.parse("2026-03-31"),
+            maxLookbackMonths = 12,
+        )
+        val second = CloseCalendar.monthsToClose(first.last().second, LocalDate.parse("2026-03-31"), 12)
+        assertThat(second.first()).isEqualTo(LocalDate.parse("2025-02-01") to LocalDate.parse("2025-02-28"))
+        assertThat(second.last()).isEqualTo(LocalDate.parse("2026-01-01") to LocalDate.parse("2026-01-31"))
+        val third = CloseCalendar.monthsToClose(second.last().second, LocalDate.parse("2026-03-31"), 12)
+        assertThat(third).containsExactly(
+            LocalDate.parse("2026-02-01") to LocalDate.parse("2026-02-28"),
+            LocalDate.parse("2026-03-01") to LocalDate.parse("2026-03-31"),
+        )
     }
 }

--- a/openbank-statement-service/src/test/kotlin/com/openbank/statement/infrastructure/client/BookedEntryRestAdapterTest.kt
+++ b/openbank-statement-service/src/test/kotlin/com/openbank/statement/infrastructure/client/BookedEntryRestAdapterTest.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.statement.infrastructure.client
+
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Pagination behavior of [BookedEntryRestAdapter]. transaction-service caps `limit` at 200 and
+ * defaults it to 50 — before the pagination loop a pocket with 51+ entries in a month got a silently
+ * truncated statement that could never pass reconciliation. These tests pin: full-window paging,
+ * upstream-order preservation, and the fail-closed hard cap.
+ */
+class BookedEntryRestAdapterTest {
+
+    private val accountId: UUID = UUID.randomUUID()
+    private val from: LocalDate = LocalDate.parse("2026-06-01")
+    private val to: LocalDate = LocalDate.parse("2026-06-30")
+
+    /** Serves a fixed dataset page-by-page according to limit/offset, recording every call. */
+    private class PagingFakeClient(private val dataset: List<TransactionDto>) : TransactionRestClient {
+        val calls = mutableListOf<Pair<Int, Int>>() // (limit, offset)
+
+        override fun searchByAccount(
+            accountId: UUID,
+            dateFrom: String,
+            dateTo: String,
+            status: String,
+            limit: Int,
+            offset: Int,
+        ): Uni<TransactionSearchResponse> {
+            calls += limit to offset
+            val page = dataset.drop(offset).take(limit)
+            return Uni.createFrom().item(TransactionSearchResponse(page))
+        }
+    }
+
+    private fun dto(i: Int, currency: String = "CZK") = TransactionDto(
+        referenceNumber = "TX-%05d".format(i),
+        amount = BigDecimal("10.00"),
+        currencyCode = currency,
+        sourceAccountId = accountId.toString(),
+        bookingDate = "2026-06-15",
+        status = "COMPLETED",
+    )
+
+    @Test
+    fun `pages through the whole window and preserves upstream order`() {
+        // 437 entries → pages of 200 + 200 + 37; the short last page terminates the loop.
+        val client = PagingFakeClient((0 until 437).map { dto(it) })
+        val adapter = BookedEntryRestAdapter(client)
+
+        val entries = adapter.bookedEntries(accountId, "CZK", from, to)
+            .subscribe().withSubscriber(UniAssertSubscriber.create()).awaitItem().item
+
+        assertThat(entries).hasSize(437)
+        assertThat(client.calls).containsExactly(200 to 0, 200 to 200, 200 to 400)
+        // Concatenated pages must keep the upstream ordering (initiatedAt desc from the service).
+        assertThat(entries.map { it.entryRef }).isEqualTo((0 until 437).map { "TX-%05d".format(it) })
+    }
+
+    @Test
+    fun `an exact page-multiple window needs one extra empty page to terminate`() {
+        val client = PagingFakeClient((0 until 200).map { dto(it) })
+        val adapter = BookedEntryRestAdapter(client)
+
+        val entries = adapter.bookedEntries(accountId, "CZK", from, to)
+            .subscribe().withSubscriber(UniAssertSubscriber.create()).awaitItem().item
+
+        assertThat(entries).hasSize(200)
+        assertThat(client.calls).containsExactly(200 to 0, 200 to 200)
+    }
+
+    @Test
+    fun `currency filter applies across all pages`() {
+        // Alternate currencies so the filter has to work on every page, not just the first.
+        val client = PagingFakeClient((0 until 437).map { dto(it, currency = if (it % 2 == 0) "CZK" else "EUR") })
+        val adapter = BookedEntryRestAdapter(client)
+
+        val entries = adapter.bookedEntries(accountId, "EUR", from, to)
+            .subscribe().withSubscriber(UniAssertSubscriber.create()).awaitItem().item
+
+        assertThat(entries).hasSize(218)
+        assertThat(entries).allSatisfy { assertThat(it.currency).isEqualTo("EUR") }
+    }
+
+    @Test
+    fun `a non-terminating upstream fails loudly instead of minting a truncated statement`() {
+        // Pathological upstream: every page is full regardless of offset. The adapter must fail
+        // closed at the hard cap rather than return a silently incomplete window.
+        val fullPage = (0 until 200).map { dto(it) }
+        val client = object : TransactionRestClient {
+            var calls = 0
+            override fun searchByAccount(
+                accountId: UUID,
+                dateFrom: String,
+                dateTo: String,
+                status: String,
+                limit: Int,
+                offset: Int,
+            ): Uni<TransactionSearchResponse> {
+                calls++
+                return Uni.createFrom().item(TransactionSearchResponse(fullPage))
+            }
+        }
+        val adapter = BookedEntryRestAdapter(client)
+
+        val failure = adapter.bookedEntries(accountId, "CZK", from, to)
+            .subscribe().withSubscriber(UniAssertSubscriber.create()).awaitFailure().failure
+
+        assertThat(failure).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failure).hasMessageContaining("truncated")
+        assertThat(client.calls).isEqualTo(100) // 100 pages × 200 = the 20_000-entry hard cap
+    }
+}


### PR DESCRIPTION
## What

Two period-close correctness defects found by the closing audit (docs/audits/2026-07-16-closing-audit.md, findings S-1 and S-3):

1. **Booked-entry read was silently capped at 50 entries.** `BookedEntryRestAdapter` sent no `limit`/`offset`; transaction-service defaults `limit=50`. Any pocket with 51+ COMPLETED entries in a month computed a wrong net movement, failed `ReconciliationPolicy` on every scheduled and manual pass, and never received a statement. Renders truncated identically. Now pages through the full window (limit=200 per page, upstream max) and **fails loudly** past a 20k hard cap — a possibly-truncated statement is never minted silently; the close records the pocket as failed and a later run retries.

2. **Catch-up permanently dropped the oldest owed months.** `CloseCalendar` capped a large gap with `takeLast(maxLookbackMonths)`; since the close cursor only moves forward, the dropped older months were never enumerated again — a silent permanent hole in the legal sequence, plus guaranteed opening-balance mismatches for the kept windows. `take()` keeps the OLDEST months; healing progresses oldest-first across runs, which balance chaining requires anyway.

## Tests

- New `BookedEntryRestAdapterTest`: 200+200+37 pagination (order + call sequence), exact-page-multiple termination, cross-page currency filter, fail-closed cap.
- `CloseCalendarTest`: cap now asserts oldest-first retention + a three-run convergence scenario.
- `:openbank-statement-service:test` 57 tests green; ktlint + detekt green (JDK 25).

Refs #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)