### PR TITLE
chore(release): exclude src/test from release-please commit parsing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -54,7 +54,10 @@
   ],
   "packages": {
     "openbank-account-service": {
-      "component": "account-service"
+      "component": "account-service",
+      "exclude-paths": [
+        "openbank-account-service/src/test"
+      ]
     },
     "openbank-admin-ui": {
       "component": "admin-ui",
@@ -64,154 +67,305 @@
           "path": "package.json",
           "jsonpath": "$.version"
         }
+      ],
+      "exclude-paths": [
+        "openbank-admin-ui/src/test",
+        "openbank-admin-ui/e2e"
       ]
     },
     "openbank-agent-service": {
-      "component": "agent-service"
+      "component": "agent-service",
+      "exclude-paths": [
+        "openbank-agent-service/src/test"
+      ]
     },
     "openbank-aml-service": {
-      "component": "aml-service"
+      "component": "aml-service",
+      "exclude-paths": [
+        "openbank-aml-service/src/test"
+      ]
     },
     "openbank-anacredit-service": {
-      "component": "anacredit-service"
+      "component": "anacredit-service",
+      "exclude-paths": [
+        "openbank-anacredit-service/src/test"
+      ]
     },
     "openbank-audit-service": {
-      "component": "audit-service"
+      "component": "audit-service",
+      "exclude-paths": [
+        "openbank-audit-service/src/test"
+      ]
     },
     "openbank-authz-policy-auditor": {
-      "component": "authz-policy-auditor"
+      "component": "authz-policy-auditor",
+      "exclude-paths": [
+        "openbank-authz-policy-auditor/src/test"
+      ]
     },
     "openbank-balance-service": {
-      "component": "balance-service"
+      "component": "balance-service",
+      "exclude-paths": [
+        "openbank-balance-service/src/test"
+      ]
     },
     "openbank-billing-service": {
-      "component": "billing-service"
+      "component": "billing-service",
+      "exclude-paths": [
+        "openbank-billing-service/src/test"
+      ]
     },
     "openbank-card-issuance-service": {
-      "component": "card-issuance-service"
+      "component": "card-issuance-service",
+      "exclude-paths": [
+        "openbank-card-issuance-service/src/test"
+      ]
     },
     "openbank-clearing-service": {
-      "component": "clearing-service"
+      "component": "clearing-service",
+      "exclude-paths": [
+        "openbank-clearing-service/src/test"
+      ]
     },
     "openbank-clearing-simulator": {
-      "component": "clearing-simulator"
+      "component": "clearing-simulator",
+      "exclude-paths": [
+        "openbank-clearing-simulator/src/test"
+      ]
     },
     "openbank-consent-service": {
-      "component": "consent-service"
+      "component": "consent-service",
+      "exclude-paths": [
+        "openbank-consent-service/src/test"
+      ]
     },
     "openbank-control-liveness-sentinel": {
-      "component": "control-liveness-sentinel"
+      "component": "control-liveness-sentinel",
+      "exclude-paths": [
+        "openbank-control-liveness-sentinel/src/test"
+      ]
     },
     "openbank-copilot-service": {
-      "component": "copilot-service"
+      "component": "copilot-service",
+      "exclude-paths": [
+        "openbank-copilot-service/src/test"
+      ]
     },
     "openbank-customer-edge": {
-      "component": "customer-edge"
+      "component": "customer-edge",
+      "exclude-paths": [
+        "openbank-customer-edge/src/test"
+      ]
     },
     "openbank-devops-agent": {
-      "component": "devops-agent"
+      "component": "devops-agent",
+      "exclude-paths": [
+        "openbank-devops-agent/src/test"
+      ]
     },
     "openbank-dispute-service": {
-      "component": "dispute-service"
+      "component": "dispute-service",
+      "exclude-paths": [
+        "openbank-dispute-service/src/test"
+      ]
     },
     "openbank-docs-truth-agent": {
-      "component": "docs-truth-agent"
+      "component": "docs-truth-agent",
+      "exclude-paths": [
+        "openbank-docs-truth-agent/src/test"
+      ]
     },
     "openbank-document-service": {
-      "component": "document-service"
+      "component": "document-service",
+      "exclude-paths": [
+        "openbank-document-service/src/test"
+      ]
     },
     "openbank-domestic-payment": {
-      "component": "domestic-payment"
+      "component": "domestic-payment",
+      "exclude-paths": [
+        "openbank-domestic-payment/src/test"
+      ]
     },
     "openbank-finops-agent": {
-      "component": "finops-agent"
+      "component": "finops-agent",
+      "exclude-paths": [
+        "openbank-finops-agent/src/test"
+      ]
     },
     "openbank-finrep-service": {
-      "component": "finrep-service"
+      "component": "finrep-service",
+      "exclude-paths": [
+        "openbank-finrep-service/src/test"
+      ]
     },
     "openbank-flaky-test-hunter": {
-      "component": "flaky-test-hunter"
+      "component": "flaky-test-hunter",
+      "exclude-paths": [
+        "openbank-flaky-test-hunter/src/test"
+      ]
     },
     "openbank-fraud-service": {
-      "component": "fraud-service"
+      "component": "fraud-service",
+      "exclude-paths": [
+        "openbank-fraud-service/src/test"
+      ]
     },
     "openbank-fx-service": {
-      "component": "fx-service"
+      "component": "fx-service",
+      "exclude-paths": [
+        "openbank-fx-service/src/test"
+      ]
     },
     "openbank-governance-auditor": {
-      "component": "governance-auditor"
+      "component": "governance-auditor",
+      "exclude-paths": [
+        "openbank-governance-auditor/src/test"
+      ]
     },
     "openbank-interest-service": {
-      "component": "interest-service"
+      "component": "interest-service",
+      "exclude-paths": [
+        "openbank-interest-service/src/test"
+      ]
     },
     "openbank-kyc-service": {
-      "component": "kyc-service"
+      "component": "kyc-service",
+      "exclude-paths": [
+        "openbank-kyc-service/src/test"
+      ]
     },
     "openbank-ledger-service": {
-      "component": "ledger-service"
+      "component": "ledger-service",
+      "exclude-paths": [
+        "openbank-ledger-service/src/test"
+      ]
     },
     "openbank-lending-service": {
-      "component": "lending-service"
+      "component": "lending-service",
+      "exclude-paths": [
+        "openbank-lending-service/src/test"
+      ]
     },
     "openbank-notification-service": {
-      "component": "notification-service"
+      "component": "notification-service",
+      "exclude-paths": [
+        "openbank-notification-service/src/test"
+      ]
     },
     "openbank-onboarding-service": {
-      "component": "onboarding-service"
+      "component": "onboarding-service",
+      "exclude-paths": [
+        "openbank-onboarding-service/src/test"
+      ]
     },
     "openbank-party-service": {
-      "component": "party-service"
+      "component": "party-service",
+      "exclude-paths": [
+        "openbank-party-service/src/test"
+      ]
     },
     "openbank-pid-service": {
-      "component": "pid-service"
+      "component": "pid-service",
+      "exclude-paths": [
+        "openbank-pid-service/src/test"
+      ]
     },
     "openbank-product-catalog": {
-      "component": "product-catalog"
+      "component": "product-catalog",
+      "exclude-paths": [
+        "openbank-product-catalog/src/test"
+      ]
     },
     "openbank-psd2-service": {
-      "component": "psd2-service"
+      "component": "psd2-service",
+      "exclude-paths": [
+        "openbank-psd2-service/src/test"
+      ]
     },
     "openbank-release-steward": {
-      "component": "release-steward"
+      "component": "release-steward",
+      "exclude-paths": [
+        "openbank-release-steward/src/test"
+      ]
     },
     "openbank-sanctions-service": {
-      "component": "sanctions-service"
+      "component": "sanctions-service",
+      "exclude-paths": [
+        "openbank-sanctions-service/src/test"
+      ]
     },
     "openbank-sca-service": {
-      "component": "sca-service"
+      "component": "sca-service",
+      "exclude-paths": [
+        "openbank-sca-service/src/test"
+      ]
     },
     "openbank-sdd-service": {
-      "component": "sdd-service"
+      "component": "sdd-service",
+      "exclude-paths": [
+        "openbank-sdd-service/src/test"
+      ]
     },
     "openbank-security-scanner": {
-      "component": "security-scanner"
+      "component": "security-scanner",
+      "exclude-paths": [
+        "openbank-security-scanner/src/test"
+      ]
     },
     "openbank-sepa-instant": {
-      "component": "sepa-instant"
+      "component": "sepa-instant",
+      "exclude-paths": [
+        "openbank-sepa-instant/src/test"
+      ]
     },
     "openbank-sepa-payment": {
-      "component": "sepa-payment"
+      "component": "sepa-payment",
+      "exclude-paths": [
+        "openbank-sepa-payment/src/test"
+      ]
     },
     "openbank-settlement-service": {
-      "component": "settlement-service"
+      "component": "settlement-service",
+      "exclude-paths": [
+        "openbank-settlement-service/src/test"
+      ]
     },
     "openbank-standing-order-service": {
-      "component": "standing-order-service"
+      "component": "standing-order-service",
+      "exclude-paths": [
+        "openbank-standing-order-service/src/test"
+      ]
     },
     "openbank-statement-service": {
-      "component": "statement-service"
+      "component": "statement-service",
+      "exclude-paths": [
+        "openbank-statement-service/src/test"
+      ]
     },
     "openbank-swift-service": {
-      "component": "swift-service"
+      "component": "swift-service",
+      "exclude-paths": [
+        "openbank-swift-service/src/test"
+      ]
     },
     "openbank-tpp-registry-service": {
-      "component": "tpp-registry-service"
+      "component": "tpp-registry-service",
+      "exclude-paths": [
+        "openbank-tpp-registry-service/src/test"
+      ]
     },
     "openbank-transaction-service": {
-      "component": "transaction-service"
+      "component": "transaction-service",
+      "exclude-paths": [
+        "openbank-transaction-service/src/test"
+      ]
     },
     "openbank-vop-service": {
-      "component": "vop-service"
+      "component": "vop-service",
+      "exclude-paths": [
+        "openbank-vop-service/src/test"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

A change confined to `src/test` cuts real releases.

[#1166](https://github.com/JiRaska/open-bank-oss/pull/1166) touched only Pact test files, but in four modules at once, and produced four release PRs — [#1170](https://github.com/JiRaska/open-bank-oss/pull/1170), [#1171](https://github.com/JiRaska/open-bank-oss/pull/1171), [#1172](https://github.com/JiRaska/open-bank-oss/pull/1172), [#1173](https://github.com/JiRaska/open-bank-oss/pull/1173) — each bumping `version.txt` and appending a CHANGELOG entry for a service whose product code never changed. Since each component's changelog quotes the triggering commit verbatim, `openbank-account-service` 0.15.2 shipped crediting a `**party-service:**` fix it never received.

[`CLAUDE.md`](CLAUDE.md) promises:

> A change under `<service>/src/main/**` is released by **release-please** from your Conventional Commit

Nothing encoded that. Every package entry was bare `{"component": "..."}` with `"release-type": "simple"`, so **any** file under `openbank-<svc>/` was release-triggering. Docs and config disagreed; config won.

## Why `exclude-paths` and not `include-paths`

The issue proposed `include-paths`. **That option does not exist** — it is absent from [release-please's config schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json), which offers only `exclude-paths`:

> Path of commits to be excluded from parsing. If all files from commit belong to one of the paths it will be skipped

The inverted semantics look like they would break on a cross-service commit like #1166 — but they don't, because exclusion is evaluated **per release path**. From [`src/util/commit-exclude.ts`](https://github.com/googleapis/release-please/blob/main/src/util/commit-exclude.ts):

```ts
!commit.files
  .filter(file => this.isRelevant(file, packagePath))
  .every(file => excludePaths.some(path => this.isRelevant(file, path)))
```

Files are first narrowed to those relevant to the package, and the commit is skipped only if **all** of them match an excluded path. Matching is prefix-based (`file.indexOf(`${path}/`) === 0`), not glob — hence the explicit per-package paths rather than a wildcard.

So for #1166 and `openbank-account-service`: the only relevant file is its own Pact test, it matches the exclude, the commit is skipped for that package. Meanwhile a commit touching `src/main` — alone or alongside its tests — still releases, because the `src/main` file matches no exclude.

## Change

Adds `exclude-paths` to all **51** packages:

- 50 services → `["openbank-<svc>/src/test"]`
- `openbank-admin-ui` → `["openbank-admin-ui/src/test", "openbank-admin-ui/e2e"]` (no `src/main`; its 28 tests live in `src/test`, 1 in `e2e`)

Every listed path was verified to exist on disk. No other config key is touched.

## Test plan

Logic replayed against the real `#1166` commit and control cases, using the matching rule from `commit-exclude.ts`:

| input | packages | result | expected |
|---|---|---|---|
| `#1166` (4 Pact test files, 4 services) | account, kyc, onboarding, party | **SKIP** all four | SKIP |
| `src/main/kotlin/Foo.kt` | ledger | **BUMP** | BUMP |
| `src/main/Foo.kt` + `src/test/FooTest.kt` | ledger | **BUMP** | BUMP |
| `src/test/kotlin/FooTest.kt` only | ledger | **SKIP** | SKIP |

- [x] `release-please-config.json` parses; 51 packages intact
- [x] Every excluded path exists on disk
- [ ] First post-merge release cycle confirms behavior against the live GitHub API

## Notes for review

- **Changelog-section visibility is not a substitute.** A `test(...)` commit maps to a `hidden: true` section, which suppresses the changelog *line* but still cuts the version bump. Only path exclusion prevents the release.
- **Not fixed here:** `openbank-admin-ui` also carries generated JSON at its root (`cluster-topology.json`, `infra-lifecycle.json`, `catalog.json`, `app-status.json`). Deploy PRs regenerate these, which still triggers an admin-ui release. That is a separate question from test-only bumps — deliberately out of scope.
- **The alternative was to fix the docs instead.** If test-only bumps were intended (a released artifact does embed its tests), `CLAUDE.md` would be what's wrong. This PR takes the position the docs are right and the config was the defect; say so if you disagree and I'll invert it.
- Already-shipped misattributions (account-service 0.15.2 et al.) are left as-is — history, not something to rewrite.

Closes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
