### PR TITLE
chore(gitops): auto-deploy services @ a798e8bbe909dbb8f06c75f249cf9cd4fe4c0ca4

### DIFF
--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -26,7 +26,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: interest-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-237c397c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-a798e8bb
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8125}


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit a798e8bbe909dbb8f06c75f249cf9cd4fe4c0ca4.

**Changed services:** ["openbank-interest-service"]

Each image tag was updated to `sandbox-a798e8bbe909dbb8f06c75f249cf9cd4fe4c0ca4` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.