### PR TITLE
ci(governance): guard gitops Secret/ConfigMap refs against undeclared names

### DIFF
--- a/.github/scripts/check-gitops-secret-refs.py
+++ b/.github/scripts/check-gitops-secret-refs.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+# See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+#
+# ---------------------------------------------------------------------------------------
+# Guard: every Secret/ConfigMap a gitops workload consumes must be declared by something
+# in gitops (rules.yaml: gitops_ref_integrity).
+#
+# THE FAILURE THIS CATCHES
+# A service is merged with a complete-looking manifest that reads a Secret nobody creates.
+# Nothing fails at merge: the YAML is valid, ArgoCD syncs it happily (the Rollout is a
+# legal object), and CI never runs the pod. Kyverno admits it. The pod then sits in
+# CreateContainerConfigError forever, and the only signal is `kubectl describe` on a pod
+# nobody is watching.
+#
+# vop-service, 2026-07-16: shipped in #1195 with `OIDC_CLIENT_SECRET <- secretKeyRef:
+# vop-oidc`, but no ExternalSecret ever declared `vop-oidc`. It appeared exactly once in
+# the whole repo -- at the point of consumption. The pod restarted 26 times over 10
+# minutes with `Error: secret "vop-oidc" not found` while every dashboard stayed green,
+# and it was found by hand (#1232). Its sibling gap -- absent from ALL_SERVICES -- already
+# has a guard (check-deploy-coverage.sh); this is the same shape one layer down, and it
+# only surfaced after that one was fixed. Two of three vop gaps were "a name referenced
+# but never declared"; that is the invariant worth enforcing.
+#
+# WHAT COUNTS AS A DECLARATION
+# There are no literal `kind: Secret` objects in gitops -- every Secret is produced by an
+# operator from a declaration. So a bare name-existence grep would flag all of them. The
+# producers, and the names they yield:
+#   ExternalSecret  -> spec.target.name (falls back to metadata.name, per the ESO default)
+#   ConfigMap       -> metadata.name
+#   Certificate     -> spec.secretName                        (cert-manager)
+#   Cluster (CNPG)  -> <name>-app, <name>-superuser, <name>-ca, <name>-server,
+#                      <name>-replication                      (postgresql.cnpg.io)
+# CNPG is why `vop-db-app` must NOT be flagged: it is real, and correct, and appears
+# nowhere as a declaration -- the operator derives it from the Cluster name. A guard that
+# cannot model that fails every database-backed service, gets muted, and protects nothing
+# (see check-deploy-coverage.sh on why a Dockerfile rule was rejected for the same reason).
+#
+# Matching is by (namespace, name). A workload with no explicit namespace is matched
+# against declarations in its own file's directory component -- ArgoCD sets the namespace
+# per Application, so cross-component collisions are not a concern.
+# ---------------------------------------------------------------------------------------
+import sys
+from pathlib import Path
+
+import yaml
+
+GITOPS = Path("openbank-infra/gitops")
+
+# Kinds whose pod template consumes Secrets/ConfigMaps.
+WORKLOAD_KINDS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet", "Job", "CronJob"}
+
+# Secrets an operator or the platform materialises without a gitops declaration.
+# Keep this SHORT and justified -- every entry is a hole in the guard.
+IGNORED_NAMES = {
+    # kubernetes.io/dockerconfigjson pull secrets are provisioned per-namespace by the
+    # platform bootstrap, not by a gitops object.
+    "ecr-pull-secret",
+    "regcred",
+    # openbao-db-rotation-sync (ADR-0099 Tier 1) reads the per-database admin passwords
+    # OpenBao itself rotates service credentials with. It CANNOT be an ExternalSecret:
+    # ClusterSecretStore `vault-kv` is backed by http://openbao.vault.svc:8200, so
+    # projecting it would make OpenBao bootstrap from OpenBao. Genuinely out-of-band,
+    # hand-created, no ownerReferences -- verified live 2026-07-16. Note the flip side:
+    # nothing recreates it if the vault namespace is rebuilt, and the weekly rotation
+    # CronJob would then fail quietly. Tracked as fragility, not as a guard bug.
+    "openbao-db-admin-passwords",
+}
+
+
+def pod_specs(doc):
+    """Yield every PodSpec inside a workload doc (CronJob nests one level deeper)."""
+    kind = doc.get("kind")
+    spec = doc.get("spec") or {}
+    if kind == "CronJob":
+        tmpl = (spec.get("jobTemplate") or {}).get("spec", {}).get("template") or {}
+    else:
+        tmpl = spec.get("template") or {}
+    ps = tmpl.get("spec")
+    if isinstance(ps, dict):
+        yield ps
+
+
+def refs_in(ps):
+    """Yield (kind, name) for every Secret/ConfigMap the PodSpec consumes."""
+    for c in (ps.get("containers") or []) + (ps.get("initContainers") or []):
+        for e in c.get("env") or []:
+            vf = e.get("valueFrom") or {}
+            for key, kind in (("secretKeyRef", "Secret"), ("configMapKeyRef", "ConfigMap")):
+                ref = vf.get(key)
+                if isinstance(ref, dict) and ref.get("name") and not ref.get("optional"):
+                    yield kind, ref["name"]
+        for ef in c.get("envFrom") or []:
+            for key, kind in (("secretRef", "Secret"), ("configMapRef", "ConfigMap")):
+                ref = ef.get(key)
+                if isinstance(ref, dict) and ref.get("name") and not ref.get("optional"):
+                    yield kind, ref["name"]
+    for v in ps.get("volumes") or []:
+        sec = v.get("secret") or {}
+        if sec.get("secretName") and not sec.get("optional"):
+            yield "Secret", sec["secretName"]
+        cm = v.get("configMap") or {}
+        if cm.get("name") and not cm.get("optional"):
+            yield "ConfigMap", cm["name"]
+
+
+def declarations(doc):
+    """Yield (kind, name) for everything this doc causes to exist."""
+    kind, meta = doc.get("kind"), doc.get("metadata") or {}
+    name, spec = meta.get("name"), doc.get("spec") or {}
+    if kind == "ConfigMap" and name:
+        yield "ConfigMap", name
+    elif kind == "ExternalSecret":
+        yield "Secret", (spec.get("target") or {}).get("name") or name
+    elif kind == "SealedSecret" and name:
+        yield "Secret", name
+    elif kind == "Secret" and name:
+        yield "Secret", name
+    elif kind == "Certificate" and spec.get("secretName"):
+        yield "Secret", spec["secretName"]
+    elif kind == "Cluster" and name and "cnpg" in str(doc.get("apiVersion", "")):
+        # CloudNativePG derives these from the Cluster name; none appear in gitops.
+        for suffix in ("app", "superuser", "ca", "server", "replication"):
+            yield "Secret", f"{name}-{suffix}"
+
+
+def component_of(path):
+    """gitops/components/<component>/... -> <component>; the namespace proxy."""
+    parts = path.parts
+    return parts[parts.index("components") + 1] if "components" in parts else str(path.parent)
+
+
+def main():
+    if not GITOPS.is_dir():
+        print(f"ERROR: {GITOPS} not found -- run from the repo root.", file=sys.stderr)
+        return 2
+
+    declared, consumed = set(), []
+    for path in sorted(GITOPS.rglob("*.yaml")):
+        try:
+            docs = [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+        except yaml.YAMLError as exc:
+            print(f"ERROR: {path}: unparseable YAML: {exc}", file=sys.stderr)
+            return 2
+        comp = component_of(path)
+        for doc in docs:
+            ns = (doc.get("metadata") or {}).get("namespace") or comp
+            for kind, name in declarations(doc):
+                declared.add((ns, kind, name))
+            if doc.get("kind") in WORKLOAD_KINDS:
+                for ps in pod_specs(doc):
+                    for kind, name in refs_in(ps):
+                        consumed.append((ns, kind, name, path, (doc.get("metadata") or {}).get("name")))
+
+    missing = [
+        (ns, kind, name, path, owner)
+        for ns, kind, name, path, owner in consumed
+        if name not in IGNORED_NAMES and (ns, kind, name) not in declared
+    ]
+
+    print(f"gitops ref integrity: {len(declared)} declared, {len(consumed)} references checked")
+    if not missing:
+        print("OK: every referenced Secret/ConfigMap is declared.")
+        return 0
+
+    seen, out = set(), []
+    for ns, kind, name, path, owner in missing:
+        if (ns, kind, name) in seen:
+            continue
+        seen.add((ns, kind, name))
+        out.append((ns, kind, name, path, owner))
+
+    print(f"\nFAIL: {len(out)} referenced {'name is' if len(out) == 1 else 'names are'} "
+          f"declared nowhere in gitops:\n", file=sys.stderr)
+    for ns, kind, name, path, owner in out:
+        print(f"  {kind} {ns}/{name}", file=sys.stderr)
+        print(f"    consumed by {owner} in {path}", file=sys.stderr)
+        print(f"    nothing declares it -- the pod will sit in CreateContainerConfigError.",
+              file=sys.stderr)
+        if kind == "Secret":
+            print(f"    fix: add an ExternalSecret with target.name: {name} "
+                  f"(see the component's oidc-externalsecrets.yaml for the pattern)",
+                  file=sys.stderr)
+        print(file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,15 @@ jobs:
       - name: "deploy-coverage guard (released + gitops => in ALL_SERVICES, enforced)"
         run: bash .github/scripts/check-deploy-coverage.sh
 
+      # gitops ref-integrity guard (rules.yaml: gitops_ref_integrity). The layer below
+      # deploy-coverage: that one proves a service gets BUILT, this one proves the manifest
+      # it deploys can actually START. A secretKeyRef to a Secret nobody declares passes
+      # YAML validation, ArgoCD sync and Kyverno admission alike — the pod then sits in
+      # CreateContainerConfigError forever with no signal but `kubectl describe`. vop-service
+      # burned an hour on exactly this (#1232) right after #1229 fixed its ALL_SERVICES gap.
+      - name: "gitops ref-integrity guard (referenced Secret/ConfigMap => declared)"
+        run: python3 .github/scripts/check-gitops-secret-refs.py
+
       # quarkus.application.version override guard (ADR-0029 release_invariant).
       # The convention plugin openbank.quarkus-service reads version.txt into the
       # Gradle project version and the Quarkus Gradle plugin stamps it into

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "3ef403e1da68041e"
+    openbank.tech/policy-checksum: "fb391478cbc8c382"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2427,6 +2427,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3ef403e1da68041e"
+        openbank.tech/policy-checksum: "fb391478cbc8c382"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "1c1c934477800c04"
+    openbank.tech/policy-checksum: "316a65dd00d10ce4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2370,6 +2370,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1c1c934477800c04"
+        openbank.tech/policy-checksum: "316a65dd00d10ce4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "470421502fe39d0b"
+    openbank.tech/policy-checksum: "379a0b2ab3f25219"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2471,6 +2471,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "470421502fe39d0b"
+        openbank.tech/policy-checksum: "379a0b2ab3f25219"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "8b9694fb4e5a1dd6"
+    openbank.tech/policy-checksum: "6d0180d0024ca8ff"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2376,6 +2376,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b9694fb4e5a1dd6"
+        openbank.tech/policy-checksum: "6d0180d0024ca8ff"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "50c861fd9664a990"
+    openbank.tech/policy-checksum: "87dffe43f550ec98"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2408,6 +2408,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "50c861fd9664a990"
+        openbank.tech/policy-checksum: "87dffe43f550ec98"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "95de91b9140672bc"
+    openbank.tech/policy-checksum: "c9639266e9ef2a25"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2459,6 +2459,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95de91b9140672bc"
+        openbank.tech/policy-checksum: "c9639266e9ef2a25"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "fd5619c2a6353e60"
+    openbank.tech/policy-checksum: "693388dcceb8600c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1681,6 +1681,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fd5619c2a6353e60"
+        openbank.tech/policy-checksum: "693388dcceb8600c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "fd5619c2a6353e60"
+    openbank.tech/policy-checksum: "693388dcceb8600c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1681,6 +1681,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fd5619c2a6353e60"
+        openbank.tech/policy-checksum: "693388dcceb8600c"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "c59ce5f65373d0de"
+    openbank.tech/policy-checksum: "0ef37db213a351fb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2387,6 +2387,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c59ce5f65373d0de"
+        openbank.tech/policy-checksum: "0ef37db213a351fb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "86b4cbe655d953db"
+    openbank.tech/policy-checksum: "dd5f98e8b278d72a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2438,6 +2438,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "86b4cbe655d953db"
+        openbank.tech/policy-checksum: "dd5f98e8b278d72a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "8ffc5465fb48f466"
+    openbank.tech/policy-checksum: "7f344cf890d7583b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2372,6 +2372,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8ffc5465fb48f466"
+        openbank.tech/policy-checksum: "7f344cf890d7583b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "bf3b811a4f029f61"
+    openbank.tech/policy-checksum: "6180cd9ae586bb8b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2485,6 +2485,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bf3b811a4f029f61"
+        openbank.tech/policy-checksum: "6180cd9ae586bb8b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "d02b0fdff94f869f"
+    openbank.tech/policy-checksum: "06f072db20456582"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2440,6 +2440,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d02b0fdff94f869f"
+        openbank.tech/policy-checksum: "06f072db20456582"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "fd5619c2a6353e60"
+    openbank.tech/policy-checksum: "693388dcceb8600c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1681,6 +1681,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "fd5619c2a6353e60"
+        openbank.tech/policy-checksum: "693388dcceb8600c"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5b9c08a84766bbe3"
+    openbank.tech/policy-checksum: "c404c68d236d4982"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2385,6 +2385,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9490191cb36faa71"
+    openbank.tech/policy-checksum: "ba64ecbcfce0df1a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2430,6 +2430,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d92bfa6a2d996a09"
+    openbank.tech/policy-checksum: "ff5a4cf909eb93e0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2415,6 +2415,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b7cc813252ecaee7" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "1047f91608aab24a" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -374,7 +374,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "56c3bdf0e13b6b49"
+        openbank.tech/policy-checksum: "aea484cbd3a322d5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -727,7 +727,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d92bfa6a2d996a09" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "ff5a4cf909eb93e0" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1050,7 +1050,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d0eaf4f303b4a662"
+        openbank.tech/policy-checksum: "1b006ddf95d36dcd"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1365,7 +1365,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "9490191cb36faa71" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "ba64ecbcfce0df1a" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1780,7 +1780,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5b9c08a84766bbe3"
+        openbank.tech/policy-checksum: "c404c68d236d4982"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2036,7 +2036,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c9ce3d9a9c17f907" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "7d029b20964acc21" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2436,7 +2436,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c91c01c3bc3f9604"
+        openbank.tech/policy-checksum: "51d5877b53fdd602"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2749,7 +2749,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "297d1feca6fe0dc0"
+        openbank.tech/policy-checksum: "1f6f922aa505f764"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d0eaf4f303b4a662"
+    openbank.tech/policy-checksum: "1b006ddf95d36dcd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2388,6 +2388,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "56c3bdf0e13b6b49"
+    openbank.tech/policy-checksum: "aea484cbd3a322d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2409,6 +2409,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c9ce3d9a9c17f907"
+    openbank.tech/policy-checksum: "7d029b20964acc21"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2389,6 +2389,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c91c01c3bc3f9604"
+    openbank.tech/policy-checksum: "51d5877b53fdd602"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2392,6 +2392,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b7cc813252ecaee7"
+    openbank.tech/policy-checksum: "1047f91608aab24a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2445,6 +2445,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "297d1feca6fe0dc0"
+    openbank.tech/policy-checksum: "1f6f922aa505f764"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2396,6 +2396,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "fe6162fc22c873c6"
+    openbank.tech/policy-checksum: "aa4ca1d4ce0089cf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2398,6 +2398,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fe6162fc22c873c6"
+        openbank.tech/policy-checksum: "aa4ca1d4ce0089cf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "d3f4ec69b6875e4b"
+    openbank.tech/policy-checksum: "43accd74ccc3cda6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2376,6 +2376,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d3f4ec69b6875e4b"
+        openbank.tech/policy-checksum: "43accd74ccc3cda6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "0051ffe899308049"
+    openbank.tech/policy-checksum: "8b5d8a53b87e487e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2412,6 +2412,32 @@ data:
     # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
     # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
     # of truth when it and CLAUDE.md disagree.
+    gitops_ref_integrity:
+      script: .github/scripts/check-gitops-secret-refs.py
+      wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+      # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+      # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+      # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+      # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+      # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+      rule: >-
+        Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+        must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+        operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+        CNPG Cluster credentials).
+      basis: referenced_implies_declared
+      # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+      # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+      # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+      # guard unusable, and the allowlist justification -- lives in the script header, where it
+      # is stored once. Keep this block to the rule itself.
+      # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+      # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+      # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+      # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+      # naming `Secret payments/vop-oidc`; restored, it passes.
+      incident: 2026-07-16
+
     deploy_coverage:
       script: .github/scripts/check-deploy-coverage.sh
       wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0051ffe899308049"
+        openbank.tech/policy-checksum: "8b5d8a53b87e487e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1227,30 +1227,16 @@ gitops_ref_integrity:
     operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
     CNPG Cluster credentials).
   basis: referenced_implies_declared
-  # WHAT COUNTS AS A DECLARATION -- and why a plain grep cannot do this: there is not one
-  # literal `kind: Secret` in gitops. Every Secret is produced by an operator from a
-  # declaration, so a name-existence check would flag all 300+ of them. The guard models the
-  # producers instead: ExternalSecret -> spec.target.name; Certificate -> spec.secretName;
-  # CNPG Cluster -> <name>-{app,superuser,ca,server,replication}. The CNPG case is the one
-  # that matters: `vop-db-app` is real and correct yet appears nowhere as a declaration --
-  # the operator derives it from the Cluster name. A guard that cannot model that fails every
-  # database-backed service, gets muted, and protects nothing (the same reasoning that killed
-  # the Dockerfile rule under deploy_coverage).
-  # ALLOWLIST: in-script (IGNORED_NAMES), deliberately tiny -- every entry is a hole.
-  # openbao-db-admin-passwords is the only interesting one: ClusterSecretStore `vault-kv` is
-  # backed by openbao itself, so projecting OpenBao's own DB admin passwords through ESO
-  # would make it bootstrap from itself. Genuinely out-of-band. Its flip side is real
-  # fragility -- hand-created, no ownerReferences, nothing recreates it if the vault
-  # namespace is rebuilt, and the weekly ADR-0099 rotation CronJob would then fail quietly.
-  # PRIOR ART: vop-service, 2026-07-16. Shipped in #1195 consuming `vop-oidc`, which appeared
-  # exactly ONCE in the repo -- at the point of consumption. 26 restarts over 10 minutes with
-  # `Error: secret "vop-oidc" not found`, every dashboard green, found by hand (#1232). Its
-  # sibling gap (absent from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is
-  # the same shape one layer down and only surfaced after that one was fixed. Two of vop's
-  # three gaps were "a name referenced but never declared".
-  # VERIFIED BY REVERT, not by running green: with #1232's ExternalSecret removed the guard
-  # fails naming `Secret payments/vop-oidc`; restored, it passes. A guard only proven to run
-  # is not proven to fire.
+  # NOTE: rules.yaml is embedded VERBATIM (comments included) into all 27 OPA bundle
+  # ConfigMaps, so prose here is duplicated 27x and moves every policy-checksum. The full
+  # rationale -- why a grep cannot do this, the CNPG `vop-db-app` case that makes a naive
+  # guard unusable, and the allowlist justification -- lives in the script header, where it
+  # is stored once. Keep this block to the rule itself.
+  # PRIOR ART: vop-service, 2026-07-16 -- shipped in #1195 consuming `vop-oidc`, a name that
+  # appeared exactly ONCE in the repo, at the point of consumption. Its sibling gap (absent
+  # from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is the same shape one
+  # layer down. Verified by REVERT: with #1232's ExternalSecret removed the guard fails
+  # naming `Secret payments/vop-oidc`; restored, it passes.
   incident: 2026-07-16
 
 deploy_coverage:

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1213,6 +1213,46 @@ finops_cost_groups:
 # stale. Routing by kind; the human-readable form lives in CLAUDE.md ("Capturing what
 # we learn"). This is a process rule (not CI-enforced), but rules.yaml is the source
 # of truth when it and CLAUDE.md disagree.
+gitops_ref_integrity:
+  script: .github/scripts/check-gitops-secret-refs.py
+  wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)
+  # THE RULE: every Secret/ConfigMap a gitops workload consumes must be declared by
+  # something in gitops. A manifest that reads a Secret nobody creates passes every gate
+  # we have: the YAML is valid, ArgoCD syncs it (the Rollout is a legal object), CI never
+  # runs the pod, and Kyverno admits it. The pod then sits in CreateContainerConfigError
+  # indefinitely and the only signal is `kubectl describe` on a pod nobody watches.
+  rule: >-
+    Every secretKeyRef / configMapKeyRef / envFrom / volume reference in a gitops workload
+    must resolve to a Secret or ConfigMap declared in gitops -- directly, or via the
+    operator that derives it (ExternalSecret target, cert-manager Certificate secretName,
+    CNPG Cluster credentials).
+  basis: referenced_implies_declared
+  # WHAT COUNTS AS A DECLARATION -- and why a plain grep cannot do this: there is not one
+  # literal `kind: Secret` in gitops. Every Secret is produced by an operator from a
+  # declaration, so a name-existence check would flag all 300+ of them. The guard models the
+  # producers instead: ExternalSecret -> spec.target.name; Certificate -> spec.secretName;
+  # CNPG Cluster -> <name>-{app,superuser,ca,server,replication}. The CNPG case is the one
+  # that matters: `vop-db-app` is real and correct yet appears nowhere as a declaration --
+  # the operator derives it from the Cluster name. A guard that cannot model that fails every
+  # database-backed service, gets muted, and protects nothing (the same reasoning that killed
+  # the Dockerfile rule under deploy_coverage).
+  # ALLOWLIST: in-script (IGNORED_NAMES), deliberately tiny -- every entry is a hole.
+  # openbao-db-admin-passwords is the only interesting one: ClusterSecretStore `vault-kv` is
+  # backed by openbao itself, so projecting OpenBao's own DB admin passwords through ESO
+  # would make it bootstrap from itself. Genuinely out-of-band. Its flip side is real
+  # fragility -- hand-created, no ownerReferences, nothing recreates it if the vault
+  # namespace is rebuilt, and the weekly ADR-0099 rotation CronJob would then fail quietly.
+  # PRIOR ART: vop-service, 2026-07-16. Shipped in #1195 consuming `vop-oidc`, which appeared
+  # exactly ONCE in the repo -- at the point of consumption. 26 restarts over 10 minutes with
+  # `Error: secret "vop-oidc" not found`, every dashboard green, found by hand (#1232). Its
+  # sibling gap (absent from ALL_SERVICES, #1229) is guarded by deploy_coverage below; this is
+  # the same shape one layer down and only surfaced after that one was fixed. Two of vop's
+  # three gaps were "a name referenced but never declared".
+  # VERIFIED BY REVERT, not by running green: with #1232's ExternalSecret removed the guard
+  # fails naming `Secret payments/vop-oidc`; restored, it passes. A guard only proven to run
+  # is not proven to fire.
+  incident: 2026-07-16
+
 deploy_coverage:
   script: .github/scripts/check-deploy-coverage.sh
   wired_into: .github/workflows/ci.yml   # governance job -> all-green (a REQUIRED check)


### PR DESCRIPTION
Refs #1195, #1229, #1232

## The failure this catches

A manifest that consumes a Secret nobody creates passes **every gate we have**: the YAML is valid,
ArgoCD syncs it (the Rollout is a legal object), CI never runs the pod, Kyverno admits it. The pod
then sits in `CreateContainerConfigError` indefinitely and the only signal is `kubectl describe` on a
pod nobody is watching.

**vop-service, 2026-07-16.** #1195 shipped it consuming `vop-oidc` — a name that appeared exactly
**once** in the whole repo, at the point of consumption:

```
Error: secret "vop-oidc" not found          (x26 over 10m)
```

Every dashboard stayed green. Found by hand; fixed by #1232.

## Where it sits

`check-deploy-coverage.sh` (#1229) proves a service gets **built**. This proves the manifest it
deploys can **start**. Same shape, one layer down — and it only surfaced *after* the deploy-coverage
gap was fixed. Two of vop's three gaps were "a name referenced but never declared"; that is the
invariant worth enforcing.

## Why a grep can't do this

There is not one literal `kind: Secret` in gitops — every Secret is produced by an operator from a
declaration, so a name-existence check flags all 300+. The guard models the producers:

| producer | yields |
|---|---|
| `ExternalSecret` | `spec.target.name` (falls back to `metadata.name`) |
| `Certificate` (cert-manager) | `spec.secretName` |
| `Cluster` (CNPG) | `<name>-{app,superuser,ca,server,replication}` |
| `ConfigMap` / `SealedSecret` / `Secret` | `metadata.name` |

The CNPG row is the reason to write this carefully: **`vop-db-app` is real and correct yet declared
nowhere** — the operator derives it from the Cluster name. A guard that cannot model that fails every
database-backed service, gets muted, and protects nothing. That is the same reasoning that rejected a
"every service needs a Dockerfile" rule under `deploy_coverage`.

## Verified by revert, not by running green

```
main as-is                        -> OK: 447 declared, 315 references checked        exit 0
#1232's ExternalSecret removed    -> FAIL: Secret payments/vop-oidc                  exit 1
                                     consumed by vop-service in payments-services.yaml
```

A guard only proven to *run* is not proven to *fire*.

## Allowlist

One entry, `openbao-db-admin-passwords`. `ClusterSecretStore vault-kv` is backed by
`http://openbao.vault.svc:8200` — openbao itself — so projecting OpenBao's own DB admin passwords
through ESO would make it bootstrap from itself. Genuinely out-of-band: hand-created, no
`ownerReferences` (verified live).

**Worth noting as its own fragility, out of scope here:** nothing recreates that secret if the `vault`
namespace is rebuilt, and the weekly ADR-0099 rotation CronJob would then fail quietly. Recorded in
the allowlist comment and in `rules.yaml`.

## Wiring

`.github/workflows/ci.yml` job `validate` (→ `all-green`, a required check), beside the
deploy-coverage guard. pyyaml is already installed in that job. Rule recorded as
`rules.yaml: gitops_ref_integrity`, per `knowledge_capture` — a checkable rule belongs in a CI guard,
not in prose that the next contributor won't read.