### PR TITLE
chore(gitops): auto-deploy services @ 3e1c2ab65df89e79c873c74d755e1dadcf7eb6f9

### DIFF
--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -2761,7 +2761,7 @@ spec:
       containers:
         - name: vop-service
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-cef5fdcd
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-vop-service:sandbox-3e1c2ab6
 
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 3e1c2ab65df89e79c873c74d755e1dadcf7eb6f9.

**Changed services:** ["openbank-vop-service"]

Each image tag was updated to `sandbox-3e1c2ab65df89e79c873c74d755e1dadcf7eb6f9` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.