### PR TITLE
fix(ci): add clearing-simulator to auto-deploy ALL_SERVICES

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -111,7 +111,18 @@ jobs:
           # gitops manifest, ADR-0162 onboarding-agreement + ADR-0169 SCA-document-binding
           # PRs (#1137, #1142) merged and released — but never in ALL_SERVICES, so every
           # push since it shipped silently deployed nothing. Added here.
-          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-document-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service openbank-control-liveness-sentinel openbank-governance-auditor openbank-release-steward openbank-docs-truth-agent openbank-authz-policy-auditor openbank-flaky-test-hunter'
+            # clearing-simulator: the same gap again, and live. Released (0.4.4), real
+            # Dockerfile (EXPOSE 8139), real gitops manifest — but never in ALL_SERVICES,
+            # so its manifest still pinned the image built on 2026-06-22 and every push
+            # since deployed nothing. It also went unattested for the whole of that window
+            # (its .att dates from the 2026-07-16 hand-fix, its .sig from June), because
+            # the SBOM-attestation policy graduated to Enforce while nothing rebuilt it —
+            # one reschedule in that window and it would have died like keycloak did.
+            # Audit at the time: 50 released components, 47 here; the only legitimate
+            # absentee is admin-ui (own admin-ui-deploy.yml). finrep-service is the third
+            # and needs a Dockerfile first — see #1205, which also tracks a guard so this
+            # list stops drifting out of sync with release-please by hand.
+          ALL_SERVICES='openbank-account-service openbank-ledger-service openbank-transaction-service openbank-pid-service openbank-balance-service openbank-consent-service openbank-psd2-service openbank-tpp-registry-service openbank-agent-service openbank-copilot-service openbank-sca-service openbank-party-service openbank-notification-service openbank-audit-service openbank-kyc-service openbank-document-service openbank-sepa-payment openbank-domestic-payment openbank-aml-service openbank-card-issuance-service openbank-fx-service openbank-standing-order-service openbank-swift-service openbank-sanctions-service openbank-fraud-service openbank-security-scanner openbank-product-catalog openbank-clearing-service openbank-interest-service openbank-dispute-service openbank-sepa-instant openbank-lending-service openbank-statement-service openbank-sdd-service openbank-customer-edge openbank-onboarding-service openbank-settlement-service openbank-finops-agent openbank-devops-agent openbank-billing-service openbank-anacredit-service openbank-control-liveness-sentinel openbank-governance-auditor openbank-release-steward openbank-docs-truth-agent openbank-authz-policy-auditor openbank-flaky-test-hunter openbank-clearing-simulator'
 
           # Manual dispatch: rebuild the requested module(s), or the full deployable
           # fleet when no input is given. Only services that actually carry a gitops


### PR DESCRIPTION
## Why

`openbank-clearing-simulator` is a released component (0.4.4) with a real `Dockerfile` (EXPOSE 8139) and a real gitops manifest — but it was never in `auto-deploy.yml`'s `ALL_SERVICES`. So its manifest still pinned `sandbox-0af2ee215`, **built 2026-06-22**: every push for the last 24 days deployed nothing. Silently, because a service that is never built produces no build failure.

It also sat **unattested for that whole window**. Its `.sig` dates from June; its `.att` carries today's date, from the 2026-07-16 hand-fix. The SBOM-attestation policy graduated to Enforce (#310) while nothing was rebuilding it, so a single pod reschedule in those four days would have failed admission and left it down — exactly how `keycloak` and money-path `sepa-payment` went down today.

## This is the fourth instance of one class

`auto-deploy.yml`'s own comments already document the previous three:

> `merged, released, gitops manifest present — but never in ALL_SERVICES, so every one of their Deployments sat perpetually blocked at the placeholder sandbox-pending tag ... and none had a per-service Dockerfile either.`

> `document-service had the exact same gap ... but never in ALL_SERVICES, so every push since it shipped silently deployed nothing.`

`ALL_SERVICES` is hand-maintained and must stay in sync with release-please's package list; nothing checks that it does. Each recurrence has been fixed by appending an entry and a comment. A comment is not a control — hence the guard tracked in #1205.

**Audit at the time of this PR: 50 released components, 47 in `ALL_SERVICES`.**

| Absentee | Verdict |
|---|---|
| `openbank-admin-ui` | legitimate — has its own `admin-ui-deploy.yml` |
| `openbank-clearing-simulator` | **this PR** |
| `openbank-finrep-service` | needs a `Dockerfile` and an ECR repo first — #1205 |

## Verified before adding, not assumed

Adding a service here makes auto-deploy build it on every relevant push, so a broken entry breaks the pipeline for the whole fleet:

- [x] `./gradlew :openbank-clearing-simulator:build` passes.
- [x] `application.yaml` enables `quarkus.management` on **8087**, matching the manifest's `port: management` probe target. This is the trap that crashlooped `copilot-service` and would have hit `product-catalog` on its first scale-up (#1165) — a manifest probing a management port whose block is absent.
- [x] `EXPOSE 8139` matches `application.yaml` (`http.port: 8139`) and the manifest's `containerPort`. The workflow greps that line for the container port and **silently falls back to 8080** when it is absent or wrong.
- [x] Pod is live and `1/1` — its probes pass today, so the management interface is real, not just configured.
- [x] Not money-path (`openbank-clearing-service` is; `openbank-clearing-simulator` is a different module).
- [x] `actionlint` clean apart from the pre-existing `openbank-build` custom self-hosted runner label (present on `main`, 1 occurrence, unrelated).

One thing worth knowing for review: the per-service `Dockerfile` is **not** used for the build. Both `build-push-service.sh` and this workflow generate their own from a canonical template and only grep the per-service file for its `EXPOSE` line. So `clearing-simulator`'s selective per-module `COPY` — which `anacredit-service`'s Dockerfile explicitly warns against — is inert here.

## Test plan

- [ ] Next push touching `openbank-clearing-simulator/**` builds, signs, attests and opens a gitops bump PR instead of doing nothing.

## Linked issues

Refs #1205