### PR TITLE
fix(ledger): add balance-service provider states to broker pact verification

### DIFF
--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/contract/LedgerPactBrokerProviderVerificationTest.kt
@@ -78,4 +78,27 @@ class LedgerPactBrokerProviderVerificationTest {
     fun stateWithSeededChartOfAccounts() {
         // No-op — see docstring.
     }
+
+    /**
+     * The broker serves EVERY consumer's pact for this provider, not just billing-service's, so
+     * this class must handle every state its git-pact counterpart does: a state this class lacks
+     * fails verification with MissingStateChangeMethod, the result publishes as a failure, and
+     * `can-i-deploy` then blocks ledger-service deploys on a pair that is otherwise healthy —
+     * which is exactly what happened to balance-service's two trial-balance interactions and kept
+     * the #945 reversal fix out of the sandbox.
+     *
+     * Bodies mirror [LedgerPactProviderVerificationTest] verbatim (no-op by design): the pact uses
+     * type matchers, so any valid trial-balance response satisfies the contract shape, and seeding
+     * real double-entry data here would couple the provider test to the internal posting API — the
+     * anti-pattern Pact exists to avoid. LedgerApiIT covers the seeded-data path.
+     */
+    @State("ledger has journal entries for the reporting date")
+    fun stateWithJournalEntries() {
+        // No-op — see docstring.
+    }
+
+    @State("ledger has no journal entries")
+    fun stateWithNoJournalEntries() {
+        // No setup needed — a fresh Testcontainer DB has no journals by default.
+    }
 }


### PR DESCRIPTION
## What

**This is the gate that has kept the #945 trial-balance reversal fix out of the sandbox since 2026-07-12.**

#1018 added `LedgerPactBrokerProviderVerificationTest` to close the billing-service "no verified pact" gap (#1009). But the broker serves **every** consumer's pact for this provider, not just billing-service's — including balance-service's two trial-balance interactions. Their provider states were only implemented on the git-pact class, so the new broker class failed:

```
MissingStateChangeMethod: Did not find a test class method annotated with
@State("ledger has journal entries for the reporting date")
for Interaction "GET trial-balance as-of a specific date"
with Consumer "openbank-balance-service"
```

That failure **publishes to the broker**, so `can-i-deploy` blocks every ledger-service deploy:

```
The verification for the pact between the version of openbank-balance-service currently in
sandbox (dae215b5) and the latest version of openbank-ledger-service with tag main (9b29570e) failed
```

Confirmed live: auto-deploy run 29484258584 built and pushed `sandbox-86eabc2f` fine, then `Gitops PR` logged `[openbank-ledger-service] blocked by can-i-deploy this run — skipping manifest update`. Sandbox is still on `sandbox-31e6692a` (2026-07-12, pre-fix) — i.e. it has been computing trial balances, and year-close content hashes, with the known #939 REVERSED-entry defect, carrying the +200 CZK tie-out residual (#860).

## Fix

Add the two missing `@State` methods, mirroring `LedgerPactProviderVerificationTest` verbatim (no-op by design — the pact uses type matchers, so any valid trial-balance response satisfies the contract shape; seeding real double-entry data would couple the provider test to the internal posting API, the anti-pattern Pact exists to avoid).

Also documents the class invariant that bit here: **a broker-based provider class must handle every state its git-pact counterpart does**, because the broker is not scoped to one consumer.

## Verification

- `:openbank-ledger-service:compileTestKotlin` + ktlint + detekt green (JDK 25).
- The broker class is `@EnabledIfSystemProperty("pactbroker.url")`, so it only actually runs on the main-push lane where the broker is configured; the real proof is the post-merge `can-i-deploy` going green and auto-deploy bumping the gitops tag past `sandbox-31e6692a`. Will confirm on this PR after merge.

Refs #945, #1009, #1018, #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)