### PR TITLE
fix(infra): bind the post-attest verify to the SBOM the run just built

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,21 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
 - **A provenance failure must fail the build that caused it.** `continue-on-error` /
   `|| echo "::warning::"` on a sign/attest step buys a green deploy that produces an
   undeployable image — the damage lands days later on whoever is on call, not on the author.
-  Verify with `cosign verify-attestation` after attesting; never trust `attest` exit 0 alone.
+  Verify with `cosign verify-attestation` after attesting; never trust `attest` exit 0 alone —
+  but see the next bullet: an unqualified verify does not prove YOUR envelope is the good one.
+- **`cosign attest` is ADDITIVE, so a green `verify-attestation` is not necessarily about your
+  build.** Each attest APPENDS an envelope to the image's `.att` tag instead of replacing, and
+  `verify-attestation` exits 0 if **any** envelope verifies. cosign v2 has no strict/newest-envelope
+  flag (`--policy` is any-match too — it errors only when *zero* attestations match). So a trivy run
+  that emits a truncated SBOM and still exits 0 pushes a junk predicate, and the verify passes
+  against an *earlier* build's envelope: green build, image shipped with provenance that is
+  technically present and substantively worthless. Proven live — an image carrying both a
+  549-component SBOM and a 2-byte `{}` predicate verifies PASS. Two layers, both needed: check the
+  SBOM BEFORE attesting (parses as JSON, `bomFormat == "CycloneDX"`, non-zero `components` — a junk
+  envelope, once pushed, can never be un-pushed, only outlived by the next real build), and bind the
+  post-attest verify to the run by requiring the CycloneDX `serialNumber` trivy minted for THIS SBOM
+  to appear among the envelopes that verified. `openbank-infra/scripts/lib/cosign-attest.sh` does
+  both — source it, never hand-roll `attest` + `verify`.
 
 ### OPA / Rego policies (ADR-0031/ADR-0034)
 - **Editing any shared policy source ripples the OPA bundle checksum of every service.** Each

--- a/openbank-infra/scripts/lib/cosign-attest.sh
+++ b/openbank-infra/scripts/lib/cosign-attest.sh
@@ -13,7 +13,7 @@
 # unattested image is admitted never, so the gap only surfaces when a pod happens to
 # reschedule, long after the push that caused it.
 #
-# Two invariants this helper exists to hold:
+# Three invariants this helper exists to hold:
 #
 #   1. --platform is ALWAYS passed to `trivy image`. trivy defaults to linux/amd64 for
 #      REMOTE (registry) scans regardless of host arch. Fleet images are built
@@ -23,6 +23,13 @@
 #   2. A failed attestation is FATAL (return 1). The image is verified with
 #      `cosign verify-attestation` after the fact, so "attest exited 0" is not taken
 #      on trust. A silently-unattested image is an image that cannot be deployed.
+#   3. The SBOM is proven substantive BEFORE it is attested, and the post-attest verify
+#      is bound to the envelope THIS run pushed. `cosign attest` APPENDS an envelope to
+#      the image's `.att` tag rather than replacing, and `cosign verify-attestation`
+#      passes when ANY envelope verifies — so an unqualified verify can be reporting on
+#      a previous build's good SBOM while the envelope just pushed is empty. cosign v2
+#      offers no "verify the newest envelope" flag (--policy is any-match too), so the
+#      binding is done here, on the CycloneDX serialNumber trivy mints per run.
 #
 # cosign v2 is pinned ON PURPOSE: kyverno 3.2.6 discovers signatures/attestations only
 # via the legacy `sha256-<digest>.sig` / `.att` tag scheme. cosign v3 writes OCI 1.1
@@ -58,14 +65,51 @@ resolve_cosign_v2() {
   printf '%s\n' "$bin"
 }
 
+# assert_cyclonedx_sbom <sbom-file>
+#
+# Fail unless the file is a substantive CycloneDX document. trivy can exit 0 having
+# written a truncated or component-less BOM (a partial scan, a disk-full write, a broken
+# image index); attesting one produces provenance that is technically present and
+# substantively worthless — exactly the "silently-bad provenance step" this helper exists
+# to stop. Echoes the BOM serialNumber on success; it is unique per trivy run, which is
+# what lets the post-attest verify below bind to THIS run's envelope.
+assert_cyclonedx_sbom() {
+  local sbom="$1" format components serial
+
+  if ! jq -e . "$sbom" >/dev/null 2>&1; then
+    echo "ERROR: ${sbom} is not valid JSON — trivy produced a truncated SBOM." >&2
+    return 1
+  fi
+  format="$(jq -r '.bomFormat // empty' "$sbom")"
+  if [ "$format" != "CycloneDX" ]; then
+    echo "ERROR: ${sbom} has bomFormat='${format}', expected 'CycloneDX'." >&2
+    return 1
+  fi
+  components="$(jq -r '.components // [] | length' "$sbom")"
+  if [ "$components" -lt 1 ]; then
+    echo "ERROR: ${sbom} lists zero components — refusing to attest an empty SBOM." >&2
+    return 1
+  fi
+  serial="$(jq -r '.serialNumber // empty' "$sbom")"
+  if [ -z "$serial" ]; then
+    echo "ERROR: ${sbom} carries no serialNumber — the attestation could not be bound" >&2
+    echo "       to this run, so it would not be provable. Refusing to attest." >&2
+    return 1
+  fi
+
+  echo "    SBOM sane: ${components} components, serialNumber=${serial}" >&2
+  printf '%s\n' "$serial"
+}
+
 # cosign_attest_sbom <image-ref> <platform> [cosign-bin]
 #
-# Generate a CycloneDX SBOM for the image with trivy, bind it to the image digest with
-# `cosign attest`, then PROVE it landed with `cosign verify-attestation`. Returns 0 only
-# if the attestation is verifiable afterwards; returns 1 on any failure.
+# Generate a CycloneDX SBOM for the image with trivy, check it is substantive, bind it to
+# the image digest with `cosign attest`, then PROVE that this run's envelope landed with
+# `cosign verify-attestation`. Returns 0 only if that envelope is verifiable afterwards;
+# returns 1 on any failure.
 cosign_attest_sbom() {
   local image="$1" platform="$2" bin="${3:-}"
-  local sbom
+  local sbom serial envelopes
 
   if [ -z "$image" ] || [ -z "$platform" ]; then
     echo "ERROR: cosign_attest_sbom requires <image> <platform>." >&2
@@ -83,6 +127,10 @@ cosign_attest_sbom() {
     echo "ERROR: trivy unavailable — cannot generate the SBOM for ${image}." >&2
     return 1
   fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq unavailable — cannot check the SBOM or bind the attestation to it." >&2
+    return 1
+  fi
 
   sbom="${TMPDIR:-/tmp}/$(echo "$image" | tr '/:@' '___').cdx.json"
 
@@ -92,6 +140,10 @@ cosign_attest_sbom() {
     echo "ERROR: trivy SBOM generation failed for ${image} (platform=${platform})." >&2
     return 1
   fi
+
+  # Check the SBOM BEFORE attesting: a junk predicate that reaches `cosign attest` is
+  # permanent — the envelope cannot be un-pushed, only outlived by the next real build.
+  serial="$(assert_cyclonedx_sbom "$sbom")" || return 1
 
   echo "==> cosign attest (cyclonedx) ${image}"
   if ! COSIGN_YES=true "$bin" attest --key "$COSIGN_KEY" --type cyclonedx \
@@ -103,13 +155,28 @@ cosign_attest_sbom() {
   # Never trust `attest` exit 0 alone: verify the attestation is actually discoverable
   # the same way kyverno will discover it at admission.
   echo "==> cosign verify-attestation ${image}"
-  if ! COSIGN_YES=true "$bin" verify-attestation --key "$COSIGN_KEY" --type cyclonedx \
-       "$image" >/dev/null 2>&1; then
+  if ! envelopes="$(COSIGN_YES=true "$bin" verify-attestation --key "$COSIGN_KEY" \
+       --type cyclonedx "$image" 2>/dev/null)"; then
     echo "ERROR: cosign verify-attestation failed for ${image} — the attestation did not land." >&2
     return 1
   fi
 
-  echo "    attested + verified SBOM (key=${COSIGN_KEY})"
+  # …and do not trust that a PASS is about this run. verify-attestation prints every
+  # envelope that verified, one JSON line each, and exits 0 if ANY of them did; since
+  # `attest` appends, an older good envelope covers for a new bad one. Require the
+  # serialNumber of the SBOM just generated to appear among them. `try … catch empty`
+  # keeps a pre-existing undecodable envelope from failing the run on someone else's
+  # behalf — only the absence of OUR serial is fatal.
+  if ! printf '%s\n' "$envelopes" | jq -e -s --arg serial "$serial" \
+       '[ .[] | try (.payload | @base64d | fromjson | .predicate.serialNumber) catch empty ]
+        | index($serial) != null' >/dev/null 2>&1; then
+    echo "ERROR: cosign verify-attestation for ${image} verified no envelope carrying this" >&2
+    echo "       run's SBOM (serialNumber=${serial}). The attestation that verified belongs" >&2
+    echo "       to an earlier build — this image's own provenance did not land." >&2
+    return 1
+  fi
+
+  echo "    attested + verified SBOM (key=${COSIGN_KEY}, serialNumber=${serial})"
   return 0
 }
 

--- a/openbank-infra/scripts/lib/cosign-attest.sh
+++ b/openbank-infra/scripts/lib/cosign-attest.sh
@@ -85,9 +85,12 @@ assert_cyclonedx_sbom() {
     echo "ERROR: ${sbom} has bomFormat='${format}', expected 'CycloneDX'." >&2
     return 1
   fi
-  components="$(jq -r '.components // [] | length' "$sbom")"
+  # Type-check before counting: jq's `length` is defined on every type, so a scalar
+  # `.components` ("scan_failed", 5) would report a non-zero "count" and sail through.
+  components="$(jq -r 'if (.components | type) == "array" then (.components | length) else 0 end' "$sbom")"
   if [ "$components" -lt 1 ]; then
-    echo "ERROR: ${sbom} lists zero components — refusing to attest an empty SBOM." >&2
+    echo "ERROR: ${sbom} has no components array, or it is empty — refusing to attest" >&2
+    echo "       an SBOM that inventories nothing." >&2
     return 1
   fi
   serial="$(jq -r '.serialNumber // empty' "$sbom")"


### PR DESCRIPTION
## Why

`lib/cosign-attest.sh` (PR #1177) runs `cosign verify-attestation` after `cosign attest` so that *"attest exited 0" is not taken on trust*. **The check is weaker than its comment claims.**

`cosign attest` is **additive** — it appends an envelope to the image's `.att` tag rather than replacing — and `cosign verify-attestation` exits 0 if **any** envelope verifies. So the post-attest verify never proved that *the envelope this run pushed* is good; it can pass against a previously-good one.

Verified on the live `openbank-keycloak:26.6.3-optimized`, which currently carries two envelopes:

| envelope | `bomFormat` | components | predicate bytes |
|---|---|---|---|
| 0 | `CycloneDX` | 549 | 563708 |
| 1 | *(absent)* | *(absent)* | 2 — `{}` |

`cosign verify-attestation --key awskms:///alias/openbank-cosign-signing --type cyclonedx <image>` returns **PASS** (exit 0) against that pair. *(Read-only check. The junk envelope is left as-is — it self-clears on the next real build.)*

The failure mode #1177 set out to close therefore stayed open at one remove: trivy emits a truncated/empty SBOM but exits 0 → `attest` pushes a junk predicate → `verify-attestation` passes against an *older* envelope → build goes green → the image ships with provenance that is technically present and substantively worthless. Low probability, but a silently-bad provenance step is exactly what caused the 2026-07-16 fleet outage.

## What changed

Two layers, because neither covers the other's case:

1. **Check the SBOM before attesting** (`assert_cyclonedx_sbom`) — valid JSON, `bomFormat == "CycloneDX"`, non-zero `components`, `serialNumber` present. A junk predicate that reaches `cosign attest` is permanent: it cannot be un-pushed, only outlived. This is the cheap layer and it catches the trivy-truncation case at the source.
2. **Bind the post-attest verify to this run** — trivy mints a fresh CycloneDX `serialNumber` (`urn:uuid:…`) per run, so the verify now requires that serial to appear among the envelopes that verified, decoding them out of `verify-attestation`'s stdout with `jq … @base64d`. A pre-existing undecodable envelope is tolerated (`try … catch empty`) — only the absence of *this run's* serial is fatal.

On the obvious alternative: **cosign v2 offers no strict/newest-envelope flag.** `--policy` is any-match too (cosign errors only when *zero* attestations match), so it cannot express this either. The serialNumber binding is the least fragile option available. If cosign ever gains a strict mode, layer 2 should collapse into it.

The **cosign v2 pin and its rationale are untouched**: kyverno 3.2.6 discovers signatures/attestations only via the legacy `sha256-<digest>.sig` / `.att` tag scheme, and cosign v3 writes OCI 1.1 referrers it cannot find.

## Testing

No build-push script was run, and no `sign`/`attest`/`clean` was issued against any real image. Both new code paths were exercised against fixtures derived from the live envelopes above:

- `assert_cyclonedx_sbom` — good SBOM (rc=0, 549 components); `{}` (rc=1, bomFormat); truncated JSON (rc=1, parse); `components: []` (rc=1); `serialNumber` deleted (rc=1).
- Envelope binding, against the real 2-envelope `verify-attestation` output — this run's serial → rc=0 (passes *despite* the junk envelope alongside); a foreign serial → rc=1 (the regression this PR closes); both cases again with an extra undecodable envelope appended → unchanged.
- `bash -n` clean; `shellcheck -S warning` clean.

## Linked issues

N/A — no tracking issue; this is a follow-up correction to #1177 (which closed #310), found while reading the helper.