### PR TITLE
fix(infra): pin the two DaemonSet images at ECR instead of trusting Kyverno

### DIFF
--- a/openbank-infra/gitops/apps/alloy.yaml
+++ b/openbank-infra/gitops/apps/alloy.yaml
@@ -39,6 +39,21 @@ spec:
           registry: public.ecr.aws/d7v4f3x6
           repository: alloy
           tag: v1.5.1
+        # Pin the config-reloader sidecar straight at the ECR pull-through cache rather
+        # than letting Kyverno's rewrite-ghcr rule do it. That policy is a mutating
+        # webhook with failurePolicy: Ignore — it FAILS OPEN, so a pod admitted while
+        # Kyverno is momentarily unreachable keeps the ghcr.io ref and containerd pulls
+        # it over NAT. Measured 2026-07-16: 19 of 670 eligible containers were live on
+        # un-rewritten refs, including a node-exporter pod from 00:44 that night.
+        # That silent leak is what the Karpenter overnight consolidation freeze in
+        # main.tf works around (~100 GB/night, $4-5) — a DaemonSet pays it on EVERY new
+        # node, so the rewrite has to be deterministic, not best-effort. Chart default
+        # is ghcr.io/jimmidyson/configmap-reload (verified: helm show values
+        # grafana/alloy --version 0.10.1). Tag stays the chart default.
+        configReloader:
+          image:
+            registry: 265175468565.dkr.ecr.eu-north-1.amazonaws.com
+            repository: ghcr/jimmidyson/configmap-reload
         controller:
           type: daemonset
           # Node-level log collector: run at system-node-critical so the DaemonSet

--- a/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
+++ b/openbank-infra/gitops/apps/kube-prometheus-stack.yaml
@@ -356,6 +356,24 @@ spec:
                 authToken: $GLITCHTIP_API_TOKEN
         nodeExporter:
           enabled: true
+        # Pin node-exporter straight at the ECR pull-through cache rather than letting
+        # Kyverno's rewrite-quay rule do it. That policy is a mutating webhook with
+        # failurePolicy: Ignore — it FAILS OPEN, so a pod admitted while Kyverno is
+        # momentarily unreachable keeps the quay.io ref and containerd pulls it over
+        # NAT. Proven here on 2026-07-16: two node-exporter pods created that morning
+        # carried the rewritten ECR ref, while the one created at 00:44 was still on
+        # quay.io — same DaemonSet, same day, different outcome. A DaemonSet pays that
+        # on EVERY new node, which is the leak the Karpenter overnight consolidation
+        # freeze in main.tf works around (~100 GB/night, $4-5).
+        # `image` here is the prometheus-node-exporter SUBCHART's key, not the parent's
+        # (verified: helm show values prometheus-community/prometheus-node-exporter ->
+        # registry: quay.io, repository: prometheus/node-exporter). distroless stays
+        # true, so the chart keeps resolving the -distroless tag suffix; the
+        # pull-through mirrors the tag verbatim.
+        prometheus-node-exporter:
+          image:
+            registry: 265175468565.dkr.ecr.eu-north-1.amazonaws.com
+            repository: quay/prometheus/node-exporter
         # EKS managed control plane: AWS runs (and hides) kube-controller-manager,
         # kube-scheduler, etcd and kube-proxy — none expose scrapeable metrics
         # endpoints to the cluster. Leaving these chart defaults enabled created


### PR DESCRIPTION
## Linked issues

Refs #1263 — partial fix: the two DaemonSet images the freeze comment names.

## The finding

`ecr-pull-through-rewrite` is a mutating webhook with **`failurePolicy: Ignore`** — it **fails open**.
A pod admitted while Kyverno is momentarily unreachable keeps its `ghcr.io`/`quay.io` ref and
containerd pulls it over NAT. Nothing reports it: the pod runs fine, just expensively.

Measured live, 2026-07-16: **19 of 670 eligible containers** were running on un-rewritten refs.

The cleanest evidence is one DaemonSet on one day:

| node-exporter pod created | image |
|---|---|
| 12:13 | `265175468565.dkr.ecr…/quay/prometheus/node-exporter:v1.11.1-distroless` |
| 11:53 | `265175468565.dkr.ecr…/quay/prometheus/node-exporter:v1.11.1-distroless` |
| **00:44** | **`quay.io/prometheus/node-exporter:v1.11.1-distroless`** |

Same spec. Different admission-time luck.

## Why it matters here

A DaemonSet pays that on **every new node**, so Karpenter churn multiplies it — which is precisely the
leak the overnight consolidation freeze in `main.tf` works around:

> FinOps: freeze node replacement 20:00–07:00 UTC (overnight). Karpenter consolidation on idle nodes
> churn image pulls from ghcr.io / quay.io over NAT (~100 GB/night, $4-5) because containerd on a
> fresh node pulls DaemonSet images before Kyverno ECR-rewrite is active.

A best-effort webhook is the wrong mechanism for an invariant that must hold at node boot. Pinning the
ref in chart values makes the rewrite a **no-op instead of a dependency** — belt and braces, matching
`CLAUDE.md`: *"use explicit registry prefixes so the cluster's pull-through/rewrite policies apply"*.

## Scope

Deliberately the two images the freeze comment names. The other escapees (cert-manager, keda, strimzi,
metrics-server, pact-broker…) are **Deployments** — they pull once per pod, not per node, so they
barely touch the freeze rationale. Left as follow-up.

## Keys verified, not guessed

A wrong values key is silently ignored and leaves the default in place — so both were read off the
charts:

```
helm show values grafana/alloy --version 0.10.1
  -> configReloader.image.registry: ghcr.io
helm show values prometheus-community/prometheus-node-exporter
  -> image.registry: quay.io        # the SUBCHART's key, not the parent's
```

## Verified by rendering, not by reading

```
helm template ... -f <valuesObject from the Application>

alloy         -> 265175468565.dkr.ecr…/ghcr/jimmidyson/configmap-reload:v0.12.0
node-exporter -> 265175468565.dkr.ecr…/quay/prometheus/node-exporter:v1.11.1-distroless
```

`distroless` stays `true`, and the pull-through repo already carries that exact tag.

## Cost

**No increase.** This only changes where the same bytes come from — the `ecr.dkr` VPC endpoint instead
of the NAT gateway. It does not raise the NodePool cap and does not touch the freeze window; both stay
exactly as they are.


<!-- re-trigger issue-hygiene with the current body -->
