### PR TITLE
fix(document-service): upsert in save(), so an onboarding language switch works

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
@@ -43,17 +43,16 @@ class DocumentRepositoryImpl :
      * `withTransaction`, so mutating the managed entity is flushed on commit without an explicit
      * update call.
      */
-    override suspend fun save(document: Document): Document =
-        Panache.withTransaction {
-            find("id", document.id).firstResult().flatMap { existing ->
-                if (existing != null) {
-                    existing.applyFrom(document)
-                    Uni.createFrom().item(document)
-                } else {
-                    persist(document.toEntity(objectMapper)).replaceWith(document)
-                }
+    override suspend fun save(document: Document): Document = Panache.withTransaction {
+        find("id", document.id).firstResult().flatMap { existing ->
+            if (existing != null) {
+                existing.applyFrom(document)
+                Uni.createFrom().item(document)
+            } else {
+                persist(document.toEntity(objectMapper)).replaceWith(document)
             }
-        }.awaitSuspending()
+        }
+    }.awaitSuspending()
 
     override suspend fun findById(id: UUID): Document? =
         Panache.withSession { find("id", id).firstResult() }.awaitSuspending()?.toDomain(objectMapper)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
@@ -15,6 +15,7 @@ import com.openbank.document.infrastructure.persistence.mapper.toEntity
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -31,11 +32,28 @@ class DocumentRepositoryImpl :
     @Inject
     lateinit var outboxRepo: DocumentOutboxRepositoryImpl
 
-    override suspend fun save(document: Document): Document {
-        val e = document.toEntity(objectMapper)
-        Panache.withTransaction { persist(e) }.awaitSuspending()
-        return e.toDomain(objectMapper)
-    }
+    /**
+     * Upsert, not insert: [save]'s callers hand it a document that already exists — superseding an
+     * agreement archives it in place ([Document.archive] keeps the id, only the status changes).
+     * A plain `persist()` of an id the table already holds is an INSERT, which the primary key
+     * rejects: `duplicate key value violates unique constraint "documents_pkey"` surfacing as a
+     * bare 500 (seen live 2026-07-16 on every onboarding language switch, ADR-0169 D3).
+     *
+     * Mirrors [saveWithOutbox]'s find-then-apply shape, minus the outbox leg. Both run inside
+     * `withTransaction`, so mutating the managed entity is flushed on commit without an explicit
+     * update call.
+     */
+    override suspend fun save(document: Document): Document =
+        Panache.withTransaction {
+            find("id", document.id).firstResult().flatMap { existing ->
+                if (existing != null) {
+                    existing.applyFrom(document)
+                    Uni.createFrom().item(document)
+                } else {
+                    persist(document.toEntity(objectMapper)).replaceWith(document)
+                }
+            }
+        }.awaitSuspending()
 
     override suspend fun findById(id: UUID): Document? =
         Panache.withSession { find("id", id).firstResult() }.awaitSuspending()?.toDomain(objectMapper)

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImplIT.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImplIT.kt
@@ -91,4 +91,29 @@ class DocumentRepositoryImplIT {
         // The original row is the only one under that key.
         assertThat(repo.findByIdempotencyKey(key)!!.id).isNotEqualTo(duplicate.id)
     }
+
+    @Test
+    fun `save updates a document that already exists instead of inserting it again`(): Unit = onVertxContext {
+        // The onboarding language switch archives the stale agreement via save() (ADR-0169 D3).
+        // archive() keeps the id, so this is an UPDATE — a plain persist() would hit
+        // documents_pkey and surface as a 500. OnboardingDocumentServiceTest mocks the repository,
+        // so only a real Postgres catches it.
+        val doc = onboardingDoc("onboarding:${UUID.randomUUID()}")
+        repo.saveWithOutbox(doc, outbox(doc.id))
+
+        val archived = repo.save(doc.copy(status = DocumentStatus.ARCHIVED))
+
+        assertThat(archived.id).isEqualTo(doc.id)
+        assertThat(repo.findById(doc.id)!!.status).isEqualTo(DocumentStatus.ARCHIVED)
+    }
+
+    @Test
+    fun `save inserts a document that does not exist yet`(): Unit = onVertxContext {
+        val doc = onboardingDoc("onboarding:${UUID.randomUUID()}")
+
+        val saved = repo.save(doc)
+
+        assertThat(saved.id).isEqualTo(doc.id)
+        assertThat(repo.findById(doc.id)).isNotNull
+    }
 }


### PR DESCRIPTION
## Problem

Switching the onboarding language (CS ⇄ EN on the "Podepiš rámcovou smlouvu" step) always fails with a bare 500. Live trace `0753092e-4233-4c6d-97aa-4e9fc65b8aa8`, 2026-07-16 13:07:08Z:

```
WARN  org.hib.orm.jdb.error  HHH000247: ErrorCode: 0, SQLState: 23505
WARN  org.hib.orm.jdb.error  ERROR: duplicate key value violates unique constraint "documents_pkey" (23505)
ERROR GenericExceptionMapper  Unhandled exception (traceId=0753092e-…)
```

## Root cause

`ensureOnboardingAgreement` supersedes a pending agreement in the old language by archiving it (`OnboardingDocumentService` step 3):

```kotlin
agreements.forEach { documentRepository.save(it.archive()) }
```

`Document.archive()` is `copy(status = ARCHIVED)` — **same id** — so that is an UPDATE. But `save()` was insert-only:

```kotlin
override suspend fun save(document: Document): Document {
    val e = document.toEntity(objectMapper)
    Panache.withTransaction { persist(e) }.awaitSuspending()   // INSERT
    return e.toDomain(objectMapper)
}
```

It INSERTed an id the table already held, and `documents_pkey` rejected it. Archiving is `save()`'s **only** caller, so the method never worked for the one thing it is used for — ADR-0169 D3's language switch could not have succeeded once since it was written. `saveWithOutbox()`, right below it, already had the correct find-then-apply upsert.

## Fix

`save()` now mirrors `saveWithOutbox()`'s upsert, minus the outbox leg. The fix belongs in `save()` — making it do what its callers mean — not in a workaround at the call site.

## Why CI was green

`OnboardingDocumentServiceTest` **already covers this exact scenario** — `ensure supersedes a pending agreement in a different language and re-renders` — and passes. It mocks the repository:

```kotlin
coEvery { documentRepository.save(any()) } answers { firstArg() }
```

So it asserts the use-case's *intent* and can say nothing about whether persistence honours it. The repository IT covered only `saveWithOutbox`. A textbook mock-shaped blind spot: the unit test proves we call `save()` with an ARCHIVED document; nothing proved `save()` could store one.

This adds both `save()` paths to `DocumentRepositoryImplIT` (real Postgres, Testcontainers):

- **update** — run against the *old* code before fixing, it fails with exactly the production `ConstraintViolationException` / `documents_pkey`. That's what makes it a regression test rather than decoration.
- **insert** — keeps the upsert's other branch covered.

## Verification

```
DocumentRepositoryImplIT: tests=4 failures=0     (old code: 1 failure — the update case)
:openbank-document-service:test — 82/82 green, detekt clean
```

Closes #1297

Refs ADR-0169 D3

🤖 Generated with [Claude Code](https://claude.com/claude-code)