### PR TITLE
fix(authz): let the customer-edge read document content (onboarding agreement 403)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "93fa8a59c946bf85"
+    openbank.tech/policy-checksum: "4d6c2b697ec6679a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "93fa8a59c946bf85"
+        openbank.tech/policy-checksum: "4d6c2b697ec6679a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "ac669749f5702005"
+    openbank.tech/policy-checksum: "dd696ce9dc7ee4a2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ac669749f5702005"
+        openbank.tech/policy-checksum: "dd696ce9dc7ee4a2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "ab2558469b4b84a5"
+    openbank.tech/policy-checksum: "97a69dd477e82567"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ab2558469b4b84a5"
+        openbank.tech/policy-checksum: "97a69dd477e82567"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "bca078af3f10fbf3"
+    openbank.tech/policy-checksum: "b9e566963812b018"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bca078af3f10fbf3"
+        openbank.tech/policy-checksum: "b9e566963812b018"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "03ba4efac64bae10"
+    openbank.tech/policy-checksum: "9938a679bf6a3401"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "03ba4efac64bae10"
+        openbank.tech/policy-checksum: "9938a679bf6a3401"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "9b2c81222f32f648"
+    openbank.tech/policy-checksum: "9509980da989c2d5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9b2c81222f32f648"
+        openbank.tech/policy-checksum: "9509980da989c2d5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "96a52341b116fd98"
+    openbank.tech/policy-checksum: "743e1d9301e23601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -164,10 +164,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -190,7 +201,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "96a52341b116fd98"
+        openbank.tech/policy-checksum: "743e1d9301e23601"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "96a52341b116fd98"
+    openbank.tech/policy-checksum: "743e1d9301e23601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -164,10 +164,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -190,7 +201,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "96a52341b116fd98"
+        openbank.tech/policy-checksum: "743e1d9301e23601"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "900c514de2161857"
+    openbank.tech/policy-checksum: "45bbb8961e6bdcb7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "900c514de2161857"
+        openbank.tech/policy-checksum: "45bbb8961e6bdcb7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "d27f71a8ea3e0a55"
+    openbank.tech/policy-checksum: "397e40fcecb81ebf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d27f71a8ea3e0a55"
+        openbank.tech/policy-checksum: "397e40fcecb81ebf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "d04eb24d9d78b73f"
+    openbank.tech/policy-checksum: "854cc838119f7ee0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d04eb24d9d78b73f"
+        openbank.tech/policy-checksum: "854cc838119f7ee0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "d2da4aa5c9fdc6d4"
+    openbank.tech/policy-checksum: "e2c0f4d718126252"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d2da4aa5c9fdc6d4"
+        openbank.tech/policy-checksum: "e2c0f4d718126252"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9c63bd944f325079"
+    openbank.tech/policy-checksum: "6c532375a09d509a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9c63bd944f325079"
+        openbank.tech/policy-checksum: "6c532375a09d509a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "96a52341b116fd98"
+    openbank.tech/policy-checksum: "743e1d9301e23601"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -164,10 +164,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -190,7 +201,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "96a52341b116fd98"
+        openbank.tech/policy-checksum: "743e1d9301e23601"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "69115831670d9d50"
+    openbank.tech/policy-checksum: "41710fb471ca7ce9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "79a25a4ceb83669c"
+    openbank.tech/policy-checksum: "1aeea31f83647373"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1a098599a330ed73"
+    openbank.tech/policy-checksum: "30f4c8ec11627119"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3117fbbce8da9d06" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "3c3a0de99ab34fcf" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -374,7 +374,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a76cd64e7c6776ce"
+        openbank.tech/policy-checksum: "d8c9de3e476db1bf"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -727,7 +727,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1a098599a330ed73" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "30f4c8ec11627119" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1050,7 +1050,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "afa21648ea1a162a"
+        openbank.tech/policy-checksum: "e6caa84144b71123"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1365,7 +1365,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "79a25a4ceb83669c" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "1aeea31f83647373" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1780,7 +1780,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "69115831670d9d50"
+        openbank.tech/policy-checksum: "41710fb471ca7ce9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2036,7 +2036,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e685e681f8560dd6" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "7a931e945546c8a2" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2436,7 +2436,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b351a41d6375240b"
+        openbank.tech/policy-checksum: "edb7271e01775e2c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2749,7 +2749,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "049fc7a7027038b2"
+        openbank.tech/policy-checksum: "6ccced7382bb67f2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "afa21648ea1a162a"
+    openbank.tech/policy-checksum: "e6caa84144b71123"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a76cd64e7c6776ce"
+    openbank.tech/policy-checksum: "d8c9de3e476db1bf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e685e681f8560dd6"
+    openbank.tech/policy-checksum: "7a931e945546c8a2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b351a41d6375240b"
+    openbank.tech/policy-checksum: "edb7271e01775e2c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3117fbbce8da9d06"
+    openbank.tech/policy-checksum: "3c3a0de99ab34fcf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "049fc7a7027038b2"
+    openbank.tech/policy-checksum: "6ccced7382bb67f2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "3b09e38b65ea0676"
+    openbank.tech/policy-checksum: "7cebaf3cb056bffe"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3b09e38b65ea0676"
+        openbank.tech/policy-checksum: "7cebaf3cb056bffe"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "10bef434eb914efd"
+    openbank.tech/policy-checksum: "bcb3b2236726dc69"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "10bef434eb914efd"
+        openbank.tech/policy-checksum: "bcb3b2236726dc69"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "7a9f1dd6663f520a"
+    openbank.tech/policy-checksum: "a42f006ac965dcca"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -163,10 +163,21 @@ data:
     	startswith(input.action, "customer.")
     }
 
-    # The customer-edge's M2M identity calling notification-service on a customer's behalf.
-    # The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-    # IDOR guards) and injects the authoritative partyId query param the downstream handlers
+    # The customer-edge's M2M identity calling notification-, sca- or document-service on a
+    # customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+    # + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
     # scope by — so this check only needs to recognise the edge principal.
+    #
+    # The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+    # app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+    # the metadata first and 404s a non-owner before ever streaming content — the per-handler
+    # IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+    # operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+    # outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+    # "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+    # to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+    # reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+    # contents of any customer's signed agreement.
     #
     # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
     # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -189,7 +200,7 @@ data:
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device."}
+    	some family in {"notification.", "device.", "document."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7a9f1dd6663f520a"
+        openbank.tech/policy-checksum: "a42f006ac965dcca"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -149,10 +149,21 @@ allowed_reasons contains "customer-self-action" if {
 	startswith(input.action, "customer.")
 }
 
-# The customer-edge's M2M identity calling notification-service on a customer's behalf.
-# The edge authenticates the CUSTOMER itself (customer-self-action above + per-handler
-# IDOR guards) and injects the authoritative partyId query param the downstream handlers
+# The customer-edge's M2M identity calling notification-, sca- or document-service on a
+# customer's behalf. The edge authenticates the CUSTOMER itself (customer-self-action above
+# + per-handler IDOR guards) and injects the authoritative partyId the downstream handlers
 # scope by — so this check only needs to recognise the edge principal.
+#
+# The `document.` family covers the onboarding framework agreement (ADR-0169/0170): the
+# app reads the PDF bytes and signs them through CustomerDocumentResource, which fetches
+# the metadata first and 404s a non-owner before ever streaming content — the per-handler
+# IDOR guard this rule relies on. `document.read` (metadata) previously slipped through
+# operator-read-any by accident of its name while `document.readContent` (the bytes) fell
+# outside that rule's {list, read} verb set and was denied, so the sign screen rendered
+# "getDocumentContent failed: 403" with no way to complete onboarding. Granting the family
+# to the edge identity — rather than widening operator-read-any's verb taxonomy — keeps the
+# reach on the edge principal instead of handing every ROLE_OPERATOR staff session the
+# contents of any customer's signed agreement.
 #
 # NOTE (found during ADR-0034 Phase 5 rollout, issue #266): AuthorizeInterceptor never
 # produces principal.type == "SERVICE" — M2M calls authenticate with a Keycloak
@@ -175,7 +186,7 @@ allowed_reasons contains "customer-self-action" if {
 allowed_reasons contains "edge-service-notification" if {
 	input.principal.type == "HUMAN"
 	input.principal.id == "service-account-openbank-edge"
-	some family in {"notification.", "device."}
+	some family in {"notification.", "device.", "document."}
 	startswith(input.action, family)
 }
 

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -510,6 +510,34 @@ test_allow_service_device_list if {
 	decision.allow == true
 }
 
+# document.readContent — the onboarding framework agreement's PDF bytes (ADR-0169/0170).
+# The verb sits outside operator-read-any's {list, read} set, so before the document.
+# family was added here the edge could read a document's METADATA (document.read slipped
+# through operator-read-any on its name) but never its CONTENT: the app's sign screen died
+# on "getDocumentContent failed: 403" and onboarding could not complete.
+test_allow_service_document_read_content if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "document.readContent",
+		"resource": {"type": "document", "id": "d-1"},
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "edge-service-notification"
+}
+
+# Staff must NOT reach a customer's signed agreement bytes off the back of this fix:
+# operator-read-any's {list, read} verbs do not cover readContent, and this rule is pinned
+# to the edge's client_credentials identity — a real ROLE_OPERATOR session is not it.
+test_deny_operator_document_read_content if {
+	not rest.allow with input as {
+		"principal": {"id": "alice.operator", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "document.readContent",
+		"resource": {"type": "document", "id": "d-1"},
+	}
+}
+
 # The rule must NOT open other action families to the edge M2M caller (deny-by-default
 # holds) — operator-read-any also does not cover a write like party.update.
 test_deny_service_outside_notification_family if {


### PR DESCRIPTION
## Problém

Onboarding sign screen v appce umře na `getDocumentContent failed: 403` — uživatel nemůže dokončit registraci. Screenshot: prázdná plocha místo PDF, žádné zaškrtávátko, žádný podpis.

## Root cause: taxonomie názvů akcí, ne edge

`operator-read-any` pouští read rodinu podle sufixu — `some verb in {list, read}` + `endswith(action, verb)`.

- `document.read` (metadata) → matchne **náhodou svým jménem** → allow
- `document.readContent` (byty PDF) → končí na `.readContent`, mimo verb set → **deny-by-default**

Ověřeno proti živé sandbox OPA sidecar:
```
document.read:        {"allow":true, "reason":"operator-read-any"}
document.readContent: false
```
Přesně sedí na symptom: edge stáhne metadata (ownership check projde), pak dostane 403 na content.

## Fix

Přidat `document.` rodinu k identity-matched pravidlu edge (vedle `notification.`/`device.`) — **ne** rozšířit verb set `operator-read-any`:

- edge už si sám tahá metadata a **404ne non-ownera** dřív, než začne streamovat content (`CustomerDocumentResource`) — přesně ten per-handler IDOR guard, na kterém pravidlo staví
- rozšíření verb taxonomie by dalo **každé ROLE_OPERATOR staff session obsah podepsané smlouvy kteréhokoliv klienta**. Test to explicitně pinuje jako deny.

## Ověření

- `opa test` nad kompletní sadou (rest + agents + copilot_tool): **122/122**
- `opa eval` s opravenou policy: edge `document.readContent` → allow (`edge-service-notification`), staff operátor → deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)