### PR TITLE
fix(ci): make the fleet-attestation gate actually fail

### DIFF
--- a/.github/scripts/fleet-attestation-placeholders.txt
+++ b/.github/scripts/fleet-attestation-placeholders.txt
@@ -21,3 +21,9 @@
 # finrep-service: first ArgoCD registration (ADR-0097); never built via build-push-service.sh.
 # See the header note in openbank-infra/gitops/components/finrep/finrep-service.yaml.
 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-init
+
+# vop-service: first registration from #1195 (ADR-0095 Verification of Payee). Same shape as
+# finrep — module and gitops manifest merged, but no Dockerfile, no ECR repo, absent from
+# auto-deploy's ALL_SERVICES, so the tag has never been built. Tracked in #1205 alongside the
+# guard that should have refused to merge a released component in this state.
+265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-placeholder

--- a/.github/workflows/fleet-attestation.yml
+++ b/.github/workflows/fleet-attestation.yml
@@ -77,7 +77,14 @@ jobs:
         id: gate
         env:
           FLEET_ATTEST_JSON: ${{ runner.temp }}/fleet-attest.json
+        # `set -o pipefail` is load-bearing, not boilerplate. A `run:` block with no
+        # `shell:` key runs under GitHub's default `bash -e {0}` — which does NOT set
+        # pipefail (only an explicit `shell: bash` gets `-e -o pipefail`). Without it the
+        # pipeline below exits with `tee`'s status, so the gate printed
+        # "FLEET ATTESTATION GATE: FAIL" and the step still went green. Verified against
+        # run 29488481556, which reported FAIL on an absent image and concluded success.
         run: |
+          set -euo pipefail
           .github/scripts/check-fleet-attestations.sh | tee "${RUNNER_TEMP}/gate.log"
 
       - name: Job summary


### PR DESCRIPTION
## The gate does not gate

`fleet-attestation.yml` printed **`FLEET ATTESTATION GATE: FAIL — 1 of 55 declared image(s) not deployable`** and the step concluded **success**.

Its `run:` block pipes the script into `tee`:

```yaml
run: |
  .github/scripts/check-fleet-attestations.sh | tee "${RUNNER_TEMP}/gate.log"
```

A `run:` block with no `shell:` key uses GitHub's default **`bash -e {0}`**, which sets `-e` but **not** `pipefail` — only an explicit `shell: bash` gets `-e -o pipefail`. A pipeline's status is its **last** command's, so the step exits with `tee`'s 0 and the script's `exit 1` is discarded.

This is the exact failure the gate exists to catch — green while broken. It shipped a day old and has never blocked anything.

## Observed, not theorised

Run [29488481556](https://github.com/JiRaska/open-bank-oss/actions/runs/29488481556): printed `GATE: FAIL`, concluded `success`.

Mutation-tested against the live registry, with the vop entry removed from the allowlist:

| step form | exit | gate printed |
|---|---|---|
| `bash -e` (today's default) | **0** | `GATE: FAIL` |
| `set -euo pipefail` (this PR) | **1** | `GATE: FAIL` |

Both detect the problem. Only one stops it.

## Also: the thing the gate correctly flagged

`openbank-vop-service:sandbox-placeholder` — added to the placeholder allowlist here.

#1195 merged the `openbank-vop-service` module (v0.1.0) and its gitops Deployment an hour before this PR, with **no Dockerfile, no ECR repository, and no `ALL_SERVICES` entry**. That is the same first-registration shape as `finrep-service` (ADR-0097), which is already allowlisted, so it belongs in the allowlist under the file's own stated scope: *"this file may ONLY list images absent from the registry"*. It can never suppress an `UNATTESTED` image — that class stays fatal and has no allowlist.

Without the entry, fixing pipefail would just turn the gate **permanently red** on a known placeholder, and the allowlist header already says why that is self-defeating: *"A check that is permanently red because of a known placeholder is a check people learn to ignore."*

**vop-service is the sixth instance of the released-but-never-built class** (after the 6 control agents, document-service, clearing-simulator and finrep-service). It is tracked in #1205 along with the guard that should have refused to merge a released component with no Dockerfile and no `ALL_SERVICES` entry — the guard is the point; each of these has so far been fixed by hand and documented in a comment, and the class keeps recurring.

## Verified

- [x] `set -o pipefail` reproduced locally: `script | tee` → exit 0 without it, exit 1 with it
- [x] Gate run against the live registry with the fix + allowlist: `53 attested / 0 unattested / 0 absent / 2 allowlisted placeholder / 55 total` → **PASS**, exit 0
- [x] Mutation: remove the vop entry → **FAIL**, exit 1
- [x] YAML parses; `actionlint` clean apart from the pre-existing `openbank-build` self-hosted runner label
- [x] Read-only throughout — no image pushed, retagged or modified

## Linked issues

Refs #1205