### PR TITLE
fix(interest): settle a zero-tax remittance batch instead of wedging it

### DIFF
--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumer.kt
@@ -106,22 +106,35 @@ class WithholdingRemittanceSettlementConsumer(
     }
 
     /**
-     * Handles a batch whose decoded tax amount is not positive. A nil period batch (zero amount AND
-     * zero items) is legitimately settled without touching the rail; anything else is refused.
+     * Handles a batch whose decoded tax amount is not positive.
+     *
+     * A zero total is SETTLED without touching the rail, whatever the item count. Zero is not a
+     * decode artefact: [decimalOf] throws on anything unparsable, so a zero that reaches here is
+     * the producer's actual figure. And a zero total over a non-empty batch is ordinary — tax is
+     * assessed in whole CZK (`WithholdingTaxPolicy.TAX_SCALE = 0`, RoundingMode.DOWN per daňový
+     * řád), so any gross below 7.00 CZK yields `taxAmount = 0` while still being `WITHHELD`, and
+     * `WithholdingRemittancePolicy.isRemittable` does not filter those out. Refusing them wedged
+     * the batch PENDING forever — its rows already `REMITTED`, no re-drive endpoint, only SQL out.
+     *
+     * A NEGATIVE total is refused: `taxableBase` is `gross.max(ZERO)` and the rate is positive, so
+     * no policy path can produce one. It means something upstream is genuinely broken, and booking
+     * a negative debit would move money the wrong way.
      */
     private suspend fun settleNilOrRefuse(remittanceId: UUID, totalTaxAmount: BigDecimal, itemCount: Int) {
-        if (totalTaxAmount.signum() == 0 && itemCount == 0) {
-            // Nothing is due for the period — a 0.00 debit would be meaningless noise on the rail.
+        if (totalTaxAmount.signum() == 0) {
+            // Nothing is owed — a 0.00 debit would be meaningless noise on the rail. The batch's
+            // rows are already REMITTED; settling keeps the batch consistent with them.
             remitUseCase.settle(remittanceId).awaitSuspending()
-            log.infof("[withholding-remittance] batch %s is a nil batch — settled without booking", remittanceId)
+            log.infof(
+                "[withholding-remittance] batch %s totals zero tax over %d item(s) — settled without booking",
+                remittanceId,
+                itemCount,
+            )
         } else {
-            // Hard guard: a zero/negative amount with a non-empty batch means the amount failed to
-            // decode (or the producer emitted garbage). Booking 0.00 would mark real tax as paid
-            // without moving money — refuse and keep the batch PENDING.
             log.errorf(
-                "[withholding-remittance] batch %s decoded amount %s with itemCount %d — refusing to " +
-                    "book a zero/negative tax remittance. The batch stays PENDING; investigate the " +
-                    "event payload.",
+                "[withholding-remittance] batch %s decoded a NEGATIVE amount %s with itemCount %d — " +
+                    "refusing to book it. No WithholdingTaxPolicy path can produce a negative tax, so " +
+                    "this is an upstream defect. The batch stays PENDING; investigate the event payload.",
                 remittanceId,
                 totalTaxAmount,
                 itemCount,

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/kafka/WithholdingRemittanceSettlementConsumerTest.kt
@@ -141,9 +141,26 @@ class WithholdingRemittanceSettlementConsumerTest {
         verify(exactly = 0) { remitUseCase.settle(any()) }
     }
 
+    /**
+     * The reachable sub-7-CZK case, spelled out because the previous version of this test asserted
+     * the opposite and was wrong: tax is assessed in whole CZK (RoundingMode.DOWN), so a real
+     * `WITHHELD` row on gross 6.00 CZK carries `taxAmount = 0` and is still remittable. Such a
+     * batch owes nothing but MUST reach a terminal state — refusing it left it PENDING forever with
+     * its rows already REMITTED and no re-drive endpoint.
+     */
     @Test
-    fun `a zero amount with a non-empty batch is refused, not booked as 0`(): Unit = runBlocking {
+    fun `a zero total over a non-empty batch settles without touching the rail`(): Unit = runBlocking {
+        every { remitUseCase.settle(remittanceId) } returns Uni.createFrom().item(Unit)
+
         consumer.consume(record(payload = remittedPayload(totalTaxAmount = "\"0\"", itemCount = 12)))
+
+        verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
+        verify(exactly = 1) { remitUseCase.settle(remittanceId) }
+    }
+
+    @Test
+    fun `a negative amount is refused - no policy path can produce one`(): Unit = runBlocking {
+        consumer.consume(record(payload = remittedPayload(totalTaxAmount = "\"-1\"", itemCount = 3)))
 
         verify(exactly = 0) { transactionClient.initiateTransaction(any()) }
         verify(exactly = 0) { remitUseCase.settle(any()) }


### PR DESCRIPTION
Follow-up to #1246 — **my own defect, same shape as #1236**: one half of the change refuted the other half's premise. Found by an adversarial review pass explicitly modelled on the #1247 critique.

## The contradiction

#1246 added a guard that **refuses** a zero decoded amount when `itemCount != 0`, justified in its own comment as:

> a zero/negative amount with a non-empty batch means the amount failed to decode (or the producer emitted garbage)

But #1246's **other** fix made that unreachable. `decimalOf` is:

```kotlin
if (node.isNumber) node.decimalValue() else BigDecimal(node.asText())
```

A missing or garbled field → `asText()` = `""` → `BigDecimal("")` **throws**, caught and logged upstream. It does **not** decode to zero. So after that fix, a zero reaching the guard is the producer's actual figure — truthful by construction. The guard defends against a state its sibling fix eliminated.

## The state it misfires on is real

`WithholdingTaxPolicy` (CZK, non-exempt, individual):

```kotlin
val taxableBase = grossInterest.max(ZERO).setScale(TAX_SCALE, DOWN)   // TAX_SCALE = 0
val taxAmount   = taxableBase.multiply(rate).setScale(TAX_SCALE, DOWN)
… treatment = WITHHELD          // unconditional on this branch
```

Whole-CZK assessment with `RoundingMode.DOWN` (daňový řád). **Any gross below 7.00 CZK yields `taxAmount = 0` with `treatment = WITHHELD`** — e.g. gross 6.00 → base 6 → 6 × 0.15 = 0.90 → DOWN → **0**.

`WithholdingRemittancePolicy.isRemittable` filters on `status` / `treatment` / `currency` / `periodTo` — **never on `taxAmount > 0`**. So those rows are remittable and `assemble` produces `totalTaxAmount = 0, itemCount = 1`.

## Why it wedged forever

| | |
| --- | --- |
| rows | already `REMITTED` — `assembleRemittance` marked them before emitting |
| batch | refused → stays `PENDING` |
| redelivery | replays the identical event → identical refusal |
| re-assemble | `assembleRemittance` is idempotent (`findByPeriod` returns the existing batch) → **never re-emits** |
| operator | `WithholdingRemittanceResource` exposes only `assemble` / `list` / `get` — **no re-drive, no settle** |

Exit required direct SQL, and the log line actively misdirected: it told the operator to *"investigate the event payload"* for a payload that was correct. Money impact nil (zero tax genuinely owed) — but the state is self-inconsistent (`REMITTED` rows under a `PENDING` batch) and unrecoverable.

## The fix

- **Zero → settle**, whatever the item count. Nothing is owed; a 0.00 debit is noise on the rail, and settling keeps the batch consistent with its already-`REMITTED` rows.
- **Negative → still refuse.** `taxableBase` is `gross.max(ZERO)` and the rate is positive, so no policy path can produce a negative total; it means something upstream is genuinely broken, and booking a negative debit would move money the wrong way.

The discriminator is now parse-success (already guaranteed by `decimalOf` throwing), not `itemCount` — which was never a proxy for "should have been non-zero".

## The test was part of the defect

The old test fixed `itemCount = 12` with `totalTaxAmount = "0"` and asserted refusal — **asserting the implementation, never establishing that such a batch is corrupt**. It would have passed identically had the behaviour been wrong in exactly the way it was. Replaced with the reachable sub-7-CZK case asserting the batch reaches a **terminal state**, plus a negative-amount refusal test.

## Not changed (deliberate)

`isRemittable` still admits zero-tax `WITHHELD` rows. That is defensible — they were assessed and belong in the §38d audit trail; they simply owe nothing. Excluding them there is a policy question worth its own change, not something to smuggle into a defect fix.

`:openbank-interest-service:test` + ktlint + detekt green (JDK 25).

Refs #999, #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
