### PR TITLE
fix(docs-truth-agent): restore the coverage ratchet — main's koverVerify is red

### DIFF
--- a/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresFindingRepositoryIT.kt
+++ b/openbank-docs-truth-agent/src/test/kotlin/com/openbank/docstruth/PostgresFindingRepositoryIT.kt
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+
+package com.openbank.docstruth
+
+import com.openbank.docstruth.domain.model.DocsTruthCheckType
+import com.openbank.docstruth.domain.model.DocsTruthFinding
+import com.openbank.docstruth.domain.model.FindingSeverity
+import com.openbank.docstruth.domain.model.FindingStatus
+import com.openbank.docstruth.infrastructure.persistence.PostgresFindingRepository
+import com.openbank.libs.domain.identifiers.Ids
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.asUni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Repository round-trip against a real Testcontainers PostgreSQL (ADR-0166) — the thing unit tests
+ * cannot cover: that Flyway's `findings` schema and reactive Panache actually persist and read back
+ * a [DocsTruthFinding]. The entity↔domain mapping is hand-written per field, so a forgotten
+ * assignment silently nulls a column rather than failing to compile; only a round-trip catches it.
+ *
+ * [PostgresFindingRepository] is reactive (`Mutiny.SessionFactory.withSession/withTransaction`
+ * bridged to `suspend`), so its calls MUST run on a Vert.x duplicated context — a plain test thread
+ * has none and fails with "No current Vertx context found". [onVertxContext] bridges the suspend
+ * body via [VertxContextSupport.subscribeAndAwait] (mirrors anacredit-service's
+ * `PostgresCreditExposureRepositoryIT`). Each test declares an explicit `: Unit` return — a
+ * `fun x() = expr` inferring a non-`Unit` type is silently dropped by JUnit5/Kotlin.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class PostgresFindingRepositoryIT {
+
+    @Inject
+    lateinit var repository: PostgresFindingRepository
+
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        CoroutineScope(Dispatchers.Unconfined).async { block() }.asUni()
+    }
+
+    private fun finding(
+        status: FindingStatus = FindingStatus.OPEN,
+        title: String = "ADR-0139 claims Shipped but the artifact is absent",
+    ) = DocsTruthFinding(
+        id = Ids.newId().toString(),
+        checkType = DocsTruthCheckType.SHIPPED_ARTIFACT_MISSING,
+        severity = FindingSeverity.WARNING,
+        detectedAt = Instant.parse("2026-07-16T10:00:00Z"),
+        title = title,
+        component = "ADR-0139",
+        adrPath = "docs/adr/0139-ml-decisioning-platform.md",
+        rawMetricValue = BigDecimal("1"),
+        threshold = BigDecimal("0"),
+        status = status,
+    )
+
+    @Test
+    fun `a saved finding round-trips through every mapped field`(): Unit = onVertxContext {
+        val saved = finding().copy(
+            rootCause = "the ADR shipped before its artifact landed",
+            proposalUrl = "https://github.com/JiRaska/open-bank-oss/pull/1",
+            proposedFixDiff = "- Delivery-Status: Shipped\n+ Delivery-Status: Partial",
+            diagnosedAt = Instant.parse("2026-07-16T11:00:00Z"),
+            proposedAt = Instant.parse("2026-07-16T12:00:00Z"),
+        )
+        repository.save(saved)
+
+        // Recursive comparison, not field-by-field asserts: a column added to the entity but
+        // forgotten in one of the two mappers is exactly the defect this test exists for, and an
+        // explicit assert list would have to be remembered too.
+        assertThat(repository.findById(saved.id)).usingRecursiveComparison().isEqualTo(saved)
+    }
+
+    @Test
+    fun `nullable fields round-trip as null rather than empty strings`(): Unit = onVertxContext {
+        val bare = finding()
+        repository.save(bare)
+
+        val loaded = repository.findById(bare.id)
+        assertThat(loaded?.rootCause).isNull()
+        assertThat(loaded?.proposalUrl).isNull()
+        assertThat(loaded?.proposedFixDiff).isNull()
+        assertThat(loaded?.diagnosedAt).isNull()
+        assertThat(loaded?.proposedAt).isNull()
+    }
+
+    @Test
+    fun `update advances the HITL lifecycle in place`(): Unit = onVertxContext {
+        val original = finding()
+        repository.save(original)
+
+        repository.update(
+            original.copy(
+                status = FindingStatus.DIAGNOSED,
+                rootCause = "the ADR shipped before its artifact landed",
+                diagnosedAt = Instant.parse("2026-07-16T11:00:00Z"),
+            ),
+        )
+
+        val loaded = repository.findById(original.id)
+        assertThat(loaded?.status).isEqualTo(FindingStatus.DIAGNOSED)
+        assertThat(loaded?.rootCause).isEqualTo("the ADR shipped before its artifact landed")
+    }
+
+    @Test
+    fun `update upserts a finding whose row was never written`(): Unit = onVertxContext {
+        // The HITL path can hand back a finding minted before a restart, whose row never landed.
+        // update() must persist it rather than throw — that is why it is an upsert, not a merge.
+        val neverSaved = finding(title = "never persisted")
+        repository.update(neverSaved)
+
+        assertThat(repository.findById(neverSaved.id)?.title).isEqualTo("never persisted")
+    }
+
+    @Test
+    fun `findActive excludes terminal statuses`(): Unit = onVertxContext {
+        val open = finding(status = FindingStatus.OPEN, title = "open one")
+        val resolved = finding(status = FindingStatus.RESOLVED, title = "resolved one")
+        val rejected = finding(status = FindingStatus.REJECTED, title = "rejected one")
+        listOf(open, resolved, rejected).forEach { repository.save(it) }
+
+        val active = repository.findActive().map { it.id }
+
+        assertThat(active).contains(open.id)
+        // The point of the HITL queue: a decided finding must not resurface after a restart.
+        assertThat(active).doesNotContain(resolved.id, rejected.id)
+    }
+
+    @Test
+    fun `findById returns null for an unknown id rather than throwing`(): Unit = onVertxContext {
+        assertThat(repository.findById(Ids.newId().toString())).isNull()
+    }
+}


### PR DESCRIPTION
## Summary

`main` is red: `./gradlew :openbank-docs-truth-agent:koverVerify` fails on the current tip.

```
> Rule violated: lines covered percentage is 51.983300, but expected minimum is 55
```

Reproduced against a clean worktree at `cef5fdcdc` with no local modifications. It is **latent** — Services CI is path-scoped, so docs-truth-agent is not rebuilt until someone touches it, and the next person to do so inherits the failure. Introduced by #1195 (my PR), whose docs-truth-agent build was red at merge time.

## Type of change

- [x] fix (bug fix)
- [ ] feat / refactor / perf / docs / chore / security / breaking

## Linked issues

Refs #1194

## Changes

- Adds `PostgresFindingRepositoryIT` — a repository round-trip against the Testcontainers Postgres that #1195's conversion introduced. Coverage 51.98% → 66.81%.

**The floor is deliberately NOT lowered.** Coverage is ratchet-only (ADR-0020); the fix for "my new code isn't covered" is to cover it, not to move the bar. `minValue = 55` is untouched.

The test earns its place beyond the ratchet: the entity↔domain mapping is hand-written per field, so a column added to the entity but forgotten in one of the two mappers silently nulls data rather than failing to compile. Only a round-trip catches that — hence a recursive comparison rather than a field list that would itself have to be remembered. It also pins two behaviours the signatures do not reveal: `update()` is an upsert (the HITL path can hand back a finding whose row a restart never wrote), and `findActive()` excludes terminal statuses (a decided finding must not resurface).

## Definition of Done

- [x] Hexagonal layering preserved.
- [x] Unit tests added/updated — 6 new, all green.
- [x] Integration tests added/updated — this IS the integration test.
- [ ] Contract tests — N/A.
- [x] `:openbank-docs-truth-agent:build` passes against current `main` (BUILD SUCCESSFUL, was BUILD FAILED).
- [x] No new lint warnings — ktlint + detekt green.
- [ ] OpenAPI / Flyway / Avro — N/A, test-only change.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency — `VertxContextSupport` / `asUni` come transitively with the reactive stack already present.
- [ ] Auth / crypto / payment code — no.
- [ ] PII path — no.
- [ ] Cardholder data — no.

## Compliance impact

- [x] None — test-only.

## Rollout / Rollback

- **Deployment strategy:** none — test sources only, no runtime artifact changes.
- **Rollback plan:** revert; `main` returns to the current red state.
- **Data migration reversible:** N/A.

## Reviewer notes

`@RunOnVertxContext` is not used; the body runs via `VertxContextSupport.subscribeAndAwait`, mirroring anacredit-service's `PostgresCreditExposureRepositoryIT`. Reactive Panache resolves its session from a Vert.x context and a plain test thread has none. Each test declares an explicit `: Unit` — a `fun x() = expr` inferring a non-`Unit` type is silently dropped by JUnit5/Kotlin (the footgun already documented in the root `CLAUDE.md`).

**How this reached `main`, for the record:** #1195 was merged while its `build (openbank-docs-truth-agent)` check was failing, with `reviewDecision` empty — no approving review, on a PR labelled `money-path` (which `rules.yaml: review.money_path_approvals` sets to 2). Not something I can fix in a PR, but worth knowing the gate did fire and did report red before the merge.

## Verification summary

CI on this PR: **21 passed, 0 failed** (6 skipped by path-scoping, 1 neutral).

The check that matters — `build (openbank-docs-truth-agent)` — is **green here (5m16s)** and is exactly the one currently **red on `main`**.

Reproduced and verified locally against a clean worktree at `origin/main` (`cef5fdcdc`), no local modifications:

| | before | after |
|---|---|---|
| `:openbank-docs-truth-agent:koverVerify` | `BUILD FAILED` — 51.98% vs floor 55 | `BUILD SUCCESSFUL` |
| line coverage | 51.98% | **66.81%** |
| kover floor (`minValue`) | 55 | **55 — unchanged, deliberately** |
| tests | 41 | 47 (6 new, 0 failures) |

Also re-verified the other five converted agents build green **sequentially** (`control-liveness-sentinel`, `governance-auditor`, `release-steward`, `authz-policy-auditor`, `flaky-test-hunter`). Worth noting for anyone reproducing: building them in parallel locally yields a false `QuarkusBindException` — every service shares management port 8086, so two `@QuarkusTest` boots collide. CI gives each service its own job, so it does not see this.

Merged with `gh pr merge --squash`, no `--admin`, on the author's explicit instruction. `reviewDecision` is empty (the single `latestReview` is a `github-actions[bot]` `COMMENTED`, not an approval) — recorded plainly rather than implied: this is a test-only, non-money-path change to a break the same author introduced, landing with one set of eyes.
