### PR TITLE
feat(ledger): persist tie-out runs, freshness watchdog, wire break alert

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-tieout.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-tieout.yaml
@@ -1,0 +1,40 @@
+# Sub-ledger tie-out break alert (ADR-0039 Phase B). Picked up by the Prometheus operator
+# automatically (ruleSelectorNilUsesHelmValues=false), same as every other PrometheusRule in
+# this directory.
+#
+# WHY THIS EXISTS: TieOutScheduler (ledger-service, 06:00 Europe/Prague) has incremented
+# openbank_subledger_tieout_break_total on every GL ⇄ sub-ledger mismatch since ADR-0039
+# Phase B shipped — but no rule ever referenced the metric, so a confirmed integrity break
+# paged nobody (closing-audit 2026-07-16 finding L-1). A break is a recorded incident by
+# definition: the GL control account and the per-customer sub-ledger disagree, and postings
+# keep flowing against the broken control until someone acts.
+#
+# The 25h window matches the daily cadence + 1h grace (same SLA as the freshness watchdogs):
+# an unresolved break is re-detected and re-incremented by the next 06:00 run, so the alert
+# stays firing until the underlying drift is actually repaired — it cannot silently age out
+# between runs. The complementary "run went missing / errored" case is deliberately NOT a
+# metric rule: TieOutFreshnessWatchdog escalates that via ERROR logs (Alloy → Loki), the
+# pattern balance-service established after issue #855.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-tieout-alerts
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  groups:
+    - name: openbank.ledger.tieout
+      rules:
+        - alert: SubledgerTieOutBreak
+          expr: increase(openbank_subledger_tieout_break_total[25h]) > 0
+          labels:
+            severity: critical
+          annotations:
+            summary: "Sub-ledger tie-out break detected by the 06:00 ledger tie-out run"
+            description: >-
+              openbank_subledger_tieout_break_total increased within the last daily cycle —
+              the GL deposit-control account and the per-customer sub-ledger net disagree
+              (ADR-0039 Phase B). This is a confirmed integrity incident, not a transient:
+              consult ledger-service logs for the per-currency BREAK lines (control code,
+              glNet, subLedgerNet, delta) and the ledger_tieout_runs table for the run record.

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/TieOutRunRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/application/port/out/TieOutRunRepository.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.application.port.out
+
+import com.openbank.ledger.domain.model.TieOutRunRecord
+
+/** Outbound persistence port for the audit trail of tie-out runs (ADR-0039 Phase B). */
+interface TieOutRunRepository {
+
+    suspend fun save(record: TieOutRunRecord): TieOutRunRecord
+
+    suspend fun findLatest(): TieOutRunRecord?
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/TieOutRun.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/domain/model/TieOutRun.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.domain.model
+
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Outcome of one scheduled sub-ledger tie-out run (ADR-0039 Phase B).
+ *
+ * [BREAK] and [ERROR] are deliberately distinct: a break is a *confirmed* integrity incident
+ * (GL net ≠ sub-ledger net), while an error means at least one control account could not be
+ * checked at all — the day's control is missing, which is its own incident class (issue #855).
+ */
+enum class TieOutRunStatus { OK, BREAK, ERROR }
+
+/** Durable record of one tie-out run; one row per run, persisted whatever the outcome. */
+data class TieOutRunRecord(
+    val id: UUID,
+    val asOf: LocalDate,
+    val runAt: Instant,
+    val status: TieOutRunStatus,
+    val accountsChecked: Int,
+    val breaks: Int,
+    val errors: Int,
+)

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/TieOutRunEntity.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/TieOutRunEntity.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.ledger.infrastructure.persistence.entity
 
+import com.openbank.libs.domain.identifiers.Ids
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntityBase
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -19,7 +20,7 @@ import java.util.UUID
 class TieOutRunEntity : PanacheEntityBase {
     @Id
     @Column(name = "id")
-    var id: UUID = UUID.randomUUID()
+    var id: UUID = Ids.newId()
 
     @Column(name = "as_of", nullable = false)
     var asOf: LocalDate = LocalDate.EPOCH

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/TieOutRunEntity.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/TieOutRunEntity.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+/** Audit trail of sub-ledger tie-out runs (ADR-0039 Phase B); one row per run. */
+@Entity
+@Table(name = "ledger_tieout_runs")
+class TieOutRunEntity : PanacheEntityBase {
+    @Id
+    @Column(name = "id")
+    var id: UUID = UUID.randomUUID()
+
+    @Column(name = "as_of", nullable = false)
+    var asOf: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "run_at", nullable = false)
+    var runAt: Instant = Instant.EPOCH
+
+    @Column(name = "status", nullable = false)
+    var status: String = "OK"
+
+    @Column(name = "accounts_checked", nullable = false)
+    var accountsChecked: Int = 0
+
+    @Column(name = "breaks", nullable = false)
+    var breaks: Int = 0
+
+    @Column(name = "errors", nullable = false)
+    var errors: Int = 0
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheTieOutRunRepository.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/PanacheTieOutRunRepository.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.persistence.repository
+
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.domain.model.TieOutRunRecord
+import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.ledger.infrastructure.persistence.entity.TieOutRunEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepositoryBase
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+
+@ApplicationScoped
+class PanacheTieOutRunRepository :
+    TieOutRunRepository,
+    PanacheRepositoryBase<TieOutRunEntity, UUID> {
+
+    override suspend fun save(record: TieOutRunRecord): TieOutRunRecord {
+        Panache.withTransaction {
+            persist(record.toEntity())
+        }.awaitSuspending()
+        return record
+    }
+
+    override suspend fun findLatest(): TieOutRunRecord? = Panache.withSession {
+        find("order by runAt desc").firstResult()
+    }.awaitSuspending()?.toDomain()
+
+    private fun TieOutRunRecord.toEntity() = TieOutRunEntity().also {
+        it.id = id
+        it.asOf = asOf
+        it.runAt = runAt
+        it.status = status.name
+        it.accountsChecked = accountsChecked
+        it.breaks = breaks
+        it.errors = errors
+    }
+
+    private fun TieOutRunEntity.toDomain() = TieOutRunRecord(
+        id = id,
+        asOf = asOf,
+        runAt = runAt,
+        status = TieOutRunStatus.valueOf(status),
+        accountsChecked = accountsChecked,
+        breaks = breaks,
+        errors = errors,
+    )
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdog.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdog.kt
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.schedule
+
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.domain.model.TieOutRunStatus
+import io.quarkus.scheduler.Scheduled
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Freshness watchdog for the daily sub-ledger tie-out ([TieOutScheduler] @ 06:00).
+ *
+ * The tie-out is an audit-critical control (ADR-0039 Phase B) whose scheduler deliberately
+ * swallows failures so it never crashes — which means a broken run can be SILENT. That is the
+ * exact failure mode balance-service hit in issue #855 (41 days of missing reconciliation,
+ * unnoticed), and this watchdog is the same countermeasure applied to the ledger side:
+ * hourly, escalate the ABSENCE of a fresh successful run to ERROR so the log-based alerting
+ * stack (Alloy → Loki) pages. Breaks themselves page via the SubledgerTieOutBreak
+ * PrometheusRule on the break counter; this watchdog covers the two cases the counter
+ * cannot: the run not happening at all, and the run erroring before it could check.
+ * Read-only; never touches the journal.
+ */
+@ApplicationScoped
+class TieOutFreshnessWatchdog(private val runRepository: TieOutRunRepository, private val clock: Clock) {
+    private val log = Logger.getLogger(TieOutFreshnessWatchdog::class.java)
+
+    // The daily run fires at 06:00, so a healthy record is at most ~24h old; allow a 1h grace
+    // for run duration or a delayed scheduler before we call it a missed control.
+    private val staleAfter = Duration.ofHours(DAILY_SLA_HOURS)
+
+    @Scheduled(
+        cron = "{openbank.ledger.tieout.freshness-cron:0 40 * * * ?}",
+        timeZone = "Europe/Prague",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    suspend fun checkFreshness() {
+        val latest = runRepository.findLatest()
+        if (latest == null) {
+            log.error(
+                "Tie-out freshness: NO tie-out run has ever been recorded — the daily " +
+                    "GL control-account ⇄ sub-ledger tie-out (ADR-0039 Phase B) is absent. Investigate.",
+            )
+            return
+        }
+        val ageHours = Duration.between(latest.runAt, Instant.now(clock)).toHours()
+        when {
+            ageHours > staleAfter.toHours() -> log.errorf(
+                "Tie-out freshness: STALE — last run was %dh ago (as-of %s, status %s), past the " +
+                    "%dh daily SLA; a scheduled run was likely missed.",
+                ageHours,
+                latest.asOf,
+                latest.status,
+                staleAfter.toHours(),
+            )
+            latest.status == TieOutRunStatus.ERROR -> log.errorf(
+                "Tie-out freshness: last run (as-of %s) ended in ERROR — %d of %d control-account " +
+                    "checks failed; the day's control is incomplete. Investigate and re-run.",
+                latest.asOf,
+                latest.errors,
+                latest.errors + latest.accountsChecked,
+            )
+            else -> log.debugf(
+                "Tie-out freshness OK: last run %dh ago (as-of %s, status %s).",
+                ageHours,
+                latest.asOf,
+                latest.status,
+            )
+        }
+    }
+
+    private companion object {
+        // 24h daily cadence + 1h grace for run duration / a delayed scheduler.
+        const val DAILY_SLA_HOURS = 25L
+    }
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -11,6 +11,7 @@ import com.openbank.ledger.application.port.out.TieOutRunRepository
 import com.openbank.ledger.domain.model.GlAccount
 import com.openbank.ledger.domain.model.TieOutRunRecord
 import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.libs.domain.identifiers.Ids
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.scheduler.Scheduled
@@ -21,7 +22,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.util.UUID
 
 /**
  * Daily sub-ledger tie-out check (ADR-0039 Phase B). Runs at 06:00 CET after the previous
@@ -112,7 +112,9 @@ class TieOutScheduler(
         try {
             runRepository.save(
                 TieOutRunRecord(
-                    id = UUID.randomUUID(),
+                    // Durable, time-ordered run id (ADR-0106): rows are written chronologically
+                    // and read newest-first, so UUIDv7 keeps the B-tree insert local.
+                    id = Ids.newId(),
                     asOf = asOf,
                     runAt = Instant.now(clock),
                     status = status,

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -7,15 +7,21 @@ package com.openbank.ledger.infrastructure.schedule
 import com.openbank.ledger.application.port.`in`.GetControlAccountTieOutQuery
 import com.openbank.ledger.application.port.`in`.LedgerUseCase
 import com.openbank.ledger.application.port.out.GlAccountRepository
+import com.openbank.ledger.application.port.out.TieOutRunRepository
 import com.openbank.ledger.domain.model.GlAccount
+import com.openbank.ledger.domain.model.TieOutRunRecord
+import com.openbank.ledger.domain.model.TieOutRunStatus
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.runBlocking
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.util.UUID
 
 /**
  * Daily sub-ledger tie-out check (ADR-0039 Phase B). Runs at 06:00 CET after the previous
@@ -24,13 +30,19 @@ import java.time.ZoneId
  * For each deposit-control account (2100–2103) asserts:
  *   Σ per-customer sub-ledger net == GL control-account net
  *
- * A non-zero delta increments `openbank.subledger.tieout.break` (fires SubledgerTieOutBreak
- * alert) and logs ERROR. The scheduler never crashes — failures are caught and logged.
+ * A non-zero delta increments `openbank.subledger.tieout.break` (the SubledgerTieOutBreak
+ * PrometheusRule pages on any increase) and logs ERROR. Every run — OK, BREAK or ERROR —
+ * persists a [TieOutRunRecord] so the control is provable from data, and so
+ * [TieOutFreshnessWatchdog] can escalate a MISSING run (the #855 failure mode: a control
+ * that silently stops running is invisible in metrics that only fire on breaks).
+ * The scheduler never crashes — failures are caught, logged and recorded as ERROR.
  */
 @ApplicationScoped
 class TieOutScheduler(
     private val ledgerUseCase: LedgerUseCase,
     private val glAccountRepository: GlAccountRepository,
+    private val runRepository: TieOutRunRepository,
+    private val clock: Clock,
     registry: MeterRegistry,
 ) {
     private val log: Logger = Logger.getLogger(TieOutScheduler::class.java)
@@ -49,7 +61,9 @@ class TieOutScheduler(
     fun runTieOut(): Unit = runBlocking {
         val asOf = LocalDate.now(zone).minusDays(1)
         log.infof("Sub-ledger tie-out check for %s", asOf)
+        var checked = 0
         var breaks = 0
+        var errors = 0
         GlAccount.DEPOSIT_CONTROL_CODES.forEach { code ->
             try {
                 val account = glAccountRepository.findByCode(code) ?: run {
@@ -59,6 +73,7 @@ class TieOutScheduler(
                 val tieOuts = ledgerUseCase.getControlAccountTieOut(
                     GetControlAccountTieOutQuery(controlAccountId = account.id, asOf = asOf),
                 )
+                checked++
                 if (tieOuts.isEmpty()) {
                     log.infof("Tie-out: control account code=%s has no activity as of %s — OK", code, asOf)
                     return@forEach
@@ -77,11 +92,39 @@ class TieOutScheduler(
                     )
                 }
             } catch (@Suppress("TooGenericExceptionCaught") ex: Exception) {
+                errors++
                 log.errorf(ex, "Tie-out check failed for control account code=%s: %s", code, ex.message)
             }
         }
-        if (breaks == 0) {
+        if (breaks == 0 && errors == 0) {
             log.infof("Sub-ledger tie-out OK for %s", asOf)
+        }
+        recordRun(asOf, checked, breaks, errors)
+    }
+
+    private suspend fun recordRun(asOf: LocalDate, checked: Int, breaks: Int, errors: Int) {
+        // BREAK outranks ERROR: a confirmed integrity incident beats an incomplete check.
+        val status = when {
+            breaks > 0 -> TieOutRunStatus.BREAK
+            errors > 0 -> TieOutRunStatus.ERROR
+            else -> TieOutRunStatus.OK
+        }
+        try {
+            runRepository.save(
+                TieOutRunRecord(
+                    id = UUID.randomUUID(),
+                    asOf = asOf,
+                    runAt = Instant.now(clock),
+                    status = status,
+                    accountsChecked = checked,
+                    breaks = breaks,
+                    errors = errors,
+                ),
+            )
+        } catch (@Suppress("TooGenericExceptionCaught") ex: Exception) {
+            // The run itself completed; an unpersisted record must not crash the scheduler.
+            // The freshness watchdog will surface the missing row within its SLA.
+            log.errorf(ex, "Tie-out run record persist failed (status=%s asOf=%s): %s", status, asOf, ex.message)
         }
     }
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -57,49 +57,65 @@ class TieOutScheduler(
         timeZone = "Europe/Prague",
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
-    @Suppress("TooGenericExceptionCaught") // scheduler must survive any infra failure (DB, Kafka, serialization)
     fun runTieOut(): Unit = runBlocking {
         val asOf = LocalDate.now(zone).minusDays(1)
         log.infof("Sub-ledger tie-out check for %s", asOf)
-        var checked = 0
-        var breaks = 0
-        var errors = 0
-        GlAccount.DEPOSIT_CONTROL_CODES.forEach { code ->
-            try {
-                val account = glAccountRepository.findByCode(code) ?: run {
-                    log.infof("Tie-out: deposit-control account code=%s not yet seeded — skipping", code)
-                    return@forEach
-                }
-                val tieOuts = ledgerUseCase.getControlAccountTieOut(
-                    GetControlAccountTieOutQuery(controlAccountId = account.id, asOf = asOf),
-                )
-                checked++
-                if (tieOuts.isEmpty()) {
-                    log.infof("Tie-out: control account code=%s has no activity as of %s — OK", code, asOf)
-                    return@forEach
-                }
-                tieOuts.filter { !it.isTiedOut }.forEach { tieOut ->
-                    breakCounter.increment()
-                    breaks++
-                    log.errorf(
-                        "Sub-ledger tie-out BREAK: control account code=%s currency=%s glNet=%s subLedgerNet=%s delta=%s asOf=%s",
-                        code,
-                        tieOut.currency,
-                        tieOut.glNet,
-                        tieOut.subLedgerNet,
-                        tieOut.delta,
-                        asOf,
-                    )
-                }
-            } catch (@Suppress("TooGenericExceptionCaught") ex: Exception) {
-                errors++
-                log.errorf(ex, "Tie-out check failed for control account code=%s: %s", code, ex.message)
-            }
-        }
+        // Aggregate per-account outcomes rather than mutating counters inside the loop lambda:
+        // the accumulation is the same, but it reads as one expression and CodeQL can actually
+        // follow it (mutable captures across a lambda boundary read to it as never-written).
+        val outcomes = GlAccount.DEPOSIT_CONTROL_CODES.map { code -> checkControlAccount(code, asOf) }
+        val checked = outcomes.count { it.checked }
+        val breaks = outcomes.sumOf { it.breaks }
+        val errors = outcomes.count { it.failed }
         if (breaks == 0 && errors == 0) {
             log.infof("Sub-ledger tie-out OK for %s", asOf)
         }
         recordRun(asOf, checked, breaks, errors)
+    }
+
+    /**
+     * Checks one deposit-control account. A missing (not yet seeded) account is neither checked
+     * nor an error; an account with no activity as of the date IS checked and ties out trivially.
+     */
+    @Suppress("TooGenericExceptionCaught") // scheduler must survive any infra failure (DB, Kafka, serialization)
+    private suspend fun checkControlAccount(code: String, asOf: LocalDate): AccountOutcome = try {
+        val account = glAccountRepository.findByCode(code)
+        if (account == null) {
+            log.infof("Tie-out: deposit-control account code=%s not yet seeded — skipping", code)
+            AccountOutcome.SKIPPED
+        } else {
+            val tieOuts = ledgerUseCase.getControlAccountTieOut(
+                GetControlAccountTieOutQuery(controlAccountId = account.id, asOf = asOf),
+            )
+            if (tieOuts.isEmpty()) {
+                log.infof("Tie-out: control account code=%s has no activity as of %s — OK", code, asOf)
+            }
+            val broken = tieOuts.filter { !it.isTiedOut }
+            broken.forEach { tieOut ->
+                breakCounter.increment()
+                log.errorf(
+                    "Sub-ledger tie-out BREAK: control account code=%s currency=%s glNet=%s subLedgerNet=%s delta=%s asOf=%s",
+                    code,
+                    tieOut.currency,
+                    tieOut.glNet,
+                    tieOut.subLedgerNet,
+                    tieOut.delta,
+                    asOf,
+                )
+            }
+            AccountOutcome(checked = true, breaks = broken.size, failed = false)
+        }
+    } catch (ex: Exception) {
+        log.errorf(ex, "Tie-out check failed for control account code=%s: %s", code, ex.message)
+        AccountOutcome.FAILED
+    }
+
+    /** One control account's contribution to the run totals. */
+    private data class AccountOutcome(val checked: Boolean, val breaks: Int, val failed: Boolean) {
+        companion object {
+            val SKIPPED = AccountOutcome(checked = false, breaks = 0, failed = false)
+            val FAILED = AccountOutcome(checked = false, breaks = 0, failed = true)
+        }
     }
 
     private suspend fun recordRun(asOf: LocalDate, checked: Int, breaks: Int, errors: Int) {

--- a/openbank-ledger-service/src/main/resources/db/migration/V16__tieout_runs.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V16__tieout_runs.sql
@@ -1,0 +1,26 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- ADR-0039 Phase B hardening — persist every sub-ledger tie-out run.
+--
+-- The 06:00 tie-out previously left no durable record: a break only incremented a counter
+-- and logged ERROR, and a run that failed outright (DB glitch at 06:00) left NOTHING — the
+-- exact silent-missing-control failure mode balance-service hit in issue #855 (41 unnoticed
+-- days). One row per run makes both cases provable from data: a break is a recorded incident,
+-- and the ABSENCE of a fresh row is what TieOutFreshnessWatchdog escalates.
+--
+-- NEW table only; purely additive and online-safe (no lock on hot journal tables).
+
+CREATE TABLE ledger_tieout_runs (
+    id               UUID PRIMARY KEY,
+    as_of            DATE         NOT NULL,
+    run_at           TIMESTAMPTZ  NOT NULL,
+    status           VARCHAR(16)  NOT NULL
+        CONSTRAINT chk_tieout_run_status CHECK (status IN ('OK', 'BREAK', 'ERROR')),
+    accounts_checked INT          NOT NULL,
+    breaks           INT          NOT NULL,
+    errors           INT          NOT NULL
+);
+
+-- The watchdog reads "latest run" every hour; the day-end operator view reads recent history.
+CREATE INDEX idx_tieout_runs_run_at ON ledger_tieout_runs (run_at DESC);

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdogTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdogTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.schedule
+
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.domain.model.TieOutRunRecord
+import com.openbank.ledger.domain.model.TieOutRunStatus
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * The watchdog's contract is "never throw, always classify" — the ERROR-log side effects are
+ * asserted operationally via Loki; here we pin that each state (absent, fresh-OK, stale,
+ * fresh-ERROR) is readable without an exception, so a repo glitch can't kill the hourly tick.
+ */
+class TieOutFreshnessWatchdogTest {
+
+    private val now = Instant.parse("2026-07-16T10:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val runs = mockk<TieOutRunRepository>()
+    private val watchdog = TieOutFreshnessWatchdog(runs, clock)
+
+    private fun run(age: Duration, status: TieOutRunStatus) = TieOutRunRecord(
+        id = UUID.randomUUID(),
+        asOf = LocalDate.of(2026, 7, 15),
+        runAt = now.minus(age),
+        status = status,
+        accountsChecked = 4,
+        breaks = 0,
+        errors = if (status == TieOutRunStatus.ERROR) 1 else 0,
+    )
+
+    @Test
+    fun `handles absence of any run`() = runBlocking {
+        coEvery { runs.findLatest() } returns null
+        watchdog.checkFreshness() // must not throw; logs ERROR
+    }
+
+    @Test
+    fun `fresh OK run passes quietly`() = runBlocking {
+        coEvery { runs.findLatest() } returns run(Duration.ofHours(4), TieOutRunStatus.OK)
+        watchdog.checkFreshness()
+    }
+
+    @Test
+    fun `stale run is escalated without throwing`() = runBlocking {
+        coEvery { runs.findLatest() } returns run(Duration.ofHours(26), TieOutRunStatus.OK)
+        watchdog.checkFreshness()
+    }
+
+    @Test
+    fun `fresh ERROR run is escalated without throwing`() = runBlocking {
+        coEvery { runs.findLatest() } returns run(Duration.ofHours(4), TieOutRunStatus.ERROR)
+        watchdog.checkFreshness()
+    }
+}

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdogTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdogTest.kt
@@ -41,25 +41,25 @@ class TieOutFreshnessWatchdogTest {
     )
 
     @Test
-    fun `handles absence of any run`() = runBlocking {
+    fun `handles absence of any run`(): Unit = runBlocking {
         coEvery { runs.findLatest() } returns null
         watchdog.checkFreshness() // must not throw; logs ERROR
     }
 
     @Test
-    fun `fresh OK run passes quietly`() = runBlocking {
+    fun `fresh OK run passes quietly`(): Unit = runBlocking {
         coEvery { runs.findLatest() } returns run(Duration.ofHours(4), TieOutRunStatus.OK)
         watchdog.checkFreshness()
     }
 
     @Test
-    fun `stale run is escalated without throwing`() = runBlocking {
+    fun `stale run is escalated without throwing`(): Unit = runBlocking {
         coEvery { runs.findLatest() } returns run(Duration.ofHours(26), TieOutRunStatus.OK)
         watchdog.checkFreshness()
     }
 
     @Test
-    fun `fresh ERROR run is escalated without throwing`() = runBlocking {
+    fun `fresh ERROR run is escalated without throwing`(): Unit = runBlocking {
         coEvery { runs.findLatest() } returns run(Duration.ofHours(4), TieOutRunStatus.ERROR)
         watchdog.checkFreshness()
     }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.ledger.infrastructure.schedule
+
+import com.openbank.ledger.application.port.`in`.LedgerUseCase
+import com.openbank.ledger.application.port.out.GlAccountRepository
+import com.openbank.ledger.application.port.out.TieOutRunRepository
+import com.openbank.ledger.domain.model.ControlAccountTieOut
+import com.openbank.ledger.domain.model.GlAccount
+import com.openbank.ledger.domain.model.GlAccountType
+import com.openbank.ledger.domain.model.TieOutRunRecord
+import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.libs.domain.money.CurrencyCode
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+class TieOutSchedulerTest {
+
+    private val ledger = mockk<LedgerUseCase>()
+    private val glAccounts = mockk<GlAccountRepository>()
+    private val runs = mockk<TieOutRunRepository>()
+    private val registry = SimpleMeterRegistry()
+    private val clock = Clock.fixed(Instant.parse("2026-07-16T04:00:00Z"), ZoneOffset.UTC)
+
+    private val scheduler = TieOutScheduler(ledger, glAccounts, runs, clock, registry)
+
+    private fun control(code: String) = GlAccount(
+        id = UUID.randomUUID(),
+        code = code,
+        name = "Deposit control $code",
+        type = GlAccountType.LIABILITY,
+        currency = CurrencyCode("CZK"),
+        parentId = null,
+        isLeaf = true,
+        isEnabled = true,
+        createdAt = Instant.EPOCH,
+    )
+
+    private fun tieOut(controlId: UUID, delta: BigDecimal) = ControlAccountTieOut(
+        controlAccountId = controlId,
+        currency = "CZK",
+        asOf = LocalDate.of(2026, 7, 15),
+        glNet = BigDecimal("100"),
+        subLedgerNet = BigDecimal("100").add(delta),
+        delta = delta,
+        lines = emptyList(),
+    )
+
+    @Test
+    fun `persists OK run when every control ties out`() {
+        val account = control("2100")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns account
+        coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal.ZERO))
+        val saved = slot<TieOutRunRecord>()
+        coEvery { runs.save(capture(saved)) } answers { saved.captured }
+
+        scheduler.runTieOut()
+
+        assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.OK)
+        assertThat(saved.captured.accountsChecked).isEqualTo(1)
+        assertThat(saved.captured.breaks).isZero()
+        assertThat(saved.captured.errors).isZero()
+        assertThat(registry.counter("openbank.subledger.tieout.break").count()).isZero()
+    }
+
+    @Test
+    fun `persists BREAK run and increments counter on delta`() {
+        val account = control("2100")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns account
+        coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal("200")))
+        val saved = slot<TieOutRunRecord>()
+        coEvery { runs.save(capture(saved)) } answers { saved.captured }
+
+        scheduler.runTieOut()
+
+        assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.BREAK)
+        assertThat(saved.captured.breaks).isEqualTo(1)
+        assertThat(registry.counter("openbank.subledger.tieout.break").count()).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `persists ERROR run when a control check throws`() {
+        val account = control("2100")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns account
+        coEvery { ledger.getControlAccountTieOut(any()) } throws IllegalStateException("db down")
+        val saved = slot<TieOutRunRecord>()
+        coEvery { runs.save(capture(saved)) } answers { saved.captured }
+
+        scheduler.runTieOut()
+
+        assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.ERROR)
+        assertThat(saved.captured.errors).isEqualTo(1)
+        assertThat(saved.captured.accountsChecked).isZero()
+    }
+
+    @Test
+    fun `BREAK outranks ERROR when both occur`() {
+        val broken = control("2100")
+        val failing = control("2101")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns broken
+        coEvery { glAccounts.findByCode("2101") } returns failing
+        coEvery { ledger.getControlAccountTieOut(match { it.controlAccountId == broken.id }) } returns
+            listOf(tieOut(broken.id, BigDecimal("1")))
+        coEvery { ledger.getControlAccountTieOut(match { it.controlAccountId == failing.id }) } throws
+            IllegalStateException("db down")
+        val saved = slot<TieOutRunRecord>()
+        coEvery { runs.save(capture(saved)) } answers { saved.captured }
+
+        scheduler.runTieOut()
+
+        assertThat(saved.captured.status).isEqualTo(TieOutRunStatus.BREAK)
+        assertThat(saved.captured.breaks).isEqualTo(1)
+        assertThat(saved.captured.errors).isEqualTo(1)
+    }
+
+    @Test
+    fun `scheduler survives a run-record persist failure`() {
+        val account = control("2100")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns account
+        coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal.ZERO))
+        coEvery { runs.save(any()) } throws IllegalStateException("insert failed")
+
+        scheduler.runTieOut() // must not throw
+
+        coVerify(exactly = 1) { runs.save(any()) }
+    }
+}


### PR DESCRIPTION
## What

The 06:00 sub-ledger tie-out (ADR-0039 Phase B) was detect-only with a dead-end signal (closing audit, findings L-1/L-9): a break only incremented `openbank.subledger.tieout.break` and logged ERROR — **no PrometheusRule referenced that metric anywhere in gitops** (the scheduler's doc claimed an alert that never existed), no run record was persisted, and a run that failed outright left nothing. That is the exact silent-missing-control failure mode balance-service hit in #855 (41 unnoticed days), on the ledger side.

- **`ledger_tieout_runs` (V16)** — one row per run (OK/BREAK/ERROR + accounts checked/breaks/errors), persisted whatever the outcome; the control is now provable from data.
- **`TieOutFreshnessWatchdog`** — hourly; escalates a missing/stale run (>25h SLA) or an ERROR-status run to ERROR logs (Alloy → Loki paging path), mirroring balance-service's `ReconciliationFreshnessWatchdog`.
- **`SubledgerTieOutBreak` PrometheusRule (critical)** — pages on any increase of the break counter within the daily cycle (25h window = cadence + grace); an unresolved break is re-detected and re-incremented by the next 06:00 run, so the alert cannot silently age out between runs.
- Scheduler KDoc now tells the truth about the alert wiring.

BREAK vs ERROR are distinct on purpose: a break is a confirmed integrity incident (GL ≠ sub-ledger); an error means the day's control is incomplete — its own incident class, covered by the watchdog rather than the metric rule.

## Tests

- `TieOutSchedulerTest`: OK/BREAK/ERROR classification, BREAK-outranks-ERROR, counter increments, scheduler survives a persist failure.
- `TieOutFreshnessWatchdogTest`: absent/fresh/stale/error states never throw.
- `:openbank-ledger-service:test` + ktlint + detekt green (JDK 25).

Refs #855, #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)