### PR TITLE
chore(gitops): auto-deploy services @ 2bc51585b101f6bbe6e3d27f9b39310e0c9ce44f

### DIFF
--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -2761,7 +2761,7 @@ spec:
       containers:
         - name: vop-service
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-cef5fdcd
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-2bc51585
 
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 2bc51585b101f6bbe6e3d27f9b39310e0c9ce44f.

**Changed services:** ["openbank-vop-service"]

Each image tag was updated to `sandbox-2bc51585b101f6bbe6e3d27f9b39310e0c9ce44f` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.