### PR TITLE
chore(ci): graduate the api-contract gate to enforced (ADR-0048 D5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,15 +598,17 @@ jobs:
       #   editorial => info.version PATCH
       # Also asserts the D2 API invariant on HEAD:
       #   major(info.version) == openbank.api.version == newest URL major.
-      # ADVISORY until rules.yaml change_requirements.api_change flips to
-      # enforced (target 2026-08-15, ADR-0144) — findings are ::warning
-      # annotations; add --enforce to the script invocation to flip.
+      # ENFORCED (ADR-0144 graduation, ahead of the 2026-08-15 target). The gate is
+      # diff-scoped: it only classifies the spec change in THIS PR, so the fleet's
+      # historical under-bumping is not retroactively a failure — but from here a PR
+      # that changes a spec must move info.version to match what it did. Bumping is
+      # the one-line fix the error message spells out.
       # oasdiff is a pinned, checksum-verified binary (OpenSSF Pinned-Dependencies),
       # same direct-CLI pattern as gitleaks (ADR-0040). PR-only: the gate diffs
       # against the resolved PR diff base (the CURRENT merge-base, not the
       # creation-time event base.sha — the #524 × #481 ledger merge race);
       # pushes to main have already been classified.
-      - name: "api-contract gate — OpenAPI diff classification (ADR-0048 D5, advisory)"
+      - name: "api-contract gate — OpenAPI diff classification (ADR-0048 D5, enforced)"
         if: github.event_name == 'pull_request'
         env:
           OASDIFF_VERSION: "1.22.0"
@@ -618,7 +620,7 @@ jobs:
           echo "${OASDIFF_SHA256}  /tmp/oasdiff.tar.gz" | sha256sum -c -
           tar -xzf /tmp/oasdiff.tar.gz -C /tmp oasdiff
           sudo install -m 0755 /tmp/oasdiff /usr/local/bin/oasdiff
-          python3 .github/scripts/check-api-contract.py --base "${PR_DIFF_BASE}"
+          python3 .github/scripts/check-api-contract.py --base "${PR_DIFF_BASE}" --enforce
 
       # ADVISORY until rules.yaml change_classes.db_change flips to enforced
       # (target 2026-08-15, ADR-0144) — add --enforce to the invocation to flip.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "cda5ce47ddc06d66"
+    openbank.tech/policy-checksum: "52d3d516388a8aa2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1342,12 +1342,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cda5ce47ddc06d66"
+        openbank.tech/policy-checksum: "52d3d516388a8aa2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "c837b86b1ceeb3da"
+    openbank.tech/policy-checksum: "2cbc9cde8543e4a1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1285,12 +1285,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c837b86b1ceeb3da"
+        openbank.tech/policy-checksum: "2cbc9cde8543e4a1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "50cda494a303bd9c"
+    openbank.tech/policy-checksum: "72fda6f42cfb7b83"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1386,12 +1386,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "50cda494a303bd9c"
+        openbank.tech/policy-checksum: "72fda6f42cfb7b83"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "d848c86a7e9a3a74"
+    openbank.tech/policy-checksum: "14ac5fa809334b85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1291,12 +1291,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d848c86a7e9a3a74"
+        openbank.tech/policy-checksum: "14ac5fa809334b85"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "f8b4c25405bb2a98"
+    openbank.tech/policy-checksum: "ef7b8cfc9be67a5f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1323,12 +1323,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8b4c25405bb2a98"
+        openbank.tech/policy-checksum: "ef7b8cfc9be67a5f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "a96d6c7df8a2604b"
+    openbank.tech/policy-checksum: "2b21caba745cbbb4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1374,12 +1374,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a96d6c7df8a2604b"
+        openbank.tech/policy-checksum: "2b21caba745cbbb4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "ba41369e44837b49"
+    openbank.tech/policy-checksum: "af09ffc9e5cf7957"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -596,12 +596,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba41369e44837b49"
+        openbank.tech/policy-checksum: "af09ffc9e5cf7957"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "ba41369e44837b49"
+    openbank.tech/policy-checksum: "af09ffc9e5cf7957"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -596,12 +596,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba41369e44837b49"
+        openbank.tech/policy-checksum: "af09ffc9e5cf7957"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "2878558d97d2aab0"
+    openbank.tech/policy-checksum: "be5ea67c66f93643"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1302,12 +1302,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2878558d97d2aab0"
+        openbank.tech/policy-checksum: "be5ea67c66f93643"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "4e2069b9bcd6b420"
+    openbank.tech/policy-checksum: "fcb7c8952e6a56f7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1353,12 +1353,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4e2069b9bcd6b420"
+        openbank.tech/policy-checksum: "fcb7c8952e6a56f7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "2536cf0c0b72d65c"
+    openbank.tech/policy-checksum: "6b5d16372cae64d9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1287,12 +1287,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2536cf0c0b72d65c"
+        openbank.tech/policy-checksum: "6b5d16372cae64d9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "a24a28f86816c718"
+    openbank.tech/policy-checksum: "9e3772dc2474a162"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1400,12 +1400,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a24a28f86816c718"
+        openbank.tech/policy-checksum: "9e3772dc2474a162"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "19351d6192c03158"
+    openbank.tech/policy-checksum: "da10ebbf6e956ba1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1355,12 +1355,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "19351d6192c03158"
+        openbank.tech/policy-checksum: "da10ebbf6e956ba1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "ba41369e44837b49"
+    openbank.tech/policy-checksum: "af09ffc9e5cf7957"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -596,12 +596,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "ba41369e44837b49"
+        openbank.tech/policy-checksum: "af09ffc9e5cf7957"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e22e503e0c7101cf"
+    openbank.tech/policy-checksum: "911c7ef8b7cc3c0f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1300,12 +1300,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "97d11cf5d517548a"
+    openbank.tech/policy-checksum: "59be22abfc45954b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1345,12 +1345,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a0bef14e7014e151"
+    openbank.tech/policy-checksum: "5085f6a228c29cd8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1330,12 +1330,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e67b4155f73309b6" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "243bf9baa4bbfc6a" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "94bb9bf1ca61821c"
+        openbank.tech/policy-checksum: "7b3b3f1044c0f34a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a0bef14e7014e151" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "5085f6a228c29cd8" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0f3ec1fb0c9e2c37"
+        openbank.tech/policy-checksum: "ec47c88e419effa1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "97d11cf5d517548a" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "59be22abfc45954b" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e22e503e0c7101cf"
+        openbank.tech/policy-checksum: "911c7ef8b7cc3c0f"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "9d356897b12a9259" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "6041fa687eb3ee63" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8c59566331df53f1"
+        openbank.tech/policy-checksum: "232b256f9840ab4e"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a04887942b76740a"
+        openbank.tech/policy-checksum: "0e97c5254fce1aa7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0f3ec1fb0c9e2c37"
+    openbank.tech/policy-checksum: "ec47c88e419effa1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1303,12 +1303,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "94bb9bf1ca61821c"
+    openbank.tech/policy-checksum: "7b3b3f1044c0f34a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1324,12 +1324,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9d356897b12a9259"
+    openbank.tech/policy-checksum: "6041fa687eb3ee63"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1304,12 +1304,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8c59566331df53f1"
+    openbank.tech/policy-checksum: "232b256f9840ab4e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1307,12 +1307,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e67b4155f73309b6"
+    openbank.tech/policy-checksum: "243bf9baa4bbfc6a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1360,12 +1360,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a04887942b76740a"
+    openbank.tech/policy-checksum: "0e97c5254fce1aa7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1311,12 +1311,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "6b8278e97ee521cd"
+    openbank.tech/policy-checksum: "ede831b5ea8f64cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1313,12 +1313,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6b8278e97ee521cd"
+        openbank.tech/policy-checksum: "ede831b5ea8f64cb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "f0b927a95ee9eee1"
+    openbank.tech/policy-checksum: "96cc884f415effbc"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1291,12 +1291,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f0b927a95ee9eee1"
+        openbank.tech/policy-checksum: "96cc884f415effbc"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "b8efc92e554c0b78"
+    openbank.tech/policy-checksum: "aabb5970ba5cccaf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1327,12 +1327,21 @@ data:
           - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
         contract_diff_tool: oasdiff
         gate: api-contract
-        enforced: advisory
-        target_enforce_date: "2026-08-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-        # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-        # Classification + api_invariant findings are ::warning annotations. Flipping this
-        # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+        enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+        # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+        # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+        # api_invariant findings are ::error and fail the build.
+        #
+        # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+        # recent spec-changing commits added or altered endpoints without moving info.version at
+        # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+        # advisory gate that everyone walks past is worse than none: it reports the rule is held
+        # when it is not.
+        #
+        # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+        # own spec change is classified. The cost of enforcement is therefore one line per
+        # spec-touching PR (bump info.version to match what the diff did), which the error
+        # message spells out.
         ci_producer: ".github/scripts/check-api-contract.py"
       db_change:
         detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b8efc92e554c0b78"
+        openbank.tech/policy-checksum: "aabb5970ba5cccaf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -117,12 +117,21 @@ change_requirements:
       - "single @Provider verification test per provider; per-interaction target for mixed HTTP+message"
     contract_diff_tool: oasdiff
     gate: api-contract
-    enforced: advisory
-    target_enforce_date: "2026-08-15"   # ADR-0144
-    # CI producer is LIVE (advisory): .github/scripts/check-api-contract.py runs in the
-    # "Validate manifests" job on every PR (oasdiff 1.22.0, pinned + checksum-verified).
-    # Classification + api_invariant findings are ::warning annotations. Flipping this
-    # rule to enforced = pass --enforce to the script in ci.yml (one-line change).
+    enforced: enforce                   # ADR-0144 graduation, ahead of the 2026-08-15 target
+    # .github/scripts/check-api-contract.py runs with --enforce in the "Validate manifests"
+    # job on every PR (oasdiff 1.22.0, pinned + checksum-verified): classification and
+    # api_invariant findings are ::error and fail the build.
+    #
+    # Why it graduated early: while advisory, the rule was being ignored — 11 of the 12 most
+    # recent spec-changing commits added or altered endpoints without moving info.version at
+    # all (e.g. #1161 added PATCH /api/v1/parties/{id}/consent and left 1.6.0 -> 1.6.0). An
+    # advisory gate that everyone walks past is worse than none: it reports the rule is held
+    # when it is not.
+    #
+    # The gate is DIFF-SCOPED, so that history is not retroactively a failure — only a PR's
+    # own spec change is classified. The cost of enforcement is therefore one line per
+    # spec-touching PR (bump info.version to match what the diff did), which the error
+    # message spells out.
     ci_producer: ".github/scripts/check-api-contract.py"
   db_change:
     detect: ["src/main/resources/db/migration/*.sql", "Flyway/Liquibase changeset"]


### PR DESCRIPTION
## Summary

Graduates `change_requirements.api_change` from advisory to **enforced** (ADR-0144), ahead of its 2026-08-15 target. The script already existed and already ran on every PR — this passes `--enforce` and flips the rule.

## Type of change

- [x] chore (build / tooling)
- [ ] feat / fix / refactor / perf / docs / security / breaking

## Linked issues

Refs ADR-0048, ADR-0144
N/A — no issue; this is the graduation ADR-0144 already schedules.

## Changes

- `ci.yml` — `check-api-contract.py … --enforce`; step renamed advisory → enforced.
- `rules.yaml` — `enforced: advisory` + `target_enforce_date` → `enforced: enforce`, with the evidence recorded next to the rule.
- 44 OPA bundle files — the known `rules.yaml` ripple (25 of 26 generators hash it). All 27 re-run; diff is the comment plus checksums.

## Why now rather than 2026-08-15

**Because the advisory period demonstrably wasn't working.** I ran the gate in `--enforce` mode against real history before touching anything:

| commit | result |
|---|---|
| last 12 spec-changing commits | **11 fail** |

Representative: **#1161** added `PATCH /api/v1/parties/{id}/consent` — 30 lines of new spec — and left `info.version` at `1.6.0 -> 1.6.0`. Verified it is a true positive, not a gate bug: the endpoint really is new, the version really did not move.

An advisory gate everyone walks past is worse than no gate — `rules.yaml` reports the API-contract axis as governed when it demonstrably is not, and for a repo whose selling point is governance-as-code, that claim is load-bearing.

## What this costs, honestly

**~90% of spec-touching PRs would have failed under this gate.** That is the point, but it should be stated plainly rather than discovered: from here, every PR that changes an `openapi.yaml` must move `info.version` to match what the diff did.

Two things bound the cost:
- **The gate is diff-scoped.** It classifies only the PR's own spec change, so the fleet's historical under-bumping is not retroactively a failure. No back-fill needed.
- **The fix is one line**, and the error message already names it: `additive API change requires an info.version MINOR bump, but it moved 1.6.0 -> 1.6.0`.

**No open PR currently touches an `openapi.yaml`** — checked before flipping, so this breaks nobody mid-flight.

## Definition of Done

- [x] Hexagonal layering — N/A (CI config).
- [ ] Unit tests — N/A; the script is unchanged, only its invocation.
- [ ] Integration / contract tests — N/A.
- [x] Verified against real history in `--enforce` mode (12 commits) rather than by reading the rule.
- [x] `gate-graduation` guard green — now tracks 15 advisory rules, down from 16.
- [x] yamllint clean on `ci.yml`.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — the evidence lives in `rules.yaml` next to the rule, per governance-as-code.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency — oasdiff was already pinned + checksum-verified.
- [ ] Auth / crypto / payment code — no.
- [ ] PII path — no.
- [ ] Cardholder data — no.

## Compliance impact

- [x] None directly — but it is the mechanism behind ADR-0048's two-axis versioning claim. An API-contract axis nothing enforces is a governance claim without a control behind it.

## Rollout / Rollback

- **Deployment strategy:** none — CI only.
- **Rollback plan:** drop `--enforce` and restore `enforced: advisory` + the `target_enforce_date`. The gate returns to annotating, and `gate-graduation` resumes counting down to 2026-08-15.
- **Data migration reversible:** N/A.

## Reviewer notes

**This one is a judgement call and it is yours to overrule.** The mechanical change is trivial; what you are actually approving is *"CI now blocks spec PRs that don't bump"*. Given an 11/12 historical failure rate, expect it to bite the next time you touch a spec — that is the gate working, but it is a real change in day-to-day friction for a solo maintainer.

If you would rather it kept warning until the target date, revert this and the ADR-0144 countdown continues — but note that on 2026-08-15 the `gate-graduation` guard fails CI for a still-advisory rule, so the same decision arrives then with a deadline attached instead of a choice.

Verified my own PR passes the enforced gate (`no openapi.yaml changed — nothing to classify`) — the flip does not fail its own change.
