### PR TITLE
fix(infra): give dind a memory request; cap runner limit at 9Gi

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/arc-runners.tf
@@ -295,6 +295,37 @@ locals {
     ]
     env             = [{ name = "DOCKER_GROUP_GID", value = "123" }]
     securityContext = { privileged = true }
+    # Memory request (the root-cause fix, and like the runner's ephemeral-storage
+    # request below it is mostly FREE — scheduling only). Without it dind ran at
+    # request=0, which broke twice over:
+    #
+    #  1. SCHEDULING: the scheduler saw a 6Gi pod (runner only), so it packed onto
+    #     c7gd.xlarge (4 vCPU / 8Gi = 6.6Gi allocatable — the `c` family is 2Gi/vCPU
+    #     and this NodePool allows instance-category c/m/r). 6Gi "fits" 6.6Gi, but
+    #     real usage is runner ~5Gi + dind ~0.2Gi + DaemonSets ~0.8Gi ≈ 6.2Gi, which
+    #     crosses the 400Mi eviction threshold. Verified live: evictions happened on
+    #     c7gd.xlarge at `available: 392404Ki`, never on m6gd/r7gd.
+    #  2. EVICTION RANKING: kubelet ranks victims by usage-over-request. A container
+    #     with request=0 is ALWAYS over its request, so the runner pod was picked
+    #     first on any node pressure — the eviction message named dind while it was
+    #     using a mere 99Mi.
+    #
+    # The pod then died mid-build as "The self-hosted runner lost communication with
+    # the server" — the exact symptom the ephemeral-storage request below fixed for
+    # DiskPressure. Same bug, one resource over: ~24% of build jobs died this way and
+    # ~40% of pool job-minutes were wasted (measured 2026-07-16 across 4 main-push
+    # runs; dead jobs averaged 13.9 min vs 6.5 min for successes — they die late, in
+    # the Testcontainers phase, after the expensive work).
+    #
+    # 1Gi request is deliberately above dind's measured footprint (25Mi idle, 182Mi
+    # peak under load incl. its Testcontainers): it makes total pod requests 7Gi,
+    # which is what actually excludes the 6.6Gi c7gd.xlarge and forces Karpenter onto
+    # an m/r-family (or c7gd.2xlarge) node. 3Gi limit leaves room for a heavier
+    # Postgres+Redpanda pair than any service currently boots.
+    resources = {
+      requests = { memory = "1Gi" }
+      limits   = { memory = "3Gi" }
+    }
     volumeMounts = [
       { name = "work", mountPath = "/home/runner/_work" },
       { name = "dind-sock", mountPath = "/var/run" },
@@ -743,8 +774,19 @@ resource "helm_release" "arc_build" {
               # job ("self-hosted runner lost communication"), failing Trivy/builds
               # fleet-wide. 16Gi (14Gi docker-lib cap + work/slack) bounds packing to
               # ≤2 runner pods on a 50Gi node.
+              #
+              # memory limit 12Gi -> 9Gi: the 2x request/limit gap was the other half of
+              # the eviction bug documented on dind above. The scheduler reserved 6Gi but
+              # the pod was allowed 12Gi — nearly 2x the whole 6.6Gi c7gd.xlarge it could
+              # legally be placed on. 9Gi is still generous headroom over reality: the
+              # Gradle daemon is capped at -Xmx3g (gradle.properties / GRADLE_OPTS) and
+              # the measured peak across live builds is ~5Gi (runner container, incl. the
+              # forked test JVMs; Testcontainers themselves live in dind's cgroup, not
+              # here). Capping it means a runaway build now OOMKills its own container —
+              # attributable, and only that job — instead of tripping node memory
+              # pressure and taking a healthy neighbour's job down with it.
               requests = { cpu = "3", memory = "6Gi", "ephemeral-storage" = "16Gi" }
-              limits   = { memory = "12Gi" }
+              limits   = { memory = "9Gi" }
             }
           },
           local.dind_container,


### PR DESCRIPTION
Fixes #1218. Context: #1208 (the CI queue this was silently feeding).

## What was happening

CI runners were being **evicted by the kubelet mid-build**. GitHub reports it as:

> The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection.

No logs upload (`BlobNotFound`), step shows `cancelled`, job shows `failure`. It reads as a flaky test or a network blip on a random service, so it gets re-run and the cost never lands anywhere.

**Measured across 4 main-push runs (2026-07-16):**

| | |
| --- | --- |
| build jobs sampled | 83 |
| dead (evicted) | **20 → 24%** |
| productive job-minutes | 410 |
| **wasted job-minutes** | **278 → 40% of pool time** |
| mean duration: success / dead | 6.5 min / **13.9 min** |

Dead jobs die *late* — in the Testcontainers phase, after the expensive work.

## Root cause: `dind` had no `resources` block at all

Two distinct defects fall out of `request: 0`:

**1. Scheduling.** The scheduler saw a 6Gi pod (runner only) and packed onto `c7gd.xlarge` — 4 vCPU / 8Gi = **6.6Gi allocatable**, legal because this NodePool allows `instance-category: ["c","m","r"]` and the `c` family is 2Gi/vCPU. 6Gi "fits" 6.6Gi, but real usage is runner ~5Gi + dind ~0.2Gi + DaemonSets ~0.8Gi ≈ 6.2Gi → crosses the 400Mi eviction threshold.

Verified live — evictions happen on `c7gd.xlarge` and never on the larger nodes:

```
1× c7gd.xlarge  alloc=6.6Gi    ← evictions here
2× m6gd.xlarge  alloc=14.3Gi
3× r7gd.xlarge  alloc=30.9Gi
```

**2. Eviction ranking.** Kubelet ranks victims by *usage over request*. A container with `request: 0` is **always** over its request, so the runner pod is picked first on any node pressure. Quoted from the kubelet — note dind is using a mere 99Mi when it gets named:

```
The node was low on resource: memory. Threshold quantity: 400Mi, available: 392404Ki.
Container dind was using 99532Ki, request is 0, has larger consumption of memory.
```

That `available: 392404Ki` (383Mi, just under the 400Mi threshold) is the c7gd.xlarge arithmetic above, landing exactly where predicted.

## The fix

| container | before | after |
| --- | --- | --- |
| `dind` | *no resources* | `requests.memory = 1Gi`, `limits.memory = 3Gi` |
| `runner` | `requests.memory = 6Gi`, `limits.memory = 12Gi` | limit → **9Gi** |

- **1Gi dind request** is deliberately well above dind's measured footprint (25Mi idle, **182Mi peak** under load including its Testcontainers). The point isn't dind's own headroom — it's that total pod requests become **7Gi**, which is what actually excludes the 6.6Gi `c7gd.xlarge` and forces Karpenter onto an m/r-family (or `c7gd.2xlarge`) node. 3Gi limit leaves room for a heavier Postgres+Redpanda pair than any service currently boots.
- **Runner limit 12Gi → 9Gi** closes the other half. A 2× request/limit gap let one pod claim nearly 2× its node. Gradle is capped at `-Xmx3g` (`gradle.properties` + `GRADLE_OPTS`) and the measured runner peak across live builds is **~5Gi**, so 9Gi keeps real headroom. The behavioural change: a runaway build now OOMKills its own container — attributable, and only that job — instead of tripping node memory pressure and taking a healthy neighbour's job down with it.

Worst case after this change on the smallest node it can now land on (`c7gd.2xlarge`, ~14Gi allocatable): limits 9 + 3 = 12Gi, plus ~1Gi DaemonSets = 13Gi < 14Gi. The pod can no longer push its own node into pressure.

## Ruled out (so nobody re-walks this)

- **Karpenter consolidation** — 7h of logs: 67 `Underutilized` disruptions, all on nodepool `default`; the `runners` pool saw only `Empty` disruptions with **0 pods evicted**. `karpenter.sh/do-not-disrupt: true` is working.
- **Spot interruption** — `runners` is spot-only, but the interruption controller shows only **2** `CordonAndDrain` events against `runners` nodeclaims in 7h. Cannot explain 20 deaths.
- **Matrix fail-fast** — `fail-fast: false` is set.
- **Job timeout** — `timeout-minutes: 45`; deaths occur at ~14 min.
- **Stuck runners** — `arc-stuck-runner-reaper` reports `no stuck runners`. They are not stuck; they are killed.

## Note on the pattern

This is the same bug the `ephemeral-storage` request in this very block already fixed for DiskPressure — same symptom string ("runner lost communication"), same mechanism (an unaccounted resource → node pressure → eviction), one resource over. Worth knowing when reviewing: that request bounded *packing*; this one bounds *node selection*.

## Verification / rollout

- `tofu fmt -check` passes. **Not** validated with `tofu validate`/`init` locally on purpose: sandbox-platform carries known un-applied drift and an init/apply here can enact unrelated changes — this needs a **targeted apply** (`-target` the ARC scale-set) by someone with the backend, not a full apply.
- After apply, the check is: no `Evicted` events in `arc-runners`, runner pods no longer scheduled onto `c7gd.xlarge`, and the dead-job rate re-measured. #1208's queue analysis should be redone afterwards — 40% of the pool coming back changes that picture, and raising `maxRunners` before this lands would only buy more capacity to evict.


## FinOps: what does forcing a bigger node cost?

Fair challenge, and the first version of this PR ducked it — it reused the `ephemeral-storage` comment's "FREE — scheduling only", which is true for disk (no instance change) but was an *unchecked assumption* for memory, since this change deliberately pushes Karpenter onto a larger box. Checked properly:

**It costs nothing.** Karpenter's own pricing data (mined from its disruption log, eu-north-1 spot):

| instance | RAM | spot price |
| --- | --- | --- |
| `c7gd.xlarge` (today's evicting node) | 8 GiB | **$0.07/h** |
| `m6gd.xlarge` | 16 GiB | **$0.07/h** |
| `m7gd.xlarge` | 16 GiB | **$0.07/h** |
| `r6gd.xlarge` | 32 GiB | **$0.07/h** |
| `m6gd.xlarge` *(on-demand, for contrast)* | 16 GiB | $0.19/h |

All four are indistinguishable at the log's 2-decimal precision — the delta is at most ~7% and plausibly zero. Spot prices track spare capacity, not the on-demand vCPU:RAM ratio, so in this region we get **2–4× the memory for the same price**. Node count and density are unchanged either way: the `cpu = 3` request already pins one runner pod per 4-vCPU node.

**And the c7gd.xlarge nodes we'd stop using are pure waste today** — verified: all 5 eviction events in the current window landed on c7gd.xlarge (3 distinct nodes), zero on m6gd/r7gd. We are paying $0.07/h for boxes whose jobs reliably die.

### What the waste is actually worth

| | |
| --- | --- |
| full-fleet runs/day (extrapolated from the 4-run sample) | ~17 |
| build job-minutes/day | ~2,950 → ~49 node-hours/day |
| CI runner compute | ~$3.44/day ≈ **$103/month** |
| of which wasted (the 40%) | ~$1.38/day ≈ **$41/month** |
| pool ceiling if saturated 24/7 (6 × $0.07 × 24) | $10.08/day ≈ $302/month |

**Honest read: in dollars this is small** — spot Graviton is cheap, so 40% waste is ~$41/month. The reason to fix it is not the AWS bill; it is that those wasted minutes are 40% of a **6-wide pool** that is the throughput bottleneck (#1208), and that bottleneck is what left a money-path fix (#945) undeployed for four days. The dollar saving is a rounding error; the delivery latency is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
