### PR TITLE
fix(gitops): give the OPA sidecar readiness probe an initialDelaySeconds

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -201,6 +201,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -262,6 +262,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -183,6 +183,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -194,6 +194,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -157,6 +157,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -164,6 +164,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -173,6 +173,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -272,6 +272,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -251,6 +251,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -165,6 +165,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -138,6 +138,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -123,6 +123,7 @@ spec:
               containerPort: 8181
           readinessProbe:
             httpGet: {path: "/health?bundles=true", port: 8181}
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -198,6 +198,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -185,6 +185,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -196,6 +196,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -211,6 +211,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -568,6 +569,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -894,6 +896,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -1208,6 +1211,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -1496,6 +1500,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -1923,6 +1928,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -2175,6 +2181,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -2584,6 +2591,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
@@ -2871,6 +2879,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -192,6 +192,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -196,6 +196,7 @@ spec:
             httpGet:
               path: "/health?bundles=true"
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -164,6 +164,7 @@ spec:
             httpGet:
               path: /health?bundles=true
               port: 8181
+            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:


### PR DESCRIPTION
Closes #1257.

Every pod carrying the OPA sidecar logs exactly one `Readiness probe failed … connection refused` at startup. The probe declares no `initialDelaySeconds`, so it defaults to `0` and fires before OPA has bound `:8181`. The next probe 10s later succeeds — `failureThreshold: 3` gives a 30s grace that OPA comfortably makes, so the pod always goes ready.

**Nothing is broken.** The reason to fix it: the event is indistinguishable from a genuine OPA startup failure — a bundle that really fails to load opens with the same line. Chasing what looked like an `interest-service` fault cost real time today before the fleet-wide one-per-pod pattern made it obvious as noise.

## The change

`initialDelaySeconds: 5` on all **27** OPA `readinessProbe`s across the **19** manifests that declare one. 5s clears the bind race; the existing 30s failure budget is untouched.

The diff is 27 identical inserted lines and nothing else:

```
27  +            initialDelaySeconds: 5
```

## Deliberately NOT changed: the liveness probe

The liveness probe on the same port has the same omission (`periodSeconds: 15`, `failureThreshold: 3` ⇒ 45s before a container restart). Left alone on the evidence: **41 OPA containers running fleet-wide, 0 restarts between them.** The risk is latent, not real, and widening this would roll the fleet for a hypothetical. Worth its own decision if anyone ever sees an OPA restart.

## Verification — by parsing, not grepping

This bit matters, because grepping is exactly what nearly shipped a broken version of this PR.

My first pass matched the literal `path: /health?bundles=true` and reported success. It had silently skipped two manifests — `interest-service.yaml` and `sanctions-service.yaml` quote the path (`path: "/health?bundles=true"`), and interest additionally puts `httpGet` in flow style. Worse, my "did I miss any?" check used the *same* marker, so it shared the blind spot and cheerfully reported zero missing. A hardcoded `expected == 27` assertion is the only reason it got caught: 25 ≠ 27, refuse, reset, fix the matcher.

Final verification loads the YAML and inspects `readinessProbe.httpGet.path` on the parsed tree, so quoting and flow style cannot hide anything:

```
opa readiness probes with initialDelaySeconds=5: 27   missing: 0
19 files parse clean
```

Also checked: `policy-checksum` annotations untouched (this is a template change, not a bundle change), no liveness lines modified, no stray files.

## Expected effect

A pod roll for all 19 services — the probe lives in the pod template. Benign rolling restarts; verify a rolled pod produces no `connection refused` for `:8181` and still reaches ready within the unchanged failure budget.