### PR TITLE
fix(lending): reverse accrued interest on reschedule, derecognize it on write-off

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
@@ -37,19 +37,32 @@ data class LedgerPosting(val reference: String, val partyId: UUID, val amount: M
  * contra-asset); a decrease (partial release) is the reverse. The loan principal GL is never touched by
  * a provisioning entry — provisioning is an impairment overlay, not a change to the recognized asset.
  *
+ * [INTEREST_ACCRUAL_REVERSAL] unwinds a previously booked [INTEREST_ACCRUAL] when the installment it
+ * recognized income for is cancelled before cash ever arrives (a reschedule discarding the unpaid
+ * tail, issue #667/#668): the income was recognized against a receivable that will now never settle,
+ * so both are backed out — the new schedule re-accrues its own installments' interest from scratch.
+ *
  * [RESCHEDULE_FORGIVENESS] books a partial debt-relief amount granted as part of a loan restructuring
  * (issue #667/#668) — the same economic event as [WRITE_OFF] (a realized credit loss, asset off the
  * books), just partial rather than the full remaining exposure, kept as a distinct kind so an audit
  * trail can tell a restructuring's forgiveness apart from a full write-off even though both hit the
  * same GL accounts.
+ *
+ * [WRITE_OFF_INTEREST] derecognizes the accrued-but-unpaid interest receivable at write-off, alongside
+ * the principal [WRITE_OFF]: the income was legitimately earned when the installment fell due, so it is
+ * not reversed out of income — the uncollectible receivable is booked as a credit loss, exactly like
+ * the principal exposure. Kept as a distinct kind so the audit trail can split a write-off's loss into
+ * its principal and interest components.
  */
 enum class PostingKind {
     DISBURSEMENT,
     PRINCIPAL_REPAYMENT,
     INTEREST,
     INTEREST_ACCRUAL,
+    INTEREST_ACCRUAL_REVERSAL,
     INTEREST_SETTLEMENT,
     WRITE_OFF,
+    WRITE_OFF_INTEREST,
     PROVISIONING,
     RESCHEDULE_FORGIVENESS,
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -349,6 +349,9 @@ class LendingService(
                         )
                     } else {
                         // Book the loss and remove the asset from the books; we never mutate balances ourselves.
+                        // Ledger first, row mutation last (same as recordRepayment/accrueOne): a crash between
+                        // the two leaves the loan ACTIVE and the retry replays the same idempotency keys, which
+                        // the ledger collapses to the already-booked journals — exactly-once either way.
                         ledger.post(
                             LedgerPosting(
                                 "loan:${loanId.value}:writeoff",
@@ -357,6 +360,7 @@ class LendingService(
                                 PostingKind.WRITE_OFF,
                             ),
                         )
+                            .flatMap { derecognizeAccruedInterest(loan, schedule) }
                             .flatMap { loans.update(loan.copy(status = LoanStatus.WRITTEN_OFF)) }
                             .flatMap { written ->
                                 val wPayload = """{"loanId":"${written.id.value}",""" +
@@ -376,6 +380,31 @@ class LendingService(
             }
         }
 
+    /**
+     * Derecognize the loan's accrued-but-unpaid interest receivable at write-off. Every unpaid
+     * installment the servicing pass already accrued (`interestAccrued`) has an Interest Receivable
+     * balance the write-off would otherwise orphan on the books forever — the principal-only
+     * [PostingKind.WRITE_OFF] never touches it. The sum is deterministic from the schedule (write-off
+     * mutates no installment rows), so a retry recomputes the identical amount under the identical
+     * idempotency key and the ledger collapses the replay.
+     */
+    private fun derecognizeAccruedInterest(loan: Loan, schedule: List<LoanInstallment>): Uni<Unit> {
+        val accruedUnpaid = schedule
+            .filter { !it.paid && it.interestAccrued }
+            .fold(Money.zero(loan.principal.currency.code)) { acc, installment -> acc.plus(installment.interest) }
+        if (!accruedUnpaid.isPositive()) {
+            return Uni.createFrom().item(Unit)
+        }
+        return ledger.post(
+            LedgerPosting(
+                "loan:${loan.id.value}:writeoff:interest",
+                loan.partyId,
+                accruedUnpaid,
+                PostingKind.WRITE_OFF_INTEREST,
+            ),
+        )
+    }
+
     // --- Reschedule / restructuring (forbearance, issue #667/#668) ----------------------------------
 
     /**
@@ -383,8 +412,13 @@ class LendingService(
      * new schedule is generated from the outstanding balance (net of any [RescheduleRequest.principalForgiveness])
      * at the new rate/term/first-due-date, via the same pure [Amortization.schedule] primitive
      * [bookLoan] uses at origination. Already-paid installments are untouched; new rows continue the
-     * installment numbering after the last paid one, so a future repayment's ledger reference
-     * (`"loan:<id>:inst:<number>:..."`) can never collide with an already-posted one.
+     * installment numbering after the highest existing one — paid or not — so a future ledger
+     * reference (`"loan:<id>:inst:<number>:..."`) can never collide with an already-posted one
+     * (an accrued-unpaid row posts its accrual reference before it is ever discarded).
+     *
+     * Any unpaid installment whose interest was already accrued has its accrual REVERSED on the
+     * ledger before the row is deleted (see [reverseAccruedUnpaidInterest]) — otherwise the posted
+     * Interest Receivable could never settle and the new schedule would recognize the same income twice.
      */
     @Suppress("LongMethod") // reschedule mirrors bookLoan's shape: validation + schedule build + persist + post
     override fun reschedule(loanId: LoanId, request: RescheduleRequest, rescheduledBy: String): Uni<Loan> =
@@ -440,7 +474,45 @@ class LendingService(
         } else {
             Uni.createFrom().item(Unit)
         }
-        return forgive.flatMap { buildAndPersistNewSchedule(loan, schedule, newPrincipal, generation, request) }
+        return forgive
+            .flatMap { reverseAccruedUnpaidInterest(loan, schedule, generation) }
+            .flatMap { buildAndPersistNewSchedule(loan, schedule, newPrincipal, generation, request) }
+    }
+
+    /**
+     * Unwind the interest accrual of every unpaid installment the reschedule is about to discard.
+     * Each such row already posted an INTEREST_ACCRUAL (income against a receivable) that its
+     * INTEREST_SETTLEMENT can now never clear — deleting it without this reversal would strand the
+     * receivable on the books AND double-recognize the income once the new schedule re-accrues.
+     *
+     * Ledger first, row deletion last (same as accrueOne's post-then-mark): a crash between the two
+     * leaves the old rows in place, and the retry replays the same generation-scoped idempotency keys
+     * (the loan version only bumps after the delete succeeds), which the ledger collapses to the
+     * already-booked reversals — exactly-once either way.
+     */
+    private fun reverseAccruedUnpaidInterest(
+        loan: Loan,
+        schedule: List<LoanInstallment>,
+        generation: Long,
+    ): Uni<Unit> {
+        // Zero-interest rows are flagged accrued without ever posting (see accrueOne): nothing to reverse.
+        val accruedUnpaid = schedule.filter { !it.paid && it.interestAccrued && it.interest.isPositive() }
+        if (accruedUnpaid.isEmpty()) {
+            return Uni.createFrom().item(Unit)
+        }
+        return Multi.createFrom().iterable(accruedUnpaid)
+            .onItem().transformToUniAndConcatenate { installment ->
+                ledger.post(
+                    LedgerPosting(
+                        "loan:${loan.id.value}:inst:${installment.number}:accrual-reversal:gen$generation",
+                        loan.partyId,
+                        installment.interest,
+                        PostingKind.INTEREST_ACCRUAL_REVERSAL,
+                    ),
+                )
+            }
+            .collect().asList()
+            .replaceWith(Unit)
     }
 
     private fun buildAndPersistNewSchedule(
@@ -450,7 +522,11 @@ class LendingService(
         generation: Long,
         request: RescheduleRequest,
     ): Uni<Loan> {
-        val paidCount = schedule.count { it.paid }
+        // Continue numbering after the HIGHEST existing number, not the paid count: an accrued-unpaid
+        // row being discarded has already posted its "...inst:<n>:accrual" ledger reference, so
+        // recycling its number would collapse the replacement row's own accrual/settlement postings
+        // into the discarded row's journals (the ledger dedupes on that exact string).
+        val lastNumber = schedule.maxOfOrNull { it.number } ?: 0
         val newSchedule = Amortization.schedule(
             principal = newPrincipal,
             nominalAnnualRate = request.newNominalAnnualRate,
@@ -462,7 +538,7 @@ class LendingService(
         val rows = newSchedule.installments.map { i ->
             LoanInstallment(
                 loanId = loan.id,
-                number = paidCount + i.number,
+                number = lastNumber + i.number,
                 dueDate = i.dueDate,
                 openingBalance = i.openingBalance,
                 principal = i.principal,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactory.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactory.kt
@@ -30,8 +30,10 @@ data class LendingGlAccounts(
  *   PRINCIPAL_REPAYMENT  DEBIT  Funding Clearing     CREDIT Loans Receivable     (cash in, asset reduced)
  *   INTEREST             DEBIT  Funding Clearing     CREDIT Interest Income       (cash in, income earned — early payment)
  *   INTEREST_ACCRUAL     DEBIT  Interest Receivable  CREDIT Interest Income       (income earned at due date, no cash yet)
+ *   INTEREST_ACCRUAL_REVERSAL DEBIT Interest Income  CREDIT Interest Receivable   (accrual unwound: installment cancelled by reschedule)
  *   INTEREST_SETTLEMENT  DEBIT  Funding Clearing     CREDIT Interest Receivable   (cash in, accrued receivable cleared)
  *   WRITE_OFF            DEBIT  Loan Loss Expense    CREDIT Loans Receivable      (loss booked, asset off)
+ *   WRITE_OFF_INTEREST   DEBIT  Loan Loss Expense    CREDIT Interest Receivable   (accrued receivable uncollectible at write-off)
  *   RESCHEDULE_FORGIVENESS DEBIT Loan Loss Expense   CREDIT Loans Receivable      (partial forgiveness, restructuring)
  *   PROVISIONING (Δ≥0)   DEBIT  Loan Loss Expense    CREDIT Loan Loss Allowance   (impairment increases: more provision)
  *   PROVISIONING (Δ<0)   DEBIT  Loan Loss Allowance  CREDIT Loan Loss Expense    (impairment decreases: partial release)
@@ -68,8 +70,10 @@ object LendingJournalFactory {
             PostingKind.PRINCIPAL_REPAYMENT -> accounts.fundingClearing to accounts.loansReceivable
             PostingKind.INTEREST -> accounts.fundingClearing to accounts.interestIncome
             PostingKind.INTEREST_ACCRUAL -> accounts.interestReceivable to accounts.interestIncome
+            PostingKind.INTEREST_ACCRUAL_REVERSAL -> accounts.interestIncome to accounts.interestReceivable
             PostingKind.INTEREST_SETTLEMENT -> accounts.fundingClearing to accounts.interestReceivable
             PostingKind.WRITE_OFF -> accounts.loanLossExpense to accounts.loansReceivable
+            PostingKind.WRITE_OFF_INTEREST -> accounts.loanLossExpense to accounts.interestReceivable
             PostingKind.RESCHEDULE_FORGIVENESS -> accounts.loanLossExpense to accounts.loansReceivable
             PostingKind.PROVISIONING -> error("unreachable: handled above")
         }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -43,6 +43,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
 import io.smallrye.mutiny.Uni
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -368,6 +369,112 @@ class LendingServiceTest {
     }
 
     @Test
+    fun `write-off also derecognizes the accrued-but-unpaid interest receivable`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        // #1 paid; #2 and #3 unpaid with interest already accrued (a receivable is on the books);
+        // #4 unpaid but never accrued (no receivable exists for it — must not be derecognized).
+        val schedule = listOf(
+            LoanInstallment(
+                loanId = loanId, number = 1, dueDate = firstDue,
+                openingBalance = eur("12000.00"), principal = eur("946.19"),
+                interest = eur("120.00"), payment = eur("1066.19"), closingBalance = eur("11053.81"),
+                paid = true, paidAt = fixedNow,
+            ),
+            LoanInstallment(
+                loanId = loanId, number = 2, dueDate = firstDue.plusMonths(1),
+                openingBalance = eur("11053.81"), principal = eur("955.65"),
+                interest = eur("110.54"), payment = eur("1066.19"), closingBalance = eur("10098.16"),
+                interestAccrued = true, accruedAt = fixedNow,
+            ),
+            LoanInstallment(
+                loanId = loanId, number = 3, dueDate = firstDue.plusMonths(2),
+                openingBalance = eur("10098.16"), principal = eur("965.21"),
+                interest = eur("100.98"), payment = eur("1066.19"), closingBalance = eur("9132.95"),
+                interestAccrued = true, accruedAt = fixedNow,
+            ),
+            LoanInstallment(
+                loanId = loanId,
+                number = 4,
+                dueDate = firstDue.plusMonths(3),
+                openingBalance = eur("9132.95"),
+                principal = eur("974.86"),
+                interest = eur("91.33"),
+                payment = eur("1066.19"),
+                closingBalance = eur("8158.09"),
+            ),
+        )
+        val postings = mutableListOf<LedgerPosting>()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+
+        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol", reason = "insolvency"))
+            .await().indefinitely()
+
+        // Principal loss plus the interest receivable: nothing of the loan stays on the books.
+        assertThat(postings.map { it.kind })
+            .containsExactly(PostingKind.WRITE_OFF, PostingKind.WRITE_OFF_INTEREST)
+        val interestLeg = postings.single { it.kind == PostingKind.WRITE_OFF_INTEREST }
+        // Only the ACCRUED unpaid interest (#2 + #3 = 110.54 + 100.98); #4 never posted a receivable.
+        assertThat(interestLeg.amount).isEqualTo(eur("211.52"))
+        assertThat(interestLeg.reference).isEqualTo("loan:${loanId.value}:writeoff:interest")
+        // Both ledger legs are booked before the loan row is marked WRITTEN_OFF (crash safety).
+        verifyOrder {
+            ledger.post(match { it.kind == PostingKind.WRITE_OFF })
+            ledger.post(match { it.kind == PostingKind.WRITE_OFF_INTEREST })
+            loans.update(any())
+        }
+    }
+
+    @Test
+    fun `write-off retry after a ledger failure replays identical idempotency keys and only then marks the loan`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        // Unpaid installment #2 has its interest accrued: a receivable exists to derecognize.
+        val schedule = twoInstallmentSchedule(loanId).map {
+            if (it.paid) it else it.copy(interestAccrued = true, accruedAt = fixedNow)
+        }
+        val postings = mutableListOf<LedgerPosting>()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        // Attempt 1: the principal leg books, the interest leg dies on the wire.
+        every { ledger.post(capture(postings)) } answers {
+            if (firstArg<LedgerPosting>().kind == PostingKind.WRITE_OFF_INTEREST) {
+                Uni.createFrom().failure(IllegalStateException("ledger down"))
+            } else {
+                Uni.createFrom().item(Unit)
+            }
+        }
+
+        assertThatThrownBy {
+            service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol")).await().indefinitely()
+        }.isInstanceOf(IllegalStateException::class.java).hasMessageContaining("ledger down")
+        // Crash safety: the loan stays ACTIVE until every ledger leg has booked, so a retry re-enters.
+        verify(exactly = 0) { loans.update(any()) }
+
+        // Attempt 2: ledger is back.
+        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+
+        val written = service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol")).await().indefinitely()
+
+        assertThat(written.status).isEqualTo(LoanStatus.WRITTEN_OFF)
+        // The retry replays byte-identical idempotency keys, so the ledger collapses the replays —
+        // the principal leg is posted twice here but can only ever book once.
+        val principalRefs = postings.filter { it.kind == PostingKind.WRITE_OFF }.map { it.reference }
+        val interestRefs = postings.filter { it.kind == PostingKind.WRITE_OFF_INTEREST }.map { it.reference }
+        assertThat(principalRefs).hasSize(2).containsOnly("loan:${loanId.value}:writeoff")
+        assertThat(interestRefs).hasSize(2).containsOnly("loan:${loanId.value}:writeoff:interest")
+        assertThat(postings.filter { it.kind == PostingKind.WRITE_OFF_INTEREST }.map { it.amount }.toSet())
+            .containsExactly(eur("110.54"))
+        verify(exactly = 1) { loans.update(any()) }
+    }
+
+    @Test
     fun `write-off refuses a loan that is not ACTIVE`() {
         val loanId = LoanId.random()
         every { loans.findById(loanId) } returns
@@ -446,7 +553,7 @@ class LendingServiceTest {
     }
 
     @Test
-    fun `reschedule replaces the unpaid tail, numbering new rows after the last paid installment`() {
+    fun `reschedule replaces the unpaid tail, numbering new rows after the highest existing installment`() {
         val loanId = LoanId.random()
         val loan = activeLoan(loanId)
         val schedule = twoInstallmentSchedule(loanId)
@@ -458,9 +565,10 @@ class LendingServiceTest {
 
         assertThat(result.status).isEqualTo(LoanStatus.ACTIVE)
         verify(exactly = 1) { installments.deleteUnpaid(loanId) }
-        // One paid installment (#1) already exists; the new schedule's rows must continue from #2 —
-        // never restart at #1, or a future repayment's ledger reference would collide with the paid one.
-        assertThat(rowsSlot.captured.first().number).isEqualTo(2)
+        // Installments #1 (paid) and #2 (unpaid, discarded) already exist; the new schedule's rows must
+        // continue from #3 — never reuse a discarded number, or a future ledger reference
+        // ("loan:<id>:inst:<n>:...") would collide with one the discarded row may already have posted.
+        assertThat(rowsSlot.captured.first().number).isEqualTo(3)
         assertThat(rowsSlot.captured.map { it.number }).isSorted()
         assertThat(rowsSlot.captured).hasSize(24)
         verify(exactly = 0) { ledger.post(match { it.kind == PostingKind.RESCHEDULE_FORGIVENESS }) }
@@ -496,6 +604,101 @@ class LendingServiceTest {
         service.reschedule(loanId, rescheduleRequest(forgiveness = eur("1000.00")), "carol").await().indefinitely()
 
         assertThat(loanSlot.captured.version).isEqualTo(loan.version + 1)
+    }
+
+    @Test
+    fun `reschedule reverses each accrued-unpaid installment's accrual before deleting the tail`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        // Unpaid installment #2 already had its interest recognized by the accrual pass: an Interest
+        // Receivable of 110.54 is on the books that its settlement can now never clear.
+        val schedule = twoInstallmentSchedule(loanId).map {
+            if (it.paid) it else it.copy(interestAccrued = true, accruedAt = fixedNow)
+        }
+        mockRescheduleHappyPath(loanId, loan, schedule)
+        val postings = mutableListOf<LedgerPosting>()
+        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
+
+        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
+
+        assertThat(postings).hasSize(1)
+        val reversal = postings.single()
+        assertThat(reversal.kind).isEqualTo(PostingKind.INTEREST_ACCRUAL_REVERSAL)
+        assertThat(reversal.amount).isEqualTo(eur("110.54"))
+        // Generation-scoped key, same durable-version pattern as the forgiveness posting: a second
+        // reschedule of the same loan can never replay this journal.
+        assertThat(reversal.reference).isEqualTo("loan:${loanId.value}:inst:2:accrual-reversal:gen1")
+        // The ledger reversal is posted BEFORE the row is deleted: a crash in between leaves the row
+        // for the retry, which replays the same key idempotently.
+        verifyOrder {
+            ledger.post(any())
+            installments.deleteUnpaid(loanId)
+        }
+    }
+
+    @Test
+    fun `reschedule posts no reversal for an accrued zero-interest installment`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        // A zero-interest row is flagged accrued by the pass without ever posting: nothing to reverse.
+        val schedule = listOf(
+            twoInstallmentSchedule(loanId).first(),
+            LoanInstallment(
+                loanId = loanId, number = 2, dueDate = firstDue.plusMonths(1),
+                openingBalance = eur("11053.81"), principal = eur("1066.19"),
+                interest = eur("0.00"), payment = eur("1066.19"), closingBalance = eur("9987.62"),
+                interestAccrued = true, accruedAt = fixedNow,
+            ),
+        )
+        mockRescheduleHappyPath(loanId, loan, schedule)
+
+        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
+
+        verify(exactly = 0) { ledger.post(any()) }
+        verify(exactly = 1) { installments.deleteUnpaid(loanId) }
+    }
+
+    @Test
+    fun `reschedule retry after a ledger failure replays the identical reversal key and never deletes early`() {
+        val loanId = LoanId.random()
+        val loan = activeLoan(loanId)
+        val schedule = twoInstallmentSchedule(loanId).map {
+            if (it.paid) it else it.copy(interestAccrued = true, accruedAt = fixedNow)
+        }
+        val postings = mutableListOf<LedgerPosting>()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        // Attempt 1: the reversal dies on the wire.
+        every { ledger.post(capture(postings)) } returns
+            Uni.createFrom().failure(IllegalStateException("ledger down"))
+
+        assertThatThrownBy {
+            service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
+        }.isInstanceOf(IllegalStateException::class.java).hasMessageContaining("ledger down")
+        // Nothing was mutated: the rows are still there and the version was not bumped, so the retry
+        // recomputes the same generation and thus the same idempotency key.
+        verify(exactly = 0) { installments.deleteUnpaid(any()) }
+        verify(exactly = 0) { loans.update(any()) }
+
+        // Attempt 2: ledger is back; complete the happy path.
+        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
+        every { installments.deleteUnpaid(loanId) } returns Uni.createFrom().item(1)
+        every { installments.saveAll(any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            Uni.createFrom().item(firstArg<List<LoanInstallment>>())
+        }
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+
+        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
+
+        // Both attempts posted the reversal under the byte-identical idempotency key: the ledger
+        // collapses the replay, so the receivable is backed out exactly once.
+        assertThat(postings).hasSize(2)
+        assertThat(postings.map { it.reference }.toSet())
+            .containsExactly("loan:${loanId.value}:inst:2:accrual-reversal:gen1")
+        assertThat(postings.map { it.kind }.toSet()).containsExactly(PostingKind.INTEREST_ACCRUAL_REVERSAL)
+        assertThat(postings.map { it.amount }.toSet()).containsExactly(eur("110.54"))
     }
 
     @Test

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactoryTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactoryTest.kt
@@ -87,6 +87,18 @@ class LendingJournalFactoryTest {
     }
 
     @Test
+    fun `interest accrual reversal backs the accrual out - income debited, receivable credited`() {
+        val lines = LendingJournalFactory.buildLines(
+            posting(PostingKind.INTEREST_ACCRUAL_REVERSAL, "loan:1:inst:1:accrual-reversal:gen1"),
+            accounts,
+        )
+        // The exact mirror of INTEREST_ACCRUAL: the installment was cancelled by a reschedule before
+        // cash arrived, so the recognized income and its receivable are both unwound.
+        assertThat(lines.single { side(it) == "DEBIT" }.glAccountId).isEqualTo(accounts.interestIncome)
+        assertThat(lines.single { side(it) == "CREDIT" }.glAccountId).isEqualTo(accounts.interestReceivable)
+    }
+
+    @Test
     fun `write-off debits the loan loss expense`() {
         val lines = LendingJournalFactory.buildLines(
             posting(PostingKind.WRITE_OFF, "loan:1:writeoff"),
@@ -94,6 +106,17 @@ class LendingJournalFactoryTest {
         )
         assertThat(lines.single { side(it) == "DEBIT" }.glAccountId).isEqualTo(accounts.loanLossExpense)
         assertThat(lines.single { side(it) == "CREDIT" }.glAccountId).isEqualTo(accounts.loansReceivable)
+    }
+
+    @Test
+    fun `write-off of accrued interest books the loss against the receivable, not against income`() {
+        val lines = LendingJournalFactory.buildLines(
+            posting(PostingKind.WRITE_OFF_INTEREST, "loan:1:writeoff:interest"),
+            accounts,
+        )
+        // The income was legitimately earned at accrual; the uncollectible receivable is a credit loss.
+        assertThat(lines.single { side(it) == "DEBIT" }.glAccountId).isEqualTo(accounts.loanLossExpense)
+        assertThat(lines.single { side(it) == "CREDIT" }.glAccountId).isEqualTo(accounts.interestReceivable)
     }
 
     @Test


### PR DESCRIPTION
Closing audit (`docs/audits/2026-07-16-closing-audit.md`) findings **N-1** and **N-2** — the two accrued-interest defects in lending.

## 1. Reschedule destroyed accrued-but-unpaid installments → income recognized twice

`deleteUnpaid()` dropped every unpaid installment with **no `interestAccrued` filter**. But such a row has already posted an `INTEREST_ACCRUAL` (Dr Interest Receivable / Cr Interest Income). Deleting it means:

- its `INTEREST_SETTLEMENT` can never occur → the receivable is **stranded on the GL forever**, and
- the new schedule re-accrues interest on the same outstanding principal → **the same income recognized twice**.

The trigger is not exotic: forbearance of a delinquent loan is *the* normal reschedule case, and a delinquent loan is exactly the one with accrued unpaid installments.

**Fix:** every accrued unpaid installment posts an `INTEREST_ACCRUAL_REVERSAL` (Dr Interest Income / Cr Interest Receivable) *before* its row is discarded. The installment is cancelled, so the income was never truly earned — both legs back out, and the new schedule re-accrues from scratch.

## 2. Write-off derecognized principal only → orphaned interest receivable

`writeOff` booked `outstandingBalance` (principal). Accrued unpaid interest receivable stayed live on the books forever, on a WRITTEN_OFF loan.

**Fix:** `WRITE_OFF_INTEREST` (Dr Loan Loss Expense / Cr Interest Receivable) alongside the principal `WRITE_OFF`.

Note the deliberate asymmetry with #1: this is **not** an income reversal. That interest *was* legitimately earned when the installment fell due; what failed is collection. So the uncollectible receivable is booked as a credit loss, exactly like the principal exposure. Kept as its own `PostingKind` so an audit trail can split a write-off's loss into principal and interest components.

## Crash safety

Both post to the ledger **before** mutating rows, matching the existing `recordRepayment` / `accrueOne` ordering: a crash between the two replays the same idempotency key on retry and the ledger collapses it to the already-booked journal — exactly-once either way. Reschedule keys carry the persisted generation number, reusing the pattern the forgiveness posting already established, so a retried reschedule cannot double-post.

Deliberately **not** in scope: the service's broader multi-transaction model (audit finding N-3 — reschedule is 3 separate txs). These two flows are made economically correct and retry-safe; the transaction consolidation is a separate change.

## Tests

`:openbank-lending-service:test` + ktlint + detekt green (JDK 25). Added: reschedule posts reversals before delete; write-off derecognizes the receivable; retry after a simulated ledger failure does not double-post (idempotency-key equality).

Refs #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
