### PR TITLE
fix(customer-edge): accept a customer's access token to enrol a native passkey

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnKeycloakClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnKeycloakClient.kt
@@ -32,6 +32,14 @@ import java.time.Duration
  * against `kc.open-bank.tech` 2026-07-14 (both a `client_credentials` token mint and a
  * `requested_subject`+`audience=openbank-app` token-exchange succeeded end to end).
  */
+/**
+ * The identity behind a customer's own access token, as told by Keycloak introspection.
+ * [keycloakUserId] is the token's `sub` — the EXISTING Keycloak user, which is why a caller
+ * holding one must never be routed through [WebAuthnKeycloakClient.ensureUser] (that would mint a
+ * second, synthetic-email user for a party that already has one).
+ */
+data class CustomerTokenIdentity(val partyId: String, val keycloakUserId: String)
+
 @ApplicationScoped
 class WebAuthnKeycloakClient {
 
@@ -167,6 +175,51 @@ class WebAuthnKeycloakClient {
         val refreshToken = tree.get("refresh_token")?.asText()
         Log.debugf("impersonate: minted token for kcUserId=%s", keycloakUserId)
         return accessToken to refreshToken
+    }
+
+    /**
+     * Verify a customer's own Keycloak access token via RFC 7662 introspection and return the
+     * identity it carries, or null if the token is absent/expired/forged/from another realm.
+     *
+     * Why introspection and not the injected [org.eclipse.microprofile.jwt.JsonWebToken]:
+     * [WebAuthnResource] is deliberately un-annotated so that the registration routes can accept an
+     * [EnrollmentTicketService] ticket, which is NOT a JWT. Touching the injected token there would
+     * make Quarkus authenticate the request and reject a ticket-bearing call outright (the very
+     * failure that class's KDoc warns about). Introspection asks Keycloak to do the signature and
+     * expiry checks out-of-band, so the ticket path stays untouched — and rolling one's own JWT
+     * verification here would be strictly worse than delegating to the issuer.
+     *
+     * The endpoint is realm-scoped, so a token minted by any other realm is `active: false`.
+     */
+    fun introspectCustomerToken(accessToken: String): CustomerTokenIdentity? {
+        val formBody = "client_id=$clientId&client_secret=$clientSecret" +
+            "&token=${URLEncoder.encode(accessToken, StandardCharsets.UTF_8)}"
+        val resp = runCatching {
+            http.send(
+                HttpRequest.newBuilder()
+                    .uri(URI.create("$adminUrl/realms/$realm/protocol/openid-connect/token/introspect"))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .timeout(Duration.ofSeconds(HTTP_TIMEOUT_SECONDS))
+                    .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                    .build(),
+                HttpResponse.BodyHandlers.ofString(),
+            )
+        }.getOrElse { e ->
+            // Fail closed: an unreachable Keycloak must not enrol an unverified credential.
+            Log.warnf(e, "introspectCustomerToken: introspection call failed")
+            return null
+        }
+        if (resp.statusCode() != HTTP_OK) {
+            Log.warnf("introspectCustomerToken: introspection returned %d", resp.statusCode())
+            return null
+        }
+        val tree = runCatching { json.readTree(resp.body()) }.getOrNull() ?: return null
+        if (tree.get("active")?.asBoolean() != true) return null
+        val subject = tree.get("sub")?.asText()?.takeIf { it.isNotBlank() } ?: return null
+        // Same precedence as every other customer route (CustomerEdgeResource.resolvePartyIdClaim):
+        // the explicit party_id claim wins, sub is the ADR-0069 `party.id == sub` fallback.
+        val partyId = tree.get("party_id")?.asText()?.takeIf { it.isNotBlank() } ?: subject
+        return CustomerTokenIdentity(partyId = partyId, keycloakUserId = subject)
     }
 
     companion object {

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResource.kt
@@ -43,17 +43,19 @@ import java.util.Base64
  * [com.openbank.customeredge.infrastructure.rest.OnboardingResource]'s `startOnboarding`: a
  * class-level `@RolesAllowed` (or being on a class Quarkus's proactive OIDC filter otherwise
  * guards) pre-empts method-level `@PermitAll` with a bare 401 before this code runs. That matters
- * doubly here: [registerBegin]/[registerComplete]'s bearer token is an [EnrollmentTicketService]
- * ticket, not a Keycloak-issued JWT — the OIDC filter would reject it as malformed before this
- * class ever saw it. [authBegin]/[authComplete] need no token at all (obtaining one is the point).
+ * doubly here: [registerBegin]/[registerComplete]'s bearer may be an [EnrollmentTicketService]
+ * ticket rather than a Keycloak-issued JWT — the OIDC filter would reject it as malformed before
+ * this class ever saw it. [authBegin]/[authComplete] need no token at all (obtaining one is the
+ * point). A token-bearing caller is verified out-of-band instead, by
+ * [WebAuthnKeycloakClient.introspectCustomerToken] — see [authorizedEnroller].
  *
- * KNOWN GAP (tracked, not silently swept under the rug): a party that onboarded via the F1 hosted
- * Keycloak flow (`ASWebAuthenticationSession` — the default today) has a passkey registered with
- * *Keycloak's own* WebAuthn RP, not this one. This edge RP has an entirely separate credential
- * store, so [authBegin]/[authComplete] only work for a device that has previously completed
- * [registerBegin]/[registerComplete] against THIS RP. Today that only happens via the native F2
- * onboarding branch (`AppConfig.useNativePasskey`); there is no "register a native edge passkey"
- * flow yet for an already-onboarded F1 user. Out of scope here — see the tracking issue.
+ * A party that onboarded via the F1 hosted Keycloak flow (`ASWebAuthenticationSession`) has a
+ * passkey registered with *Keycloak's own* WebAuthn RP, not this one, and this edge RP keeps an
+ * entirely separate credential store — so [authBegin]/[authComplete] only ever work for a device
+ * that has completed [registerBegin]/[registerComplete] against THIS RP. Such a party bridges
+ * across by enrolling with their access token after a hosted login
+ * ([tech.openbank.app.auth.AuthService.enrollPasskey]); [authorizedEnroller] accepts exactly that,
+ * which is also the recovery path when this RP's credential store is lost (issue #1260).
  */
 @Path("/customer/v1/webauthn")
 @Produces(MediaType.APPLICATION_JSON)
@@ -84,8 +86,8 @@ class WebAuthnResource(
     @PermitAll
     @Blocking
     fun registerBegin(@HeaderParam("Authorization") authorization: String?): Response {
-        val partyId = authorizedPartyId(authorization)
-            ?: return unauthorized("Invalid or expired enrollment ticket")
+        val partyId = authorizedEnroller(authorization)?.partyId
+            ?: return unauthorized("Invalid or expired enrollment credential")
 
         val challenge = randomBytes()
         challengeStore.save(Base64UrlUtil.encodeToString(challenge), PURPOSE_REGISTRATION)
@@ -109,8 +111,9 @@ class WebAuthnResource(
         @HeaderParam("Authorization") authorization: String?,
         request: RegistrationCompleteRequestDto,
     ): Response {
-        val partyId = authorizedPartyId(authorization)
-            ?: return unauthorized("Invalid or expired enrollment ticket")
+        val enroller = authorizedEnroller(authorization)
+            ?: return unauthorized("Invalid or expired enrollment credential")
+        val partyId = enroller.partyId
 
         val clientDataJsonBytes = Base64UrlUtil.decode(request.clientDataJson)
         val challenge = extractChallenge(clientDataJsonBytes)
@@ -140,13 +143,22 @@ class WebAuthnResource(
             ?: return badRequest("Attestation missing credential data")
         val credentialId = Base64UrlUtil.encodeToString(attestedCredentialData.credentialId)
 
-        // party.id == Keycloak sub (ADR-0069 invariant): use the party's own edge-visible identity
-        // (partyId, the enrollment ticket's subject) to derive a synthetic username/email, since
-        // this is a brand-new party with no email known to the edge at this layer. The realm's
-        // party-id protocol mapper (openbank-app client) then carries party_id as a claim on any
-        // future token regardless of how this user later authenticates.
-        val syntheticEmail = "party+$partyId@openbank.internal"
-        val keycloakUserId = keycloakClient.ensureUser(syntheticEmail, partyId, displayName = "OpenBank Customer")
+        // An enroller who authenticated with their own access token ALREADY has a Keycloak user —
+        // bind the credential to that `sub`. Routing them through ensureUser() instead would look
+        // up the synthetic `party+<id>@openbank.internal` address, not find their real one, and
+        // create a SECOND user for the same party: the credential would then mint a session for an
+        // account holding none of their data, and party_id == sub would break for it.
+        //
+        // Only the ticket path lands in ensureUser: party.id == Keycloak sub (ADR-0069 invariant),
+        // and the edge knows no email for a brand-new party at this layer, so it derives a
+        // synthetic one. The realm's party-id protocol mapper (openbank-app client) then carries
+        // party_id as a claim on any future token regardless of how this user later authenticates.
+        val keycloakUserId = enroller.existingKeycloakUserId
+            ?: keycloakClient.ensureUser(
+                email = "party+$partyId@openbank.internal",
+                partyId = partyId,
+                displayName = "OpenBank Customer",
+            )
 
         credentialStore.save(
             RegisteredCredential(
@@ -255,10 +267,40 @@ class WebAuthnResource(
     // ── Internals ─────────────────────────────────────────────────────────────────────────
 
     /** Reads the `Authorization: Bearer <ticket>` header and resolves it to a partyId, or null. */
-    private fun authorizedPartyId(authorization: String?): String? {
-        val ticket = authorization?.removePrefix("Bearer ")?.trim()?.takeIf { it.isNotBlank() } ?: return null
-        return ticketService.verify(ticket)
+    /**
+     * Resolve the party enrolling a credential from the `Authorization` bearer, which may be
+     * EITHER of two credentials — deliberately, and in this order:
+     *
+     *  1. an [EnrollmentTicketService] ticket — the native F2 onboarding branch, where the party
+     *     was just created via M2M and no Keycloak session exists yet;
+     *  2. the party's own Keycloak access token — an already-onboarded user enrolling a native
+     *     credential on this device ([tech.openbank.app.auth.AuthService.enrollPasskey], the F1→F2
+     *     bridge and the only recovery path when this RP's credential store is lost, issue #1260).
+     *
+     * Case 2 was the KNOWN GAP in this class's KDoc: the app has always sent its access token here,
+     * and a JWT happens to have the ticket's three dot-separated parts, so it reached
+     * [EnrollmentTicketService.verify], failed the numeric-expiry parse and fell out as a bare 401.
+     * Enrolment could therefore never succeed for an existing session.
+     *
+     * The ticket is tried first because it is the cheap local HMAC check; a token costs a Keycloak
+     * round-trip. Both fail closed.
+     */
+    private fun authorizedEnroller(authorization: String?): Enroller? {
+        val bearer = authorization?.removePrefix("Bearer ")?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        ticketService.verify(bearer)?.let { partyId ->
+            // Ticket path: brand-new party, no Keycloak user yet — registerComplete creates one.
+            return Enroller(partyId = partyId, existingKeycloakUserId = null)
+        }
+        return keycloakClient.introspectCustomerToken(bearer)
+            ?.let { Enroller(partyId = it.partyId, existingKeycloakUserId = it.keycloakUserId) }
     }
+
+    /**
+     * A party permitted to enrol a credential. [existingKeycloakUserId] is non-null only when the
+     * caller authenticated with their own access token, i.e. the Keycloak user already exists and
+     * must be reused rather than re-created.
+     */
+    private data class Enroller(val partyId: String, val existingKeycloakUserId: String?)
 
     private fun extractChallenge(clientDataJsonBytes: ByteArray): String? = runCatching {
         jsonMapper.readTree(clientDataJsonBytes).get("challenge")?.asText()

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResourceTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /**
@@ -33,6 +34,13 @@ class WebAuthnResourceTest {
     ).apply {
         rpId = "open-bank.tech"
         origin = "https://open-bank.tech"
+    }
+
+    @BeforeEach
+    fun `default to no access-token identity`() {
+        // The registration routes fall back to Keycloak introspection when the bearer is not a
+        // ticket; unless a test says otherwise, that fallback finds nothing.
+        every { keycloakClient.introspectCustomerToken(any()) } returns null
     }
 
     // ---- register/begin: enrollment ticket gate --------------------------------------------
@@ -84,6 +92,69 @@ class WebAuthnResourceTest {
 
         assertThat(resp.status).isEqualTo(401)
         verify(exactly = 0) { challengeStore.consume(any()) }
+    }
+
+    // ---- register/*: the access-token path (F1 -> F2 bridge, issue #1260 recovery) ---------
+
+    @Test
+    fun `register begin accepts the party's own access token when the bearer is not a ticket`() {
+        // The app's enrollPasskey sends a Keycloak access token, not a ticket. A JWT has the
+        // ticket's three dot-separated parts, so it reaches the ticket service and fails there —
+        // introspection is what must recognise it.
+        every { ticketService.verify("kc-access-token") } returns null
+        every { keycloakClient.introspectCustomerToken("kc-access-token") } returns
+            CustomerTokenIdentity(partyId = "party-123", keycloakUserId = "kc-user-9")
+        every { challengeStore.save(any(), "registration") } returns Unit
+
+        val resp = resource.registerBegin(authorization = "Bearer kc-access-token")
+
+        assertThat(resp.status).isEqualTo(200)
+        assertThat((resp.entity as RegistrationChallengeDto).userName).isEqualTo("party-123")
+    }
+
+    @Test
+    fun `register begin is rejected when introspection does not recognise the token`() {
+        every { ticketService.verify(any()) } returns null
+        every { keycloakClient.introspectCustomerToken("forged") } returns null
+
+        val resp = resource.registerBegin(authorization = "Bearer forged")
+
+        assertThat(resp.status).isEqualTo(401)
+        verify(exactly = 0) { challengeStore.save(any(), any()) }
+    }
+
+    @Test
+    fun `register complete with an access token gets past the auth gate`() {
+        // Proves the token is accepted as an enrolment credential: the request now fails on its
+        // malformed clientDataJSON (400) rather than on authorization (401). The crypto path
+        // beyond this point needs a real authenticator, so it is exercised on a device.
+        every { ticketService.verify(any()) } returns null
+        every { keycloakClient.introspectCustomerToken("kc-access-token") } returns
+            CustomerTokenIdentity(partyId = "party-123", keycloakUserId = "kc-user-9")
+
+        val resp = resource.registerComplete(
+            authorization = "Bearer kc-access-token",
+            request = RegistrationCompleteRequestDto("id", "attestation", "bm90LWpzb24"), // "not-json"
+        )
+
+        assertThat(resp.status).isEqualTo(400)
+    }
+
+    @Test
+    fun `an access-token enroller never has a second Keycloak user created for their party`() {
+        // The token's `sub` IS the user. ensureUser() looks up a synthetic
+        // party+<id>@openbank.internal address, would not find their real one, and would create a
+        // duplicate — binding the new credential to an account holding none of their data.
+        every { ticketService.verify(any()) } returns null
+        every { keycloakClient.introspectCustomerToken("kc-access-token") } returns
+            CustomerTokenIdentity(partyId = "party-123", keycloakUserId = "kc-user-9")
+
+        resource.registerComplete(
+            authorization = "Bearer kc-access-token",
+            request = RegistrationCompleteRequestDto("id", "attestation", "bm90LWpzb24"),
+        )
+
+        verify(exactly = 0) { keycloakClient.ensureUser(any(), any(), any()) }
     }
 
     // ---- auth/begin + auth/complete: fully public, challenge-store gate --------------------


### PR DESCRIPTION
## Problem

`AuthService.enrollPasskey` (app) has always sent the party's **Keycloak access token** to `POST /customer/v1/webauthn/register/begin`. That endpoint only ever accepted an **`EnrollmentTicketService` HMAC ticket**. Native passkey enrolment for an existing session could therefore never succeed.

Live proof from TestFlight build 29, right after a successful hosted login:

```
16/Jul/2026:12:37:12 +0000 | POST /customer/v1/webauthn/register/begin | 401 | 48 bytes
```

48 bytes is exactly `{"error":"Invalid or expired enrollment ticket"}`.

## Why nobody noticed

A JWT has the same three dot-separated parts as a ticket, so it sailed through the arity check in `EnrollmentTicketService.verify`, died on `expiresAtRaw.toLongOrNull()` parsing the JWT payload as an epoch, and returned `null` — **indistinguishable from a forged ticket**. `enrollPasskey` is best-effort by contract (returns `false`, never throws), so the app swallowed the 401 silently and carried on. The only visible symptom was Face ID never starting to work.

`WebAuthnResource`'s own KDoc had this filed as a known gap: *"there is no 'register a native edge passkey' flow yet for an already-onboarded F1 user."* The app-side bridge was written against a contract the edge never had.

## Why it matters more now

This is the **only recovery path** when the edge RP's credential store is lost — which is exactly how it surfaced. The edge Redis restarted (issue #1260: passkey credentials live in an `emptyDir` Valkey with `--save "" --appendonly no`), every credential vanished, and Face ID could not be re-enrolled **by any means**, hosted login included.

## Fix

`register/begin` and `register/complete` now accept **either** credential:

1. the enrollment ticket — native F2 onboarding, where no Keycloak session exists yet (unchanged, tried first: cheap local HMAC);
2. the party's own access token — verified out-of-band via **RFC 7662 introspection** (`WebAuthnKeycloakClient.introspectCustomerToken`).

Introspection rather than the injected `JsonWebToken`: this resource is deliberately un-annotated so that a ticket-bearing call isn't rejected by Quarkus's proactive OIDC filter before application code runs — touching the injected token would resurrect precisely that failure, which the class KDoc warns about. Delegating signature/expiry checks to the issuer also beats hand-rolling JWT verification here. Fails closed: an unreachable Keycloak enrols nothing.

## A trap found while fixing it

`registerComplete` called `ensureUser(syntheticEmail, ...)` unconditionally. For a token-authenticated enroller that would look up `party+<id>@openbank.internal`, **miss their real account, and create a second Keycloak user for the same party** — the new passkey would mint sessions for an account holding none of their data, and `party_id == sub` (ADR-0069) would break for it. It now binds to the token's `sub`; `ensureUser` stays on the ticket path only. Covered by `an access-token enroller never has a second Keycloak user created for their party`.

## Verification

- `:openbank-customer-edge:test` — **175/175 green** (12 in `WebAuthnResourceTest`, 4 new), detekt clean.
- The crypto leg (attestation verification) still needs a real authenticator, so the new `register/complete` test asserts the auth gate is passed (400 on malformed clientDataJSON rather than 401) rather than faking webauthn4j fixtures.
- **Server-side only** — no app release needed. Build 29 starts enrolling as soon as this deploys, which also un-breaks Face ID for @JiRaska's device today.

Refs #1260, ADR-0066 F2

🤖 Generated with [Claude Code](https://claude.com/claude-code)