### PR TITLE
chore(gitops): auto-deploy services @ 218d1df76ca59acef8694333fdea2975a95844aa

### DIFF
--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ledger-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-ledger-service:sandbox-218d1df7
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Automated gitops image-tag update triggered by commit 218d1df76ca59acef8694333fdea2975a95844aa.

**Changed services:** ["openbank-ledger-service"]

Each image tag was updated to `sandbox-218d1df76ca59acef8694333fdea2975a95844aa` (the short SHA of the
triggering commit). ArgoCD syncs automatically after merge.

## Linked issues

N/A — automated gitops update, no user-visible change.