### PR TITLE
chore(gitops): auto-deploy services @ cef5fdcdcbfee797628474a2b50d5178648e4caa

### DIFF
--- a/openbank-infra/gitops/components/finrep/finrep-service.yaml
+++ b/openbank-infra/gitops/components/finrep/finrep-service.yaml
@@ -33,7 +33,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: finrep-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-init
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-finrep-service:sandbox-cef5fdcd
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -2761,7 +2761,7 @@ spec:
       containers:
         - name: vop-service
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-placeholder
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-cef5fdcd
 
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit cef5fdcdcbfee797628474a2b50d5178648e4caa.

**Changed services:** ["openbank-finrep-service","openbank-vop-service"]

Each image tag was updated to `sandbox-cef5fdcdcbfee797628474a2b50d5178648e4caa` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.