### PR TITLE
fix(vop): match legal forms per token so a different payee is never confirmed

### DIFF
--- a/openbank-admin-ui/src/app/payments/page.tsx
+++ b/openbank-admin-ui/src/app/payments/page.tsx
@@ -366,8 +366,17 @@ function PaymentsContent() {
       setCreateError(t('Vyplňte všechna povinná pole', 'Please fill all required fields'))
       return
     }
-    if (f.instant && f.vopStatus !== 'match' && f.vopStatus !== 'close_match') {
-      setCreateError(t('SCT Inst vyžaduje úspěšné ověření příjemce (VoP)', 'SCT Inst requires successful Verification of Payee'))
+    // VoP fails open (ADR-0171 §3): a lookup that produced no name — a non-domestic IBAN, a
+    // scheme outage — must not refuse the payment, or the control breaches the execution-time
+    // obligation it exists to serve. Only an actual name mismatch blocks; no_data proceeds on
+    // the warning the panel above already shows. This gate predates the real backend, when the
+    // mock could only ever return match/close_match/no_match and no_data was unreachable.
+    if (f.instant && (f.vopStatus === 'idle' || f.vopStatus === 'loading')) {
+      setCreateError(t('SCT Inst vyžaduje ověření příjemce (VoP) — spusťte ověření', 'SCT Inst requires Verification of Payee — run the check first'))
+      return
+    }
+    if (f.instant && f.vopStatus === 'no_match') {
+      setCreateError(t('Jméno příjemce nesouhlasí (VoP NO_MATCH) — platbu nelze odeslat', 'Payee name does not match (VoP NO_MATCH) — payment cannot be sent'))
       return
     }
     setCreating(true)

--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/domain/match/VopNameMatchPolicy.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/domain/match/VopNameMatchPolicy.kt
@@ -58,20 +58,30 @@ class VopNameMatchPolicy(private val maxEditDistance: Int = DEFAULT_MAX_EDIT_DIS
 
         if (supplied == actual) return VopOutcome.MATCH
 
-        val suppliedCore = stripLegalForms(supplied)
-        val actualCore = stripLegalForms(actual)
-        // A legal-form suffix is presentation, not identity: "Acme s.r.o." and "Acme" are the
-        // same payee. Only the suffix differed, so this is a full MATCH, not a near-miss.
-        if (suppliedCore.isNotBlank() && suppliedCore == actualCore) return VopOutcome.MATCH
+        val suppliedTokens = tokenize(supplied)
+        val actualTokens = tokenize(actual)
+        val suppliedStripped = stripLegalForm(suppliedTokens)
+        val actualStripped = stripLegalForm(actualTokens)
+
+        // A legal form is presentation, not identity: "Acme s.r.o." and "Acme" are the same payee,
+        // so drop it when only one side carries one.
+        //
+        // When *both* sides carry one, they are only the same payee if the forms agree — and that
+        // case already returned MATCH on the equality above. Two *different* forms are two
+        // different registered entities: "Acme s.r.o." and "Acme a.s." are distinct companies, and
+        // registering the look-alike form is a known fraud shape. Stripping both would confirm
+        // them as one payee, which is the outcome this control exists to prevent.
+        val bothCarryForm = suppliedStripped != null && actualStripped != null
+        val suppliedCore = if (bothCarryForm) suppliedTokens else suppliedStripped ?: suppliedTokens
+        val actualCore = if (bothCarryForm) actualTokens else actualStripped ?: actualTokens
+
+        if (suppliedCore == actualCore) return VopOutcome.MATCH
 
         return if (isCloseMatch(suppliedCore, actualCore)) VopOutcome.CLOSE_MATCH else VopOutcome.NO_MATCH
     }
 
-    private fun isCloseMatch(supplied: String, actual: String): Boolean {
-        if (supplied.isBlank() || actual.isBlank()) return false
-
-        val suppliedTokens = supplied.split(TOKEN_SEPARATOR).filter { it.isNotBlank() }
-        val actualTokens = actual.split(TOKEN_SEPARATOR).filter { it.isNotBlank() }
+    private fun isCloseMatch(suppliedTokens: List<String>, actualTokens: List<String>): Boolean {
+        if (suppliedTokens.isEmpty() || actualTokens.isEmpty()) return false
 
         // Reordering: "Jiří Raška" vs "Raška Jiří". Same tokens, different order — the payer knows
         // the name, their PSP's field order differs from ours.
@@ -85,7 +95,11 @@ class VopNameMatchPolicy(private val maxEditDistance: Int = DEFAULT_MAX_EDIT_DIS
         if (isSubsetByOneToken(suppliedTokens, actualTokens)) return true
 
         // A single-character typo anywhere in the whole string.
-        return levenshteinWithin(supplied, actual, maxEditDistance)
+        return levenshteinWithin(
+            suppliedTokens.joinToString(" "),
+            actualTokens.joinToString(" "),
+            maxEditDistance,
+        )
     }
 
     /**
@@ -134,26 +148,24 @@ class VopNameMatchPolicy(private val maxEditDistance: Int = DEFAULT_MAX_EDIT_DIS
         }
     }
 
+    private fun tokenize(normalized: String): List<String> =
+        normalized.split(TOKEN_SEPARATOR).filter { it.isNotBlank() }
+
     /**
-     * Strip trailing legal-form designators. Only a *trailing* suffix is removed: "s.r.o." at the
-     * end of "Acme s.r.o." is a legal form, but a company genuinely named "SRO Praha" keeps its
-     * leading token. Returns the input unchanged when stripping would empty it.
+     * [tokens] with one trailing legal-form designator removed, or `null` when they carry none.
+     *
+     * A form is only ever matched as *whole trailing tokens*, never as a character suffix. "as" is
+     * a legal form; "Tomas" is a name that merely ends in those letters. Stripping by character
+     * suffix turned "Jan Tomas" into "Jan Tom" and then reported it a full MATCH against a
+     * different payee — the exact outcome VoP exists to prevent.
+     *
+     * Only a *trailing* form is removed: a company genuinely named "SRO Praha" keeps its leading
+     * token. Longest form first, so "spol s r o" wins over the "s r o" nested inside it. A name
+     * consisting of nothing but a legal form keeps it, since an empty core identifies no one.
      */
-    private fun stripLegalForms(normalized: String): String {
-        var result = normalized
-        var changed = true
-        while (changed) {
-            changed = false
-            for (form in LEGAL_FORMS) {
-                val candidate = result.removeSuffix(form).trim().removeSuffix(",").trim()
-                if (candidate != result && candidate.isNotBlank()) {
-                    result = candidate
-                    changed = true
-                }
-            }
-        }
-        return result
-    }
+    private fun stripLegalForm(tokens: List<String>): List<String>? = LEGAL_FORM_TOKENS.firstOrNull { form ->
+        tokens.size > form.size && tokens.subList(tokens.size - form.size, tokens.size) == form
+    }?.let { form -> tokens.subList(0, tokens.size - form.size) }
 
     companion object {
         /** One character — a typo, not a different name. */
@@ -177,6 +189,14 @@ class VopNameMatchPolicy(private val maxEditDistance: Int = DEFAULT_MAX_EDIT_DIS
             "sa", "s.a.", "sas", "sarl", "s.a.r.l.", "bv", "b.v.", "nv", "n.v.",
             "oy", "ab", "as.", "aps", "spa", "s.p.a.", "srl", "s.r.l.", "sp. z o.o.", "sp z o o",
         )
+
+        /**
+         * [LEGAL_FORMS] pre-tokenised, longest first so a form nested inside a longer one
+         * ("s r o" within "spol s r o") never wins the match.
+         */
+        private val LEGAL_FORM_TOKENS: List<List<String>> = LEGAL_FORMS
+            .map { form -> form.split(TOKEN_SEPARATOR).filter { it.isNotBlank() } }
+            .sortedByDescending { it.size }
 
         /**
          * True iff the Levenshtein edit distance between [a] and [b] is at most [max]. Early-exits

--- a/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/adapter/AccountHolderNameLookupAdapter.kt
+++ b/openbank-vop-service/src/main/kotlin/com/openbank/vop/infrastructure/adapter/AccountHolderNameLookupAdapter.kt
@@ -44,7 +44,6 @@ open class AccountHolderNameLookupAdapter(
     lateinit var self: AccountHolderNameLookupAdapter
 
     override fun lookupHolderName(iban: String): Uni<String?> = self.lookupWithResilience(iban)
-        .onFailure(::isNotFound).recoverWithItem(null as String?)
         .onFailure().transform { failure ->
             if (failure is NameLookupUnavailableException) failure else NameLookupUnavailableException(failure)
         }
@@ -68,6 +67,13 @@ open class AccountHolderNameLookupAdapter(
                 }
             }
         }
+        // Recover INSIDE the guarded method, not outside it. A 404 is an ordinary answer — "we
+        // hold no name for this IBAN" — but it reaches the caller as a failed Uni, and SmallRye
+        // Fault Tolerance judges this method by the Uni it returns. Recovering outside left
+        // @Retry replaying every unknown IBAN three times and @CircuitBreaker counting each as a
+        // failure, so a handful of them opened the breaker and turned *genuine* verifications
+        // into NO_DATA for 10s. Mapped here, a 404 is simply a success carrying null.
+        .onFailure(::isNotFound).recoverWithItem(null as String?)
 
     /** A 404 on either hop means "we hold no name for this IBAN" — a NO_DATA answer, not an error. */
     private fun isNotFound(failure: Throwable): Boolean = failure is WebApplicationException &&

--- a/openbank-vop-service/src/test/kotlin/com/openbank/vop/domain/VopNameMatchPolicyTest.kt
+++ b/openbank-vop-service/src/test/kotlin/com/openbank/vop/domain/VopNameMatchPolicyTest.kt
@@ -125,4 +125,64 @@ class VopNameMatchPolicyTest {
         assertThatThrownBy { VopNameMatchPolicy(maxEditDistance = -1) }
             .isInstanceOf(IllegalArgumentException::class.java)
     }
+
+    @ParameterizedTest(name = "a name ending in a legal-form's letters is not stripped: \"{0}\" vs \"{1}\"")
+    @CsvSource(
+        // A legal form is only a legal form as a whole token. These names merely END in the
+        // letters of one ("as", "sa", "ab", "ag", "oy"). Stripping by character suffix reduced
+        // both sides to the same core and reported a full MATCH between different people.
+        "Jan Tomas,Jan Tom",
+        "Maria Teresa,Maria Tere",
+        "John Thomas,John Thom",
+        "Petr Lukas,Petr Luk",
+        "Eva Kolomaz,Eva Koloma",
+        "Ivan Zlatohlavek,Ivan Zlatohlav",
+    )
+    fun `a legal form is matched per token, never as a character suffix`(supplied: String, actual: String) {
+        assertThat(policy.match(supplied, actual)).isNotEqualTo(VopOutcome.MATCH)
+    }
+
+    @ParameterizedTest(name = "different legal forms are different entities: \"{0}\" vs \"{1}\"")
+    @CsvSource(
+        // Two DIFFERENT registered forms on the same core are two different companies, and
+        // registering the look-alike form is a known fraud shape. Stripping both would confirm
+        // them as one payee.
+        "Acme s.r.o.,Acme a.s.",
+        "Acme Ltd,Acme LLC",
+        "Acme GmbH,Acme AG",
+        "Acme s.r.o.,Acme spol s r o",
+    )
+    fun `two different legal forms on the same core are not one payee`(supplied: String, actual: String) {
+        assertThat(policy.match(supplied, actual)).isNotEqualTo(VopOutcome.MATCH)
+    }
+
+    @Test
+    fun `the same legal form on both sides is still the same payee`() {
+        // The at-most-one-side rule must not break the ordinary case: the same form written
+        // either way is one company, whatever the punctuation or padding.
+        assertThat(policy.match("Acme s.r.o.", "Acme s.r.o.")).isEqualTo(VopOutcome.MATCH)
+        assertThat(policy.match("Acme, s.r.o.", "Acme s.r.o.")).isEqualTo(VopOutcome.MATCH)
+        assertThat(policy.match("ACME S.R.O.", "acme s.r.o.")).isEqualTo(VopOutcome.MATCH)
+    }
+
+    @Test
+    fun `a leading legal-form token is part of the name`() {
+        // "SRO Praha" is a company genuinely named that; only a TRAILING form is presentation.
+        assertThat(policy.match("SRO Praha", "Praha")).isNotEqualTo(VopOutcome.MATCH)
+        assertThat(policy.match("AS Roma", "Roma")).isNotEqualTo(VopOutcome.MATCH)
+    }
+
+    @Test
+    fun `a name that is only a legal form keeps it`() {
+        // Stripping would leave an empty core, which identifies no one.
+        assertThat(policy.match("Acme", "s.r.o.")).isNotEqualTo(VopOutcome.MATCH)
+    }
+
+    @Test
+    fun `a multi-token legal form is stripped whole`() {
+        // "spol s r o" must win over the "s r o" nested inside it, else "Acme spol s r o" would
+        // strip to "Acme spol" and stop matching "Acme".
+        assertThat(policy.match("Acme spol s r o", "Acme")).isEqualTo(VopOutcome.MATCH)
+        assertThat(policy.match("Acme s r o", "Acme")).isEqualTo(VopOutcome.MATCH)
+    }
 }


### PR DESCRIPTION
Fixes the four blocking findings in #1204, raised reviewing #1195.

**Retargeted to `main`.** This originally stacked on `chore/audit-immediate-fixes`, but #1195 squash-merged as `91460fcc6` and its branch was deleted, so GitHub retargeted this PR. It is now a rebase of the single fix commit onto `main`.

**The four defects are live on `main` as of `91460fcc6`** — `VopNameMatchPolicy.kt:148` still strips by character suffix, `page.tsx:369` still blocks on `no_data`, `AccountHolderNameLookupAdapter.kt:47` still recovers 404 outside the guarded method.

## 1 + 2 — `VopNameMatchPolicy` confirms the wrong payee

`stripLegalForms` used `removeSuffix` against the whole normalized string, and `LEGAL_FORMS` holds two-letter entries (`as`, `sa`, `ab`, `ag`, `ug`, `oy`). `MatchKey.normalize` doesn't tokenize, so the strip shears the tail off ordinary names:

| supplied | actual | stripped to | on `main` | with this PR |
|---|---|---|---|---|
| `Jan Tomas` | `Jan Tom` | `jan tom` | **MATCH** | `NO_MATCH` |
| `Maria Teresa` | `Maria Tere` | `maria tere` | **MATCH** | `NO_MATCH` |
| `John Thomas` | `John Thom` | `john thom` | **MATCH** | `NO_MATCH` |

A form is now matched only as whole trailing tokens, longest first. That also fixes a latent bug in passing: the multi-token forms were unreachable, so `Acme spol s r o` never matched `Acme`.

Stripping now happens only when **at most one** side carries a form. Two different forms on one core are two different registered entities — `Acme s.r.o.` vs `Acme a.s.` — and registering the look-alike form is a known fraud shape. Identical forms already return MATCH on the equality check above, so the ordinary case is untouched.

## 4 — the circuit breaker trips on ordinary unknown IBANs

The 404→`null` recovery sits outside `lookupWithResilience`. SmallRye FT judges the method by the `Uni` it returns, so `@Retry` replays every unknown IBAN 3× and `@CircuitBreaker` counts each as a failure — a handful open the breaker and turn *genuine* verifications into `NO_DATA` for 10s. Moved inside, a 404 is simply a success carrying null.

## 3 — the UI refuses every SCT Inst payment

The submit gate blocks unless `vopStatus` is `match`/`close_match`. It predates the real backend, when the `Math.random()` mock couldn't emit `no_data`. With a live backend and `domestic-iban-prefixes: CZ`, every non-CZ IBAN → `no_data`, so in practice every genuine SCT Inst payment is refused, as is every payment during an outage — contradicting ADR-0171 §3 and #1195's own reviewer note. Only `no_match` blocks now; an unverified form still requires the check to be run.

## Verification

- `VopNameMatchPolicyTest` **39/39 green** against current `main`. The new cases were confirmed to **fail against the pre-fix policy** — reverted the main-code change with the tests in place and watched them go red, so they genuinely guard the regression rather than merely passing.
- `:openbank-vop-service:ktlintCheck detekt build quarkusBuild` all green (`quarkusBuild` included so CDI/ArC wiring is actually validated).
- admin-ui `tsc --noEmit` clean; `eslint` 0 errors.

### Correction to an earlier claim

I previously reported here and on #1204 that `service-registry.guard.test.ts` fails because the #1168 registry guard rejects #1195's `vop` entry. **That was wrong.** `openbank-admin-ui/catalog.json` is gitignored and CI-generated, so that test fails on ENOENT in any fresh worktree regardless of the change. Not a defect in #1195, and not caused by this PR. The four finops failures are likewise pre-existing and unrelated.

Closes #1204
Refs #1195