### PR TITLE
ci(deploy): open deploy PRs with a GitHub App token so the commit is actually signed

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -26,8 +26,11 @@
 #   - OIDC → arn:aws:iam::265175468565:role/openbank-arc-build-runner (same as
 #     auto-deploy.yml, has ECR push + KMS cosign alias/openbank-cosign-signing).
 #   - GitOps change lands via a PR (never direct push to main) — normal review gate.
-#   - GITOPS_PR_TOKEN (fine-grained PAT) lets the PR trigger required checks so
-#     auto-merge actually fires; falls back to GITHUB_TOKEN (manual-merge only).
+#   - A GitHub App installation token (GITOPS_APP_ID + GITOPS_APP_PRIVATE_KEY) opens the
+#     PR: it both triggers the required checks and gets its commit signed by GitHub, which
+#     required_signatures demands. Falls back to the GITOPS_PR_TOKEN user PAT (checks run,
+#     but the commit is unsigned → PR strands until re-signed by hand), then to
+#     GITHUB_TOKEN (manual-merge only — its PRs do not trigger workflows). See issue #1269.
 
 name: Admin-UI deploy
 
@@ -87,6 +90,9 @@ jobs:
       AWS_REGION: eu-north-1
       AWS_DEFAULT_REGION: eu-north-1
       MANIFEST: openbank-infra/gitops/components/admin-ui/admin-ui.yaml
+      # Mirrored into env because the `secrets` context is NOT available in a step-level `if:`
+      # — only job-level env can read it. Used solely to decide whether to mint an App token.
+      GITOPS_APP_ID: ${{ secrets.GITOPS_APP_ID }}
 
     outputs:
       tag: ${{ steps.build.outputs.tag }}
@@ -410,17 +416,39 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # GitHub signs API-created commits for GitHub *App* tokens (and the web UI's web-flow
+      # key) — never for a user PAT. GITOPS_PR_TOKEN is a user PAT, so `sign-commits: true`
+      # below faithfully routed the commit through the API and GitHub declined to sign it:
+      # every bot deploy commit since #806 came out `verified=false; reason=unsigned`, and
+      # required_signatures stranded the PR until a human re-signed it by hand (issue #1269).
+      # An App installation token is the only option that satisfies both constraints at once:
+      # it triggers the required checks (GITHUB_TOKEN does not) AND its commits get signed
+      # (a PAT's do not).
+      - name: Mint a GitHub App installation token
+        id: app_token
+        if: ${{ steps.rewrite.outputs.changed == 'true' && env.GITOPS_APP_ID != '' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GITOPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
       - name: Open GitOps PR (auto-merge)
         id: gitops_pr
         if: steps.rewrite.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
-          # Create the commit through the GitHub API so it is signed/verified. The
-          # main ruleset enforces required_signatures; a plain git commit here is
-          # unsigned → the deploy PR is blocked forever and the admin UI silently
-          # stops updating (had to be re-signed by hand every time). sign-commits
-          # makes the bot commit verified so auto-merge actually lands it.
+          # Preference order, and why each rung exists:
+          #   1. App installation token — triggers required checks AND gets its commit signed.
+          #      The only rung that actually works end-to-end (issue #1269).
+          #   2. GITOPS_PR_TOKEN (user PAT) — triggers the required checks, but its commit is
+          #      unsigned, so the PR strands until a human re-signs. Kept as a fallback only
+          #      so the pipeline still opens a rescuable PR while the App is being set up.
+          #   3. GITHUB_TOKEN — a PR opened with it does NOT trigger workflows (anti-recursion),
+          #      so the required checks never run and there is nothing to auto-merge against.
+          token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # Route the commit through the GitHub API so GitHub can sign it. Necessary but NOT
+          # sufficient on its own — the token above decides whether the signing actually
+          # happens. The "Verify the deploy commit is signed" step below is what proves it did.
           sign-commits: true
           branch: chore/admin-ui-deploy-${{ github.sha }}
           delete-branch: true
@@ -442,11 +470,13 @@ jobs:
       # Uses the same retry pattern as auto-deploy.yml (required checks register with
       # a small lag after PR creation → keep retrying until enablePullRequestAutoMerge
       # accepts, or give up after 8 attempts and leave it for a human).
+      # Runs BEFORE the signature guard on purpose: arming auto-merge is what lets a manual
+      # re-sign land by itself, so it must happen even on the run where the guard then fails.
       - name: Enable auto-merge
         if: steps.gitops_pr.outputs.pull-request-number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
             const { data: pr } = await github.rest.pulls.get({
@@ -467,4 +497,41 @@ jobs:
                 await new Promise(r => setTimeout(r, 12000));
               }
             }
-            core.notice('could not enable auto-merge after retries — check GITOPS_PR_TOKEN / branch protection');
+            core.notice('could not enable auto-merge after retries — check the App token / GITOPS_PR_TOKEN / branch protection');
+
+      # The failure this guards against is silent by construction: create-pull-request logs
+      # "Commit verified: false; reason: unsigned" and exits 0, the PR opens with every check
+      # green and auto-merge armed, and it simply never merges. That reads as healthy from
+      # every angle except the one nobody checks — which is how #806 shipped a fix that
+      # no-opped for five days and stranded seven deploy PRs at once (issue #1269).
+      # Fail loudly instead: an unsigned commit means required_signatures WILL strand this PR.
+      #
+      # Keep this LAST in the job, and `always()`: core.setFailed() skips every subsequent
+      # step that is not always(), so any step appended after this one would be silently
+      # starved on exactly the runs where it matters most.
+      - name: Verify the deploy commit is signed
+        if: ${{ always() && steps.gitops_pr.outputs.pull-request-number != '' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number,
+            });
+            const unsigned = commits.filter(c => !c.commit.verification?.verified);
+            if (unsigned.length === 0) {
+              core.info(`all ${commits.length} commit(s) on PR #${pull_number} are signed and verified`);
+              return;
+            }
+            for (const c of unsigned) {
+              core.error(`${c.sha}: verified=false reason=${c.commit.verification?.reason ?? 'unknown'} committer=${c.commit.committer?.name}`);
+            }
+            core.setFailed(
+              `PR #${pull_number} carries ${unsigned.length} unsigned commit(s); the main ruleset's ` +
+              `required_signatures will block it and this deploy will never land. ` +
+              `Most likely cause: no GitHub App token — GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY unset, so the ` +
+              `run fell back to the GITOPS_PR_TOKEN user PAT, whose API commits GitHub does not sign (issue #1269). ` +
+              `To rescue this PR by hand: amend the commit locally with a GPG signature and force-push — ` +
+              `auto-merge is already armed and fires on its own once the signature is valid.`
+            );

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -10,9 +10,13 @@
 #   5. Opens a PR (`chore/gitops-auto-deploy-<sha>`) and enables auto-merge, so the
 #      manifest update lands on main as soon as CI is green.
 #
-# The PR is opened by github-actions[bot], which satisfies the issue-hygiene exemption
-# (bot PR → no Linked issues required) and GitHub treats the API-created commit as
-# verified, so the "require signed commits" ruleset is satisfied on merge.
+# The PR is opened by a bot identity, which satisfies the issue-hygiene exemption (bot PR →
+# no Linked issues required). It must be a GitHub *App* token (GITOPS_APP_ID +
+# GITOPS_APP_PRIVATE_KEY): GitHub signs API-created commits only for Apps and the web UI, so
+# an App token is what satisfies the "require signed commits" ruleset. A user PAT does NOT
+# get signed — that assumption was wrong for five days and stranded seven deploy PRs with
+# green checks and auto-merge armed (issue #1269). The "Verify the deploy commit is signed"
+# step below fails the run rather than letting that recur silently.
 #
 # Security notes:
 #  - contents:write + pull-requests:write scoped to this workflow only.
@@ -749,6 +753,9 @@ jobs:
       # skipped entirely — no PACT_BROKER_URL) means "no filter, process everything", matching
       # the pre-fix behavior for that case; an explicit `[]` means "checked, none passed".
       DEPLOYABLE_SERVICES: ${{ needs.can-i-deploy.outputs.deployable || '' }}
+      # Mirrored into env because the `secrets` context is NOT available in a step-level `if:`
+      # — only job-level env can read it. Used solely to decide whether to mint an App token.
+      GITOPS_APP_ID: ${{ secrets.GITOPS_APP_ID }}
     steps:
       # persist-credentials: false — otherwise actions/checkout leaves its own
       # Authorization extraheader in the git config AND peter-evans/create-pull-request
@@ -757,6 +764,22 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # GitHub signs API-created commits for GitHub *App* tokens (and the web UI's web-flow
+      # key) — never for a user PAT. GITOPS_PR_TOKEN is a user PAT, so `sign-commits: true`
+      # below faithfully routed the commit through the API and GitHub declined to sign it:
+      # every bot deploy commit since #806 came out `verified=false; reason=unsigned`, and
+      # required_signatures stranded the PR until a human re-signed it by hand (issue #1269).
+      # An App installation token is the only option that satisfies both constraints at once:
+      # it triggers the required checks (GITHUB_TOKEN does not) AND its commits get signed
+      # (a PAT's do not).
+      - name: Mint a GitHub App installation token
+        id: app_token
+        if: env.GITOPS_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GITOPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
 
       - name: Rewrite image tags in gitops manifests
         id: rewrite
@@ -811,16 +834,18 @@ jobs:
         if: steps.rewrite.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          # GITOPS_PR_TOKEN (a fine-grained PAT / GitHub App token with contents+pull_requests
-          # write) so the PR actually triggers the required checks — a PR opened with the
-          # default GITHUB_TOKEN does NOT trigger workflows (anti-recursion), so the required
-          # checks (all-green / Validate manifests / Gitleaks / issue-hygiene) never run and
-          # the PR can never auto-merge. Falls back to GITHUB_TOKEN so the pipeline still opens
-          # a (manually-mergeable) PR if the secret is not set.
-          token: ${{ secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
-          # Create the commit through the GitHub API so it is signed/verified — the main
-          # ruleset enforces required_signatures, and an unsigned bot commit blocks the
-          # deploy PR forever (services silently stop updating until a human re-signs it).
+          # Preference order, and why each rung exists:
+          #   1. App installation token — triggers required checks AND gets its commit signed.
+          #      The only rung that actually works end-to-end (issue #1269).
+          #   2. GITOPS_PR_TOKEN (user PAT) — triggers the required checks, but its commit is
+          #      unsigned, so the PR strands until a human re-signs. Kept as a fallback only
+          #      so the pipeline still opens a rescuable PR while the App is being set up.
+          #   3. GITHUB_TOKEN — a PR opened with it does NOT trigger workflows (anti-recursion),
+          #      so the required checks never run and there is nothing to auto-merge against.
+          token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          # Route the commit through the GitHub API so GitHub can sign it. Necessary but NOT
+          # sufficient on its own — the token above decides whether the signing actually
+          # happens. The "Verify the deploy commit is signed" step below is what proves it did.
           sign-commits: true
           branch: chore/gitops-auto-deploy-${{ github.sha }}
           delete-branch: true
@@ -842,17 +867,19 @@ jobs:
             gitops
 
       # peter-evans/create-pull-request has no auto-merge input (the old `auto-merge: squash`
-      # was silently ignored). Enable it explicitly. Only effective when GITOPS_PR_TOKEN is set
-      # — otherwise the GITHUB_TOKEN PR's required checks never run and there is nothing to
-      # merge against (an admin merges it by hand, as today).
+      # was silently ignored). Enable it explicitly. Only effective when an App token or
+      # GITOPS_PR_TOKEN is set — otherwise the GITHUB_TOKEN PR's required checks never run and
+      # there is nothing to merge against (an admin merges it by hand, as today).
       # github-script (octokit), NOT gh — the openbank-build runner image has no gh CLI.
       # enablePullRequestAutoMerge is rejected ("Pull request is in clean status") until the
       # PR's required check runs register, which lags PR creation, so retry until it sticks.
+      # Runs BEFORE the signature guard on purpose: arming auto-merge is what lets a manual
+      # re-sign land by itself, so it must happen even on the run where the guard then fails.
       - name: Enable auto-merge
         if: steps.gitops_pr.outputs.pull-request-number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
             const { data: pr } = await github.rest.pulls.get({
@@ -873,7 +900,7 @@ jobs:
                 await new Promise(r => setTimeout(r, 12000));
               }
             }
-            core.notice('could not enable auto-merge after retries — check GITOPS_PR_TOKEN / branch protection');
+            core.notice('could not enable auto-merge after retries — check the App token / GITOPS_PR_TOKEN / branch protection');
 
       # Record that these service versions are now deployed to sandbox so that future
       # can-i-deploy calls by consumers can verify against the correct provider version.
@@ -971,3 +998,41 @@ jobs:
             echo "::error::one or more record-deployments failed — broker matrix now diverges from what is actually deployed (ADR-0092)"
             exit 1
           fi
+
+      # The failure this guards against is silent by construction: create-pull-request logs
+      # "Commit verified: false; reason: unsigned" and exits 0, the PR opens with every check
+      # green and auto-merge armed, and it simply never merges. That reads as healthy from
+      # every angle except the one nobody checks — which is how #806 shipped a fix that
+      # no-opped for five days and stranded seven deploy PRs at once (issue #1269).
+      # Fail loudly instead: an unsigned commit means required_signatures WILL strand this PR.
+      #
+      # LAST step in the job, and `always()`, both deliberate: core.setFailed() skips every
+      # subsequent step that is not always(), so putting this any earlier would silently
+      # starve record-deployment and diverge the Pact broker from reality (ADR-0092) on every
+      # run until the App is configured — trading one silent failure for another.
+      - name: Verify the deploy commit is signed
+        if: ${{ always() && steps.gitops_pr.outputs.pull-request-number != '' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner, repo: context.repo.repo, pull_number,
+            });
+            const unsigned = commits.filter(c => !c.commit.verification?.verified);
+            if (unsigned.length === 0) {
+              core.info(`all ${commits.length} commit(s) on PR #${pull_number} are signed and verified`);
+              return;
+            }
+            for (const c of unsigned) {
+              core.error(`${c.sha}: verified=false reason=${c.commit.verification?.reason ?? 'unknown'} committer=${c.commit.committer?.name}`);
+            }
+            core.setFailed(
+              `PR #${pull_number} carries ${unsigned.length} unsigned commit(s); the main ruleset's ` +
+              `required_signatures will block it and this deploy will never land. ` +
+              `Most likely cause: no GitHub App token — GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY unset, so the ` +
+              `run fell back to the GITOPS_PR_TOKEN user PAT, whose API commits GitHub does not sign (issue #1269). ` +
+              `To rescue this PR by hand: amend the commit locally with a GPG signature and force-push — ` +
+              `auto-merge is already armed and fires on its own once the signature is valid.`
+            );


### PR DESCRIPTION
## What

Opens deploy PRs with a **GitHub App installation token** instead of a user PAT, and adds a guard that **fails the run when the deploy commit is unsigned**.

`sign-commits: true` (added in #806, 2026-07-11) has never once worked. It faithfully routes the commit through the GitHub API — but GitHub signs API-created commits only for **GitHub App** tokens and the web UI's `web-flow` key, never for a **user PAT**. `GITOPS_PR_TOKEN` is a user PAT, so every bot deploy commit since 07-11 came out `verified=false; reason=unsigned`, `required_signatures` blocked it, and the PR stranded with all checks green and auto-merge armed until a human re-signed it by hand.

The action reports it and exits 0:

```
Created commit 83335a2d96063d2bcd33c3b65d6bda923e36f84a for local commit 46f7d4b...
Commit verified: false; reason: unsigned
```

so nothing ever went red. On 2026-07-16 seven deploy PRs stranded at once and `customer-edge` (#1254) sat undeployed for hours.

An App token is the only rung that satisfies both constraints at once — it triggers the required checks (`GITHUB_TOKEN` does not) *and* its commits get signed (a PAT's do not).

## ⚠️ Requires a manual setup step before it takes effect

I can't create a GitHub App or add secrets — that's on you. Until `GITOPS_APP_ID` / `GITOPS_APP_PRIVATE_KEY` exist, the token falls back to the PAT, the commit stays unsigned, and **the new guard will fail every auto-deploy run**. That red is intentional and accurate (deploys genuinely need a manual re-sign today), but it will be red.

To finish the fix:

1. **Create a GitHub App** (Settings → Developer settings → GitHub Apps → New). Repository permissions: **Contents: Read & write**, **Pull requests: Read & write**. Nothing else.
2. **Install it** on `JiRaska/open-bank-oss`.
3. **Generate a private key** and add two repo secrets: `GITOPS_APP_ID` (the App's numeric ID) and `GITOPS_APP_PRIVATE_KEY` (the whole `.pem`, `BEGIN`/`END` lines included).
4. Optionally retire `GITOPS_PR_TOKEN` once a deploy PR lands signed on its own — the fallback rung stops being load-bearing at that point.

The App also needs to be allowed by the `main-protection` ruleset the same way the PAT's identity is today, if it's actor-restricted.

## Verifying it worked

The acceptance criterion is a bot-opened deploy PR whose **branch** commit is verified with no human touching it:

```bash
gh api repos/JiRaska/open-bank-oss/pulls/<N>/commits --jq '.[].commit.verification'
```

Don't check the squash commit on `main` — GitHub signs that one itself, so it always reads `verified=true` and proves nothing. That's part of why this went unnoticed for five days.

## Notes on the guard's placement

It's the **last** step in the job and gated on `always()`, both deliberately. `core.setFailed()` skips every subsequent non-`always()` step, so placing it earlier would have starved `Record sandbox deployment in Pact broker` and diverged the broker from reality (ADR-0092) on every run until the App is set up — trading one silent failure for another. Auto-merge is armed *before* the guard runs, so the manual re-sign rescue still lands by itself.

## Test plan

- [x] `actionlint` clean on both workflows (only the pre-existing `openbank-build` self-hosted-label false positive).
- [x] YAML parses.
- [x] Fallback chain degrades correctly: when the App step is skipped, `steps.app_token.outputs.token` is empty and falsy, so it falls through to the PAT.
- [ ] **After the secrets land:** an auto-deploy PR opens signed and auto-merges with nobody touching it.
- [ ] **Guard proves itself:** the first run on the current (PAT-only) config goes red at "Verify the deploy commit is signed" — that failure *is* the guard working.

Closes #1269
