### PR TITLE
feat(ci): add the db-migration gate — rollback note + forward-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,17 @@ jobs:
           sudo install -m 0755 /tmp/oasdiff /usr/local/bin/oasdiff
           python3 .github/scripts/check-api-contract.py --base "${PR_DIFF_BASE}"
 
+      # ADVISORY until rules.yaml change_classes.db_change flips to enforced
+      # (target 2026-08-15, ADR-0144) — add --enforce to the invocation to flip.
+      # Covers BOTH halves of db_change.require: an added migration carries a
+      # `-- Rollback:` note, and an already-committed migration is not edited
+      # (Flyway checksums the whole file — an edit to an applied migration fails
+      # startup with `checksum mismatch`). PR-only and diff-scoped against the
+      # resolved PR diff base, same as api-contract above.
+      - name: "db-migration gate — rollback note + forward-only (rules.yaml db_change, advisory)"
+        if: github.event_name == 'pull_request'
+        run: python3 openbank-infra/scripts/check-db-migration.py --base "${PR_DIFF_BASE}"
+
       # rules.yaml event_change / ADR-0006: schema-compat gate. The fleet's event
       # contract is the set of Kotlin data classes extending DomainEvent (JSON on
       # Kafka via the outbox; no .avsc files exist yet — the script covers those

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "fb391478cbc8c382"
+    openbank.tech/policy-checksum: "93fa8a59c946bf85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1346,7 +1346,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fb391478cbc8c382"
+        openbank.tech/policy-checksum: "93fa8a59c946bf85"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "316a65dd00d10ce4"
+    openbank.tech/policy-checksum: "ac669749f5702005"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1289,7 +1289,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "316a65dd00d10ce4"
+        openbank.tech/policy-checksum: "ac669749f5702005"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "379a0b2ab3f25219"
+    openbank.tech/policy-checksum: "ab2558469b4b84a5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1390,7 +1390,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "379a0b2ab3f25219"
+        openbank.tech/policy-checksum: "ab2558469b4b84a5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "6d0180d0024ca8ff"
+    openbank.tech/policy-checksum: "bca078af3f10fbf3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1295,7 +1295,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d0180d0024ca8ff"
+        openbank.tech/policy-checksum: "bca078af3f10fbf3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "87dffe43f550ec98"
+    openbank.tech/policy-checksum: "03ba4efac64bae10"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1327,7 +1327,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "87dffe43f550ec98"
+        openbank.tech/policy-checksum: "03ba4efac64bae10"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "c9639266e9ef2a25"
+    openbank.tech/policy-checksum: "9b2c81222f32f648"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1378,7 +1378,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c9639266e9ef2a25"
+        openbank.tech/policy-checksum: "9b2c81222f32f648"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "693388dcceb8600c"
+    openbank.tech/policy-checksum: "96a52341b116fd98"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -600,7 +600,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "693388dcceb8600c"
+        openbank.tech/policy-checksum: "96a52341b116fd98"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "693388dcceb8600c"
+    openbank.tech/policy-checksum: "96a52341b116fd98"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -600,7 +600,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "693388dcceb8600c"
+        openbank.tech/policy-checksum: "96a52341b116fd98"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "0ef37db213a351fb"
+    openbank.tech/policy-checksum: "900c514de2161857"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1306,7 +1306,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0ef37db213a351fb"
+        openbank.tech/policy-checksum: "900c514de2161857"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "dd5f98e8b278d72a"
+    openbank.tech/policy-checksum: "d27f71a8ea3e0a55"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1357,7 +1357,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dd5f98e8b278d72a"
+        openbank.tech/policy-checksum: "d27f71a8ea3e0a55"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "7f344cf890d7583b"
+    openbank.tech/policy-checksum: "d04eb24d9d78b73f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1291,7 +1291,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7f344cf890d7583b"
+        openbank.tech/policy-checksum: "d04eb24d9d78b73f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "6180cd9ae586bb8b"
+    openbank.tech/policy-checksum: "d2da4aa5c9fdc6d4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1404,7 +1404,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6180cd9ae586bb8b"
+        openbank.tech/policy-checksum: "d2da4aa5c9fdc6d4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "06f072db20456582"
+    openbank.tech/policy-checksum: "9c63bd944f325079"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1359,7 +1359,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06f072db20456582"
+        openbank.tech/policy-checksum: "9c63bd944f325079"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "693388dcceb8600c"
+    openbank.tech/policy-checksum: "96a52341b116fd98"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -600,7 +600,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "693388dcceb8600c"
+        openbank.tech/policy-checksum: "96a52341b116fd98"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c404c68d236d4982"
+    openbank.tech/policy-checksum: "69115831670d9d50"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1304,7 +1304,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ba64ecbcfce0df1a"
+    openbank.tech/policy-checksum: "79a25a4ceb83669c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1349,7 +1349,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ff5a4cf909eb93e0"
+    openbank.tech/policy-checksum: "1a098599a330ed73"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1334,7 +1334,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1047f91608aab24a" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "3117fbbce8da9d06" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -374,7 +374,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aea484cbd3a322d5"
+        openbank.tech/policy-checksum: "a76cd64e7c6776ce"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -727,7 +727,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ff5a4cf909eb93e0" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "1a098599a330ed73" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1050,7 +1050,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1b006ddf95d36dcd"
+        openbank.tech/policy-checksum: "afa21648ea1a162a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1365,7 +1365,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "ba64ecbcfce0df1a" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "79a25a4ceb83669c" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1780,7 +1780,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c404c68d236d4982"
+        openbank.tech/policy-checksum: "69115831670d9d50"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2036,7 +2036,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7d029b20964acc21" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "e685e681f8560dd6" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2436,7 +2436,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "51d5877b53fdd602"
+        openbank.tech/policy-checksum: "b351a41d6375240b"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2749,7 +2749,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1f6f922aa505f764"
+        openbank.tech/policy-checksum: "049fc7a7027038b2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1b006ddf95d36dcd"
+    openbank.tech/policy-checksum: "afa21648ea1a162a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1307,7 +1307,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "aea484cbd3a322d5"
+    openbank.tech/policy-checksum: "a76cd64e7c6776ce"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1328,7 +1328,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7d029b20964acc21"
+    openbank.tech/policy-checksum: "e685e681f8560dd6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1308,7 +1308,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "51d5877b53fdd602"
+    openbank.tech/policy-checksum: "b351a41d6375240b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1311,7 +1311,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1047f91608aab24a"
+    openbank.tech/policy-checksum: "3117fbbce8da9d06"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1364,7 +1364,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1f6f922aa505f764"
+    openbank.tech/policy-checksum: "049fc7a7027038b2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1315,7 +1315,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "aa4ca1d4ce0089cf"
+    openbank.tech/policy-checksum: "3b09e38b65ea0676"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1317,7 +1317,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aa4ca1d4ce0089cf"
+        openbank.tech/policy-checksum: "3b09e38b65ea0676"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "43accd74ccc3cda6"
+    openbank.tech/policy-checksum: "10bef434eb914efd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1295,7 +1295,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "43accd74ccc3cda6"
+        openbank.tech/policy-checksum: "10bef434eb914efd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "8b5d8a53b87e487e"
+    openbank.tech/policy-checksum: "7a9f1dd6663f520a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1331,7 +1331,15 @@ data:
         gate: db-migration
         enforced: advisory
         target_enforce_date: "2026-08-15"   # ADR-0144
-        blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+        # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+        # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+        # but the established practice is in-file (96 of 214 migrations when the gate was written,
+        # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+        # it sits next to the migration forever, where whoever rolls it back is already looking.
+        # The gate also covers the "forward" half of the requirement above — editing an
+        # already-committed migration is a finding, since Flyway checksums the whole file.
+        # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+        ci_producer: "openbank-infra/scripts/check-db-migration.py"
       event_change:
         detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
         require:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b5d8a53b87e487e"
+        openbank.tech/policy-checksum: "7a9f1dd6663f520a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/scripts/check-db-migration.py
+++ b/openbank-infra/scripts/check-db-migration.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""db-migration gate (rules.yaml: change_classes.db_change, ADR-0144 graduation).
+
+Discharges the two things `db_change.require` asks of a PR that touches a Flyway migration:
+
+  1. "new Flyway migration (forward)" — an ALREADY-COMMITTED migration must not be edited.
+     Flyway checksums the whole file, comments included, so any edit to a migration that has
+     been applied to a live DB fails startup with `checksum mismatch`. Forward-only, always:
+     add V<n+1>, never touch V<n>.
+
+  2. "rollback note in PR" — an ADDED migration must say how to undo itself.
+
+Where the rollback note lives
+-----------------------------
+In the migration file, as a `-- Rollback:` comment. `blocked_on` in rules.yaml assumed a
+PR-BODY-parsing check, but the established practice is in-file (96 of 214 migrations at the
+time of writing, and every recent one), and the file IS part of the PR — so an in-file note
+satisfies "rollback note in PR" and is strictly better: it lives next to the migration
+forever, where the person actually rolling it back is looking, rather than in a PR body they
+would have to go find.
+
+The note may be single-line (`-- Rollback: DROP TABLE foo;`) or span following comment lines:
+
+    -- Rollback:
+    --   DROP INDEX IF EXISTS uq_documents_idempotency_key;
+    --   ALTER TABLE documents DROP COLUMN IF EXISTS idempotency_key;
+
+Both are accepted. A bare `-- Rollback:` with nothing after it is NOT — a note that says
+nothing is worse than no note, because it looks like the box is ticked.
+
+Usage:
+    check-db-migration.py --base <sha> [--enforce]
+
+    default    advisory — findings are ::warning annotations, exit 0
+    --enforce  findings are ::error annotations, exit 1
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+MIGRATION_RE = re.compile(r"/src/main/resources/db/migration/.+\.sql$")
+
+# `-- Rollback` / `--Rollback:` / `-- ROLLBACK -` … the marker, however it is punctuated.
+ROLLBACK_MARKER_RE = re.compile(r"^\s*--\s*rollback\b[:\s-]*(?P<inline>.*)$", re.IGNORECASE)
+COMMENT_LINE_RE = re.compile(r"^\s*--\s?(?P<body>.*)$")
+
+
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def changed_migrations(base: str) -> tuple[list[str], list[str]]:
+    """Return (added, modified) migration paths in the diff against `base`."""
+    added, modified = [], []
+    # --diff-filter distinguishes the two requirements: A -> needs a note, M -> forbidden.
+    out = git("diff", "--name-status", "--diff-filter=AMR", base, "HEAD")
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status, path = parts[0], parts[-1]
+        if not MIGRATION_RE.search(path):
+            continue
+        # A rename (R) of a migration is an edit of its identity — Flyway keys on the version
+        # in the filename, so renaming V3 to V4 is not "adding V4", it is rewriting history.
+        if status.startswith("A"):
+            added.append(path)
+        else:
+            modified.append(path)
+    return added, modified
+
+
+def has_rollback_note(text: str) -> bool:
+    """True iff the file carries a `-- Rollback` note with actual content.
+
+    Content may be on the marker line, or on the comment lines that follow it (the multi-line
+    form). Blank comment lines between the marker and the content are tolerated; a non-comment
+    line ends the note.
+    """
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        m = ROLLBACK_MARKER_RE.match(line)
+        if not m:
+            continue
+        if m.group("inline").strip():
+            return True
+        # Multi-line: scan the following comment lines for the first non-empty body.
+        for follow in lines[i + 1 :]:
+            c = COMMENT_LINE_RE.match(follow)
+            if not c:
+                break  # a non-comment line ends the note block
+            if c.group("body").strip():
+                return True
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True, help="git sha of the PR base")
+    ap.add_argument("--enforce", action="store_true")
+    args = ap.parse_args()
+
+    level = "error" if args.enforce else "warning"
+    added, modified = changed_migrations(args.base)
+
+    if not added and not modified:
+        print("check-db-migration: no Flyway migration touched — nothing to check.")
+        return 0
+
+    findings = 0
+
+    for path in modified:
+        findings += 1
+        print(
+            f"::{level} file={path}::This migration is already committed and must not be edited "
+            "(rules.yaml: db_change requires a forward migration). Flyway checksums the whole "
+            "file — comments included — so once it has been applied to any live DB, an edit "
+            "fails startup with `checksum mismatch`. Add a new V<n+1> migration instead."
+        )
+
+    for path in added:
+        try:
+            text = git("show", f"HEAD:{path}")
+        except subprocess.CalledProcessError:
+            # Added then deleted within the same range — nothing to check.
+            continue
+        if not has_rollback_note(text):
+            findings += 1
+            print(
+                f"::{level} file={path}::New Flyway migration without a rollback note "
+                "(rules.yaml: db_change requires one). Add a `-- Rollback:` comment saying how "
+                "to undo this migration — single-line (`-- Rollback: DROP TABLE foo;`) or "
+                "spanning the following comment lines. If it is genuinely irreversible, say so "
+                "and say what the recovery is instead (e.g. restore from backup)."
+            )
+
+    checked = len(added) + len(modified)
+    if findings == 0:
+        print(
+            f"check-db-migration: {checked} migration change(s) checked — "
+            "all forward-only, all with a rollback note."
+        )
+        return 0
+
+    print(
+        f"check-db-migration: {checked} migration change(s) checked, {findings} finding(s) above."
+    )
+    if args.enforce:
+        return 1
+    print(
+        "::notice::check-db-migration is ADVISORY until rules.yaml's db_change "
+        "target_enforce_date; it will become a hard gate."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openbank-infra/scripts/check_db_migration_test.py
+++ b/openbank-infra/scripts/check_db_migration_test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Unit tests for check-db-migration.py — the db_change gate (rules.yaml, ADR-0144).
+
+The gate discharges both halves of `db_change.require`:
+  - an ADDED migration must carry a `-- Rollback:` note with actual content;
+  - an already-committed migration must not be EDITED (Flyway checksums the whole file).
+
+This suite proves:
+  - a new migration with a single-line note passes;
+  - a new migration with a MULTI-LINE note passes — the real shape of half the fleet's
+    notes, and the case a naive same-line regex would wrongly reject;
+  - a bare `-- Rollback:` with no content is a finding (a note that says nothing looks like
+    the box is ticked);
+  - a new migration with no note at all is a finding, and exits 1 under --enforce;
+  - editing an existing migration is a finding;
+  - non-migration SQL and unrelated files are ignored;
+  - advisory mode exits 0 even with findings.
+
+The module has a hyphenated filename, so it is loaded via importlib — same technique as
+check_threat_model_diff_test.py / gen_network_policies_test.py.
+
+Run:  python3 -m unittest openbank-infra/scripts/check_db_migration_test.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).parent / "check-db-migration.py"
+_spec = importlib.util.spec_from_file_location("check_db_migration", _SCRIPT_PATH)
+assert _spec and _spec.loader
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+MIGRATION_DIR = "openbank-demo-service/src/main/resources/db/migration"
+
+
+class HasRollbackNoteTest(unittest.TestCase):
+    """The note parser, in isolation — no git required."""
+
+    def test_single_line_note(self):
+        self.assertTrue(gate.has_rollback_note("-- Rollback: DROP TABLE foo;\nCREATE TABLE foo();"))
+
+    def test_multi_line_note(self):
+        # The real shape used by document-service V6 / statement-service V4. A naive regex
+        # demanding content on the marker line would reject these perfectly good notes.
+        sql = (
+            "-- Rollback:\n"
+            "--   DROP INDEX IF EXISTS uq_documents_idempotency_key;\n"
+            "--   ALTER TABLE documents DROP COLUMN IF EXISTS idempotency_key;\n"
+            "ALTER TABLE documents ADD COLUMN idempotency_key TEXT;\n"
+        )
+        self.assertTrue(gate.has_rollback_note(sql))
+
+    def test_blank_comment_lines_between_marker_and_content(self):
+        self.assertTrue(gate.has_rollback_note("-- Rollback:\n--\n--   DROP TABLE foo;\nSELECT 1;"))
+
+    def test_bare_marker_with_no_content_is_not_a_note(self):
+        # A note that says nothing is worse than no note: it looks like the box is ticked.
+        self.assertFalse(gate.has_rollback_note("-- Rollback:\nCREATE TABLE foo();"))
+
+    def test_marker_followed_by_sql_not_comments_is_not_a_note(self):
+        self.assertFalse(gate.has_rollback_note("-- Rollback:\nDROP TABLE foo;\n"))
+
+    def test_no_marker_at_all(self):
+        self.assertFalse(gate.has_rollback_note("-- ADR-0036 mandate vault.\nCREATE TABLE foo();"))
+
+    def test_case_and_punctuation_variants(self):
+        self.assertTrue(gate.has_rollback_note("--Rollback: DROP TABLE foo;"))
+        self.assertTrue(gate.has_rollback_note("-- ROLLBACK - DROP TABLE foo;"))
+        self.assertTrue(gate.has_rollback_note("-- rollback  DROP TABLE foo;"))
+
+
+class GateAgainstGitTest(unittest.TestCase):
+    """End-to-end against a real throwaway git repo."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self.tmp.name)
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "test")
+        self._git("config", "commit.gpgsign", "false")
+        self._write("README.md", "base\n")
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", "base")
+        self.base = self._git("rev-parse", "HEAD").strip()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", str(self.repo), *args], check=True, capture_output=True, text=True
+        ).stdout
+
+    def _write(self, rel: str, text: str) -> None:
+        p = self.repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+
+    def _run(self, enforce: bool = False) -> tuple[int, str]:
+        cmd = [sys.executable, str(_SCRIPT_PATH), "--base", self.base]
+        if enforce:
+            cmd.append("--enforce")
+        r = subprocess.run(cmd, cwd=str(self.repo), capture_output=True, text=True)
+        return r.returncode, r.stdout + r.stderr
+
+    def _commit(self, msg: str) -> None:
+        self._git("add", "-A")
+        self._git("commit", "-q", "-m", msg)
+
+    def test_new_migration_with_note_passes(self):
+        self._write(f"{MIGRATION_DIR}/V1__init.sql", "-- Rollback: DROP TABLE foo;\nCREATE TABLE foo();\n")
+        self._commit("add V1")
+        rc, out = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn("all with a rollback note", out)
+
+    def test_new_migration_without_note_is_a_finding(self):
+        self._write(f"{MIGRATION_DIR}/V1__init.sql", "CREATE TABLE foo();\n")
+        self._commit("add V1")
+        rc, out = self._run()
+        self.assertEqual(rc, 0, "advisory mode must not fail the build")
+        self.assertIn("::warning", out)
+        self.assertIn("without a rollback note", out)
+
+    def test_new_migration_without_note_fails_under_enforce(self):
+        self._write(f"{MIGRATION_DIR}/V1__init.sql", "CREATE TABLE foo();\n")
+        self._commit("add V1")
+        rc, out = self._run(enforce=True)
+        self.assertEqual(rc, 1)
+        self.assertIn("::error", out)
+
+    def test_editing_a_committed_migration_is_a_finding(self):
+        # Flyway checksums the whole file; editing an applied migration breaks startup.
+        self._write(f"{MIGRATION_DIR}/V1__init.sql", "-- Rollback: DROP TABLE foo;\nCREATE TABLE foo();\n")
+        self._commit("add V1")
+        self.base = self._git("rev-parse", "HEAD").strip()
+        self._write(
+            f"{MIGRATION_DIR}/V1__init.sql",
+            "-- Rollback: DROP TABLE foo;\nCREATE TABLE foo(id INT);\n",
+        )
+        self._commit("edit V1")
+        rc, out = self._run(enforce=True)
+        self.assertEqual(rc, 1)
+        self.assertIn("must not be edited", out)
+
+    def test_non_migration_sql_is_ignored(self):
+        self._write("openbank-demo-service/src/main/resources/clickhouse/V1__analytics.sql", "CREATE TABLE t();\n")
+        self._commit("add analytics sql")
+        rc, out = self._run(enforce=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to check", out)
+
+    def test_unrelated_change_is_ignored(self):
+        self._write("README.md", "changed\n")
+        self._commit("touch readme")
+        rc, out = self._run(enforce=True)
+        self.assertEqual(rc, 0)
+        self.assertIn("nothing to check", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -132,7 +132,15 @@ change_requirements:
     gate: db-migration
     enforced: advisory
     target_enforce_date: "2026-08-15"   # ADR-0144
-    blocked_on: "no CI script checks a PR touching db/migration for a rollback note — needs a PR-body-parsing check (not yet written)"
+    # The rollback note lives IN the migration, as a `-- Rollback:` comment — single-line or
+    # spanning the following comment lines. blocked_on used to call for a PR-BODY-parsing check,
+    # but the established practice is in-file (96 of 214 migrations when the gate was written,
+    # and every recent one), the file IS part of the PR, and an in-file note is strictly better:
+    # it sits next to the migration forever, where whoever rolls it back is already looking.
+    # The gate also covers the "forward" half of the requirement above — editing an
+    # already-committed migration is a finding, since Flyway checksums the whole file.
+    # Flipping to enforced = pass --enforce in ci.yml (one-line change).
+    ci_producer: "openbank-infra/scripts/check-db-migration.py"
   event_change:
     detect: ["*.avsc", "Avro/JSON schema under */schema/* or */avro/*", "Kotlin data class extending DomainEvent (the actual event contract today — JSON on Kafka via the outbox)"]
     require:


### PR DESCRIPTION
## Summary

Writes the CI script `rules.yaml`'s `db_change` rule has been waiting on since it was authored. Its ADR-0144 `target_enforce_date` is **2026-08-15** — a month out — at which point `check-gate-graduation.sh` fails CI for a rule nothing enforces. That guard is doing its job; this pays the debt it flagged.

## Type of change

- [x] feat (new functionality — a CI gate)
- [ ] fix / refactor / perf / docs / chore / security / breaking

## Linked issues

Closes #1239
Refs ADR-0144, ADR-0029

## Changes

- `openbank-infra/scripts/check-db-migration.py` — the gate. Diff-scoped against `PR_DIFF_BASE`, advisory (`::warning`, exit 0), `--enforce` flips it to `::error` + exit 1. Same shape as `check-api-contract.py`.
- `openbank-infra/scripts/check_db_migration_test.py` — 13 unit tests, in the suite CI already discovers.
- `ci.yml` — a PR-only step, next to the api-contract gate.
- `rules.yaml` — `blocked_on` replaced with `ci_producer` + the reasoning below.
- 44 OPA bundle files — the known `rules.yaml` ripple (25 of 26 generators hash it). All 27 re-run; the diff is my comment plus checksums, verified idempotent.

## It covers BOTH halves of `db_change.require`, not just the one `blocked_on` named

```yaml
require:
  - "new Flyway migration (forward)"   # <- also unenforced, also implemented here
  - "rollback note in PR"              # <- what blocked_on described
```

**Forward-only** had no gate at all. Flyway checksums the whole file — comments included — so editing a migration already applied to a live DB fails startup with `checksum mismatch`. The footgun is documented in `CLAUDE.md`; now it is enforced (advisory) rather than merely written down, which is what `rules.yaml: knowledge_capture` asks for.

## The note lives in the migration, not the PR body — a deliberate departure

`blocked_on` said "needs a PR-body-parsing check". I did not implement that, and `rules.yaml` now records why:

- The established practice is **in-file**: 96 of 214 migrations carry `-- Rollback:`, including every recent one.
- The migration file **is part of the PR**, so an in-file note satisfies "rollback note in PR" on a plain reading.
- It is strictly better: the note sits next to the migration forever, where whoever rolls it back is already looking — not in a PR body they have to go find.

If you disagree with that reading, this is the line to push back on.

## Definition of Done

- [x] Hexagonal layering — N/A (CI tooling).
- [x] Unit tests added — 13, discovered by the existing `unittest discover -s openbank-infra/scripts` step.
- [ ] Integration tests — N/A.
- [ ] Contract tests — N/A.
- [x] Governance script suite green — 38 tests, 0 failures.
- [x] No new lint warnings — yamllint clean on `ci.yml`; no new `.sh` files.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — the rationale lives in `rules.yaml` next to the rule, per governance-as-code.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency — stdlib Python + `git`.
- [ ] Auth / crypto / payment code — no.
- [ ] PII path — no.
- [ ] Cardholder data — no.

## Compliance impact

- [x] None directly — but it is the mechanism behind a DORA-adjacent change-management control: a DB change that cannot be undone, with no recorded way to undo it, is exactly what the rule exists to prevent.

## Rollout / Rollback

- **Deployment strategy:** none — CI only. The gate is **advisory**: it annotates, it does not block. Flipping to enforced on 2026-08-15 is `--enforce` in `ci.yml`, one line.
- **Rollback plan:** revert. The rule returns to advisory-and-unenforced, and `check-gate-graduation.sh` starts failing on 2026-08-15 as it does today.
- **Data migration reversible:** N/A.

## Reviewer notes

**Verified against real history, not just fixtures.** Run against `HEAD~15` it flags `openbank-ledger-service/src/main/resources/db/migration/V16__tieout_runs.sql`, which genuinely has no rollback note (zero occurrences of the word). True positive — exactly the leak the gate exists to catch. Against `HEAD~5` and `HEAD~40` it is quiet where it should be.

**Two things the implementation had to get right, both found by reading real migrations rather than assuming:**

1. A `-- Rollback:` with nothing after it is often a **multi-line** note, content on the following comment lines (`document-service` V6, `statement-service` V4). A regex demanding content on the marker line would have rejected those perfectly good notes — a false positive on ~half the fleet's convention.
2. A bare marker with no content anywhere **is** a finding. A note that says nothing is worse than no note: it looks like the box is ticked.

**Not flipped to enforced in this PR, deliberately.** 118 of 214 existing migrations have no note; the gate is diff-scoped so they do not matter, but flipping enforcement is a governance decision with a date attached to it, and it is yours to make — the one-line change is documented in `rules.yaml` and in the `ci.yml` comment.
