### PR TITLE
fix(kafka): customer-edge mTLS identity + ACLs — audit events are being dropped

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge-msg-override.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-msg-override.yaml
@@ -24,11 +24,9 @@
 # as onboarding-service's msg-override ConfigMap
 # (openbank-infra/gitops/components/onboarding/onboarding-service-msg-override.yaml).
 #
-# NOTE: this fix is config-wiring only. customer-edge has no KafkaUser ACL / mTLS setup at
-# all yet and is still on the anonymous plaintext :9092 listener, which the cluster now
-# denies (`allow.everyone.if.no.acl.found: "false"`) — so party-events-in is not actually
-# consumable in the live cluster until a separate KafkaUser + mTLS change lands (out of
-# scope here; see the comment in customer-edge.yaml).
+# The KafkaUser + mTLS wiring this fix originally depended on (and flagged as out of scope)
+# now exists: kafka-customer-edge-mtls.yaml grants the `customer-edge` principal Read on this
+# group, and customer-edge.yaml points the client at the tls:9093 listener.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -70,9 +70,43 @@ spec:
             - name: management
               containerPort: 8085
           env:
-            # Customer audit trail -> Strimzi bus (EdgeAuditPublisher, best-effort).
+            # Customer audit trail -> Strimzi bus (EdgeAuditPublisher, best-effort) and the
+            # ADR-0072 onboarding-resume consumer.
+            #
+            # ADR-0137: the mTLS listener :9093, not the anonymous plaintext :9092 listener.
+            # Since #2794 the broker runs allow.everyone.if.no.acl.found=false cluster-wide, so
+            # User:ANONYMOUS is denied on every resource — on :9092 the audit producer got
+            # TopicAuthorizationException (every event dropped) and the resume consumer got
+            # GroupAuthorizationException.
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            # mTLS client identity (KafkaUser `customer-edge`, kafka-customer-edge-mtls.yaml) —
+            # same pattern as agent-service / pid-service. Keystore + cluster-CA truststore are
+            # Strimzi-minted in `messaging` and projected into this namespace by the
+            # ExternalSecrets in that file. These KAFKA_* env vars map to the global `kafka.*`
+            # client config that SmallRye applies to every channel, so they take effect on the
+            # deployed image without waiting for a rebuild (unlike per-channel mp.messaging keys,
+            # which is why group.id goes through the ConfigMap below instead).
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka-keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: customer-edge-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka-truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
             # issue #686: group.id / auto.offset.reset override (customer-edge-msg-override
             # ConfigMap, mounted below) as an external Quarkus config source, since the dotted
             # YAML keys in application.yaml silently never register as the plain MicroProfile
@@ -82,18 +116,6 @@ spec:
             # (quarkusio/quarkus#30106, smallrye/smallrye-reactive-messaging#2028).
             - name: QUARKUS_CONFIG_LOCATIONS
               value: /mnt/msg-config/override.properties
-            #
-            # NOTE (found while wiring this): unlike the rest of the fleet, customer-edge has no
-            # KafkaUser ACL resource at all and is still on the anonymous plaintext :9092
-            # listener above (KAFKA_BOOTSTRAP_SERVERS), not the mTLS :9093 listener. The Kafka
-            # cluster config (openbank-infra/gitops/components/kafka/kafka.yaml) now sets
-            # `allow.everyone.if.no.acl.found: "false"` cluster-wide ("All 33 deployed Kafka
-            # clients migrated to mTLS:9093 ... User:ANONYMOUS ... is now denied on every topic").
-            # That means this group.id fix alone does NOT make party-events-in consumable in a
-            # real cluster — User:ANONYMOUS is denied before group.id is ever evaluated. Getting
-            # a working KafkaUser + mTLS keystore/truststore wired for customer-edge (same pattern
-            # as kafka-pid-mtls.yaml / kafka-anacredit-mtls.yaml) is a separate, larger change and
-            # out of scope for this config-wiring-only fix; flagging so it isn't mistaken for done.
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: http://keycloak.iam.svc:8080/realms/openbank-customers
             - name: OIDC_CLIENT_ID
@@ -199,6 +221,12 @@ spec:
             - name: msg-override
               mountPath: /mnt/msg-config
               readOnly: true
+            - name: kafka-keystore
+              mountPath: /mnt/kafka-keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka-truststore
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /q/health/ready
@@ -299,6 +327,14 @@ spec:
         - name: msg-override
           configMap:
             name: customer-edge-msg-override
+        # Kafka mTLS material, projected from `messaging` by the ExternalSecrets in
+        # kafka-customer-edge-mtls.yaml.
+        - name: kafka-keystore
+          secret:
+            secretName: customer-edge-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
 ---
 apiVersion: v1
 kind: Service

--- a/openbank-infra/gitops/components/customer-edge/kafka-customer-edge-mtls.yaml
+++ b/openbank-infra/gitops/components/customer-edge/kafka-customer-edge-mtls.yaml
@@ -1,0 +1,120 @@
+# Kafka mTLS identity + ACLs for customer-edge (ADR-0137 fleet gate, issue #686
+# follow-up flagged in customer-edge.yaml / customer-edge-msg-override.yaml).
+#
+# customer-edge has two Kafka channels (openbank-customer-edge application.yaml):
+#   - customer-audit-out -> openbank.customer.audit  (EdgeAuditPublisher, ADR-0086
+#     customer audit trail; audit-service is the consumer)
+#   - party-events-in    <- party.events, group customer-edge-onboarding-resume
+#     (OnboardingResumeService, ADR-0072 four-eyes auto-resume; pid-service produces)
+#
+# Until this change customer-edge had NO KafkaUser at all and pointed at the anonymous
+# plaintext plain:9092 listener. The ADR-0137 fleet sweep (#2665) then flipped the broker
+# to allow.everyone.if.no.acl.found=false (#2794, components/kafka/kafka.yaml), which
+# denies User:ANONYMOUS on every resource — so the edge logs a permanent
+#   TopicAuthorizationException: Topic authorization failed for topics [openbank.customer.audit]
+#   GroupAuthorizationException: Not authorized to access group: customer-edge-onboarding-resume
+# and every customer audit event is dropped (compliance-relevant, ADR-0086). The edge was
+# missed by the sweep's client inventory: it was counted among the "33 migrated" clients but
+# never got a manifest.
+#
+# Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one principal for all
+# of this service's Kafka traffic. These resources live in `messaging` (where the Strimzi
+# User Operator watches); the User Operator mints a per-user Secret of the same name there
+# (user.crt/key/p12 + user.password + ca.crt). Those secrets are projected into the
+# `customer-edge` namespace by the External Secrets below — the same cross-namespace pattern
+# as kafka-agent-mtls.yaml / kafka-pid-mtls.yaml. `customer-edge` had no ESO Kafka-cert
+# projection before this change.
+#
+# The eso-kafka-cert-reader Role in `messaging` (components/payments/kafka-scheme-accepted-acl.yaml)
+# is resourceNames-scoped, so `customer-edge` is added to its allow-list there.
+---
+# ── KafkaUser: customer-edge ────────────────────────────────────────────────
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  annotations:
+    # ADR-0137: certs (KafkaUsers→Strimzi secrets→ESO projection) must land before the
+    # customer-edge Rollout rolls pods onto mTLS; lower waves sync first and ArgoCD blocks
+    # on ExternalSecrets reaching SecretSynced.
+    argocd.argoproj.io/sync-wave: "-2"
+  name: customer-edge
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      # Producer: EdgeAuditPublisher -> openbank.customer.audit. Write only; the edge never
+      # reads its own audit trail back (audit-service holds the Read grant).
+      - resource:
+          type: topic
+          name: openbank.customer.audit
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # Consumer: OnboardingResumeService <- party.events (pid-service's party-events-out).
+      # Unprefixed topic name is deliberate and matches the producer — pid-service publishes
+      # `party.events`, distinct from party-service's `openbank.party.events`.
+      - resource:
+          type: topic
+          name: party.events
+          patternType: literal
+        operations: [Read, Describe]
+        host: "*"
+      - resource:
+          type: group
+          name: customer-edge-onboarding-resume
+          patternType: literal
+        operations: [Read]
+        host: "*"
+---
+# ── ExternalSecret: customer-edge keystore ──────────────────────────────────
+# Projects the Strimzi-minted customer-edge Secret from `messaging` into `customer-edge`.
+# `dataFrom.extract` copies every key verbatim, preserving the binary PKCS#12 payload
+# byte-for-byte. deletionPolicy: Retain so a transient store/RBAC blip never deletes a
+# live keystore out from under a running pod.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: customer-edge-kafka-keystore
+  namespace: customer-edge
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: customer-edge-kafka-keystore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: customer-edge
+---
+# ── ExternalSecret: cluster CA truststore ───────────────────────────────────
+# Shared cluster-CA truststore projected into `customer-edge` — identical pattern to every
+# other onboarded namespace (payments, pid, platform, audit, …).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  name: kafka-cluster-ca-truststore
+  namespace: customer-edge
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kafka-messaging-certs
+  target:
+    name: kafka-cluster-ca-truststore
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+    - extract:
+        key: openbank-cluster-cluster-ca-cert

--- a/openbank-infra/gitops/components/customer-edge/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/customer-edge/kafka-topic.yaml
@@ -1,0 +1,20 @@
+# Customer audit trail topic (ADR-0086), produced by customer-edge's EdgeAuditPublisher and
+# consumed by audit-service (audit-events-in, kafka-audit-mtls.yaml already grants it Read).
+# Declared explicitly (the broker does not auto-create topics — kafka.yaml) so the Strimzi
+# topic operator manages it and the producer has a destination: the topic did not exist on the
+# broker at all, so even an authorized produce would have failed with UNKNOWN_TOPIC_OR_PARTITION.
+# Lives in `messaging` (the topic operator only watches its own namespace). Single partition +
+# RF 1 for the single-broker sandbox; prod should raise partitions for parallelism and RF to 3.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: openbank.customer.audit
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -313,6 +313,7 @@ rules:
       - anacredit-service               # issue #638: LoanStageEventConsumer (ADR-0037 follow-up)
       - agent-service                   # issue #686: oversight-triggers consumer, ns platform (first ESO client there)
       - document-service                # ADR-0161/0162: document lifecycle events, ns documents (first ESO client there)
+      - customer-edge                   # ADR-0086 audit trail + ADR-0072 resume, ns customer-edge (first ESO Kafka client there); missed by the #2665 sweep
       - openbank-cluster-cluster-ca-cert
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/openbank-infra/gitops/components/pid/kafka-pid-mtls.yaml
+++ b/openbank-infra/gitops/components/pid/kafka-pid-mtls.yaml
@@ -4,12 +4,18 @@
 #   - party.events       (channel party-events-out)
 #   - openbank.pid.events (channel pid-events-out)
 #
-# Neither topic is under scheme-accepted ACL control, so no Write ACLs are needed here;
-# the KafkaUser is required solely to mint a client certificate for the tls:9093 listener.
+# This user originally carried no ACLs at all: at the time, only payment.scheme-accepted was
+# ACL-guarded and everything else inherited allow.everyone.if.no.acl.found=true, so the
+# KafkaUser existed solely to mint a tls:9093 client certificate. That premise died with
+# #2794, which flipped the gate to `false` cluster-wide (components/kafka/kafka.yaml) —
+# deny-by-default now applies to EVERY resource, so an authenticated principal with no ACLs
+# is denied on its own domain-event topics. Both Write grants below are therefore required
+# for pid's outbox dispatcher to publish at all; without them party.events stays empty and
+# customer-edge's ADR-0072 onboarding auto-resume never fires even once its own ACLs land
+# (kafka-customer-edge-mtls.yaml).
 #
 # Identity model (ADR-0137): one KafkaUser = one mTLS client cert = one principal for all
-# of this service's Kafka traffic. ACL entries are only required for locked-down topics;
-# own domain-event topics inherit allow.everyone.if.no.acl.found=true.
+# of this service's Kafka traffic.
 #
 # These resources live in `messaging` (where the Strimzi User Operator watches); the User
 # Operator mints a per-user Secret of the same name there (user.crt/key/p12 + user.password
@@ -31,6 +37,24 @@ metadata:
 spec:
   authentication:
     type: tls
+  authorization:
+    type: simple
+    acls:
+      # Outbox dispatcher -> party.events (PartyEventPublisher, channel party-events-out).
+      # Consumed by customer-edge's OnboardingResumeService.
+      - resource:
+          type: topic
+          name: party.events
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
+      # Outbox dispatcher -> openbank.pid.events (PidOutboxDispatcher, channel pid-events-out).
+      - resource:
+          type: topic
+          name: openbank.pid.events
+          patternType: literal
+        operations: [Write, Describe]
+        host: "*"
 ---
 # ── ExternalSecret: pid-service keystore ────────────────────────────────────
 # Projects the Strimzi-minted pid-service Secret from `messaging` into `pid`.

--- a/openbank-infra/gitops/components/pid/kafka-topic.yaml
+++ b/openbank-infra/gitops/components/pid/kafka-topic.yaml
@@ -1,13 +1,30 @@
-# Domain event topic produced by pid-service. Declared explicitly (the broker does not
-# auto-create topics — kafka.yaml) so the Strimzi topic operator manages it and the
-# outbox producer has a destination. The service's KafkaUser (kafka-pid-mtls.yaml)
-# already grants Write/Describe on this topic — this CR was the missing piece. Single
-# partition + RF 1 for the single-broker sandbox; prod should raise partitions for
-# parallelism and RF to 3.
+# Domain event topics produced by pid-service. Declared explicitly (the broker does not
+# auto-create topics — kafka.yaml) so the Strimzi topic operator manages them and the
+# outbox producer has a destination. Write/Describe for both is granted by the service's
+# KafkaUser (kafka-pid-mtls.yaml). Single partition + RF 1 for the single-broker sandbox;
+# prod should raise partitions for parallelism and RF to 3.
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
   name: openbank.pid.events
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 604800000
+    cleanup.policy: delete
+---
+# Unprefixed name is deliberate: it is what pid-service's party-events-out channel publishes
+# and what customer-edge's party-events-in consumes (ADR-0072 onboarding auto-resume). Not to
+# be confused with party-service's separate `openbank.party.events`. This topic never existed
+# on the broker, so the resume flow could not have worked even before the ACL gate flip.
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: party.events
   namespace: messaging
   labels:
     strimzi.io/cluster: openbank-cluster


### PR DESCRIPTION
## Problem

customer-edge logs these on every poll in the sandbox (still live as of 2026-07-16 ~13:47):

```
org.apache.kafka.common.errors.TopicAuthorizationException: Topic authorization failed for topics [openbank.customer.audit]
org.apache.kafka.common.errors.GroupAuthorizationException: Not authorized to access group: customer-edge-onboarding-resume
```

**Every ADR-0086 customer audit event the edge emits is being dropped** (compliance-relevant), and the ADR-0072 onboarding auto-resume consumer is dead.

## Root cause

customer-edge was **never migrated by the ADR-0137 fleet sweep (#2665)** — it has no KafkaUser at all and still points at the anonymous plaintext `plain:9092` listener. It was counted among the "33 migrated clients" in the kafka.yaml comment but never got a manifest. #2794 then flipped `allow.everyone.if.no.acl.found` to `false` cluster-wide, which denies `User:ANONYMOUS` on every resource — including the un-ACL'd topics the edge relied on. `kubectl get kafkausers -n messaging` shows 32 users, none of them customer-edge.

## Fix

Standard per-service wiring, same pattern as `kafka-agent-mtls.yaml` / `kafka-pid-mtls.yaml`:

- **KafkaUser `customer-edge`** — Write+Describe on `openbank.customer.audit`, Read+Describe on `party.events`, Read on group `customer-edge-onboarding-resume`.
- **ESO projection** of the Strimzi keystore + cluster-CA truststore into the `customer-edge` namespace, plus the namespace's entry in the resourceNames-scoped `eso-kafka-cert-reader` Role.
- **Rollout**: `tls:9093` bootstrap + `KAFKA_*` SSL env + keystore mounts. The `KAFKA_*` env maps to the global `kafka.*` client config, so this lands on the deployed image (`sandbox-b16b1437`) with no rebuild.

## Two adjacent gaps found while investigating

Both are required for the ACL fix to actually deliver events, so they're in the same PR:

1. **Neither `openbank.customer.audit` nor `party.events` existed on the broker.** The broker does not auto-create topics, so even an authorized produce would have failed with `UNKNOWN_TOPIC_OR_PARTITION`. Both are now declared KafkaTopics. (`party.events` is pid-service's unprefixed topic — distinct from party-service's `openbank.party.events`.)
2. **pid-service's KafkaUser carried no ACLs**, on the explicitly-documented but since-invalidated premise that un-ACL'd topics inherit allow-everyone. After #2794 its outbox cannot publish `party.events` or `openbank.pid.events` at all — silent today only because pid has been idle. Write+Describe granted for both.

Gap 2 suggests other #2665-era users may carry the same stale no-ACL premise; worth a follow-up sweep (`kubectl get kafkausers -n messaging` shows pid-service was the only one with an empty AUTHORIZATION column, so the fleet is otherwise clean).

## Verification

All six manifests pass `kubectl apply --dry-run=server` against the live sandbox. Post-merge, once ArgoCD syncs: KafkaUser Ready + both ExternalSecrets SecretSynced, edge pod rolls onto 9093, and the two authorization errors stop. E2E (audit event produced and consumed by audit-service; resume consumer joining its group) needs the merge to land first — I'll confirm on the live cluster and report back.

Refs #2665, #686, ADR-0137, ADR-0086, ADR-0072

🤖 Generated with [Claude Code](https://claude.com/claude-code)