### PR TITLE
fix(gitops): add the missing vop-service OIDC ExternalSecret

### DIFF
--- a/openbank-infra/gitops/components/payments/oidc-externalsecrets.yaml
+++ b/openbank-infra/gitops/components/payments/oidc-externalsecrets.yaml
@@ -266,3 +266,33 @@ spec:
       remoteRef:
         key: account-service
         property: OIDC_CLIENT_SECRET
+---
+# ADR-0171: vop-service OIDC client secret (Verification of Payee).
+# #1195 shipped the Rollout with `OIDC_CLIENT_SECRET <- secretKeyRef: vop-oidc` but no
+# ExternalSecret to materialise it, so the pod sat in CreateContainerConfigError from its
+# first admission — the image and the DB cluster were fine, the secret simply did not exist.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: vop-oidc
+  namespace: payments
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: vop-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: account-service
+        property: OIDC_CLIENT_SECRET


### PR DESCRIPTION
## Why

`vop-service` has been in `CreateContainerConfigError` since its first admission. Its Rollout reads:

```yaml
- name: OIDC_CLIENT_SECRET
  valueFrom:
    secretKeyRef:
      name: vop-oidc
      key: OIDC_CLIENT_SECRET
```

…but #1195 shipped the Rollout **without an ExternalSecret to materialise `vop-oidc`**, so the secret has never existed. Every other payments service declares one in this same file.

## What was actually fine

Worth stating, because it narrows the fix and rules out today's other failure classes:

| link in the chain | state |
|---|---|
| image built + pushed | ✅ `openbank-vop-service:sandbox-cef5fdcd` |
| cosign signature | ✅ |
| SBOM attestation | ✅ verifies against the KMS key Kyverno uses |
| Kyverno admission | ✅ **admitted** — the pod exists |
| `vop-db` CloudNativePG cluster | ✅ healthy, `vop-db-app` secret present |
| `vop-opa-bundle` ConfigMap | ✅ mounted |
| **`vop-oidc` secret** | ❌ **absent — nothing creates it** |

That is why this surfaced as a *config* error rather than an admission or image failure. It is not the SBOM class that took the fleet down this morning.

## The fix

Modelled on `swift-service-oidc` / `clearing-simulator-oidc` in this file: `vault-kv` ClusterSecretStore, `key: account-service`, `property: OIDC_CLIENT_SECRET`.

Verified the target name and `secretKey` match what the Rollout actually references (`secret/vop-oidc`, key `OIDC_CLIENT_SECRET`) — a mismatch there fails in exactly the same way while looking fixed.

- [x] YAML parses; 11 ExternalSecrets, no duplicate names
- [x] `target.name` and `secretKey` cross-checked against the Rollout's `secretKeyRef`
- [ ] ArgoCD sync → `vop-oidc` syncs → the Rollout completes

## Linked issues

Refs #1205