### PR TITLE
feat(customer-edge): serve published consent documents to the onboarding step

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
@@ -11,13 +11,16 @@ import jakarta.annotation.security.PermitAll
 import jakarta.annotation.security.RolesAllowed
 import jakarta.inject.Inject
 import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.jwt.JsonWebToken
+import java.time.Instant
 
 /**
  * Public onboarding entry point (ADR-0069).
@@ -53,7 +56,16 @@ class OnboardingResource(
         private const val MAX_LEGAL_NAME_LENGTH = 500
         private const val STATUS_PAYLOAD_TOO_LARGE = 413
         private val VALID_PARTY_TYPES = setOf("INDIVIDUAL", "LEGAL_ENTITY", "SOLE_TRADER")
+
+        private const val TERMS_TTL_MS = 5 * 60 * 1000L
+        // The X-Customer-Party-Id header value for the pre-party terms call — document-service's
+        // template routes don't scope by party, but UpstreamClient always sends the header.
+        private const val ONBOARDING_PARTY_PLACEHOLDER = "onboarding-anonymous"
     }
+
+    // Instance field (the resource is a Quarkus singleton): per-lang cache of the serialized
+    // /terms response so an anonymous burst can't fan out to document-service.
+    private val termsCache = java.util.concurrent.ConcurrentHashMap<String, Pair<Long, String>>()
 
     @Inject
     lateinit var jsonMapper: ObjectMapper
@@ -66,6 +78,9 @@ class OnboardingResource(
 
     @ConfigProperty(name = "openbank.edge.party-service-url")
     lateinit var partyServiceUrl: String
+
+    @ConfigProperty(name = "openbank.edge.document-service-url")
+    lateinit var documentServiceUrl: String
 
     @POST
     @Path("/start")
@@ -135,4 +150,65 @@ class OnboardingResource(
     @RolesAllowed("ROLE_CUSTOMER")
     @Blocking
     fun registerParty(body: String): Response = customerEdge.registerParty(body)
+
+    /**
+     * The PUBLISHED contractual documents shown on the onboarding consent step (framework
+     * agreement + general terms), before any credential exists — informed consent requires the
+     * text to be READABLE at the moment the user ticks "I agree", and at that point there is no
+     * account, no token and no personalised document yet (the personalised agreement is created
+     * and signed after `account.created`, ADR-0169/0170).
+     *
+     * Same security class as [startOnboarding] above (the already-public onboarding surface,
+     * behind the same ingress rate limit) — deliberately NOT a new exposure category: read-only,
+     * serves only PUBLISHED template text (a bank's public terms — no PII, no party data, no
+     * template internals beyond what every prospective customer must be able to read anyway).
+     *
+     * Upstream call uses the edge M2M token against document-service's template list (the same
+     * ROLE_OPERATOR-gated route the admin cockpit reads); responses are cached for [TERMS_TTL_MS]
+     * per lang so an anonymous burst can't fan out to document-service.
+     */
+    @GET
+    @Path("/terms")
+    @PermitAll
+    @Blocking
+    fun onboardingTerms(@QueryParam("lang") lang: String?): Response {
+        val l = if (lang?.lowercase() == "en") "EN" else "CS"
+        val now = Instant.now().toEpochMilli()
+        termsCache[l]?.let { (at, body) ->
+            if (now - at < TERMS_TTL_MS) {
+                return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
+            }
+        }
+
+        val wanted = listOf("RAMCOVA_SMLOUVA_$l", "VOP_$l")
+        val resp = upstream.get("$documentServiceUrl/api/v1/documents/templates?limit=100", ONBOARDING_PARTY_PLACEHOLDER)
+        val raw = (resp.entity as? String).orEmpty()
+        if (resp.status != 200) {
+            return Response.status(502)
+                .entity("""{"error":"document templates unavailable"}""")
+                .type(MediaType.APPLICATION_JSON).build()
+        }
+        val docs = runCatching {
+            jsonMapper.readTree(raw)
+                .filter { it.get("status")?.asText() == "PUBLISHED" && it.get("code")?.asText() in wanted }
+                // Stable order: agreement first, then terms — the consent screen renders in order.
+                .sortedBy { wanted.indexOf(it.get("code")?.asText()) }
+                .map {
+                    mapOf(
+                        "code" to it.get("code")?.asText(),
+                        "name" to it.get("name")?.asText(),
+                        "version" to it.get("version")?.asText(),
+                        "publishedAt" to it.get("createdAt")?.asText(),
+                        "html" to it.get("bodyHtml")?.asText(),
+                    )
+                }
+        }.getOrElse {
+            return Response.status(502)
+                .entity("""{"error":"document templates unreadable"}""")
+                .type(MediaType.APPLICATION_JSON).build()
+        }
+        val body = jsonMapper.writeValueAsString(mapOf("documents" to docs))
+        termsCache[l] = now to body
+        return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
+    }
 }

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
@@ -58,6 +58,9 @@ class OnboardingResource(
         private val VALID_PARTY_TYPES = setOf("INDIVIDUAL", "LEGAL_ENTITY", "SOLE_TRADER")
 
         private const val TERMS_TTL_MS = 5 * 60 * 1000L
+        private const val STATUS_OK = 200
+        private const val STATUS_BAD_GATEWAY = 502
+
         // The X-Customer-Party-Id header value for the pre-party terms call — document-service's
         // template routes don't scope by party, but UpstreamClient always sends the header.
         private const val ONBOARDING_PARTY_PLACEHOLDER = "onboarding-anonymous"
@@ -181,10 +184,13 @@ class OnboardingResource(
         }
 
         val wanted = listOf("RAMCOVA_SMLOUVA_$l", "VOP_$l")
-        val resp = upstream.get("$documentServiceUrl/api/v1/documents/templates?limit=100", ONBOARDING_PARTY_PLACEHOLDER)
+        val resp = upstream.get(
+            "$documentServiceUrl/api/v1/documents/templates?limit=100",
+            ONBOARDING_PARTY_PLACEHOLDER,
+        )
         val raw = (resp.entity as? String).orEmpty()
-        if (resp.status != 200) {
-            return Response.status(502)
+        if (resp.status != STATUS_OK) {
+            return Response.status(STATUS_BAD_GATEWAY)
                 .entity("""{"error":"document templates unavailable"}""")
                 .type(MediaType.APPLICATION_JSON).build()
         }
@@ -203,7 +209,7 @@ class OnboardingResource(
                     )
                 }
         }.getOrElse {
-            return Response.status(502)
+            return Response.status(STATUS_BAD_GATEWAY)
                 .entity("""{"error":"document templates unreadable"}""")
                 .type(MediaType.APPLICATION_JSON).build()
         }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/OnboardingTermsTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/OnboardingTermsTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.customeredge.infrastructure.rest.OnboardingResource
+import com.openbank.customeredge.infrastructure.rest.UpstreamClient
+import com.openbank.customeredge.infrastructure.webauthn.EnrollmentTicketService
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.ws.rs.core.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for GET /onboarding/terms — the pre-credential consent-step documents
+ * (ADR-0169/0170 informed-consent gap): only PUBLISHED templates of the two wanted codes
+ * come back, ordered agreement-first, and an upstream failure maps to 502 (never a leak
+ * of the upstream body).
+ */
+class OnboardingTermsTest {
+
+    private val mapper = ObjectMapper()
+
+    private fun resource(upstream: UpstreamClient): OnboardingResource = OnboardingResource(
+        upstream,
+        mockk<EnrollmentTicketService>(relaxed = true),
+    ).apply {
+        jsonMapper = mapper
+        partyServiceUrl = "http://party"
+        documentServiceUrl = "http://documents"
+    }
+
+    private fun templates(vararg rows: Triple<String, String, String>): Response {
+        val arr = rows.joinToString(",") { (code, status, name) ->
+            """{"code":"$code","status":"$status","name":"$name","version":"1.1.0",""" +
+                """"createdAt":"2026-01-01T00:00:00Z","bodyHtml":"<p>text $code</p>"}"""
+        }
+        return Response.ok("[$arr]").build()
+    }
+
+    @Test
+    fun `returns published agreement and terms in stable order`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns templates(
+            Triple("VOP_CS", "PUBLISHED", "Všeobecné obchodní podmínky"),
+            Triple("RAMCOVA_SMLOUVA_CS", "RETIRED", "stará"),
+            Triple("RAMCOVA_SMLOUVA_CS", "PUBLISHED", "Rámcová smlouva"),
+            Triple("UCET_SMLOUVA_CS", "PUBLISHED", "jiný dokument"),
+        )
+
+        val resp = resource(upstream).onboardingTerms("cs")
+
+        assertThat(resp.status).isEqualTo(200)
+        val docs = mapper.readTree(resp.entity as String).get("documents")
+        assertThat(docs.size()).isEqualTo(2)
+        assertThat(docs[0].get("code").asText()).isEqualTo("RAMCOVA_SMLOUVA_CS")
+        assertThat(docs[1].get("code").asText()).isEqualTo("VOP_CS")
+        assertThat(docs[0].get("html").asText()).contains("text RAMCOVA_SMLOUVA_CS")
+        assertThat(docs[0].get("version").asText()).isEqualTo("1.1.0")
+    }
+
+    @Test
+    fun `lang en selects the english templates and anything else falls back to cs`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns templates(
+            Triple("RAMCOVA_SMLOUVA_EN", "PUBLISHED", "Framework Agreement"),
+            Triple("VOP_EN", "PUBLISHED", "General Terms"),
+        )
+
+        val resp = resource(upstream).onboardingTerms("en")
+
+        assertThat(resp.status).isEqualTo(200)
+        val docs = mapper.readTree(resp.entity as String).get("documents")
+        assertThat(docs.size()).isEqualTo(2)
+        assertThat(docs[0].get("code").asText()).isEqualTo("RAMCOVA_SMLOUVA_EN")
+    }
+
+    @Test
+    fun `upstream failure maps to 502 without leaking the upstream body`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns
+            Response.status(500).entity("""{"internal":"stacktrace"}""").build()
+
+        val resp = resource(upstream).onboardingTerms("de")
+
+        assertThat(resp.status).isEqualTo(502)
+        assertThat(resp.entity as String).doesNotContain("stacktrace")
+    }
+}


### PR DESCRIPTION
## Proč

Consent krok onboardingu nechává uživatele zaškrtnout „souhlasím s podmínkami výše" u dokumentů, které si nemůže otevřít — v tom kroku neexistuje účet, token ani personalizovaná smlouva (ta vzniká a podepisuje se až po `account.created`, ADR-0169/0170). Informovaný souhlas vyžaduje čitelný text v momentě zaškrtnutí.

## Co

`GET /customer/v1/onboarding/terms?lang=cs|en` v `OnboardingResource` — **stejná bezpečnostní třída jako už-veřejný `/onboarding/start`** (záměrně žádná nová kategorie expozice):

- read-only, servíruje jen **PUBLISHED** šablony rámcové smlouvy + VOP (veřejné podmínky banky — žádné PII, žádná party data)
- stejný ingress rate-limit perimetr jako start
- upstream přes edge M2M token na template list document-service (route bez `@Authorize` — stejný dosah, jaký má admin cockpit); **žádná OPA změna není potřeba**
- per-lang cache 5 min — anonymní burst se nerozvětví do document-service

## Testy

Unit: published-only + řazení smlouva-první, lang fallback, upstream failure → 502 bez leaku upstream body.

Appková strana (klikatelné karty dokumentů + reálná KYC metadata místo vymyšlených) následuje v openbank-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)