### PR TITLE
fix(lending): capitalize accrued interest on reschedule, derecognize it on write-off

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "4d6c2b697ec6679a"
+    openbank.tech/policy-checksum: "cda5ce47ddc06d66"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1572,6 +1572,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d6c2b697ec6679a"
+        openbank.tech/policy-checksum: "cda5ce47ddc06d66"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "dd696ce9dc7ee4a2"
+    openbank.tech/policy-checksum: "c837b86b1ceeb3da"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1515,6 +1515,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dd696ce9dc7ee4a2"
+        openbank.tech/policy-checksum: "c837b86b1ceeb3da"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "97a69dd477e82567"
+    openbank.tech/policy-checksum: "50cda494a303bd9c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1616,6 +1616,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "97a69dd477e82567"
+        openbank.tech/policy-checksum: "50cda494a303bd9c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "b9e566963812b018"
+    openbank.tech/policy-checksum: "d848c86a7e9a3a74"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1521,6 +1521,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b9e566963812b018"
+        openbank.tech/policy-checksum: "d848c86a7e9a3a74"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "9938a679bf6a3401"
+    openbank.tech/policy-checksum: "f8b4c25405bb2a98"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1553,6 +1553,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9938a679bf6a3401"
+        openbank.tech/policy-checksum: "f8b4c25405bb2a98"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "9509980da989c2d5"
+    openbank.tech/policy-checksum: "a96d6c7df8a2604b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1604,6 +1604,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9509980da989c2d5"
+        openbank.tech/policy-checksum: "a96d6c7df8a2604b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "743e1d9301e23601"
+    openbank.tech/policy-checksum: "ba41369e44837b49"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -826,6 +826,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "743e1d9301e23601"
+        openbank.tech/policy-checksum: "ba41369e44837b49"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "743e1d9301e23601"
+    openbank.tech/policy-checksum: "ba41369e44837b49"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -826,6 +826,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "743e1d9301e23601"
+        openbank.tech/policy-checksum: "ba41369e44837b49"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "45bbb8961e6bdcb7"
+    openbank.tech/policy-checksum: "2878558d97d2aab0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1532,6 +1532,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "45bbb8961e6bdcb7"
+        openbank.tech/policy-checksum: "2878558d97d2aab0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "397e40fcecb81ebf"
+    openbank.tech/policy-checksum: "4e2069b9bcd6b420"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1583,6 +1583,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "397e40fcecb81ebf"
+        openbank.tech/policy-checksum: "4e2069b9bcd6b420"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "854cc838119f7ee0"
+    openbank.tech/policy-checksum: "2536cf0c0b72d65c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1517,6 +1517,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "854cc838119f7ee0"
+        openbank.tech/policy-checksum: "2536cf0c0b72d65c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "e2c0f4d718126252"
+    openbank.tech/policy-checksum: "a24a28f86816c718"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1630,6 +1630,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e2c0f4d718126252"
+        openbank.tech/policy-checksum: "a24a28f86816c718"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "6c532375a09d509a"
+    openbank.tech/policy-checksum: "19351d6192c03158"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1585,6 +1585,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c532375a09d509a"
+        openbank.tech/policy-checksum: "19351d6192c03158"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "743e1d9301e23601"
+    openbank.tech/policy-checksum: "ba41369e44837b49"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -826,6 +826,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "743e1d9301e23601"
+        openbank.tech/policy-checksum: "ba41369e44837b49"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "41710fb471ca7ce9"
+    openbank.tech/policy-checksum: "e22e503e0c7101cf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1530,6 +1530,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1aeea31f83647373"
+    openbank.tech/policy-checksum: "97d11cf5d517548a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1575,6 +1575,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "30f4c8ec11627119"
+    openbank.tech/policy-checksum: "a0bef14e7014e151"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1560,6 +1560,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3c3a0de99ab34fcf" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "e67b4155f73309b6" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d8c9de3e476db1bf"
+        openbank.tech/policy-checksum: "94bb9bf1ca61821c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "30f4c8ec11627119" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "a0bef14e7014e151" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e6caa84144b71123"
+        openbank.tech/policy-checksum: "0f3ec1fb0c9e2c37"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1aeea31f83647373" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "97d11cf5d517548a" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "41710fb471ca7ce9"
+        openbank.tech/policy-checksum: "e22e503e0c7101cf"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7a931e945546c8a2" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "9d356897b12a9259" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "edb7271e01775e2c"
+        openbank.tech/policy-checksum: "8c59566331df53f1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6ccced7382bb67f2"
+        openbank.tech/policy-checksum: "a04887942b76740a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e6caa84144b71123"
+    openbank.tech/policy-checksum: "0f3ec1fb0c9e2c37"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1533,6 +1533,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d8c9de3e476db1bf"
+    openbank.tech/policy-checksum: "94bb9bf1ca61821c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1554,6 +1554,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7a931e945546c8a2"
+    openbank.tech/policy-checksum: "9d356897b12a9259"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1534,6 +1534,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "edb7271e01775e2c"
+    openbank.tech/policy-checksum: "8c59566331df53f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1537,6 +1537,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3c3a0de99ab34fcf"
+    openbank.tech/policy-checksum: "e67b4155f73309b6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1590,6 +1590,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6ccced7382bb67f2"
+    openbank.tech/policy-checksum: "a04887942b76740a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1541,6 +1541,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "7cebaf3cb056bffe"
+    openbank.tech/policy-checksum: "6b8278e97ee521cd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1543,6 +1543,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7cebaf3cb056bffe"
+        openbank.tech/policy-checksum: "6b8278e97ee521cd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "bcb3b2236726dc69"
+    openbank.tech/policy-checksum: "f0b927a95ee9eee1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1521,6 +1521,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bcb3b2236726dc69"
+        openbank.tech/policy-checksum: "f0b927a95ee9eee1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "a42f006ac965dcca"
+    openbank.tech/policy-checksum: "b8efc92e554c0b78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1557,6 +1557,51 @@ data:
           - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
         gate: dst-clock-injection
         enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+      money_path_ledger_economics:
+        # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+        # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+        #
+        # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+        # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+        # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+        # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+        # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+        # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+        # re-landed correctly in #1253.
+        #
+        # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+        # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+        # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+        # balance test fails on it immediately.
+        #
+        # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+        # same mapping production uses), net debits/credits per account, assert each balance against a
+        # hardcoded expected value. Reference implementation:
+        # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+        #
+        # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+        # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+        #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+        #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+        #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+        #     balances against literals instead. The balanced-journal property belongs in the factory's own
+        #     test, where an unbalanced branch could actually appear.
+        #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+        #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+        #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+        detect:
+          - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+        require:
+          - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+          - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+          - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+        gate: none
+        # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+        # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+        # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+        # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+        # money-path two-approval rule.
+        enforced: convention
       release_please_merge:
         # A release-please merge commit that reorders the tail of .release-please-manifest.json can
         # SILENTLY drop a component line while it stays in release-please-config.json. The

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a42f006ac965dcca"
+        openbank.tech/policy-checksum: "b8efc92e554c0b78"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
@@ -42,14 +42,30 @@ data class LedgerPosting(val reference: String, val partyId: UUID, val amount: M
  * books), just partial rather than the full remaining exposure, kept as a distinct kind so an audit
  * trail can tell a restructuring's forgiveness apart from a full write-off even though both hit the
  * same GL accounts.
+ *
+ * [INTEREST_CAPITALIZATION] rolls an accrued-but-unpaid interest receivable into the restructured
+ * principal when a reschedule discards the installment that carried it (#1245). The income is NOT
+ * reversed: an installment can only be accrued once it has fallen due (`findAccruable` gates on
+ * `dueDate <= asOf`), so that interest was genuinely earned — reversing it would silently forgive
+ * it, and ADR-0028 is explicit that debt relief happens ONLY through
+ * [RESCHEDULE_FORGIVENESS]. So the receivable moves into the asset it is now part of, and the
+ * borrower still owes it.
+ *
+ * [WRITE_OFF_INTEREST] derecognizes the accrued-but-unpaid interest receivable at write-off, alongside
+ * the principal [WRITE_OFF]. Same premise as above — the income was earned when the installment fell
+ * due, so it is not reversed; what failed is collection, and an uncollectible receivable is a credit
+ * loss exactly like the principal exposure. Kept as a distinct kind so the audit trail can split a
+ * write-off's loss into its principal and interest components.
  */
 enum class PostingKind {
     DISBURSEMENT,
     PRINCIPAL_REPAYMENT,
     INTEREST,
     INTEREST_ACCRUAL,
+    INTEREST_CAPITALIZATION,
     INTEREST_SETTLEMENT,
     WRITE_OFF,
+    WRITE_OFF_INTEREST,
     PROVISIONING,
     RESCHEDULE_FORGIVENESS,
 }

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/port/out/CreditRiskPorts.kt
@@ -46,10 +46,10 @@ data class LedgerPosting(val reference: String, val partyId: UUID, val amount: M
  * [INTEREST_CAPITALIZATION] rolls an accrued-but-unpaid interest receivable into the restructured
  * principal when a reschedule discards the installment that carried it (#1245). The income is NOT
  * reversed: an installment can only be accrued once it has fallen due (`findAccruable` gates on
- * `dueDate <= asOf`), so that interest was genuinely earned — reversing it would silently forgive
- * it, and ADR-0028 is explicit that debt relief happens ONLY through
- * [RESCHEDULE_FORGIVENESS]. So the receivable moves into the asset it is now part of, and the
- * borrower still owes it.
+ * `dueDate <= asOf`), so that interest was genuinely earned — reversing it would silently forgive it,
+ * bypassing [RESCHEDULE_FORGIVENESS], the one mechanism ADR-0028 gives debt relief so that it stays
+ * explicit and auditable. So the receivable moves into the asset it is now part of, and the borrower
+ * still owes it.
  *
  * [WRITE_OFF_INTEREST] derecognizes the accrued-but-unpaid interest receivable at write-off, alongside
  * the principal [WRITE_OFF]. Same premise as above — the income was earned when the installment fell

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -243,6 +243,32 @@ class LendingService(
     override fun listLoans(partyId: UUID): Uni<List<Loan>> = loans.findByParty(partyId)
 
     override fun recordRepayment(loanId: LoanId, installmentId: UUID): Uni<LoanInstallment> =
+        loans.findById(loanId).flatMap { loan ->
+            when {
+                loan == null ->
+                    Uni.createFrom().failure(IllegalArgumentException("Loan not found: $loanId"))
+                // A WRITTEN_OFF loan's installments still read paid=false / interestAccrued=true —
+                // writeOff derecognizes on the ledger and never mutates the rows. Without this guard a
+                // recovery payment posts PRINCIPAL_REPAYMENT against an asset already credited off by
+                // WRITE_OFF, and INTEREST_SETTLEMENT against a receivable already credited off by
+                // WRITE_OFF_INTEREST — driving both GLs negative. The idempotency keys differ, so the
+                // ledger cannot collapse them.
+                //
+                // A recovery on a written-off loan is NOT a repayment: the asset is gone, so there is
+                // nothing to reduce. It is Dr Funding Clearing / Cr Loan Loss Expense (recovery income)
+                // and needs its own use case — refused here rather than silently mis-booked (#1245).
+                loan.status == LoanStatus.WRITTEN_OFF ->
+                    Uni.createFrom().failure(
+                        IllegalStateException(
+                            "Loan $loanId is WRITTEN_OFF: a recovery is not a repayment and must be " +
+                                "booked as recovery income, not against a derecognized asset",
+                        ),
+                    )
+                else -> recordRepaymentAgainst(loanId, installmentId)
+            }
+        }
+
+    private fun recordRepaymentAgainst(loanId: LoanId, installmentId: UUID): Uni<LoanInstallment> =
         installments.findByLoan(loanId).flatMap { schedule ->
             val target = schedule.firstOrNull { it.id == installmentId }
             when {
@@ -349,6 +375,9 @@ class LendingService(
                         )
                     } else {
                         // Book the loss and remove the asset from the books; we never mutate balances ourselves.
+                        // Ledger first, row mutation last (as accrueOne does — NOT recordRepayment, which
+                        // marks the row paid before posting): a crash between them leaves the loan ACTIVE and
+                        // the retry replays the same idempotency keys, which the ledger collapses.
                         ledger.post(
                             LedgerPosting(
                                 "loan:${loanId.value}:writeoff",
@@ -357,6 +386,7 @@ class LendingService(
                                 PostingKind.WRITE_OFF,
                             ),
                         )
+                            .flatMap { derecognizeAccruedInterest(loan, schedule) }
                             .flatMap { loans.update(loan.copy(status = LoanStatus.WRITTEN_OFF)) }
                             .flatMap { written ->
                                 val wPayload = """{"loanId":"${written.id.value}",""" +
@@ -375,6 +405,43 @@ class LendingService(
                 }
             }
         }
+
+    /**
+     * Derecognize the loan's accrued-but-unpaid interest receivable at write-off. Every unpaid
+     * installment the servicing pass already accrued has an Interest Receivable balance the principal-only
+     * [PostingKind.WRITE_OFF] never touches and would otherwise orphan on the books forever.
+     *
+     * The income stays recognized: an installment can only be accrued once it has fallen due
+     * (`findAccruable` gates on `dueDate <= asOf`), so it was genuinely earned — what failed is
+     * collection, and an uncollectible receivable is a credit loss, not a revenue reversal.
+     *
+     * ONE POSTING PER INSTALLMENT, deliberately. An aggregate `loan:<id>:writeoff:interest` key over a
+     * summed amount looks simpler and is unsafe: the loan is still ACTIVE until `loans.update` runs, so
+     * `findAccruable` can accrue another installment between a crash and the retry. The retry would then
+     * recompute a LARGER sum under the SAME key, and the ledger — which dedupes on the key without
+     * comparing payloads — would silently return the smaller original journal, stranding the difference
+     * on the GL forever. Per-installment keys make a newly-accrued row post its own journal and the
+     * already-handled ones collapse, which is correct under any interleaving (#1245).
+     */
+    private fun derecognizeAccruedInterest(loan: Loan, schedule: List<LoanInstallment>): Uni<Unit> {
+        val accruedUnpaid = schedule.filter { !it.paid && it.interestAccrued && it.interest.isPositive() }
+        if (accruedUnpaid.isEmpty()) {
+            return Uni.createFrom().item(Unit)
+        }
+        return Multi.createFrom().iterable(accruedUnpaid)
+            .onItem().transformToUniAndConcatenate { installment ->
+                ledger.post(
+                    LedgerPosting(
+                        "loan:${loan.id.value}:inst:${installment.number}:writeoff-interest",
+                        loan.partyId,
+                        installment.interest,
+                        PostingKind.WRITE_OFF_INTEREST,
+                    ),
+                )
+            }
+            .collect().asList()
+            .replaceWith(Unit)
+    }
 
     // --- Reschedule / restructuring (forbearance, issue #667/#668) ----------------------------------
 
@@ -422,7 +489,12 @@ class LendingService(
                 ),
             )
         }
-        val newPrincipal = outstanding.minus(request.principalForgiveness)
+        // Accrued-but-unpaid interest on the installments this reschedule is about to discard. Each such
+        // row already posted an INTEREST_ACCRUAL whose INTEREST_SETTLEMENT can now never happen, so the
+        // receivable would be stranded on the GL forever (#1245 / audit N-1). It is CAPITALIZED into the
+        // restructured principal, not reversed — see [capitalizeAccruedUnpaidInterest].
+        val capitalized = accruedUnpaidInterest(loan, schedule)
+        val newPrincipal = outstanding.plus(capitalized).minus(request.principalForgiveness)
         // A monotonically-increasing, DURABLY PERSISTED generation number, not just loan.version + 1
         // computed-and-discarded — the idempotency key below must never repeat across two separate
         // reschedules of the same loan, or the second one's forgiveness would replay the first one's
@@ -440,7 +512,56 @@ class LendingService(
         } else {
             Uni.createFrom().item(Unit)
         }
-        return forgive.flatMap { buildAndPersistNewSchedule(loan, schedule, newPrincipal, generation, request) }
+        return forgive
+            .flatMap { capitalizeAccruedUnpaidInterest(loan, schedule) }
+            .flatMap { buildAndPersistNewSchedule(loan, schedule, newPrincipal, generation, request) }
+    }
+
+    /** Accrued-but-unpaid interest on the installments a reschedule will discard. */
+    private fun accruedUnpaidInterest(loan: Loan, schedule: List<LoanInstallment>): Money = schedule
+        .filter { !it.paid && it.interestAccrued }
+        .fold(Money.zero(loan.principal.currency.code)) { acc, i -> acc.plus(i.interest) }
+
+    /**
+     * Roll the accrued-but-unpaid interest of every installment this reschedule discards into the
+     * restructured principal: `Dr Loans Receivable / Cr Interest Receivable`, one posting per row.
+     *
+     * WHY CAPITALIZE AND NOT REVERSE. `interestAccrued` has exactly one writer — `markAccrued`, called
+     * only from [accrueOne], fed only by `findAccruable` (`WHERE dueDate <= :asOf`). So every row here
+     * has ALREADY FALLEN DUE and its interest was genuinely earned. Reversing the accrual
+     * (Dr Interest Income) would un-earn it: the borrower would owe nothing for a period they held the
+     * money, no relief would be booked against Loan Loss Expense, and `loan.rescheduled` would report
+     * `principalForgiveness: 0.00` while real relief had been granted — debt forgiveness as a silent
+     * side effect. ADR-0028 is explicit that relief happens ONLY through
+     * [PostingKind.RESCHEDULE_FORGIVENESS]. It is also the treatment [derecognizeAccruedInterest]
+     * already applies on write-off, for the identical fact pattern.
+     *
+     * (The "new schedule re-accrues the same income twice" worry does not apply: [Amortization.schedule]
+     * charges `opening × periodRate` for periods running from `newFirstDueDate` forward and never
+     * re-charges the elapsed period the old accrual covered. Same principal, different period.)
+     *
+     * Ledger first, row deletion last: a crash between them leaves the old rows in place and the retry
+     * replays the same per-installment keys, which the ledger collapses.
+     */
+    private fun capitalizeAccruedUnpaidInterest(loan: Loan, schedule: List<LoanInstallment>): Uni<Unit> {
+        // Zero-interest rows are flagged accrued without ever posting (see accrueOne): nothing to move.
+        val accruedUnpaid = schedule.filter { !it.paid && it.interestAccrued && it.interest.isPositive() }
+        if (accruedUnpaid.isEmpty()) {
+            return Uni.createFrom().item(Unit)
+        }
+        return Multi.createFrom().iterable(accruedUnpaid)
+            .onItem().transformToUniAndConcatenate { installment ->
+                ledger.post(
+                    LedgerPosting(
+                        "loan:${loan.id.value}:inst:${installment.number}:capitalization",
+                        loan.partyId,
+                        installment.interest,
+                        PostingKind.INTEREST_CAPITALIZATION,
+                    ),
+                )
+            }
+            .collect().asList()
+            .replaceWith(Unit)
     }
 
     private fun buildAndPersistNewSchedule(
@@ -450,7 +571,18 @@ class LendingService(
         generation: Long,
         request: RescheduleRequest,
     ): Uni<Loan> {
-        val paidCount = schedule.count { it.paid }
+        // Continue numbering after the HIGHEST existing number, not the paid count. Two bugs, both live
+        // before this (#1245), both silent:
+        //   * `paidCount` recycles a discarded unpaid row's number. That row already posted
+        //     "loan:<id>:inst:<n>:accrual", and deleteUnpaid frees the number so UNIQUE(loan_id, number)
+        //     does not catch it — so the replacement row's own accrual collapses into the discarded row's
+        //     journal and the income is NEVER POSTED.
+        //   * recordRepayment pays by installment id with no ordering constraint, so the paid set need not
+        //     be a prefix: pay only #5 of 12 and `paidCount` = 1 makes the new row #5 collide with the
+        //     SURVIVING paid row #5 — a hard UNIQUE violation.
+        // maxOfOrNull runs over the full schedule (paid + about-to-be-deleted), and surviving paid rows
+        // always hold numbers below the new block, so numbering is strictly monotonic across generations.
+        val lastNumber = schedule.maxOfOrNull { it.number } ?: 0
         val newSchedule = Amortization.schedule(
             principal = newPrincipal,
             nominalAnnualRate = request.newNominalAnnualRate,
@@ -462,7 +594,7 @@ class LendingService(
         val rows = newSchedule.installments.map { i ->
             LoanInstallment(
                 loanId = loan.id,
-                number = paidCount + i.number,
+                number = lastNumber + i.number,
                 dueDate = i.dueDate,
                 openingBalance = i.openingBalance,
                 principal = i.principal,

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/application/usecase/LendingService.kt
@@ -69,7 +69,11 @@ import java.util.UUID
 // TooManyFunctions: this is the single application service for the whole bounded context
 // (ADR-0028), implementing eight cohesive inbound-port interfaces — splitting it would scatter
 // one aggregate's orchestration across files for no behavioral benefit.
-@Suppress("LongParameterList", "TooManyFunctions")
+// LargeClass: the accrued-interest work (#1245) pushed it over the budget. Suppressed rather than
+// split in a money-path fix whose point is to be reviewable — an extraction here would bury the
+// three-line economic change in a file move. The same call CustomerEdgeResource made. Splitting the
+// servicing/provisioning loops out is a real follow-up, not a drive-by.
+@Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 class LendingService(
     private val applications: LoanApplicationRepository,
     private val loans: LoanRepository,
@@ -482,6 +486,21 @@ class LendingService(
         if (!outstanding.isPositive()) {
             return Uni.createFrom().failure(IllegalStateException("Nothing to reschedule: outstanding balance is zero"))
         }
+        // A newFirstDueDate on or before an already-accrued installment's dueDate re-charges a period
+        // that was already recognized: the old accrual (now capitalized into newPrincipal) AND the new
+        // schedule's first installment both cover it. Nothing rejected this before — it double-charged
+        // on the pre-capitalization code too, just by a smaller amount. Forbearance moves due dates
+        // FORWARD; a backdated one is a data error, not a business case.
+        val lastAccruedDue = schedule.filter { !it.paid && it.interestAccrued }.maxOfOrNull { it.dueDate }
+        if (lastAccruedDue != null && !request.newFirstDueDate.isAfter(lastAccruedDue)) {
+            return Uni.createFrom().failure(
+                IllegalArgumentException(
+                    "newFirstDueDate ${request.newFirstDueDate} must be after the last accrued " +
+                        "installment's dueDate $lastAccruedDue — interest for that period is already " +
+                        "recognized and would be charged twice",
+                ),
+            )
+        }
         if (request.principalForgiveness.amount > outstanding.amount) {
             return Uni.createFrom().failure(
                 IllegalArgumentException(
@@ -532,13 +551,25 @@ class LendingService(
      * (Dr Interest Income) would un-earn it: the borrower would owe nothing for a period they held the
      * money, no relief would be booked against Loan Loss Expense, and `loan.rescheduled` would report
      * `principalForgiveness: 0.00` while real relief had been granted — debt forgiveness as a silent
-     * side effect. ADR-0028 is explicit that relief happens ONLY through
-     * [PostingKind.RESCHEDULE_FORGIVENESS]. It is also the treatment [derecognizeAccruedInterest]
-     * already applies on write-off, for the identical fact pattern.
+     * side effect, bypassing the one mechanism ADR-0028 gives relief: an explicit
+     * [PostingKind.RESCHEDULE_FORGIVENESS]. (ADR-0028 does not *say* relief may happen only that way —
+     * it is silent on accrued interest at reschedule, which is why this bug existed. The argument above
+     * stands on its own; the ADR merely shows relief is meant to be explicit and auditable.) This is
+     * also the treatment [derecognizeAccruedInterest] applies on write-off, for the identical fact
+     * pattern.
      *
-     * (The "new schedule re-accrues the same income twice" worry does not apply: [Amortization.schedule]
-     * charges `opening × periodRate` for periods running from `newFirstDueDate` forward and never
-     * re-charges the elapsed period the old accrual covered. Same principal, different period.)
+     * The "new schedule re-accrues the same income twice" worry does not apply *given a sane
+     * `newFirstDueDate`: [Amortization.schedule] charges `opening × periodRate` from `newFirstDueDate`
+     * forward, so a first period starting after the last accrued due date cannot re-charge it. That
+     * precondition is enforced in [rescheduleAgainst] — without it, `newFirstDueDate` on or before an
+     * accrued installment's `dueDate` double-charges that period (both here and, historically, on the
+     * pre-capitalization code).
+     *
+     * Caveat worth knowing: "fell due therefore earned" is this service's *current* recognition model,
+     * not the IFRS 9 test. Under IFRS 9 5.4.1(b) a credit-impaired (Stage 3) asset accrues on the NET
+     * carrying amount, not gross — and a delinquent loan being forborne is very likely Stage 3. That
+     * indicts [accrueOne]'s gross accrual, not this function: given the accrual happened at gross,
+     * capitalizing is the internally consistent exit.
      *
      * Ledger first, row deletion last: a crash between them leaves the old rows in place and the retry
      * replays the same per-installment keys, which the ledger collapses.

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactory.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingJournalFactory.kt
@@ -30,8 +30,10 @@ data class LendingGlAccounts(
  *   PRINCIPAL_REPAYMENT  DEBIT  Funding Clearing     CREDIT Loans Receivable     (cash in, asset reduced)
  *   INTEREST             DEBIT  Funding Clearing     CREDIT Interest Income       (cash in, income earned — early payment)
  *   INTEREST_ACCRUAL     DEBIT  Interest Receivable  CREDIT Interest Income       (income earned at due date, no cash yet)
+ *   INTEREST_CAPITALIZATION DEBIT Loans Receivable  CREDIT Interest Receivable   (accrued interest rolled into the restructured principal)
  *   INTEREST_SETTLEMENT  DEBIT  Funding Clearing     CREDIT Interest Receivable   (cash in, accrued receivable cleared)
  *   WRITE_OFF            DEBIT  Loan Loss Expense    CREDIT Loans Receivable      (loss booked, asset off)
+ *   WRITE_OFF_INTEREST   DEBIT  Loan Loss Expense    CREDIT Interest Receivable   (accrued receivable uncollectible at write-off)
  *   RESCHEDULE_FORGIVENESS DEBIT Loan Loss Expense   CREDIT Loans Receivable      (partial forgiveness, restructuring)
  *   PROVISIONING (Δ≥0)   DEBIT  Loan Loss Expense    CREDIT Loan Loss Allowance   (impairment increases: more provision)
  *   PROVISIONING (Δ<0)   DEBIT  Loan Loss Allowance  CREDIT Loan Loss Expense    (impairment decreases: partial release)
@@ -68,8 +70,10 @@ object LendingJournalFactory {
             PostingKind.PRINCIPAL_REPAYMENT -> accounts.fundingClearing to accounts.loansReceivable
             PostingKind.INTEREST -> accounts.fundingClearing to accounts.interestIncome
             PostingKind.INTEREST_ACCRUAL -> accounts.interestReceivable to accounts.interestIncome
+            PostingKind.INTEREST_CAPITALIZATION -> accounts.loansReceivable to accounts.interestReceivable
             PostingKind.INTEREST_SETTLEMENT -> accounts.fundingClearing to accounts.interestReceivable
             PostingKind.WRITE_OFF -> accounts.loanLossExpense to accounts.loansReceivable
+            PostingKind.WRITE_OFF_INTEREST -> accounts.loanLossExpense to accounts.interestReceivable
             PostingKind.RESCHEDULE_FORGIVENESS -> accounts.loanLossExpense to accounts.loansReceivable
             PostingKind.PROVISIONING -> error("unreachable: handled above")
         }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingGlOutcomeTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingGlOutcomeTest.kt
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.lending.application.usecase
+
+import com.openbank.lending.application.port.out.CollateralRepository
+import com.openbank.lending.application.port.out.CollateralValuationPort
+import com.openbank.lending.application.port.out.InstallmentRepository
+import com.openbank.lending.application.port.out.LedgerPosting
+import com.openbank.lending.application.port.out.LedgerPostingPort
+import com.openbank.lending.application.port.out.LendingOutboxMessage
+import com.openbank.lending.application.port.out.LoanApplicationRepository
+import com.openbank.lending.application.port.out.LoanEventEmitter
+import com.openbank.lending.application.port.out.LoanRepository
+import com.openbank.lending.application.port.out.ProvisioningRepository
+import com.openbank.lending.application.port.out.RiskParameterSource
+import com.openbank.lending.domain.model.Loan
+import com.openbank.lending.domain.model.LoanInstallment
+import com.openbank.lending.domain.model.LoanStatus
+import com.openbank.lending.domain.model.RescheduleRequest
+import com.openbank.lending.domain.model.WriteOffRequest
+import com.openbank.lending.infrastructure.client.LendingGlAccounts
+import com.openbank.lending.infrastructure.client.LendingJournalFactory
+import com.openbank.libs.domain.identifiers.LoanApplicationId
+import com.openbank.libs.domain.identifiers.LoanId
+import com.openbank.libs.domain.money.Money
+import com.openbank.libs.lending.AmortizationMethod
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.smallrye.mutiny.Uni
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+
+/**
+ * ECONOMIC-OUTCOME tests: assert the GL balances a flow produces, not which journals it emitted.
+ *
+ * WHY THIS FILE EXISTS. #1236 shipped a reschedule that silently forgave already-earned interest, and
+ * every one of its tests passed. They asserted *mechanics* — posting kinds, ordering, reference strings
+ * — which the defective code satisfied perfectly. No test asked the only question that matters: after
+ * this flow, what does the general ledger say? That question fails the defect immediately (#1245).
+ *
+ * The harness replays captured postings through the real [LendingJournalFactory] — the same mapping
+ * production uses — and sums debits/credits per account. A test asserting `interestIncome == 110.54`
+ * cannot be satisfied by emitting the right *kind* of journal; only by getting the economics right.
+ *
+ * Add a case here for every new [com.openbank.lending.application.port.out.PostingKind], not just a
+ * mapping assertion in LendingJournalFactoryTest.
+ */
+class LendingGlOutcomeTest {
+
+    private val applications = mockk<LoanApplicationRepository>()
+    private val loans = mockk<LoanRepository>()
+    private val installments = mockk<InstallmentRepository>()
+    private val collateral = mockk<CollateralRepository>()
+    private val ledger = mockk<LedgerPostingPort>()
+    private val valuation = mockk<CollateralValuationPort>()
+    private val riskParameters = mockk<RiskParameterSource>()
+    private val events = mockk<LoanEventEmitter>()
+    private val clock = Clock.fixed(Instant.parse("2026-04-01T00:00:00Z"), ZoneOffset.UTC)
+    private val provisioning = mockk<ProvisioningRepository>()
+
+    private val service = LendingService(
+        applications, loans, installments, collateral, ledger,
+        valuation, riskParameters, events, clock, provisioning,
+    )
+
+    private val partyId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private fun eur(v: String) = Money.of(v, "EUR")
+
+    // --- the GL harness --------------------------------------------------------------------------
+
+    private val gl = LendingGlAccounts(
+        loansReceivable = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001"),
+        fundingClearing = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000002"),
+        interestIncome = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000003"),
+        interestReceivable = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000004"),
+        loanLossExpense = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000005"),
+        loanLossAllowance = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000006"),
+    )
+
+    /**
+     * Replay postings through the production journal factory and net each account.
+     * Debit-positive: a debit adds, a credit subtracts — so an asset/expense reads positive when it has
+     * a debit balance, and income reads NEGATIVE when it has been earned (credit balance). Stated
+     * explicitly so an assertion's sign can never be mistaken for a bug in the harness.
+     */
+    private fun ledgerBalances(postings: List<LedgerPosting>): Map<UUID, BigDecimal> {
+        val balances = mutableMapOf<UUID, BigDecimal>()
+        postings.forEach { posting ->
+            LendingJournalFactory.buildLines(posting, gl).forEach { line ->
+                val signed = if (line.side == "DEBIT") line.amount else line.amount.negate()
+                balances.merge(line.glAccountId, signed, BigDecimal::add)
+            }
+        }
+        return balances
+    }
+
+    private fun Map<UUID, BigDecimal>.of(account: UUID): BigDecimal = this[account] ?: BigDecimal.ZERO
+
+    /** Every journal the factory builds must self-balance; a flow's postings must net to zero overall. */
+    private fun assertDoubleEntryHolds(balances: Map<UUID, BigDecimal>) {
+        val net = balances.values.fold(BigDecimal.ZERO, BigDecimal::add)
+        assertThat(net.compareTo(BigDecimal.ZERO))
+            .describedAs("debits minus credits across all accounts must be zero, was $net")
+            .isEqualTo(0)
+    }
+
+    // --- fixtures --------------------------------------------------------------------------------
+
+    private val loanId = LoanId(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+
+    private val bookedAt = OffsetDateTime.parse("2026-01-01T00:00:00Z")
+
+    private fun activeLoan() = Loan(
+        id = loanId,
+        applicationId = LoanApplicationId.random(),
+        partyId = partyId,
+        principal = eur("12000.00"),
+        nominalAnnualRate = BigDecimal("0.12"),
+        termPeriods = 12,
+        periodsPerYear = 12,
+        method = AmortizationMethod.ANNUITY,
+        firstDueDate = LocalDate.parse("2026-01-31"),
+        status = LoanStatus.ACTIVE,
+        disbursedAt = bookedAt,
+        version = 0,
+        createdAt = bookedAt,
+    )
+
+    /**
+     * #1 paid; #2 fell due 2026-02-28 and its interest was ACCRUED but never collected; #3.. still future.
+     * This is a delinquent loan — the normal forbearance and write-off case, and the exact shape the
+     * accrued-interest defects live in.
+     */
+    private fun delinquentSchedule() = listOf(
+        LoanInstallment(
+            loanId = loanId, number = 1, dueDate = LocalDate.parse("2026-01-31"),
+            openingBalance = eur("12000.00"), principal = eur("946.19"), interest = eur("120.00"),
+            payment = eur("1066.19"), closingBalance = eur("11053.81"),
+            paid = true, interestAccrued = true,
+        ),
+        LoanInstallment(
+            loanId = loanId, number = 2, dueDate = LocalDate.parse("2026-02-28"),
+            openingBalance = eur("11053.81"), principal = eur("955.65"), interest = eur("110.54"),
+            payment = eur("1066.19"), closingBalance = eur("10098.16"),
+            paid = false, interestAccrued = true,
+        ),
+        LoanInstallment(
+            loanId = loanId, number = 3, dueDate = LocalDate.parse("2026-03-31"),
+            openingBalance = eur("10098.16"), principal = eur("965.21"), interest = eur("100.98"),
+            payment = eur("1066.19"), closingBalance = eur("9132.95"),
+            paid = false, interestAccrued = false,
+        ),
+    )
+
+    private fun captureLedger(): MutableList<LedgerPosting> {
+        val captured = mutableListOf<LedgerPosting>()
+        val s = slot<LedgerPosting>()
+        every { ledger.post(capture(s)) } answers {
+            captured += s.captured
+            Uni.createFrom().item(Unit)
+        }
+        return captured
+    }
+
+    // --- write-off ------------------------------------------------------------------------------
+
+    @Test
+    fun `write-off derecognizes principal AND the accrued receivable, and keeps the earned income`() {
+        val loan = activeLoan()
+        val schedule = delinquentSchedule()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        val postings = captureLedger()
+
+        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "risk-officer")).await().indefinitely()
+
+        val b = ledgerBalances(postings)
+        assertDoubleEntryHolds(b)
+
+        // Principal (opening balance of the first unpaid installment) + the accrued interest both leave.
+        assertThat(b.of(gl.loansReceivable)).isEqualByComparingTo("-11053.81")
+        assertThat(b.of(gl.interestReceivable))
+            .describedAs("the accrued receivable must not be orphaned on a written-off loan")
+            .isEqualByComparingTo("-110.54")
+
+        // The loss carries BOTH components.
+        assertThat(b.of(gl.loanLossExpense)).isEqualByComparingTo("11164.35")
+
+        // The income stays earned: an installment can only accrue once it has fallen due.
+        assertThat(b.of(gl.interestIncome))
+            .describedAs("write-off is a collection failure, not a revenue reversal")
+            .isEqualByComparingTo("0.00")
+    }
+
+    @Test
+    fun `write-off posts one interest journal per accrued installment, not one aggregate`() {
+        val loan = activeLoan()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(delinquentSchedule())
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        val postings = captureLedger()
+
+        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "risk-officer")).await().indefinitely()
+
+        // An aggregate key over a summed amount is unsafe: the loan stays ACTIVE until loans.update, so
+        // the accrual scheduler can add a row between a crash and the retry, and the ledger — which
+        // dedupes on the key without comparing payloads — would silently keep the smaller sum.
+        assertThat(postings.map { it.reference })
+            .contains("loan:${loanId.value}:inst:2:writeoff-interest")
+            .doesNotContain("loan:${loanId.value}:writeoff:interest")
+    }
+
+    @Test
+    fun `a recovery on a written-off loan is refused, not booked against the derecognized asset`() {
+        val writtenOff = activeLoan().copy(status = LoanStatus.WRITTEN_OFF)
+        every { loans.findById(loanId) } returns Uni.createFrom().item(writtenOff)
+        val postings = captureLedger()
+
+        val failure = runCatching {
+            service.recordRepayment(loanId, delinquentSchedule()[1].id).await().indefinitely()
+        }.exceptionOrNull()
+
+        // Without the guard: INTEREST_SETTLEMENT credits a receivable WRITE_OFF_INTEREST already cleared,
+        // driving Interest Receivable negative. The idempotency keys differ, so the ledger cannot save us.
+        assertThat(failure).isInstanceOf(IllegalStateException::class.java)
+        assertThat(failure?.message).contains("WRITTEN_OFF")
+        assertThat(postings).describedAs("nothing may be posted for a refused recovery").isEmpty()
+    }
+
+    // --- reschedule -----------------------------------------------------------------------------
+
+    @Test
+    fun `reschedule capitalizes accrued interest and never un-earns it`() {
+        val loan = activeLoan()
+        val schedule = delinquentSchedule()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { installments.deleteUnpaid(loanId) } returns Uni.createFrom().item(2)
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        val postings = captureLedger()
+
+        service.reschedule(
+            loanId,
+            RescheduleRequest(
+                newNominalAnnualRate = BigDecimal("0.10"),
+                newTermPeriods = 12,
+                newFirstDueDate = LocalDate.parse("2026-05-31"),
+                principalForgiveness = eur("0.00"),
+            ),
+            rescheduledBy = "risk-officer",
+        ).await().indefinitely()
+
+        val b = ledgerBalances(postings)
+        assertDoubleEntryHolds(b)
+
+        // THE REGRESSION GUARD. #1236 reversed the accrual here (Dr Interest Income), which would make
+        // this -110.54: the February interest owed by nobody and earned by no one — debt relief granted
+        // as a side effect, outside RESCHEDULE_FORGIVENESS and outside the audit trail (ADR-0028 is
+        // explicit that relief happens ONLY through that posting).
+        assertThat(b.of(gl.interestIncome))
+            .describedAs("a reschedule must never un-earn interest that already fell due")
+            .isEqualByComparingTo("0.00")
+
+        // The receivable is not stranded — it moves into the restructured asset the borrower still owes.
+        assertThat(b.of(gl.interestReceivable)).isEqualByComparingTo("-110.54")
+        assertThat(b.of(gl.loansReceivable)).isEqualByComparingTo("110.54")
+
+        // And no relief was granted: none was asked for.
+        assertThat(b.of(gl.loanLossExpense))
+            .describedAs("no forgiveness was requested, so none may be booked")
+            .isEqualByComparingTo("0.00")
+    }
+
+    @Test
+    fun `reschedule rolls the capitalized interest into the new principal`() {
+        val loan = activeLoan()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(delinquentSchedule())
+        every { installments.deleteUnpaid(loanId) } returns Uni.createFrom().item(2)
+        val rows = slot<List<LoanInstallment>>()
+        every { installments.saveAll(capture(rows)) } answers { Uni.createFrom().item(rows.captured) }
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        every { ledger.post(any()) } returns Uni.createFrom().item(Unit)
+
+        service.reschedule(
+            loanId,
+            RescheduleRequest(
+                newNominalAnnualRate = BigDecimal("0.10"),
+                newTermPeriods = 12,
+                newFirstDueDate = LocalDate.parse("2026-05-31"),
+                principalForgiveness = eur("0.00"),
+            ),
+            rescheduledBy = "risk-officer",
+        ).await().indefinitely()
+
+        // outstanding 11053.81 (opening balance of first unpaid) + 110.54 accrued = 11164.35
+        assertThat(rows.captured.first().openingBalance)
+            .describedAs("the capitalized interest must be part of the restructured principal")
+            .isEqualTo(eur("11164.35"))
+
+        // Numbering continues after the HIGHEST existing number (3), not the paid count (1): recycling a
+        // discarded row's number collapses the replacement's accrual into the discarded row's journal.
+        assertThat(rows.captured.first().number).isEqualTo(4)
+    }
+
+    @Test
+    fun `reschedule with forgiveness books relief explicitly and still capitalizes the interest`() {
+        val loan = activeLoan()
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(delinquentSchedule())
+        every { installments.deleteUnpaid(loanId) } returns Uni.createFrom().item(2)
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        val postings = captureLedger()
+
+        service.reschedule(
+            loanId,
+            RescheduleRequest(
+                newNominalAnnualRate = BigDecimal("0.10"),
+                newTermPeriods = 12,
+                newFirstDueDate = LocalDate.parse("2026-05-31"),
+                principalForgiveness = eur("1000.00"),
+            ),
+            rescheduledBy = "risk-officer",
+        ).await().indefinitely()
+
+        val b = ledgerBalances(postings)
+        assertDoubleEntryHolds(b)
+
+        // Relief is visible and lands where relief belongs — not silently in a revenue line.
+        assertThat(b.of(gl.loanLossExpense)).isEqualByComparingTo("1000.00")
+        assertThat(b.of(gl.interestIncome)).isEqualByComparingTo("0.00")
+        // Loans receivable: -1000.00 forgiven, +110.54 capitalized.
+        assertThat(b.of(gl.loansReceivable)).isEqualByComparingTo("-889.46")
+    }
+
+    @Test
+    fun `a reschedule with nothing accrued posts no capitalization`() {
+        val loan = activeLoan()
+        val cleanSchedule = delinquentSchedule().map { it.copy(interestAccrued = false) }
+        every { loans.findById(loanId) } returns Uni.createFrom().item(loan)
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(cleanSchedule)
+        every { installments.deleteUnpaid(loanId) } returns Uni.createFrom().item(2)
+        every { installments.saveAll(any()) } answers { Uni.createFrom().item(firstArg<List<LoanInstallment>>()) }
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        val postings = captureLedger()
+
+        service.reschedule(
+            loanId,
+            RescheduleRequest(
+                newNominalAnnualRate = BigDecimal("0.10"),
+                newTermPeriods = 12,
+                newFirstDueDate = LocalDate.parse("2026-05-31"),
+                principalForgiveness = eur("0.00"),
+            ),
+            rescheduledBy = "risk-officer",
+        ).await().indefinitely()
+
+        assertThat(postings).describedAs("nothing accrued, so nothing to capitalize").isEmpty()
+    }
+}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingGlOutcomeTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingGlOutcomeTest.kt
@@ -225,19 +225,58 @@ class LendingGlOutcomeTest {
 
     @Test
     fun `a recovery on a written-off loan is refused, not booked against the derecognized asset`() {
+        val schedule = delinquentSchedule()
         val writtenOff = activeLoan().copy(status = LoanStatus.WRITTEN_OFF)
         every { loans.findById(loanId) } returns Uni.createFrom().item(writtenOff)
+        // Stub the whole downstream path ON PURPOSE, even though the guard should short-circuit before
+        // reaching any of it. An earlier version stubbed only findById, so removing the guard made the
+        // flow die on an unstubbed mock — the test went red, but for the WRONG reason, and
+        // `postings.isEmpty()` passed vacuously without ever demonstrating the harm. With these stubs
+        // the unguarded flow RUNS to completion and the assertions below fail on the real GL damage.
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { installments.markPaid(any(), any()) } returns Uni.createFrom().item(1)
         val postings = captureLedger()
 
         val failure = runCatching {
-            service.recordRepayment(loanId, delinquentSchedule()[1].id).await().indefinitely()
+            service.recordRepayment(loanId, schedule[1].id).await().indefinitely()
         }.exceptionOrNull()
 
-        // Without the guard: INTEREST_SETTLEMENT credits a receivable WRITE_OFF_INTEREST already cleared,
-        // driving Interest Receivable negative. The idempotency keys differ, so the ledger cannot save us.
         assertThat(failure).isInstanceOf(IllegalStateException::class.java)
         assertThat(failure?.message).contains("WRITTEN_OFF")
         assertThat(postings).describedAs("nothing may be posted for a refused recovery").isEmpty()
+    }
+
+    @Test
+    fun `write-off then recovery must not drive Interest Receivable negative`() {
+        val schedule = delinquentSchedule()
+        val loan = activeLoan()
+        every { loans.findById(loanId) } returnsMany listOf(
+            Uni.createFrom().item(loan), // writeOff sees ACTIVE
+            Uni.createFrom().item(loan.copy(status = LoanStatus.WRITTEN_OFF)), // the recovery attempt
+        )
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        every { installments.markPaid(any(), any()) } returns Uni.createFrom().item(1)
+        every { loans.update(any()) } answers { Uni.createFrom().item(firstArg<Loan>()) }
+        every { events.emit(any<LendingOutboxMessage>()) } returns Uni.createFrom().item(Unit)
+        val postings = captureLedger()
+
+        // Both flows against ONE captured ledger: write off the loan, then attempt a recovery on the
+        // installment whose receivable WRITE_OFF_INTEREST just derecognized. writeOff mutates no
+        // installment rows, so #2 still reads paid=false/interestAccrued=true and recordRepayment would
+        // post INTEREST_SETTLEMENT against a receivable that is already gone.
+        service.writeOff(loanId, WriteOffRequest(writtenOffBy = "risk-officer")).await().indefinitely()
+        runCatching { service.recordRepayment(loanId, schedule[1].id).await().indefinitely() }
+
+        val b = ledgerBalances(postings)
+        // THE ECONOMIC ASSERTION. Unguarded this reads -221.08: WRITE_OFF_INTEREST credits 110.54 and
+        // INTEREST_SETTLEMENT credits it again against a receivable of 110.54. The idempotency keys
+        // differ (`inst:2:writeoff-interest` vs `inst:2:interest`), so the ledger cannot collapse them.
+        assertThat(b.of(gl.interestReceivable))
+            .describedAs("a receivable may be cleared once, never twice — it cannot go below -110.54")
+            .isEqualByComparingTo("-110.54")
+        assertThat(b.of(gl.loansReceivable))
+            .describedAs("principal is derecognized once; a recovery must not reduce it again")
+            .isEqualByComparingTo("-11053.81")
     }
 
     // --- reschedule -----------------------------------------------------------------------------
@@ -270,8 +309,8 @@ class LendingGlOutcomeTest {
 
         // THE REGRESSION GUARD. #1236 reversed the accrual here (Dr Interest Income), which would make
         // this -110.54: the February interest owed by nobody and earned by no one — debt relief granted
-        // as a side effect, outside RESCHEDULE_FORGIVENESS and outside the audit trail (ADR-0028 is
-        // explicit that relief happens ONLY through that posting).
+        // as a side effect, bypassing RESCHEDULE_FORGIVENESS — the one mechanism ADR-0028 gives relief,
+        // so that it stays explicit and auditable.
         assertThat(b.of(gl.interestIncome))
             .describedAs("a reschedule must never un-earn interest that already fell due")
             .isEqualByComparingTo("0.00")
@@ -349,6 +388,35 @@ class LendingGlOutcomeTest {
         assertThat(b.of(gl.interestIncome)).isEqualByComparingTo("0.00")
         // Loans receivable: -1000.00 forgiven, +110.54 capitalized.
         assertThat(b.of(gl.loansReceivable)).isEqualByComparingTo("-889.46")
+    }
+
+    @Test
+    fun `a reschedule may not backdate newFirstDueDate onto an already-accrued period`() {
+        val schedule = delinquentSchedule() // #2 accrued, due 2026-02-28
+        every { loans.findById(loanId) } returns Uni.createFrom().item(activeLoan())
+        every { installments.findByLoan(loanId) } returns Uni.createFrom().item(schedule)
+        val postings = captureLedger()
+
+        // Without the guard the new schedule's first installment covers a period the old accrual
+        // already recognized: 110.54 capitalized into newPrincipal AND ~111.64 charged again by the
+        // new row #1 — 222.18 of interest for one month. Nothing rejected this before; the
+        // pre-capitalization code double-charged here too, just by a smaller amount.
+        val failure = runCatching {
+            service.reschedule(
+                loanId,
+                RescheduleRequest(
+                    newNominalAnnualRate = BigDecimal("0.10"),
+                    newTermPeriods = 12,
+                    newFirstDueDate = LocalDate.parse("2026-02-28"), // == accrued #2's dueDate
+                    principalForgiveness = eur("0.00"),
+                ),
+                rescheduledBy = "risk-officer",
+            ).await().indefinitely()
+        }.exceptionOrNull()
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+        assertThat(failure?.message).contains("already recognized")
+        assertThat(postings).describedAs("a rejected reschedule posts nothing").isEmpty()
     }
 
     @Test

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceEdgeCasesTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceEdgeCasesTest.kt
@@ -284,6 +284,8 @@ class LendingServiceEdgeCasesTest {
     @Test
     fun `repayment fails when the installment is not on the loan`() {
         val loanId = LoanId.random()
+        // recordRepayment now loads the loan first (#1245).
+        every { loans.findById(loanId) } returns Uni.createFrom().item(activeLoan(loanId))
         every { installments.findByLoan(loanId) } returns Uni.createFrom().item(listOf(installment(loanId, 1)))
 
         assertThatThrownBy {
@@ -299,6 +301,8 @@ class LendingServiceEdgeCasesTest {
     fun `repayment refuses an installment that is already paid`() {
         val loanId = LoanId.random()
         val paid = installment(loanId, 1, paid = true)
+        // recordRepayment now loads the loan first (#1245).
+        every { loans.findById(loanId) } returns Uni.createFrom().item(activeLoan(loanId))
         every { installments.findByLoan(loanId) } returns Uni.createFrom().item(listOf(paid))
 
         assertThatThrownBy {

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/application/usecase/LendingServiceTest.kt
@@ -277,6 +277,8 @@ class LendingServiceTest {
             interestAccrued = true,
         )
         val postings = mutableListOf<LedgerPosting>()
+        // recordRepayment now loads the loan first — a WRITTEN_OFF loan must refuse a recovery (#1245).
+        every { loans.findById(loanId) } returns Uni.createFrom().item(activeLoan(loanId))
         every { installments.findByLoan(loanId) } returns Uni.createFrom().item(listOf(installment))
         every { installments.markPaid(instId, any()) } returns Uni.createFrom().item(1)
         every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
@@ -299,6 +301,8 @@ class LendingServiceTest {
             interestAccrued = false,
         )
         val postings = mutableListOf<LedgerPosting>()
+        // recordRepayment now loads the loan first — a WRITTEN_OFF loan must refuse a recovery (#1245).
+        every { loans.findById(loanId) } returns Uni.createFrom().item(activeLoan(loanId))
         every { installments.findByLoan(loanId) } returns Uni.createFrom().item(listOf(installment))
         every { installments.markPaid(instId, any()) } returns Uni.createFrom().item(1)
         every { ledger.post(capture(postings)) } returns Uni.createFrom().item(Unit)
@@ -446,7 +450,7 @@ class LendingServiceTest {
     }
 
     @Test
-    fun `reschedule replaces the unpaid tail, numbering new rows after the last paid installment`() {
+    fun `reschedule replaces the unpaid tail, numbering new rows after the highest existing number`() {
         val loanId = LoanId.random()
         val loan = activeLoan(loanId)
         val schedule = twoInstallmentSchedule(loanId)
@@ -458,9 +462,15 @@ class LendingServiceTest {
 
         assertThat(result.status).isEqualTo(LoanStatus.ACTIVE)
         verify(exactly = 1) { installments.deleteUnpaid(loanId) }
-        // One paid installment (#1) already exists; the new schedule's rows must continue from #2 —
-        // never restart at #1, or a future repayment's ledger reference would collide with the paid one.
-        assertThat(rowsSlot.captured.first().number).isEqualTo(2)
+        // Continue after the HIGHEST existing number (#2), not the paid count (1). This expectation was
+        // `2` and that pinned a weaker rule than the code needs: it only protected against colliding with
+        // a PAID row, while an unpaid row that was already accrued has likewise posted
+        // "loan:<id>:inst:<n>:accrual" — and deleteUnpaid frees its number, so UNIQUE(loan_id, number)
+        // does not catch the recycle. The replacement row's own accrual then collapses into the discarded
+        // row's journal and the income is never posted (#1245). Never recycling any number is the only
+        // rule that holds regardless of accrual state; the cost is gaps, and numbers are identifiers,
+        // not a count.
+        assertThat(rowsSlot.captured.first().number).isEqualTo(3)
         assertThat(rowsSlot.captured.map { it.number }).isSorted()
         assertThat(rowsSlot.captured).hasSize(24)
         verify(exactly = 0) { ledger.post(match { it.kind == PostingKind.RESCHEDULE_FORGIVENESS }) }

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -347,6 +347,51 @@ change_requirements:
       - "no Instant.now() / LocalDateTime.now() / System.currentTimeMillis() / Clock.System.now() in domain or application layer"
     gate: dst-clock-injection
     enforced: enforce                   # ADR-0100 simulation harness live (#1725); gate clean fleet-wide
+  money_path_ledger_economics:
+    # THE RULE: a change to how a money-path service posts to the ledger must be covered by a test that
+    # asserts the resulting GL ACCOUNT BALANCES, not merely which journals were emitted.
+    #
+    # WHY. #1236 (lending, 2026-07-16) shipped a reschedule that silently forgave already-earned
+    # interest — Dr Interest Income where the receivable should have been capitalised — and EVERY check
+    # was green. Its tests asserted mechanics: posting kinds, ordering, reference strings,
+    # idempotency-key equality. The defective code satisfied all of them perfectly: it emitted exactly
+    # the right KIND of journal and merely pointed one leg at the wrong account. No test asked the only
+    # question that matters — after this flow, what does the general ledger say? Reverted in #1247,
+    # re-landed correctly in #1253.
+    #
+    # The failure mode is specific and repeatable: net profit is UNCHANGED, so nothing looks wrong,
+    # while the CLASSIFICATION is wrong — a credit concession lands in a revenue line. Interest Income
+    # and Loan Loss Expense are separately-reported FINREP lines. A mechanics test cannot see this; a
+    # balance test fails on it immediately.
+    #
+    # THE PATTERN: capture the postings, replay them through the service's real journal factory (the
+    # same mapping production uses), net debits/credits per account, assert each balance against a
+    # hardcoded expected value. Reference implementation:
+    # openbank-lending-service/src/test/kotlin/.../LendingGlOutcomeTest.kt.
+    #
+    # A BALANCE TEST IS NOT AUTOMATICALLY AN ECONOMIC TEST. Two traps, both found by review ON THE
+    # REFERENCE IMPLEMENTATION ITSELF — and this entry previously recommended the first one as a virtue:
+    #   * A whole-ledger "debits == credits" assertion is TAUTOLOGICAL when the factory emits one debit
+    #     and one credit of equal value per posting: identically zero for every input, INCLUDING a leg
+    #     mapped to the wrong account — the very defect being guarded against. Assert per-account
+    #     balances against literals instead. The balanced-journal property belongs in the factory's own
+    #     test, where an unbalanced branch could actually appear.
+    #   * A mutation can turn a test red FOR THE WRONG REASON — the unguarded flow dying on an unstubbed
+    #     mock before it ever reaches the ledger, so "no postings were made" passes vacuously. Stub
+    #     enough that the DEFECTIVE path runs, and assert the wrong balance it actually produces.
+    detect:
+      - "money_path service change to a ledger PostingKind, its GL account mapping, or a posting flow"
+    require:
+      - "a test asserting the GL ACCOUNT BALANCES the flow produces, not only the journals it emits"
+      - "a new PostingKind covered by a balance assertion, not only a mapping assertion"
+      - "the test proven to fail against the defect it guards — AND for the right reason, not on an unstubbed mock"
+    gate: none
+    # Deliberately NOT a CI gate. "This test asserts economics" is not detectable by a regex, and a gate
+    # that pretended to check it — grepping for balance assertions, say — would pass a test asserting the
+    # WRONG balances, or one going red on an unstubbed mock. That is worse than an honest convention: it would read as coverage while providing
+    # none, which is the same class of failure it exists to prevent. Enforced by review, under the
+    # money-path two-approval rule.
+    enforced: convention
   release_please_merge:
     # A release-please merge commit that reorders the tail of .release-please-manifest.json can
     # SILENTLY drop a component line while it stays in release-please-config.json. The


### PR DESCRIPTION
Re-lands the audit's **N-1 / N-2** findings correctly, after #1236 was reverted (#1247). Same diagnosis; different treatment on the reschedule path, plus the two defects review found in #1236.

**Based on #1247 (the revert), so it does not depend on that merging first.** Retarget to `main` once #1247 lands.

## What was actually broken — both real

| finding | defect |
|---|---|
| **N-2** write-off | booked principal only; the accrued interest receivable stayed live on a `WRITTEN_OFF` loan forever |
| **N-1** reschedule | `deleteUnpaid` dropped accrued rows with no handling, so their `INTEREST_SETTLEMENT` could never occur and the receivable was **stranded on the GL** |

#1236 fixed N-2 correctly and N-1 wrongly.

## Why capitalize, not reverse

#1236 reversed the accrual on reschedule (`Dr Interest Income`). That is refuted by **its own argument for write-off**: *"the interest **was** legitimately earned when the installment fell due."*

`interestAccrued` has exactly one writer — `markAccrued`, called only from `accrueOne`, fed only by `findAccruable` (`WHERE dueDate <= :asOf`). **So every row a reschedule touches has already fallen due.** Identical fact pattern, opposite treatment; only one can be right.

Its stated justification was also arithmetically false: `Amortization.schedule` charges from `newFirstDueDate` forward and never re-charges the elapsed period, so no income was double-counted. What the reversal actually did was **silently forgive earned interest** — outside `RESCHEDULE_FORGIVENESS`, outside the audit trail, with `loan.rescheduled` reporting `principalForgiveness: 0.00` while real relief was granted.

**ADR-0028 settles it**: *"An optional `principalForgiveness` (debt relief, defaults to none) … when positive, books a new `RESCHEDULE_FORGIVENESS`."* Relief is explicit and visible, by design. So the receivable **moves into the asset it is now part of**:

```
INTEREST_CAPITALIZATION   Dr Loans Receivable  Cr Interest Receivable
newPrincipal = outstanding + accruedUnpaid − forgiveness
```

The borrower still owes it. Income stays in the period it was earned. This is also the treatment `WRITE_OFF_INTEREST` already applies to the identical fact pattern.

## The two defects #1236 introduced — both closed

- **`recordRepayment` now refuses a `WRITTEN_OFF` loan.** It guarded only on `target.paid`, and `writeOff` mutates no installment rows — so a recovery posted `INTEREST_SETTLEMENT` against a receivable `WRITE_OFF_INTEREST` had already credited, driving **Interest Receivable negative**. A recovery is not a repayment (the asset is gone); it is `Dr Funding Clearing / Cr Loan Loss Expense` and needs its own use case. Refused here rather than silently mis-booked.
- **`WRITE_OFF_INTEREST` uses per-installment keys**, not one aggregate. The loan stays `ACTIVE` until `loans.update`, so the accrual scheduler can add a row between a crash and the retry; the retry would post a larger sum under the same key and the ledger — which dedupes **without comparing payloads** — would silently keep the smaller original, stranding the difference. Exactly the defect being fixed. (#1236's reschedule path already did this correctly and its write-off path contradicted it.)

## Also re-lands #1236's `lastNumber` fix

Independently valuable and **live**: `paidCount` recycles a discarded row's number, so the replacement's accrual collapses into the discarded row's journal and **the income is never posted** — `deleteUnpaid` frees the number, so `UNIQUE(loan_id, number)` doesn't catch it. And since `recordRepayment` pays by id with no ordering constraint, the paid set need not be a prefix: pay only #5 of 12 and the new row #5 collides with the **surviving paid** row — a hard `UNIQUE` violation.

## The test that would have caught all of this

**`LendingGlOutcomeTest` asserts GL account balances after a flow, not which journals were emitted.**

Every #1236 test passed while it silently forgave interest, because they asserted *mechanics* — posting kinds, ordering, reference strings, idempotency-key equality — which the defective code satisfied perfectly. It emitted the right *kind* of journal and merely pointed one leg at the wrong account.

The harness replays captured postings through the **real `LendingJournalFactory`** — the same mapping production uses — and nets debits/credits per account. `assertThat(interestIncome).isEqualByComparingTo("0.00")` cannot be satisfied by emitting the right kind of journal; only by getting the economics right. The `assertDoubleEntryHolds` helper this PR originally advertised has been **removed from the `rules.yaml` recommendation**: `buildLines` always emits one debit and one credit of equal value, so it is identically zero for every input — including a leg mapped to the wrong account. A tautological assertion, in the file whose whole thesis is that tautological assertions are the enemy.

**Mutation-verified.** Three independent reviews attacked this; two of the four kills I originally claimed did not hold up, and are fixed here rather than restated:

| mutation | result | |
|---|---|---|
| reintroduce #1236's reversal | **3 tests fail** | genuine economic kill |
| revert `lastNumber` → `paidCount` | **2 tests fail** | genuine economic kill |
| remove the `WRITTEN_OFF` guard | **2 tests fail** | **was a fixture artifact — now real** |
| drop the `newFirstDueDate` validation | **2 tests fail** | new |

The recovery kill was the embarrassing one. The test stubbed only `findById`, so removing the guard made the flow die on an unstubbed mock — red, but for the wrong reason, and `assertThat(postings).isEmpty()` passed **vacuously** without ever demonstrating the harm its own comment asserted. It now stubs the full path so the defective flow *runs*, and a second test drives write-off → recovery against one captured ledger:

```
[a receivable may be cleared once, never twice — it cannot go below -110.54]
expected: -110.54
but was:  -221.08
```

That is a GL balance, not a mock error.

The aggregate-key mutation killed only a reference-string assertion; the GL test passed, because a single-pass run produces identical balances either way. So it was a mechanics kill wearing GL clothing. The crash/retry thesis it was meant to guard still has **no test** — noted as a follow-up rather than papered over.



## One existing test strengthened, not fixed

`reschedule replaces the unpaid tail, numbering new rows after the last paid installment` expected `2` and pinned the **weaker** rule — protect against colliding with *paid* rows only. An accrued unpaid row has posted its reference too. It now expects `3` and names the rule the code actually needs. Renamed to `…after the highest existing number`.

The repayment tests gained a `loans.findById` stub — `recordRepayment` legitimately loads the loan now.

## So it doesn't repeat

`rules.yaml: money_path_ledger_economics` records the rule and the pattern, with #1236 as the worked example.

**Deliberately `enforced: convention`, not a gate.** "This test asserts economics" is not detectable by a regex, and a gate that pretended to check it — grepping for balance assertions — would pass a test asserting the *wrong* balances. That reads as coverage while providing none: the same class of failure it exists to prevent. Honest convention over theatre; review enforces it under the money-path two-approval rule.

## Verification

- [x] `:openbank-lending-service:build` — compile + full test suite green
- [x] `ktlintCheck`, `detekt` green (`ktlintFormat` applied; no hand-wrapping)
- [x] `:openbank-lending-service:quarkusBuild` — CDI/ArC wiring validated
- [x] Mutation-verified four ways (table above)
- [x] All 27 OPA generators re-run; the 26 bundle diffs are the known `rules.yaml` ripple, **no rego logic changed**
- [x] No `version.txt` / `openapi.yaml` edit — release-please owns the bump; `PostingKind` is internal, no API surface change

## Governance

`openbank-lending-service` is money-path: **two approvals + threat model**. The threat model exists; these flows do not change its trust boundaries (no new actor, no new external surface) — worth a reviewer's second opinion on that.

## Linked issues

Refs #1245
