### PR TITLE
docs(party-service): document two CI gotchas from landing #1166

### DIFF
--- a/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/contract/PartyEventPactProviderVerificationTest.kt
@@ -64,6 +64,16 @@ import java.util.concurrent.TimeUnit
  * thing `can-i-deploy` actually reads. `@EnabledIfSystemProperty` keeps it a no-op locally without
  * a broker URL, same as every sibling class — verify a change with `compileTestKotlin` locally;
  * the real verification only runs in CI (`pactbroker.url` set there).
+ *
+ * Two more gotchas hit while landing this revert (#1166), worth knowing before touching this
+ * class again: (1) `services-ci.yml`'s `-Dpact.verifier.publishResults=true` is only set on a
+ * genuine `push` to `main` — a manual `workflow_dispatch` run compiles/runs this test fine but
+ * does NOT publish, so it looks green without ever unblocking `can-i-deploy`. (2) under heavy
+ * concurrent CI load, `gh run rerun`-ing an old `push`-triggered run enough times/hours later can
+ * make `auto-deploy.yml`'s "Detect changed services" step (`git diff HEAD~1 HEAD`) misfire and
+ * rebuild an unrelated service instead — if a rerun's job list doesn't match the PR's actual
+ * files, don't trust it; trigger a fresh `push` (even a trivial one touching this file) instead
+ * of continuing to rerun a stale run object.
  */
 @QuarkusTest
 @QuarkusTestResource(com.openbank.party.it.PostgresRedpandaTestResource::class)


### PR DESCRIPTION
## Summary
Non-functional docstring addition, no code change. Recorded while confirming #1166's fix actually unblocked `can-i-deploy` tonight:
- `workflow_dispatch` doesn't set `pact.verifier.publishResults=true` (only a genuine `push` to `main` does) — a manual re-run of this test looks green without ever publishing to the broker.
- Rerunning an old `push`-triggered run hours later, under heavy concurrent CI load, can make `auto-deploy.yml`'s "Detect changed services" step misfire and rebuild an unrelated service — a fresh push is more reliable than repeatedly rerunning a stale run object.

Also serves as the real `push` this repo's Pact pipeline needs to actually publish a fresh party-service verification result — #1166's own push-triggered CI run got starved by tonight's runner-queue congestion and never completed cleanly.

## Linked issues
N/A — operational follow-up from tonight's #1166, no tracking issue filed.

## Test plan
- [x] `compileTestKotlin` + `ktlintCheck` clean (docstring-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)