### PR TITLE
fix(ci): stop cancelling auto-deploy between image push and attest

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -53,12 +53,16 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  # One deploy pipeline at a time — a second push while a deploy PR is open would
-  # update the same gitops lines, causing a merge conflict. Cancel the in-flight run
-  # and let the newer commit win.
-  group: auto-deploy-${{ github.ref }}
-  cancel-in-progress: true
+# NOTE: there is deliberately NO workflow-level `concurrency` here. The serialisation this
+# pipeline needs is scoped to `gitops-pr` alone (see that job); applying it workflow-wide
+# cancelled `build-push` MID-FLIGHT, which is how the fleet ended up with unattested images
+# (#1226). `Docker push` and `Attest image SBOMs` are ~180 lines apart in that job, and a
+# cancel between them leaves the image in ECR with no attestation, forever — the superseding
+# run builds its OWN commit's tag and never comes back for the dead run's images. Since
+# verify-openbank-image-sbom-attestation is Enforce, such an image is admitted never, and the
+# deny surfaces whenever the workload next reschedules — days later, far from the cause.
+# Concurrent `build-push` runs are safe: image tags are immutable and per-SHA, so two builds
+# cannot collide. Do not re-add a workflow-level cancel.
 
 jobs:
   # ── 1. Detect which service modules actually changed ─────────────────────────
@@ -698,6 +702,15 @@ jobs:
   gitops-pr:
     name: Gitops PR
     needs: [changes, build-push, can-i-deploy]
+    # The pipeline's ONLY genuine serialisation point, and the sole thing the old
+    # workflow-level concurrency was ever justified by: a second push while a deploy PR is
+    # open would rewrite the same gitops lines and conflict. Cancelling HERE is safe and
+    # keeps the original intent (newer commit wins the PR) — cancelling the whole workflow
+    # was not, because by then build-push had already pushed images it would never attest
+    # (#1226). Anything with side effects outside this job must stay outside this group.
+    concurrency:
+      group: auto-deploy-gitops-pr-${{ github.ref }}
+      cancel-in-progress: true
     # `always()` + explicit build-push check, NOT the default "can-i-deploy must succeed":
     # can-i-deploy's own job status can be red while still emitting a `deployable` output for
     # the services that individually passed (issue #846) — this job must still run to record


### PR DESCRIPTION
Closes #1226

## The bug

`auto-deploy.yml` sets `cancel-in-progress: true` at **workflow** level. `build-push` pushes to ECR
(`Docker push (parallel)`, ~line 323) and attests ~180 lines later (`Attest image SBOMs`, ~line 506).
A cancel in that window leaves the image **pushed and permanently unattested** — the superseding run
builds its *own* commit's tag and never returns for the dead run's images.

`verify-openbank-image-sbom-attestation` is **Enforce**, so such an image is admitted never. Running
pods aren't re-admitted, so nothing breaks at push time; the deny surfaces whenever the workload next
reschedules. Same failure mode as the 2026-07-12 fleet incident.

## Evidence

Fleet sweep, all 55 `openbank-*` repos / 2105 image tags → **49 unattested images pushed on/after the
Enforce date**, three batches, each from a cancelled run:

| tag | images | run |
|---|---|---|
| `sandbox-7f281cab` | **35** | `29201992447` `chore(libs): revert duplicate FeatureStore (#950)` — cancelled |
| `sandbox-91460fcc` | 13 | `feat(vop) #1195` — cancelled |
| `sandbox-25214dd0` | 1 | `feat(ledger) #1192` — cancelled |

Verified at artifact level, not inferred from tags:

```
$ cosign verify-attestation --key <kms> --type https://cyclonedx.org/bom openbank-sepa-payment:sandbox-7f281cab
Error: no matching attestations
```

A `libs` commit is path-scoped to the **whole fleet**, so one cancelled libs deploy orphans ~35 images
at once. `sandbox-7f281cab` is exactly that — and it is why the fleet was not fully attested when the
policy graduated to Enforce on 2026-07-12. The precondition wasn't merely unverified; the rebuild that
was supposed to establish it was killed mid-run.

Cancels are routine: 2026-07-12 alone had four consecutive cancelled auto-deploys.

## The fix

The concurrency comment states its own rationale:

> One deploy pipeline at a time — a second push while a deploy PR is open would update the same gitops
> lines, causing a merge conflict.

That is a **`gitops-pr` problem only**. `build-push` pushes immutable per-SHA tags; two concurrent
builds cannot collide. So the group moves onto `gitops-pr`:

- `build-push` always completes → push and attest are never severed;
- `gitops-pr` keeps `cancel-in-progress: true` → newer commit still wins the PR, original intent intact.

**Trade-off:** a superseded commit's build now burns runner minutes instead of being killed. That is the
cheaper failure — an unattested image is a latent outage that surfaces days later, far from its cause.

## Why this wasn't caught

The superseding run frequently reports `conclusion: success` with `Build + push` **skipped** (nothing
changed for *its* commit), so the orphaned batch sits behind a green tick. `#1220` (fleet-attestation
gate) closes the detection half; this closes the cause.

## Remediation of existing images

The 49 orphans are being attested additively (trivy CycloneDX SBOM → `cosign attest` against the
**existing digest**; no rebuild, repush or retag) via `openbank-infra/scripts/lib/cosign-attest.sh`.
None are currently live — all 54 live images verify — so nothing is down; they were armed for the next
roll.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` parses; workflow-level `concurrency` gone, `gitops-pr`
  carries `auto-deploy-gitops-pr-${{ github.ref }}` / `cancel-in-progress: true`.
- `actionlint` clean on this diff (its only finding is the pre-existing `openbank-build` self-hosted
  runner label).