### PR TITLE
Revert "fix(lending): reverse accrued interest on reschedule, derecognize it on write-off"

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
@@ -37,32 +37,19 @@ data class LedgerPosting(val reference: String, val partyId: UUID, val amount: M
  * contra-asset); a decrease (partial release) is the reverse. The loan principal GL is never touched by
  * a provisioning entry — provisioning is an impairment overlay, not a change to the recognized asset.
  *
- * [INTEREST_ACCRUAL_REVERSAL] unwinds a previously booked [INTEREST_ACCRUAL] when the installment it
- * recognized income for is cancelled before cash ever arrives (a reschedule discarding the unpaid
- * tail, issue #667/#668): the income was recognized against a receivable that will now never settle,
- * so both are backed out — the new schedule re-accrues its own installments' interest from scratch.
- *
  * [RESCHEDULE_FORGIVENESS] books a partial debt-relief amount granted as part of a loan restructuring
  * (issue #667/#668) — the same economic event as [WRITE_OFF] (a realized credit loss, asset off the
  * books), just partial rather than the full remaining exposure, kept as a distinct kind so an audit
  * trail can tell a restructuring's forgiveness apart from a full write-off even though both hit the
  * same GL accounts.
- *
- * [WRITE_OFF_INTEREST] derecognizes the accrued-but-unpaid interest receivable at write-off, alongside
- * the principal [WRITE_OFF]: the income was legitimately earned when the installment fell due, so it is
- * not reversed out of income — the uncollectible receivable is booked as a credit loss, exactly like
- * the principal exposure. Kept as a distinct kind so the audit trail can split a write-off's loss into
- * its principal and interest components.
  */
 enum class PostingKind {
     DISBURSEMENT,
     PRINCIPAL_REPAYMENT,
     INTEREST,
     INTEREST_ACCRUAL,
-    INTEREST_ACCRUAL_REVERSAL,
     INTEREST_SETTLEMENT,
     WRITE_OFF,
-    WRITE_OFF_INTEREST,
     PROVISIONING,
     RESCHEDULE_FORGIVENESS,
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -349,9 +349,6 @@ class LendingService(
                         )
                     } else {
                         // Book the loss and remove the asset from the books; we never mutate balances ourselves.
-                        // Ledger first, row mutation last (same as recordRepayment/accrueOne): a crash between
-                        // the two leaves the loan ACTIVE and the retry replays the same idempotency keys, which
-                        // the ledger collapses to the already-booked journals — exactly-once either way.
                         ledger.post(
                             LedgerPosting(
                                 "loan:${loanId.value}:writeoff",
@@ -360,7 +357,6 @@ class LendingService(
                                 PostingKind.WRITE_OFF,
                             ),
                         )
-                            .flatMap { derecognizeAccruedInterest(loan, schedule) }
                             .flatMap { loans.update(loan.copy(status = LoanStatus.WRITTEN_OFF)) }
                             .flatMap { written ->
                                 val wPayload = """{"loanId":"${written.id.value}",""" +
@@ -380,31 +376,6 @@ class LendingService(
             }
         }
 
-    /**
-     * Derecognize the loan's accrued-but-unpaid interest receivable at write-off. Every unpaid
-     * installment the servicing pass already accrued (`interestAccrued`) has an Interest Receivable
-     * balance the write-off would otherwise orphan on the books forever — the principal-only
-     * [PostingKind.WRITE_OFF] never touches it. The sum is deterministic from the schedule (write-off
-     * mutates no installment rows), so a retry recomputes the identical amount under the identical
-     * idempotency key and the ledger collapses the replay.
-     */
-    private fun derecognizeAccruedInterest(loan: Loan, schedule: List<LoanInstallment>): Uni<Unit> {
-        val accruedUnpaid = schedule
-            .filter { !it.paid && it.interestAccrued }
-            .fold(Money.zero(loan.principal.currency.code)) { acc, installment -> acc.plus(installment.interest) }
-        if (!accruedUnpaid.isPositive()) {
-            return Uni.createFrom().item(Unit)
-        }
-        return ledger.post(
-            LedgerPosting(
-                "loan:${loan.id.value}:writeoff:interest",
-                loan.partyId,
-                accruedUnpaid,
-                PostingKind.WRITE_OFF_INTEREST,
-            ),
-        )
-    }
-
     // --- Reschedule / restructuring (forbearance, issue #667/#668) ----------------------------------
 
     /**
@@ -412,13 +383,8 @@ class LendingService(
      * new schedule is generated from the outstanding balance (net of any [RescheduleRequest.principalForgiveness])
      * at the new rate/term/first-due-date, via the same pure [Amortization.schedule] primitive
      * [bookLoan] uses at origination. Already-paid installments are untouched; new rows continue the
-     * installment numbering after the highest existing one — paid or not — so a future ledger
-     * reference (`"loan:<id>:inst:<number>:..."`) can never collide with an already-posted one
-     * (an accrued-unpaid row posts its accrual reference before it is ever discarded).
-     *
-     * Any unpaid installment whose interest was already accrued has its accrual REVERSED on the
-     * ledger before the row is deleted (see [reverseAccruedUnpaidInterest]) — otherwise the posted
-     * Interest Receivable could never settle and the new schedule would recognize the same income twice.
+     * installment numbering after the last paid one, so a future repayment's ledger reference
+     * (`"loan:<id>:inst:<number>:..."`) can never collide with an already-posted one.
      */
     @Suppress("LongMethod") // reschedule mirrors bookLoan's shape: validation + schedule build + persist + post
     override fun reschedule(loanId: LoanId, request: RescheduleRequest, rescheduledBy: String): Uni<Loan> =
@@ -474,45 +440,7 @@ class LendingService(
         } else {
             Uni.createFrom().item(Unit)
         }
-        return forgive
-            .flatMap { reverseAccruedUnpaidInterest(loan, schedule, generation) }
-            .flatMap { buildAndPersistNewSchedule(loan, schedule, newPrincipal, generation, request) }
-    }
-
-    /**
-     * Unwind the interest accrual of every unpaid installment the reschedule is about to discard.
-     * Each such row already posted an INTEREST_ACCRUAL (income against a receivable) that its
-     * INTEREST_SETTLEMENT can now never clear — deleting it without this reversal would strand the
-     * receivable on the books AND double-recognize the income once the new schedule re-accrues.
-     *
-     * Ledger first, row deletion last (same as accrueOne's post-then-mark): a crash between the two
-     * leaves the old rows in place, and the retry replays the same generation-scoped idempotency keys
-     * (the loan version only bumps after the delete succeeds), which the ledger collapses to the
-     * already-booked reversals — exactly-once either way.
-     */
-    private fun reverseAccruedUnpaidInterest(
-        loan: Loan,
-        schedule: List<LoanInstallment>,
-        generation: Long,
-    ): Uni<Unit> {
-        // Zero-interest rows are flagged accrued without ever posting (see accrueOne): nothing to reverse.
-        val accruedUnpaid = schedule.filter { !it.paid && it.interestAccrued && it.interest.isPositive() }
-        if (accruedUnpaid.isEmpty()) {
-            return Uni.createFrom().item(Unit)
-        }
-        return Multi.createFrom().iterable(accruedUnpaid)
-            .onItem().transformToUniAndConcatenate { installment ->
-                ledger.post(
-                    LedgerPosting(
-                        "loan:${loan.id.value}:inst:${installment.number}:accrual-reversal:gen$generation",
-                        loan.partyId,
-                        installment.interest,
-                        PostingKind.INTEREST_ACCRUAL_REVERSAL,
-                    ),
-                )
-            }
-            .collect().asList()
-            .replaceWith(Unit)
+        return forgive.flatMap { buildAndPersistNewSchedule(loan, schedule, newPrincipal, generation, request) }
     }
 
     private fun buildAndPersistNewSchedule(
@@ -522,11 +450,7 @@ class LendingService(
         generation: Long,
         request: RescheduleRequest,
     ): Uni<Loan> {
-        // Continue numbering after the HIGHEST existing number, not the paid count: an accrued-unpaid
-        // row being discarded has already posted its "...inst:<n>:accrual" ledger reference, so
-        // recycling its number would collapse the replacement row's own accrual/settlement postings
-        // into the discarded row's journals (the ledger dedupes on that exact string).
-        val lastNumber = schedule.maxOfOrNull { it.number } ?: 0
+        val paidCount = schedule.count { it.paid }
         val newSchedule = Amortization.schedule(
             principal = newPrincipal,
             nominalAnnualRate = request.newNominalAnnualRate,
@@ -538,7 +462,7 @@ class LendingService(
         val rows = newSchedule.installments.map { i ->
             LoanInstallment(
                 loanId = loan.id,
-                number = lastNumber + i.number,
+                number = paidCount + i.number,
                 dueDate = i.dueDate,
                 openingBalance = i.openingBalance,
                 principal = i.principal,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactory.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactory.kt
@@ -30,10 +30,8 @@ data class LendingGlAccounts(
  *   PRINCIPAL_REPAYMENT  DEBIT  Funding Clearing     CREDIT Loans Receivable     (cash in, asset reduced)
  *   INTEREST             DEBIT  Funding Clearing     CREDIT Interest Income       (cash in, income earned — early payment)
  *   INTEREST_ACCRUAL     DEBIT  Interest Receivable  CREDIT Interest Income       (income earned at due date, no cash yet)
- *   INTEREST_ACCRUAL_REVERSAL DEBIT Interest Income  CREDIT Interest Receivable   (accrual unwound: installment cancelled by reschedule)
  *   INTEREST_SETTLEMENT  DEBIT  Funding Clearing     CREDIT Interest Receivable   (cash in, accrued receivable cleared)
  *   WRITE_OFF            DEBIT  Loan Loss Expense    CREDIT Loans Receivable      (loss booked, asset off)
- *   WRITE_OFF_INTEREST   DEBIT  Loan Loss Expense    CREDIT Interest Receivable   (accrued receivable uncollectible at write-off)
  *   RESCHEDULE_FORGIVENESS DEBIT Loan Loss Expense   CREDIT Loans Receivable      (partial forgiveness, restructuring)
  *   PROVISIONING (Δ≥0)   DEBIT  Loan Loss Expense    CREDIT Loan Loss Allowance   (impairment increases: more provision)
  *   PROVISIONING (Δ<0)   DEBIT  Loan Loss Allowance  CREDIT Loan Loss Expense    (impairment decreases: partial release)
@@ -70,10 +68,8 @@ object LendingJournalFactory {
             PostingKind.PRINCIPAL_REPAYMENT -> accounts.fundingClearing to accounts.loansReceivable
             PostingKind.INTEREST -> accounts.fundingClearing to accounts.interestIncome
             PostingKind.INTEREST_ACCRUAL -> accounts.interestReceivable to accounts.interestIncome
-            PostingKind.INTEREST_ACCRUAL_REVERSAL -> accounts.interestIncome to accounts.interestReceivable
             PostingKind.INTEREST_SETTLEMENT -> accounts.fundingClearing to accounts.interestReceivable
             PostingKind.WRITE_OFF -> accounts.loanLossExpense to accounts.loansReceivable
-            PostingKind.WRITE_OFF_INTEREST -> accounts.loanLossExpense to accounts.interestReceivable
             PostingKind.RESCHEDULE_FORGIVENESS -> accounts.loanLossExpense to accounts.loansReceivable
             PostingKind.PROVISIONING -> error("unreachable: handled above")
         }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -43,7 +43,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import io.mockk.verifyOrder
 import io.smallrye.mutiny.Uni
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -369,112 +368,6 @@ class LendingServiceTest {
     }
 
     @Test
-    fun `write-off also derecognizes the accrued-but-unpaid interest receivable`() {
-        val loanId = LoanId.random()
-        val loan = activeLoan(loanId)
-        // #1 paid; #2 and #3 unpaid with interest already accrued (a receivable is on the books);
-        // #4 unpaid but never accrued (no receivable exists for it — must not be derecognized).
-        val schedule = listOf(
-            LoanInstallment(
-                loanId = loanId, number = 1, dueDate = firstDue,
-                openingBalance = eur("12000.00"), principal = eur("946.19"),
-                interest = eur("120.00"), payment = eur("1066.19"), closingBalance = eur("11053.81"),
-                paid = true, paidAt = fixedNow,
-            ),
-            LoanInstallment(
-                loanId = loanId, number = 2, dueDate = firstDue.plusMonths(1),
-                openingBalance = eur("11053.81"), principal = eur("955.65"),
-                interest = eur("110.54"), payment = eur("1066.19"), closingBalance = eur("10098.16"),
-                interestAccrued = true, accruedAt = fixedNow,
-            ),
-            LoanInstallment(
-                loanId = loanId, number = 3, dueDate = firstDue.plusMonths(2),
-                openingBalance = eur("10098.16"), principal = eur("965.21"),
-                interest = eur("100.98"), payment = eur("1066.19"), closingBalance = eur("9132.95"),
-                interestAccrued = true, accruedAt = fixedNow,
-            ),
-            LoanInstallment(
-                loanId = loanId,
-                number = 4,
-                dueDate = firstDue.plusMonths(3),
-                openingBalance = eur("9132.95"),
-                principal = eur("974.86"),
-                interest = eur("91.33"),
-                payment = eur("1066.19"),
-                closingBalance = eur("8158.09"),
-            ),
-        )
-        val postings = mutableListOf<LedgerPosting>()
-        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
-        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
-        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
-        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
-        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
-
-        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol", reason = "insolvency"))
-            .await().indefinitely()
-
-        // Principal loss plus the interest receivable: nothing of the loan stays on the books.
-        assertThat(postings.map { it.kind })
-            .containsExactly(PostingKind.WRITE_OFF, PostingKind.WRITE_OFF_INTEREST)
-        val interestLeg = postings.single { it.kind == PostingKind.WRITE_OFF_INTEREST }
-        // Only the ACCRUED unpaid interest (#2 + #3 = 110.54 + 100.98); #4 never posted a receivable.
-        assertThat(interestLeg.amount).isEqualTo(eur("211.52"))
-        assertThat(interestLeg.reference).isEqualTo("loan:${loanId.value}:writeoff:interest")
-        // Both ledger legs are booked before the loan row is marked WRITTEN_OFF (crash safety).
-        verifyOrder {
-            ledger.post(match { it.kind == PostingKind.WRITE_OFF })
-            ledger.post(match { it.kind == PostingKind.WRITE_OFF_INTEREST })
-            loans.update(any())
-        }
-    }
-
-    @Test
-    fun `write-off retry after a ledger failure replays identical idempotency keys and only then marks the loan`() {
-        val loanId = LoanId.random()
-        val loan = activeLoan(loanId)
-        // Unpaid installment #2 has its interest accrued: a receivable exists to derecognize.
-        val schedule = twoInstallmentSchedule(loanId).map {
-            if (it.paid) it else it.copy(interestAccrued = true, accruedAt = fixedNow)
-        }
-        val postings = mutableListOf<LedgerPosting>()
-        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
-        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
-        // Attempt 1: the principal leg books, the interest leg dies on the wire.
-        every { ledger.post(capture(postings)) } answers {
-            if (firstArg<LedgerPosting>().kind == PostingKind.WRITE_OFF_INTEREST) {
-                Uni.createFrom().failure(IllegalStateException("ledger down"))
-            } else {
-                Uni.createFrom().item(Unit)
-            }
-        }
-
-        assertThatThrownBy {
-            service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol")).await().indefinitely()
-        }.isInstanceOf(IllegalStateException::class.java).hasMessageContaining("ledger down")
-        // Crash safety: the loan stays ACTIVE until every ledger leg has booked, so a retry re-enters.
-        verify(exactly = 0) { loans.update(any()) }
-
-        // Attempt 2: ledger is back.
-        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
-        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
-        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
-
-        val written = service.writeOff(loanId, WriteOffRequest(writtenOffBy = "carol")).await().indefinitely()
-
-        assertThat(written.status).isEqualTo(LoanStatus.WRITTEN_OFF)
-        // The retry replays byte-identical idempotency keys, so the ledger collapses the replays —
-        // the principal leg is posted twice here but can only ever book once.
-        val principalRefs = postings.filter { it.kind == PostingKind.WRITE_OFF }.map { it.reference }
-        val interestRefs = postings.filter { it.kind == PostingKind.WRITE_OFF_INTEREST }.map { it.reference }
-        assertThat(principalRefs).hasSize(2).containsOnly("loan:${loanId.value}:writeoff")
-        assertThat(interestRefs).hasSize(2).containsOnly("loan:${loanId.value}:writeoff:interest")
-        assertThat(postings.filter { it.kind == PostingKind.WRITE_OFF_INTEREST }.map { it.amount }.toSet())
-            .containsExactly(eur("110.54"))
-        verify(exactly = 1) { loans.update(any()) }
-    }
-
-    @Test
     fun `write-off refuses a loan that is not ACTIVE`() {
         val loanId = LoanId.random()
         every { loans.findById(loanId) } returns
@@ -553,7 +446,7 @@ class LendingServiceTest {
     }
 
     @Test
-    fun `reschedule replaces the unpaid tail, numbering new rows after the highest existing installment`() {
+    fun `reschedule replaces the unpaid tail, numbering new rows after the last paid installment`() {
         val loanId = LoanId.random()
         val loan = activeLoan(loanId)
         val schedule = twoInstallmentSchedule(loanId)
@@ -565,10 +458,9 @@ class LendingServiceTest {
 
         assertThat(result.status).isEqualTo(LoanStatus.ACTIVE)
         verify(exactly = 1) { installments.deleteUnpaid(loanId) }
-        // Installments #1 (paid) and #2 (unpaid, discarded) already exist; the new schedule's rows must
-        // continue from #3 — never reuse a discarded number, or a future ledger reference
-        // ("loan:<id>:inst:<n>:...") would collide with one the discarded row may already have posted.
-        assertThat(rowsSlot.captured.first().number).isEqualTo(3)
+        // One paid installment (#1) already exists; the new schedule's rows must continue from #2 —
+        // never restart at #1, or a future repayment's ledger reference would collide with the paid one.
+        assertThat(rowsSlot.captured.first().number).isEqualTo(2)
         assertThat(rowsSlot.captured.map { it.number }).isSorted()
         assertThat(rowsSlot.captured).hasSize(24)
         verify(exactly = 0) { ledger.post(match { it.kind == PostingKind.RESCHEDULE_FORGIVENESS }) }
@@ -604,101 +496,6 @@ class LendingServiceTest {
         service.reschedule(loanId, rescheduleRequest(forgiveness = eur("1000.00")), "carol").await().indefinitely()
 
         assertThat(loanSlot.captured.version).isEqualTo(loan.version + 1)
-    }
-
-    @Test
-    fun `reschedule reverses each accrued-unpaid installment's accrual before deleting the tail`() {
-        val loanId = LoanId.random()
-        val loan = activeLoan(loanId)
-        // Unpaid installment #2 already had its interest recognized by the accrual pass: an Interest
-        // Receivable of 110.54 is on the books that its settlement can now never clear.
-        val schedule = twoInstallmentSchedule(loanId).map {
-            if (it.paid) it else it.copy(interestAccrued = true, accruedAt = fixedNow)
-        }
-        mockRescheduleHappyPath(loanId, loan, schedule)
-        val postings = mutableListOf<LedgerPosting>()
-        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
-
-        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
-
-        assertThat(postings).hasSize(1)
-        val reversal = postings.single()
-        assertThat(reversal.kind).isEqualTo(PostingKind.INTEREST_ACCRUAL_REVERSAL)
-        assertThat(reversal.amount).isEqualTo(eur("110.54"))
-        // Generation-scoped key, same durable-version pattern as the forgiveness posting: a second
-        // reschedule of the same loan can never replay this journal.
-        assertThat(reversal.reference).isEqualTo("loan:${loanId.value}:inst:2:accrual-reversal:gen1")
-        // The ledger reversal is posted BEFORE the row is deleted: a crash in between leaves the row
-        // for the retry, which replays the same key idempotently.
-        verifyOrder {
-            ledger.post(any())
-            installments.deleteUnpaid(loanId)
-        }
-    }
-
-    @Test
-    fun `reschedule posts no reversal for an accrued zero-interest installment`() {
-        val loanId = LoanId.random()
-        val loan = activeLoan(loanId)
-        // A zero-interest row is flagged accrued by the pass without ever posting: nothing to reverse.
-        val schedule = listOf(
-            twoInstallmentSchedule(loanId).first(),
-            LoanInstallment(
-                loanId = loanId, number = 2, dueDate = firstDue.plusMonths(1),
-                openingBalance = eur("11053.81"), principal = eur("1066.19"),
-                interest = eur("0.00"), payment = eur("1066.19"), closingBalance = eur("9987.62"),
-                interestAccrued = true, accruedAt = fixedNow,
-            ),
-        )
-        mockRescheduleHappyPath(loanId, loan, schedule)
-
-        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
-
-        verify(exactly = 0) { ledger.post(any()) }
-        verify(exactly = 1) { installments.deleteUnpaid(loanId) }
-    }
-
-    @Test
-    fun `reschedule retry after a ledger failure replays the identical reversal key and never deletes early`() {
-        val loanId = LoanId.random()
-        val loan = activeLoan(loanId)
-        val schedule = twoInstallmentSchedule(loanId).map {
-            if (it.paid) it else it.copy(interestAccrued = true, accruedAt = fixedNow)
-        }
-        val postings = mutableListOf<LedgerPosting>()
-        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
-        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
-        // Attempt 1: the reversal dies on the wire.
-        every { ledger.post(capture(postings)) } returns
-            Uni.createFrom().failure(IllegalStateException("ledger down"))
-
-        assertThatThrownBy {
-            service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
-        }.isInstanceOf(IllegalStateException::class.java).hasMessageContaining("ledger down")
-        // Nothing was mutated: the rows are still there and the version was not bumped, so the retry
-        // recomputes the same generation and thus the same idempotency key.
-        verify(exactly = 0) { installments.deleteUnpaid(any()) }
-        verify(exactly = 0) { loans.update(any()) }
-
-        // Attempt 2: ledger is back; complete the happy path.
-        every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
-        every { installments.deleteUnpaid(loanId) } returns Uni.createFrom().item(1)
-        every { installments.saveAll(any()) } answers {
-            @Suppress("UNCHECKED_CAST")
-            Uni.createFrom().item(firstArg<List<LoanInstallment>>())
-        }
-        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
-        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
-
-        service.reschedule(loanId, rescheduleRequest(), "carol").await().indefinitely()
-
-        // Both attempts posted the reversal under the byte-identical idempotency key: the ledger
-        // collapses the replay, so the receivable is backed out exactly once.
-        assertThat(postings).hasSize(2)
-        assertThat(postings.map { it.reference }.toSet())
-            .containsExactly("loan:${loanId.value}:inst:2:accrual-reversal:gen1")
-        assertThat(postings.map { it.kind }.toSet()).containsExactly(PostingKind.INTEREST_ACCRUAL_REVERSAL)
-        assertThat(postings.map { it.amount }.toSet()).containsExactly(eur("110.54"))
     }
 
     @Test

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactoryTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactoryTest.kt
@@ -87,18 +87,6 @@ class LendingJournalFactoryTest {
     }
 
     @Test
-    fun `interest accrual reversal backs the accrual out - income debited, receivable credited`() {
-        val lines = LendingJournalFactory.buildLines(
-            posting(PostingKind.INTEREST_ACCRUAL_REVERSAL, "loan:1:inst:1:accrual-reversal:gen1"),
-            accounts,
-        )
-        // The exact mirror of INTEREST_ACCRUAL: the installment was cancelled by a reschedule before
-        // cash arrived, so the recognized income and its receivable are both unwound.
-        assertThat(lines.single { side(it) == "DEBIT" }.glAccountId).isEqualTo(accounts.interestIncome)
-        assertThat(lines.single { side(it) == "CREDIT" }.glAccountId).isEqualTo(accounts.interestReceivable)
-    }
-
-    @Test
     fun `write-off debits the loan loss expense`() {
         val lines = LendingJournalFactory.buildLines(
             posting(PostingKind.WRITE_OFF, "loan:1:writeoff"),
@@ -106,17 +94,6 @@ class LendingJournalFactoryTest {
         )
         assertThat(lines.single { side(it) == "DEBIT" }.glAccountId).isEqualTo(accounts.loanLossExpense)
         assertThat(lines.single { side(it) == "CREDIT" }.glAccountId).isEqualTo(accounts.loansReceivable)
-    }
-
-    @Test
-    fun `write-off of accrued interest books the loss against the receivable, not against income`() {
-        val lines = LendingJournalFactory.buildLines(
-            posting(PostingKind.WRITE_OFF_INTEREST, "loan:1:writeoff:interest"),
-            accounts,
-        )
-        // The income was legitimately earned at accrual; the uncollectible receivable is a credit loss.
-        assertThat(lines.single { side(it) == "DEBIT" }.glAccountId).isEqualTo(accounts.loanLossExpense)
-        assertThat(lines.single { side(it) == "CREDIT" }.glAccountId).isEqualTo(accounts.interestReceivable)
     }
 
     @Test


### PR DESCRIPTION
Reverts #1236 (`b18c74e8b`). **Merge this before the pending auto-deploy bump.**

## Exposure

| | |
|---|---|
| code on `main` | **yes** |
| image built | **yes** — `sandbox-b18c74e8`, signed + attested |
| gitops pins | `sandbox-e3a4c19d` — **pre-#1236** |
| running | `sandbox-e3a4c19d` — **not deployed** |
| auto-deploy run `29495237769` | in progress; its **`Gitops PR` job has not run yet** |

The only thing between these defects and production is the bump that run is about to open. Bot gitops commits land unsigned and `required_signatures` blocks their auto-merge until someone re-signs — **that is holding the line by accident, not by design.** This revert makes it deliberate.

## Why revert rather than fix forward

Two blockers, both found by independent review after the merge (#1245).

**1. The reschedule reversal is refuted by the PR's own argument.**

#1236 justified *not* reversing income on write-off because *"that interest **was** legitimately earned when the installment fell due."* That premise holds identically on the reschedule path, and it is airtight by construction: `interestAccrued` has exactly one writer — `markAccrued`, called only from `accrueOne`, fed only by `findAccruable` (`WHERE i.dueDate <= :asOf`). **So every installment the reversal touches has already fallen due.** Same fact pattern, opposite treatment.

Its stated justification is also arithmetically false: `Amortization.schedule` charges from `newFirstDueDate` forward and never re-charges the elapsed period. Nothing was double-counted.

What it actually did (its own fixture — EUR 12,000 @ 12%, installment #2 interest 110.54 due 2026-02-28, reschedule 2026-04-01, no forgiveness; `newPrincipal` = 11,053.81, principal only — the accrued interest is **not** capitalized):

| GL account | Effect | |
|---|---|---|
| Interest Receivable | 0 | ✔ cleared |
| Interest Income | **−110.54** vs earned | ✘ understated |
| Loan Loss Expense | 0 | ✘ understated by 110.54 |
| Loans Receivable | unchanged | ✘ interest not rolled in |

**The February interest ends up owed by nobody and earned by no one** — debt relief granted as a side effect, bypassing `RESCHEDULE_FORGIVENESS`, its validation, and the audit trail. `principalForgiveness: 0.00` in the emitted event while 110.54 was forgiven. Net profit is unchanged; the **classification** is wrong, and Interest Income vs Loan Loss Expense are separately-reported FINREP lines.

This fires on **every forbearance of a delinquent loan** — the normal case, not an edge case.

**2. It regressed post-write-off recovery.**

`recordRepayment` guards only on `target.paid` — no status check — and `writeOff` mutates no installment rows, so they stay `paid=false, interestAccrued=true`. A recovery then posts `INTEREST_SETTLEMENT` against a receivable `WRITE_OFF_INTEREST` already credited → **Interest Receivable goes negative**. Different idempotency keys, so the ledger will not collapse them. Before #1236, the receivable sat stranded at +110.54 and a recovery cleared it to 0 — accidentally correct.

## What reverting costs

Honestly: the pre-existing bugs come back. The stranded receivable (N-1/N-2) is real and still needs fixing.

That is the trade: **the known state the fleet has run for months, versus a new state that silently forgives interest on every forbearance.** The follow-up (#1245) fixes it properly.

## What goes with it — deliberately

This also reverts the **`lastNumber` installment-numbering fix, which was good** and is a live silent-money bug on its own merits (recycled numbers collide with already-posted `inst:<n>:accrual` references → the ledger dedupes → income silently never posts; and with a non-prefix paid set it's a hard `UNIQUE` violation).

Taking it out is deliberate: **a revert restores a known state rather than cherry-picking from a change under question.** It re-lands on its own immediately after, where it can be reviewed on its own merits — it deserves that.

## Verification

- [x] `:openbank-lending-service:build` (compile + test) green on the reverted tree
- [x] `reverseAccruedUnpaidInterest`, `derecognizeAccruedInterest`, `INTEREST_ACCRUAL_REVERSAL`, `WRITE_OFF_INTEREST` — 0 references remain
- [x] Clean revert — nothing touched `openbank-lending-service/` after `b18c74e8b`
- [x] Signed

## Linked issues

Refs #1245