### PR TITLE
fix(gitops): declare the vop-oidc ExternalSecret so vop-service can start

### DIFF
--- a/openbank-infra/gitops/components/payments/oidc-externalsecrets.yaml
+++ b/openbank-infra/gitops/components/payments/oidc-externalsecrets.yaml
@@ -266,3 +266,33 @@ spec:
       remoteRef:
         key: account-service
         property: OIDC_CLIENT_SECRET
+---
+# ADR-0171: vop-service OIDC client secret (Verification of Payee). #1195 shipped the
+# Rollout with an OIDC_CLIENT_SECRET env from secret `vop-oidc` but never declared the
+# ExternalSecret that projects it, so every pod failed CreateContainerConfigError
+# (`secret "vop-oidc" not found`) once Kyverno started admitting them.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: vop-oidc
+  namespace: payments
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: vop-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: account-service
+        property: OIDC_CLIENT_SECRET


### PR DESCRIPTION
vop-service's pods cannot start — the last missing piece of its config from #1195.

```
vop-service=CreateContainerConfigError: secret "vop-oidc" not found
```

#1195 shipped the Rollout with an `OIDC_CLIENT_SECRET` env sourced from secret `vop-oidc`, but never declared the ExternalSecret that projects it. The gap stayed invisible while Kyverno was denying every pod for a missing image (#1229 / the ECR build); once the image existed and pods were admitted, this surfaced as the real blocker.

## The fix

Adds the **eleventh** entry to `oidc-externalsecrets.yaml`, identical in shape to its ten siblings.

**No new Vault material is needed.** As the file's own header records:

> All services share the single Keycloak confidential client `openbank-services`, so the secret VALUE is the same one stored in Vault under key `account-service` — reuse it.

All ten existing entries already point at that same key. This is the eleventh pointing at it too. The diff is purely additive: **+30 / -0**.

## Verification — against the cluster, not by inspection

- The Rollout asks for exactly `vop-oidc/OIDC_CLIENT_SECRET`; this ExternalSecret's `target.name` is `vop-oidc` and its `secretKey` is `OIDC_CLIENT_SECRET`. Read off the live Rollout, not the manifest.
- The sibling `swift-service-oidc` carries an **identical** `remoteRef` (`account-service` / `OIDC_CLIENT_SECRET`) and reports `Ready=True` — so the Vault key resolves today. That's proof by working control, rather than trusting that the key exists.
- `ClusterSecretStore vault-kv` is `Ready=True`.
- `apps/payments.yaml` syncs the whole `components/payments` directory (no kustomization, no resources list), so there is nothing to register — the file is picked up as-is.
- YAML parses; 11 documents, exactly one `vop-oidc`.

## What this does NOT fix

The pod is also being rejected by the scheduler:

```
FailedScheduling: 0/34 nodes are available: 12 node(s) had untolerated taint(s),
22 Insufficient memory, 3 Insufficient cpu
```

That is a separate capacity problem and this PR does not address it. With the secret in place the config error clears, but the pod still needs somewhere to land.

Refs #1195