### PR TITLE
docs(adr): key management, capacity, ICT exit, data residency

### DIFF
--- a/docs/adr/0007-vault-for-secrets-management.md
+++ b/docs/adr/0007-vault-for-secrets-management.md
@@ -4,11 +4,39 @@ Date: 2026-05-26
 Status: Accepted
 Delivery-Status: Partial
 
-**Delivery note (updated 2026-07-01):**
-- **Vault infrastructure** — ✅ Shipped: Vault deployed via `openbank-infra/` with ArgoCD; auto-unseal via cloud KMS; External Secrets Operator reads secrets into K8s Secrets for steady-state service operation.
-- **Dynamic database credentials** (per-pod Postgres, TTL ≤ 24h) — ⬜ Pending: services consume static credentials provisioned via External Secrets; Vault database secrets engine not yet wired.
-- **cert-manager PKI integration** — ⬜ Pending: cert-manager installed; Vault PKI engine integration deferred.
-- **HSM (FIPS 140-3)** for eIDAS QSeal and regulated signing keys — ⬜ Pending: deferred until the eIDAS signing use case (ADR-0094) activates in production.
+**Delivery note (updated 2026-07-16):**
+
+> **Naming:** the deployed engine is **OpenBao** (the Linux Foundation fork), not HashiCorp Vault —
+> see [ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md). This ADR's title and body still say
+> "Vault"; the decision it records is unchanged and the API is compatible, so the words are left as
+> written rather than retconned. Read "Vault" as "OpenBao" throughout.
+
+- **Secrets infrastructure** — ✅ Shipped: OpenBao deployed via `openbank-infra/` with ArgoCD;
+  auto-unseal via AWS KMS (`alias/openbank-vault-unseal`, `openbank-infra/gitops/apps/openbao.yaml`);
+  External Secrets Operator projects secrets into K8s Secrets for steady-state service operation.
+- **Dynamic database credentials** (per-pod Postgres, TTL ≤ 24h) — ✅ **Shipped** (corrected
+  2026-07-16; this line previously read "Pending: services consume static credentials … database
+  secrets engine not yet wired", which had been false since [ADR-0099](0099-automated-secret-rotation.md)
+  Tier 1 landed). Seven components consume short-lived credentials from the OpenBao database secrets
+  engine via the dedicated `vault-db` ClusterSecretStore — accounts, audit, balances, fx-service,
+  ledger, notifications, payments (`openbank-infra/gitops/components/*/db-dynamic-externalsecret.yaml`).
+  Lease TTL 24h, max 72h; ESO refreshes hourly to stay ahead of it. The remaining services still use
+  static credentials, so the *rollout* is partial — but the engine is wired, and ADR-0099 owns the
+  rollout from here.
+- **PKI** — 🟡 Partial, and the two halves are worth separating:
+  - The **OpenBao PKI engine is live and issuing**: a `pki-document-signing` root (RSA-2048, 10y)
+    mints per-ceremony `client-signing` leaf certs with a 300s TTL and `no_store=true`
+    (`openbank-infra/gitops/components/openbao/openbao-document-signing-pki.yaml`), and `pki-agent`
+    issues AI-agent charter identity (ADR-0031 D3b).
+  - **cert-manager ↔ OpenBao integration remains deferred.** cert-manager is deployed and does issue
+    TLS, but from Let's Encrypt and a self-signed `openbank-ca`, not from OpenBao
+    (`openbank-infra/gitops/components/platform/clusterissuer.yaml` — no Vault issuer). Services that
+    need an OpenBao-issued cert call the engine directly.
+- **HSM (FIPS 140-3)** for eIDAS QSeal and regulated signing keys — ⬜ Pending: deferred until the
+  eIDAS signing use case (ADR-0094) activates in production. Note the deferral is circular — ADR-0094
+  in turn defers to "KMS/HSM-backed" — and that signing today therefore claims only *advanced*
+  (not qualified) eIDAS assurance. [ADR-0172](0172-cryptographic-key-management-and-lifecycle.md) owns
+  the key-lifecycle picture, including this gap.
 
 ## Context
 

--- a/docs/adr/0172-cryptographic-key-management-and-lifecycle.md
+++ b/docs/adr/0172-cryptographic-key-management-and-lifecycle.md
@@ -1,0 +1,160 @@
+# ADR-0172 — Cryptographic key management and lifecycle
+
+Date: 2026-07-16
+Decision-Status: Accepted
+Delivery-Status: Partial
+Author(s): jiri.raska
+
+## Context
+
+The platform has an unusually complete **secrets** story — [ADR-0007](0007-vault-for-secrets-management.md)
+(OpenBao) and [ADR-0099](0099-automated-secret-rotation.md) (dynamic credentials + a weekly rotator) —
+and no story at all for **cryptographic keys**. Those are different things. A secret is a password you
+can change; a key is an identity or a trust anchor, and rotating one does not undo what it signed.
+
+The platform audit (`docs/audits/2026-07-16-platform-audit.md` §3.3) ranked this the #2 missing ADR
+domain. The only prior statement is one deferred bullet in ADR-0007 — and that deferral is
+**circular**: ADR-0007 defers the HSM until eIDAS activates (ADR-0094), while ADR-0094 defers back to
+"KMS/HSM-backed". Two ADRs each point at the other, so nobody owns it.
+
+This ADR is the inventory, the custody model, and — where there is a gap — a plainly-stated gap rather
+than a plan we have not funded. It deliberately does **not** re-decide secret custody (ADR-0007) or
+secret rotation (ADR-0099).
+
+## Decision
+
+**1. This ADR is the key inventory of record.** A key not listed here is not governed.
+
+| Class | Key | Custody | Rotation |
+|---|---|---|---|
+| **Code signing** | `alias/openbank-cosign-signing` (ECC_NIST_P256) — images + SBOM attestations | AWS KMS, eu-north-1 | **Manual, undefined** |
+| **Unseal** | `alias/openbank-vault-unseal` — OpenBao auto-unseal | AWS KMS | **None** |
+| **Envelope** | `aws_kms_key.secrets` (EKS etcd), `aws_kms_key.audit` (S3/CloudTrail) | AWS KMS, OpenTofu | Annual, automatic |
+| **DNSSEC** | `aws_kms_key.dnssec` (Route53 KSK) | AWS KMS, OpenTofu | **Disabled** (`enable_key_rotation = false`) |
+| **Transport CA** | Strimzi cluster CA + clients CA, ~33 KafkaUser certs | Strimzi operator, `messaging` ns | Strimzi defaults — **not configured, not documented** |
+| **Document signing** | `pki-document-signing` root (RSA-2048, 10y) → per-ceremony leaf (300s, `no_store`) | OpenBao PKI, in-cluster | Root: **none**. Leaf: ephemeral |
+| **Agent identity** | `pki-agent` CA (ADR-0031 D3b) | OpenBao PKI | Not documented |
+| **Credential issuance** | EUDI issuer EC P-256 private JWK — signs every PID/(Q)EAA | OpenBao KV | **None** |
+| **PII index** | RČ pepper (HMAC-SHA256, `BlindIndex`) | OpenBao KV | Manual + re-index (`index_key_version`) |
+| **Session** | JWT signing keys, OIDC client secrets | OpenBao KV | **Weekly**, automated (ADR-0099) |
+| **Erasure** | Transit per-subject keys (GDPR Art. 17 crypto-shredding) | OpenBao Transit | Destroyed on erasure |
+| **Public TLS** | Let's Encrypt certs | cert-manager, ACME DNS-01 | Automatic |
+| **Provenance** | Sigstore keyless (GitHub OIDC → Rekor) | Ephemeral | N/A — no key to rotate |
+| **Commit** | GPG/SSH signatures | Developer-held | Developer |
+
+**2. Prefer no key at all, then a short-lived one.** Order of preference for anything new: Sigstore
+keyless (no key) → per-act leaf cert (300s) → dynamic credential (24h) → automated weekly rotation →
+long-lived key with a documented ceremony. A new long-lived key must justify why it cannot sit higher.
+
+**3. The two crown-jewel keys are NOT in OpenTofu, and that is recorded here as a defect, not a
+design.** `alias/openbank-cosign-signing` and `alias/openbank-vault-unseal` are *referenced* by
+workflows and manifests but *declared* nowhere — only three `aws_kms_key` resources exist in the repo
+(audit, eks-secrets, dnssec). They were created out-of-band, so they have no reviewed key policy, no
+rotation setting, no tags, and no drift detection. `aws/envs/sandbox-platform/arc-runners.tf` compounds
+it by granting `kms:Sign` against a **hardcoded key UUID** with no matching resource. D1 fixes this;
+until then, this table is the only artifact that says these keys exist.
+
+**4. Signing keys and encryption keys get different custody rules — because their compromise differs
+in kind.** A compromised encryption key exposes data from that point on; a compromised **signing** key
+retroactively forges everything it ever vouched for, and rotation does not undo that. Therefore:
+- Code-signing and credential-issuance keys are **KMS-resident and never exported**; the platform never
+  holds their private material.
+- Verification uses public material only (Kyverno holds a PEM literal; the private key never leaves KMS).
+- There is **no key ceremony, no dual control, and no split knowledge** for any signing key today. For
+  a reference implementation that is an accepted gap; for a licensed bank it would not be.
+
+**5. HSM: deferred behind a named condition, not behind another ADR.** No HSM or FIPS 140-3 boundary
+exists. Signing therefore claims **advanced**, never **qualified**, eIDAS assurance — and the code says
+so (`SignatureCeremony.kt`). This ADR breaks the ADR-0007 ↔ ADR-0094 circular deferral by owning the
+condition outright: **an HSM is required before the first QES/QSeal signature is issued to a real
+party, and not before.** Until then the honest claim is "advanced signature, software key", which is
+what we make.
+
+**6. The document-signing root is not a trust anchor we would defend.** A self-generated in-cluster
+RSA-2048 root, 10-year TTL, generate-once guard, no offline material, no hierarchy, no CRL/OCSP. Fine
+for demonstrating the *flow*; not something eIDAS would accept. Recorded now rather than discovered
+later.
+
+## Decisions to deliver
+
+- **D1 — Bring the cosign and unseal keys under OpenTofu.** `aws_kms_key` + `aws_kms_alias` + reviewed
+  key policy for both; replace the hardcoded `kms:Sign` UUID with a resource reference. Unlocks
+  rotation config, tags, drift detection. *(Pending)*
+- **D2 — Fail closed on the PAdES seal.** `PdfBoxPadesSealAdapter` falls back to an ephemeral
+  self-signed cert when the keystore path is absent **or the file merely does not exist**, logging only
+  a `WARN`; the guard is opt-in via `OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true`. A misconfigured
+  mount therefore produces legally worthless signatures that look successful. Make fail-closed the
+  default outside `%dev`. *(Pending — highest value here.)*
+- **D3 — Document the Kafka CA lifetimes.** `kafka.yaml` has no `clusterCa`/`clientsCa` block, so
+  Strimzi defaults silently apply. State the validity/renewal figures, or set them. *(Pending)*
+- **D4 — DNSSEC KSK rotation.** `enable_key_rotation = false` with no compensating manual procedure.
+  Enable it or write the runbook. *(Pending)*
+- **D5 — Separate the EUDI issuer key from the RČ pepper.** Both sit in the same OpenBao KV path. A
+  credential-issuing key co-located with a PII pepper fails separation of duties. *(Pending)*
+- **D6 — A key-compromise runbook.** `docs/runbooks/` covers OpenBao operations (0002/0005/0006/0007/
+  0008) but nothing covers "the signing key is compromised" — the one case rotation cannot fix.
+  *(Pending)*
+
+## Alternatives considered
+
+- **Fold this into ADR-0007.** Fewest documents. Rejected: ADR-0007 is about *secret custody* and is
+  already `Partial` on four axes. Keys have a different lifecycle and a different failure mode
+  (retroactive forgery vs forward exposure) — and burying the inventory in a secrets ADR is precisely
+  how it stayed invisible this long.
+- **Adopt an HSM now.** The auditor-pleasing answer. Rejected: no QES is issued to any real party, the
+  platform is explicitly a reference implementation, and an unused HSM is cost and operational surface
+  bought to satisfy a document. §5 states the honest trigger instead.
+- **Rotate the cosign key on a schedule.** Rejected as premature: rotation without a revocation story
+  for already-signed images is theatre, and you cannot rotate what OpenTofu does not know exists. D1
+  first.
+- **Go fully Sigstore-keyless and drop the KMS signing key.** Genuinely attractive — the release
+  pipeline already uses keyless for SLSA provenance. Rejected for now: Kyverno verifies against a PEM
+  **offline** at admission, and keyless verification needs Rekor reachable from the cluster — a new
+  external runtime dependency on the admission path for every pod
+  ([ADR-0174](0174-ict-third-party-dependencies-and-exit-strategy.md)). Revisit if that calculus
+  changes.
+
+## Consequences
+
+**Positive**
+- One place now answers "what keys exist, who holds them, when do they change" — the first question an
+  auditor asks, and one the platform could not previously answer.
+- The circular ADR-0007 ↔ ADR-0094 HSM deferral is closed: §5 names the trigger.
+- D2 converts a silent legal failure (worthless signatures, `WARN` only) into a startup failure.
+
+**Negative**
+- The inventory is a disclosure document: it tells a reader exactly which keys are unrotated and which
+  are not in IaC. That is the right trade for a public reference implementation whose value is its
+  honesty — but it is a real trade, and worth making deliberately.
+- Six pending decisions is a backlog, not a fix. This ADR makes the gaps trackable; it does not close
+  them.
+
+**Neutral**
+- No runtime change. This is an inventory plus decisions; D1–D6 carry the delivery.
+
+## Compliance impact
+
+- **DORA:** cryptographic key management is an explicit Art. 9 protection control. This ADR is the
+  artifact; D1/D3/D4/D6 are the gaps. Note `docs/bcp/dora-ictrm.md` currently maps Art. 9 to access
+  control / encryption / patching and does not mention key lifecycle — this ADR fills that.
+- **eIDAS / eIDAS2:** signatures are **advanced**, never qualified — no HSM, no QSCD. §5 is the
+  condition under which that changes. ADR-0094 / ADR-0162 / ADR-0170 all defer QES to phase 2; this
+  ADR now owns why.
+- **GDPR:** the RČ pepper (`BlindIndex`) and the Transit crypto-shredding keys are personal-data
+  controls. Rotating the pepper requires a re-index migration (`index_key_version`), which is why it is
+  manual. Note Transit is wired in the **local-dev bootstrap only** and `VaultCryptoErasure` is
+  build-property gated off, so crypto-shredding does not run in-cluster today (ADR-0023 owns that).
+- **PCI DSS:** not applicable — no cardholder data is encrypted by these keys.
+- **CNB:** no separate obligation.
+
+## References
+
+- [ADR-0007](0007-vault-for-secrets-management.md) — secret custody (OpenBao); source of the HSM deferral this ADR takes over
+- [ADR-0099](0099-automated-secret-rotation.md) — secret *rotation*: dynamic credentials + the weekly rotator
+- [ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md) — why OpenBao rather than HashiCorp Vault
+- [ADR-0030](0030-supply-chain-security-and-ssdlc-hardening.md) — what the cosign key signs; the admission policy that verifies it
+- [ADR-0031](0031-ai-agent-governance-and-operations.md) — D3b, the `pki-agent` identity CA
+- [ADR-0094](0094-eudi-native-identity-hub.md) — the EUDI issuer key; the other half of the circular HSM deferral
+- [ADR-0137](0137-kafka-mtls-scheme-accepted-migration.md) — Kafka mTLS and the KafkaUser certs
+- [ADR-0162](0162-document-management-templating-and-e-signature-architecture.md) — PAdES sealing; the fail-open bug D2 closes
+- `docs/audits/2026-07-16-platform-audit.md` §3.3 — the gap this ADR closes

--- a/docs/adr/0173-capacity-management-and-headroom.md
+++ b/docs/adr/0173-capacity-management-and-headroom.md
@@ -1,0 +1,150 @@
+# ADR-0173 — Capacity management and headroom
+
+Date: 2026-07-16
+Decision-Status: Accepted
+Delivery-Status: Partial
+Author(s): jiri.raska
+
+## Context
+
+DORA Art. 9 expects a financial entity to manage ICT capacity and performance. The platform has a lot
+of capacity *machinery* — Karpenter, KEDA, VPA, FinOps tiers, k6 — and no capacity *policy*. Nothing
+says what the ceiling is, who set it, what happens when it is reached, or how we would know.
+
+The platform audit (`docs/audits/2026-07-16-platform-audit.md` §3.3) ranked this the #1 missing ADR
+domain: `grep` for "capacity planning" across `docs/adr` returns zero. `docs/bcp/dora-ictrm.md` maps
+Art. 9 to access control, encryption and patching — capacity is mapped nowhere.
+
+The gap already bit once. Issue #809: a no-swap node under memory pressure livelocked instead of
+OOM-killing, and stranded the ArgoCD application-controller. The fix was four layered defenses, and the
+second-order lesson (recorded in `CLAUDE.md`) was sharper: **raising resource requests pinned the
+NodePool at its `limits` cap, so Karpenter refused to provision and pods went Pending** — a cost cap
+silently behaving as a capacity cliff. That is a capacity-management failure, and there was no ADR for
+it to be recorded in.
+
+## Decision
+
+**1. The NodePool `limits` are the fleet capacity ceiling, and they are a deliberate cost decision.**
+`default` NodePool: **`cpu: 48`, `memory: 128Gi`** (`aws/envs/sandbox-platform/main.tf`), raised from
+32 under #809. arm64-only, spot+on-demand, `c/m/r` categories, `large`…`4xlarge`. The upper bound
+exists because Karpenter otherwise picked a `c6g.12xlarge` for ~20 pods; the `large` lower bound covers
+~350m/400Mi of DaemonSet overhead per node.
+
+**When the cap binds, pods go Pending — it does not autoscale past it and it does not alert.** That is
+the #809 failure mode. We accept the cap (it is the FinOps control) and fix the silence: **D1** adds
+the alert.
+
+**2. Capacity is Karpenter's to allocate, and honest requests are the input.** Karpenter bin-packs by
+*requests*, so a service that under-declares memory is not being thrifty — it is lying to the
+scheduler, and the node it lands on is the one that livelocks. **Requests are a correctness input, not
+a hint.**
+
+Kubelet eviction headroom is set explicitly in the EC2NodeClass (`default`: `memory.available<300Mi`
+hard / `500Mi` soft; `runners`: `400Mi`/`600Mi`), replacing the AL2023 default `<100Mi`, which reacts
+too late. Karpenter subtracts it from allocatable, so the bin-packing arithmetic stays honest.
+
+**3. Availability beats consolidation during the freeze window.** Disruption budgets on `default`:
+**`0%` for 11h from 20:00 UTC**, `50%` otherwise. Consolidation is `WhenEmptyOrUnderutilized` after
+`1m`; `expireAfter: 720h`. The freeze is cost-driven (~100 GB/night of NAT image pulls) and doubles as
+an overnight stability window. It lived only in a Terraform comment; this ADR is where it now lives.
+
+**4. Scale-to-zero is a FinOps tier, not a capacity strategy.** Tiers live in `rules.yaml: finops`
+(T0 always-on = `money_path_services`; T1 HTTP→0; T2 event→0; T3 cron), with
+`default_for_new_services: lowest_tier_trigger_allows` and a `money_path_sacred` guardrail. Five KEDA
+objects exist fleet-wide (product-catalog, card-issuance, sdd-service, interest-service on HTTP→0;
+notification-service on Kafka lag). **Note `notification-service` — the ADR-0057 T2 "proven pilot" —
+runs `minReplicaCount: 1`: a warm floor, not scale-to-zero.**
+
+**5. Capacity numbers we have not measured are targets, and we label them as such.**
+`docs/strategy/06-scalability-targets.md` (Sandbox 10 TPS / Tier-B 200 / Tier-A 4,000) is self-labelled
+"design targets, not yet measured". The only write benchmark
+(`perf/reports/2026-07-10-money-path-write-benchmark.md`) ran **on a laptop under docker-compose,
+explicitly never against sandbox EKS**, and says its own numbers are "an order-of-magnitude baseline,
+not a precise SLA figure". Its real value was the five latent defects it flushed out.
+
+We keep the targets as targets. **We will not quote them as capacity evidence**, and no SLO derives
+from them.
+
+**6. VPA advises; it does not act.** `updateMode: "Off"` for every service — recommendations surface in
+the admin-ui FinOps panel and a human decides. Eviction-based right-sizing on a money path is not a
+trade we want.
+
+## Decisions to deliver
+
+- **D1 — Alert before the NodePool cap binds.** There is no node CPU/memory saturation alert, no
+  NodePool-approaching-`limits` alert, and no Pending-pod alert anywhere. The forecast rules
+  (`prometheus-rules-forecast.yaml`) predict disk and PVC fill only. **The exact #809 failure mode is
+  unmonitored.** *(Pending — the highest-value item here.)*
+- **D2 — Enforce resource requests at admission.** No Kyverno policy requires requests/limits; 66
+  Deployments vs 125 files mentioning `requests:`. Given §2 makes requests a correctness input, a
+  missing request is a scheduling defect and belongs in admission, not in review. *(Pending)*
+- **D3 — Fix the FinOps tier drift.** `card-issuance`, `sdd-service` and `interest-service` carry
+  `openbank.io/finops-tier: T1` labels and live HTTPScaledObjects, but `rules.yaml: finops.declared`
+  lists only `notification-service` and `product-catalog` — and still asserts "only 2 services have a
+  declared tier today". `check-finops-tiers.py` cannot catch this: it validates the declared side only,
+  and is advisory. *(Pending — `finops-tier-drift`, target 2026-09-30.)*
+- **D4 — The `observability` NodePool has no memory limit and no disruption budgets.** It is the only
+  NodePool in GitOps rather than OpenTofu, and the only one missing both controls. *(Pending)*
+- **D5 — Karpenter runs `replicas: 1`.** The single-replica controller is the thing that provisions
+  capacity; its own comment says "prod should run 2 for HA". Recorded, not fixed. *(Pending)*
+- **D6 — ADR-0011's Layer 5 is fiction as written.** It claims a nightly k6 lane with a "p99 > 5%
+  regression gate" against the scalability budgets. There is no nightly lane, no baseline store and no
+  gate; the only k6 thresholds are advisory and the CI lane never fails a deploy on them (#334). Either
+  build it or correct ADR-0011. *(Pending)*
+
+## Alternatives considered
+
+- **Raise the NodePool cap until pods stop pending.** The obvious reflex — and how #809 was first
+  misdiagnosed. Rejected as a *policy*: the cap is the FinOps control, and removing a cost ceiling
+  because it is inconvenient turns a demo repo into an unbounded bill. The cap stays; D1 makes it
+  audible.
+- **HPA fleet-wide.** Rejected: exactly one HPA exists (rum-gateway) and it is right that it does.
+  Throughput is not the constraint here — the fleet is ~40 services at single-digit TPS in a sandbox,
+  so per-service horizontal autoscaling would add moving parts to solve a load that does not exist.
+  Karpenter handles the node axis; KEDA handles the zero axis.
+- **VPA in `Auto` mode.** Rejected: VPA evicts pods to resize them. On a money path that trades
+  availability for a cost win, and #809 already showed how badly eviction interacts with node pressure.
+  Recommendations plus a human is the right speed.
+- **Adopt a formal capacity model (queueing theory, headroom %).** Rejected as premature: there is no
+  measured baseline against real infrastructure (§5). A model fed by laptop numbers is worse than no
+  model, because it looks authoritative.
+
+## Consequences
+
+**Positive**
+- The fleet's capacity ceiling, freeze window and eviction headroom are stated somewhere other than a
+  Terraform comment.
+- The #809 lesson — a cost cap behaves as a capacity cliff, silently — becomes a decision with an alert
+  attached (D1) rather than folklore.
+- §5 stops the scalability targets being cited as evidence they are not.
+
+**Negative**
+- Six pending decisions. This ADR makes capacity legible; it does not make it managed.
+- Stating "we have no measured capacity evidence" in a public repo is a real disclosure. It is also
+  true, and the alternative — quoting laptop benchmarks as SLA figures — is worse.
+
+**Neutral**
+- No runtime change; the machinery already exists. This ADR is the policy that was missing around it.
+
+## Compliance impact
+
+- **DORA Art. 9 (ICT protection and prevention):** this is the first artifact mapping capacity and
+  performance management to Art. 9 — `docs/bcp/dora-ictrm.md` maps Art. 9 to access control,
+  encryption and patching only. D1 (saturation alerting) and D2 (enforced requests) are the gaps a
+  reviewer would hold against it.
+- **DORA Art. 11 (response and recovery):** the 20:00–07:00 disruption freeze and the #809 defenses
+  (eviction headroom, memory limits on singletons, `NodeRepair`) are availability controls; ADR-0159
+  (CNPG HA) and ADR-0134 (BCP, RTO/RPO) carry the rest.
+- **GDPR / PCI DSS / CNB:** not applicable — no personal or cardholder data, no reporting obligation.
+
+## References
+
+- [ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md) — arm64 Graviton spot-first Karpenter; the substrate this sizes
+- [ADR-0041](0041-serverless-tier-scale-to-zero-on-existing-cluster.md) / [ADR-0057](0057-scale-to-zero-workload-tiers-and-finops-classifier.md) / [ADR-0083](0083-t1-http-scale-to-zero-native-pilot.md) — the scale-to-zero tiers and the T1 promotion gate
+- [ADR-0054](0054-finops-managed-version-lifecycle-and-cost-audit.md) / [ADR-0062](0062-finops-cost-allocation-showback.md) / [ADR-0112](0112-ai-finops-agent.md) — the FinOps controls the cap serves
+- [ADR-0011](0011-testing-pyramid.md) — Layer 5 (load); D6 corrects it
+- [ADR-0134](0134-business-continuity-and-dora-ictrm.md) — BCP / ICT-RM, RTO/RPO tiering
+- [ADR-0159](0159-cnpg-ha-money-path.md) — CNPG HA + PDBs, the #809 follow-on
+- `docs/strategy/06-scalability-targets.md` — the design targets §5 refuses to treat as evidence
+- `perf/reports/2026-07-10-money-path-write-benchmark.md` — the laptop baseline, honest about itself
+- `docs/audits/2026-07-16-platform-audit.md` §3.3 — the gap this ADR closes

--- a/docs/adr/0174-ict-third-party-dependencies-and-exit-strategy.md
+++ b/docs/adr/0174-ict-third-party-dependencies-and-exit-strategy.md
@@ -1,0 +1,190 @@
+# ADR-0174 — ICT third-party dependencies and exit strategy
+
+Date: 2026-07-16
+Decision-Status: Accepted
+Delivery-Status: Partial
+Author(s): jiri.raska
+
+## Context
+
+DORA Art. 28–30 requires a register of ICT third-party providers, an assessment of concentration risk,
+and a documented, tested **exit strategy** for each critical one. The platform has none of these.
+
+`docs/bcp/dora-ictrm.md` is honest about it: Art. 28 is marked `~` with "vendor risk register
+(**pending**)", and the backlog lists "Vendor risk register for critical third-party ICT providers"
+and "Contractual DORA Art. 30 clause" as open. `docs/strategy/07-compliance-matrix.md` maps Art. 28–30
+to "Vendor register (docs/)" — **that file does not exist**. The recorded Art. 30 arrangements are
+"AWS ToS; Hetzner ToS; GitHub Enterprise (if applicable)" — and **Hetzner appears nowhere in the
+infrastructure**, so the one register-shaped artifact we have is already wrong.
+
+[ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md) asserts portability by construction and names
+an "exit/portability story" as a consequence. It is a good decision, and it has never been
+demonstrated. `R-07 Third-party cloud failure` mitigates with "Cloud-agnostic architecture (ADR-0027)"
+at residual risk Medium — with no test behind it.
+
+This ADR is the register, the concentration analysis, and the exit position. It is deliberately
+uncomfortable reading.
+
+## Decision
+
+**1. This ADR is the ICT third-party register of record.** A runtime dependency not listed here is not
+governed.
+
+| Provider | What depends on it | Criticality | If it disappears |
+|---|---|---|---|
+| **AWS** (EKS, KMS, ECR, S3, SQS, Route53, CloudTrail/Config, Cost Explorer) | Everything | **Critical** | Total outage. See §3 for what is genuinely locked. |
+| **DeepInfra** (`api.deepinfra.com`, `deepseek-ai/DeepSeek-V3.2`) | copilot, devops-agent, control-liveness-sentinel | **Non-critical by design** | Agents degrade to deterministic fallback; money path unaffected (§4) |
+| **GitHub** (`api.github.com`, ARC runners) | CI, governance agents, DORA metrics (ADR-0061) | High (build-time) | No deploys; running system unaffected |
+| **Let's Encrypt** | Public ingress TLS | High | Certs expire in ≤90d; no immediate outage |
+| **Container registries** (Docker Hub, quay.io, ghcr.io, registry.k8s.io) | Image pulls | Medium | Mitigated by ECR pull-through cache; Docker Hub rate-limit exhaustion under node churn is a *known* failure |
+| **Slack/Teams webhooks** | Outbound oversight (ADR-0059) | Low | Alerts lost; ntfy in-cluster leg survives (ADR-0088) |
+| **Maven Central / Gradle / npm** | Build only | Medium | No builds; runtime unaffected |
+
+Self-hosted and therefore **not** third parties: Pact broker, Keycloak, GlitchTip, the PID and customer
+edges — all on `open-bank.tech`.
+
+**2. The LLM topology this platform documents does not exist, and that is the single most important
+line in this ADR.**
+
+[ADR-0031](0031-ai-agent-governance-and-operations.md) decides a hybrid gateway: **LiteLLM** as the
+gateway, **vLLM** self-hosted for sensitive/air-gapped/residency work, **Anthropic** hosted for general
+reasoning, **Langfuse** for LLM observability, and `sensitive_data → self_hosted` routing.
+
+**None of it is deployed.** There is no `litellm`, no `ai-platform` namespace, no vLLM, no Anthropic
+integration, and no Langfuse anywhere in gitops. What exists is **one US provider, DeepInfra**, chosen
+on cost grounds in a YAML comment, with no ADR and no fallback.
+
+Two things make this worse than a normal delivery gap:
+- **Five agents carry `LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000`** — governance-auditor,
+  flaky-test-hunter, authz-policy-auditor, finops-agent, docs-truth-agent — pointing at a service that
+  has never existed.
+- **~16 committed OPA bundles embed the false topology as policy data**: `tool: litellm`,
+  `models: hosted {provider: anthropic}` / `self_hosted {runtime: vllm, in_cluster: true}`,
+  `routing: {sensitive_data: self_hosted}`. Per `rules.yaml: opa_bundle_sync` these are machine-
+  embedded, so the untruth is replicated fleet-wide and would be read by any policy consumer as fact.
+
+**We record the real dependency (DeepInfra, single provider, no fallback) as the governed one.** D1
+corrects the policy data; ADR-0031's topology stays a decision, but it is a *target*, not a
+description.
+
+**3. What is genuinely AWS-locked — stated plainly, because ADR-0027 claims portability.**
+
+ADR-0027's decision is sound: no FaaS/PaaS in the money path; only EKS, VPC, KMS and the audit sink as
+in-path AWS primitives; everything stateful runs in-cluster on OSS (CNPG, Strimzi, Keycloak, OpenBao,
+Valkey). All ~40 banking services are plain Quarkus containers and would move.
+
+But the substrate is more locked than "cloud-agnostic" suggests, and pretending otherwise is the
+failure mode:
+- **KMS** — envelope encryption *and* OpenBao auto-unseal. Moving clouds means re-keying the unseal
+  path (see [ADR-0172](0172-cryptographic-key-management-and-lifecycle.md)).
+- **S3 Object Lock COMPLIANCE** — the WORM audit archive. Genuinely S3-specific; not a swap.
+- **EKS Pod Identity** — chosen *over* IRSA for Karpenter, external-dns, CNPG barman. Deepens the lock.
+- **Karpenter itself is AWS-only** — and it is the load-bearing capacity mechanism ([ADR-0173](0173-capacity-management-and-headroom.md)).
+- **CloudTrail / AWS Config** — the DORA Art. 12 audit sink.
+- **Cost Explorer / Budgets** — the entire ADR-0054/0062/0112 FinOps surface.
+
+So: **the applications are portable; the platform is not.** ADR-0027's guarantee holds for the layer it
+actually covers, and this ADR names the rest rather than letting "cloud-agnostic" do work it cannot.
+
+**4. The LLM dependency is non-critical *by construction*, and that is a real control.**
+`LlmDiagnosisAdapter` reads its API key via an optional lookup, so an unseeded key **degrades to a
+deterministic fallback rather than crashlooping**; `chat()` returns null on any failure; timeouts are
+10s connect / 60s request. A DeepInfra outage silently degrades AI agents and touches no payment. This
+is the de-facto Art. 28 third-party-failure control, and it is documented only in Kotlin KDoc — so it
+is documented here.
+
+The `ModelProvider` port (ADR-0031) is what makes provider substitution a config change. Note it is
+*also* the Apache/AGPL licensing seam ([ADR-0136](0136-agent-services-agpl-in-repo-open-core.md)):
+provider-swappability is load-bearing for the open-core model, not only for exit. Two obligations, one
+seam.
+
+**5. Exit position: honest, per class.**
+- **Applications** — portable today. Plain containers, OSS data plane. *Exit: re-target the gitops
+  substrate.* Untested.
+- **Platform** — not portable without work: KMS, S3 Object Lock, Pod Identity, Karpenter, CloudTrail.
+  *Exit: a project, not a switch.* Unquantified.
+- **LLM** — portable by config (`ModelProvider` + `model-endpoint`). *Exit: change one env var.* The
+  cheapest exit in the estate, and the only one with no register entry.
+- **GitHub** — build-time only; a running cluster survives. *Exit: unassessed.*
+
+**We do not claim a tested exit for any of them.** ADR-0027's "portability preserved" is an
+architectural property, not evidence.
+
+## Decisions to deliver
+
+- **D1 — Correct the OPA policy data.** ~16 bundles assert a litellm/vLLM/Anthropic topology that does
+  not exist. This is not a doc bug: it is machine-embedded policy data claiming a residency-routing
+  control is in force when it is not. **Highest priority here** — a false control claim is worse than
+  an absent one. *(Pending)*
+- **D2 — Remove or implement `LLM_GATEWAY_URL`.** Five agents point at `litellm.ai-platform.svc:4000`,
+  which has never existed. Dead config that looks like architecture. *(Pending)*
+- **D3 — Write the register as a maintained artifact.** `docs/strategy/07-compliance-matrix.md` points
+  at a "Vendor register (docs/)" that does not exist, and `dora-ictrm.md` lists **Hetzner**, which is
+  not used. §1 is the register today; it needs an owner and a review cadence. *(Pending)*
+- **D4 — Test one exit.** The LLM is the cheapest (§5) and the most valuable to prove: swap
+  DeepInfra → a second provider in a sandbox and confirm the agents keep working. An untested exit is
+  an assertion. *(Pending)*
+- **D5 — Reconcile ADR-0031's topology with reality.** Either build the gateway or amend ADR-0031 to
+  record DeepInfra-direct as the as-built, in the house style ADR-0027 already set with its "As-built
+  deltas (honest record)". *(Pending)*
+
+## Alternatives considered
+
+- **Multi-cloud.** The textbook Art. 28 answer to concentration risk. Rejected: this is a
+  single-maintainer reference implementation on one sandbox account. Multi-cloud would double the
+  operational surface to hedge a risk the platform does not carry (it holds no real money and no real
+  customers). ADR-0027's in-cluster-OSS substrate is the proportionate control: it keeps the *option*
+  without paying for it.
+- **Add a second LLM provider now.** Cheap and tempting. Rejected as premature: with the agents
+  already degrading safely (§4) a failover adds a code path that would rarely run and never be tested
+  — the classic untested-failover trap. D4 (prove the swap works) buys the same assurance for less.
+- **Self-host the LLM (vLLM), as ADR-0031 decided.** Would resolve both the third-party and the
+  residency exposure ([ADR-0175](0175-data-residency-and-sovereignty.md)). Rejected *for now* on cost:
+  GPU capacity for a demo estate is not justifiable, and ADR-0027's FinOps posture is why the sandbox
+  is Graviton-spot in the first place. Kept as the stated target; D5 makes the gap explicit rather
+  than letting the ADR imply it is done.
+- **Say nothing until there is a register.** Rejected: the audit already found the gap, and an empty
+  register is a smaller problem than a wrong one. §1 is a real register that a reader can act on.
+
+## Consequences
+
+**Positive**
+- There is now a register. It is short and it is true, which beats the two artifacts that pointed at it
+  and were wrong.
+- The gap between ADR-0031's decided topology and the running system is written down — with the
+  policy-data corruption (D1) called out as a security-relevant issue rather than a docs nit.
+- "Cloud-agnostic" stops doing work it cannot: §3 separates the portable applications from the locked
+  platform.
+
+**Negative**
+- The honest answer to "do you have a tested exit plan?" is now, in writing, **no**. That is a real
+  disclosure for a public repo — and it is what an auditor would find in an hour anyway.
+- §2 documents that a documented control (residency routing) does not exist. Better here than
+  discovered by someone relying on it.
+
+**Neutral**
+- No runtime change. D1–D5 carry the delivery.
+
+## Compliance impact
+
+- **DORA Art. 28 (register + concentration risk):** §1 is the first register artifact. Concentration is
+  AWS, and §3 is honest about how deep. Currently `~` in `docs/bcp/dora-ictrm.md`; this ADR is what
+  that entry should point at.
+- **DORA Art. 29 (concentration):** single cloud, single region, single LLM provider, single Karpenter
+  replica. Accepted for a reference implementation; named so it is a decision rather than an oversight.
+- **DORA Art. 30 (contractual arrangements):** genuinely absent. "AWS ToS" is not an Art. 30
+  arrangement, and the recorded "Hetzner ToS" is for a provider that is not used. D3.
+- **GDPR Chapter V:** the DeepInfra dependency is also a cross-border transfer question — owned by
+  [ADR-0175](0175-data-residency-and-sovereignty.md), not here.
+- **PCI DSS / CNB:** not applicable.
+
+## References
+
+- [ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md) — the portability decision §3 bounds
+- [ADR-0031](0031-ai-agent-governance-and-operations.md) — the LLM topology §2 shows is unbuilt
+- [ADR-0136](0136-agent-services-agpl-in-repo-open-core.md) — why `ModelProvider` is also a licensing seam
+- [ADR-0172](0172-cryptographic-key-management-and-lifecycle.md) — the KMS keys that deepen the AWS lock
+- [ADR-0173](0173-capacity-management-and-headroom.md) — Karpenter, the AWS-only capacity mechanism
+- [ADR-0175](0175-data-residency-and-sovereignty.md) — where the LLM data goes
+- [ADR-0134](0134-business-continuity-and-dora-ictrm.md) — BCP/ICT-RM; `docs/bcp/dora-ictrm.md` is its artifact
+- `docs/audits/2026-07-16-platform-audit.md` §3.3, §6.3 — the gap this ADR closes

--- a/docs/adr/0175-data-residency-and-sovereignty.md
+++ b/docs/adr/0175-data-residency-and-sovereignty.md
@@ -1,0 +1,161 @@
+# ADR-0175 — Data residency and sovereignty
+
+Date: 2026-07-16
+Decision-Status: Accepted
+Delivery-Status: Partial
+Author(s): jiri.raska
+
+## Context
+
+An EU bank must be able to say where its data is. This platform cannot, and the pieces that ought to
+say it disagree with each other.
+
+[ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md) D4 says "**EU residency**" and stops there — no
+region, no classes, no rule about what may cross a boundary. [ADR-0152](0152-single-tenancy-boundary-statement.md)
+twice leans on residency ("simplifies data-residency and GDPR controllership reasoning: one deployment,
+one controller, one regulator relationship") without making a residency commitment. The platform audit
+(`docs/audits/2026-07-16-platform-audit.md` §3.3) ranked this the #4 missing ADR domain.
+
+Three concrete contradictions made this ADR urgent rather than tidy:
+
+1. **`openbank-infra/aws/README.md` states "Production is pinned to `eu-central-1` per ADR-0027's GDPR
+   condition". ADR-0027 contains no such condition** — its five go-live conditions are audit, state,
+   backups, secrets, network, and D4 says only "EU residency". A regional pin is attributed to an ADR
+   that does not make it. (ADR-0027 is itself a 2026-06-14 reconstruction of a lost original; the pin
+   may have been in the original, which is precisely why it needs re-deciding rather than inferring.)
+2. **`openbank-document-service` defaults to a different region than the entire estate:**
+   `region: ${OBJECTSTORE_S3_REGION:eu-central-1}` while everything else is `eu-north-1`. Customer
+   documents (ADR-0161) are the one workload whose residency is most likely to be asked about.
+3. **Prompt data leaves the EU today.** The copilot is customer-facing (ADR-0089), enabled in sandbox,
+   and calls `api.deepinfra.com` — a bare global endpoint, US-headquartered, no region pinning, no DPA,
+   no zero-retention agreement. The only control is a YAML comment saying "synthetic data only".
+
+## Decision
+
+**1. The estate is `eu-north-1` (Stockholm), AWS account `265175468565`.** Uniform across bootstrap,
+sandbox-platform and web-prod; VPC spans three AZs. All five S3 buckets, KMS, ECR, CloudTrail and
+CloudWatch inherit it. **This is the residency statement that did not exist.**
+
+**2. Region is decided here, not in a README.** The `eu-central-1` production pin asserted by
+`openbank-infra/aws/README.md` is **not** an ADR-0027 condition and is hereby **not adopted by
+inference**. If production is to run in `eu-central-1`, that is a decision this ADR (or its successor)
+makes explicitly. Until then: **eu-north-1 is the estate, and the README is wrong** — D1 corrects it.
+
+**3. `openbank-document-service`'s `eu-central-1` default is a defect, not an intent.** It is the only
+component defaulting outside the estate region, and it holds customer documents. Either the estate is
+multi-region (it is not) or this is a latent misconfiguration. **D2** aligns it. Treating it as an
+unstated intent would be exactly the kind of inference §2 rejects.
+
+**4. Personal data does not leave the EU. Today, we cannot prove that — so we state the exposure.**
+The copilot and the ops agents send prompt content to DeepInfra (US, global endpoint, no residency
+pinning). The stated basis is "synthetic data only", asserted in YAML comments across copilot and
+devops-agent, with **no technical control** preventing real data reaching it and no DPA behind it.
+
+The `model-gateway` config shape already carries a per-model **`sensitivity: hosted | self-hosted`**
+field — the mechanism for residency routing exists. What does not exist is anything that enforces it:
+ADR-0031's `sensitive_data → self_hosted` routing, the vLLM tier, and the LiteLLM gateway are all
+unbuilt ([ADR-0174](0174-ict-third-party-dependencies-and-exit-strategy.md) §2), while ~16 OPA bundles
+embed policy data asserting that routing **is** in force.
+
+**So the honest position is:** for a sandbox on synthetic data, hosted-LLM egress is acceptable. **It
+is not acceptable for any deployment holding real personal data**, and the control that would make it
+acceptable does not exist. D3 is the gate that makes this a rule rather than a comment.
+
+**5. Residency classes.** Three, and only the third may leave the EU:
+- **Regulated & personal** — ledger, accounts, parties, KYC, documents, audit, backups. `eu-north-1`,
+  never leaves. No exceptions, no "just for a moment" in a hosted model's context window.
+- **Operational** — metrics, traces, logs. In-cluster (Prometheus/Tempo/Loki), same region.
+- **Synthetic / non-personal** — demo data, seeded fixtures, ops-agent prompts about *infrastructure*
+  (not customers). May reach a hosted model. **This is the only class §4's egress is licensed for.**
+
+**6. Backups inherit the estate region, and the sandbox posture is not the prod posture.**
+`openbank-sandbox-db-backups` is `eu-north-1`, SSE-`AES256` (not KMS), `force_destroy = true`, 35-day
+lifecycle. The WORM `log_archive` is Object Lock COMPLIANCE with `log_retention_days` defaulting to
+**1** so `tofu destroy` is not permanently blocked. Both carry comments saying production must differ
+(10y retention, compliance-grade lock). Those comments are correct and this ADR keeps them visible
+rather than letting them read as the target state.
+
+## Decisions to deliver
+
+- **D1 — Correct `openbank-infra/aws/README.md`.** It attributes a regional pin to a condition
+  ADR-0027 does not contain. A wrong provenance claim in the infra README is worse than no claim: it
+  looks authoritative. *(Pending)*
+- **D2 — Align `openbank-document-service` to `eu-north-1`** (or state why customer documents live in a
+  second region). *(Pending)*
+- **D3 — Gate hosted-LLM egress on the data class.** Either enforce `sensitivity: self-hosted` routing
+  for anything non-synthetic (ADR-0031's decision, unbuilt), or hard-disable the customer-facing
+  copilot outside sandbox. The current control is a comment. *(Pending — the highest-value item here.)*
+- **D4 — Correct the OPA bundles' residency claim.** ~16 bundles assert `routing: {sensitive_data:
+  self_hosted}` as live policy data. Shared with [ADR-0174](0174-ict-third-party-dependencies-and-exit-strategy.md)
+  D1 — one fix, two ADRs. *(Pending)*
+- **D5 — A cross-border transfer analysis** — GDPR Chapter V, SCCs, a TIA for the LLM provider. None
+  exists. Required before any real personal data exists, not before. *(Pending)*
+- **D6 — Assert bucket regions explicitly.** Every S3 bucket inherits the provider default; none
+  declares a region or a residency guard. It happens to be right, which is not the same as being
+  constrained. *(Pending)*
+
+## Alternatives considered
+
+- **Pin production to `eu-central-1` (Frankfurt), as the README claims.** The conventional choice for
+  an EU bank, and the README may be echoing the lost ADR-0027 original. Rejected *by inference*: the
+  entire estate, account, and every IaC default is `eu-north-1`, and adopting a different prod region
+  because a README says so would be exactly the unsourced-claim problem this ADR exists to fix. If
+  Frankfurt is wanted, it is a decision to make with reasons — data-subject proximity, latency,
+  sovereignty posture — not one to inherit from a sentence.
+- **Self-host the LLM (vLLM) now and close the egress question.** The clean answer, and already
+  ADR-0031's decision. Rejected on cost: GPU capacity for a demo estate is not justifiable when
+  ADR-0027's whole posture is Graviton-spot FinOps. D3 buys the same protection by *classifying* the
+  data instead of relocating the model.
+- **Say "EU residency" and move on, as ADR-0027 did.** Rejected: that is what produced this mess. "EU
+  residency" without a region, classes, or an egress rule is a slogan — it did not stop a
+  customer-facing assistant calling a US endpoint, and it did not stop a second region appearing in a
+  service default.
+- **Ban hosted LLMs outright.** Simple and enforceable. Rejected: it would kill the ops agents (which
+  reason about infrastructure, not customers — genuinely class 3) to protect data they never see. §5's
+  classes are the proportionate line.
+
+## Consequences
+
+**Positive**
+- The platform can now answer "where is the data?" — `eu-north-1` — with a sourced statement rather
+  than three artifacts that disagree.
+- The README/ADR-0027 contradiction is resolved by deciding, not by picking whichever text was found
+  first.
+- §4 converts an implicit "we assume it's fine because the comment says synthetic" into a stated
+  exposure with a gate (D3) attached.
+
+**Negative**
+- This ADR states in public that a customer-facing assistant currently sends prompts to a US provider
+  with no DPA, protected only by a comment. That is a genuine disclosure — and it is true, discoverable
+  in one grep, and better owned than found.
+- Six pending decisions. The residency *position* is now decided; the *controls* are not built.
+
+**Neutral**
+- No runtime change. D1–D6 carry the delivery.
+
+## Compliance impact
+
+- **GDPR Art. 44–49 (Chapter V — transfers):** the LLM egress is a third-country transfer with no SCCs,
+  no TIA and no DPA. Tolerable only while the data is synthetic (§5 class 3). D5 is the gap; D3 is the
+  control that keeps §4's assertion true.
+- **GDPR Art. 5(1)(f) / Art. 32:** residency is an integrity-and-confidentiality control. §1 is the
+  statement; §5 the classes.
+- **GDPR Art. 30 (ROPA):** `docs/strategy/07-compliance-matrix.md` maps Art. 30 to "governance +
+  audit-service" — no artifact exists. Out of scope here; named so it is not mistaken for covered.
+- **DORA Art. 28–30:** the LLM provider is simultaneously a third-party (ADR-0174) and a transfer
+  (this ADR). One dependency, two regimes.
+- **ADR-0152 (single tenancy):** its claim that single-tenancy "simplifies data-residency reasoning"
+  now has something concrete to simplify *to*.
+- **PCI DSS / CNB:** not applicable — no cardholder data; no separate reporting obligation.
+
+## References
+
+- [ADR-0027](0027-cloud-agnostic-in-cluster-substrate.md) — D4 "EU residency"; the phrase this ADR makes operable
+- [ADR-0152](0152-single-tenancy-boundary-statement.md) — leans on residency reasoning without stating it
+- [ADR-0031](0031-ai-agent-governance-and-operations.md) — the `sensitive_data → self_hosted` routing that is unbuilt
+- [ADR-0089](0089-customer-facing-ai-assistant.md) — the customer-facing assistant whose egress §4 covers
+- [ADR-0161](0161-object-storage-standard-for-application-documents.md) — customer documents; D2's `eu-central-1` default
+- [ADR-0174](0174-ict-third-party-dependencies-and-exit-strategy.md) — the same LLM dependency, as a third-party register entry
+- [ADR-0118](0118-gdpr-data-lifecycle-and-retention.md) — PII classification and retention; the classes §5 builds on
+- `openbank-infra/aws/README.md` — the `eu-central-1` claim D1 corrects
+- `docs/audits/2026-07-16-platform-audit.md` §3.3 — the gap this ADR closes

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -174,6 +174,10 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0169](0169-customer-document-access-and-sca-bound-signing.md) | Customer document access & SCA-bound signing over customer-edge | Proposed | Planned | — |
 | [0170](0170-onboarding-e-signature-flow-in-the-customer-app.md) | Onboarding e-signature flow in the customer app | Proposed | Planned | — |
 | [0171](0171-verification-of-payee-for-outbound-credit-transfers.md) | Verification of Payee for outbound credit transfers | Accepted | Partial | — |
+| [0172](0172-cryptographic-key-management-and-lifecycle.md) | Cryptographic key management and lifecycle | Accepted | Partial | — |
+| [0173](0173-capacity-management-and-headroom.md) | Capacity management and headroom | Accepted | Partial | — |
+| [0174](0174-ict-third-party-dependencies-and-exit-strategy.md) | ICT third-party dependencies and exit strategy | Accepted | Partial | — |
+| [0175](0175-data-residency-and-sovereignty.md) | Data residency and sovereignty | Accepted | Partial | — |
 
 ---
 


### PR DESCRIPTION
## Summary

Writes the four ADR domains the platform audit found missing (§3.3) — cryptographic key management, capacity, ICT third-party exit, and data residency — and fixes a stale delivery note in ADR-0007 that the investigation exposed.

Each is written from what the code does, not from what would look good. **Three of the four turned up something live**, which is most of the value here.

## Type of change

- [x] docs
- [ ] feat / fix / refactor / perf / chore / security / breaking

## Linked issues

Refs #1280 (the OPA topology finding ADR-0174 §2 surfaced)
Refs ADR-0144, ADR-0029

## Changes

- **ADR-0172** — cryptographic key management and lifecycle
- **ADR-0173** — capacity management and headroom
- **ADR-0174** — ICT third-party dependencies and exit strategy
- **ADR-0175** — data residency and sovereignty
- **ADR-0007** — corrected delivery note (see below)

## What the investigation found

**ADR-0172.** Two crown-jewel keys — `alias/openbank-cosign-signing` and `alias/openbank-vault-unseal` — are **not in OpenTofu at all**. Referenced by workflows and manifests, declared nowhere; only three `aws_kms_key` resources exist (audit, eks-secrets, dnssec). Created out-of-band ⇒ no reviewed key policy, no rotation setting, no drift detection. `arc-runners.tf` grants `kms:Sign` against a **hardcoded key UUID** with no matching resource.

Also closes the **circular HSM deferral**: ADR-0007 defers the HSM until eIDAS activates (ADR-0094); ADR-0094 defers back to "KMS/HSM-backed". Neither owns it. §5 names the trigger outright.

The sharp one is **D2**: `PdfBoxPadesSealAdapter` falls back to an ephemeral self-signed cert when the keystore path is absent *or the file merely does not exist*, logging a `WARN`. The fail-closed guard is opt-in. **A misconfigured mount produces legally worthless signatures that look successful.**

**ADR-0173.** The NodePool cap (48 vCPU / 128Gi) is simultaneously the FinOps control and the fleet capacity ceiling — and when it binds, pods go Pending with **no alert**. That is exactly #809's second-order failure ("raising requests pinned the pool at its limits"), and it is *still* unmonitored (D1). Also records that `06-scalability-targets.md` is unmeasured and the only write benchmark ran on a laptop under docker-compose — so they are targets, and §5 commits to not quoting them as capacity evidence.

**ADR-0174.** The register `docs/strategy/07-compliance-matrix.md` points at never existed; its stand-in in `dora-ictrm.md` lists **Hetzner**, which the infrastructure does not use.

The finding (→ #1280): **ADR-0031's decided LLM topology does not exist.** No LiteLLM, no vLLM, no Anthropic, no Langfuse. Five agents point at a `litellm.ai-platform.svc:4000` that never existed, and **~16 OPA bundles embed the topology as policy data** — so the platform machine-asserts a `sensitive_data → self_hosted` residency control it does not run. A false control claim is worse than an absent one.

§3 also separates the **portable applications** from the **genuinely locked platform** (KMS, S3 Object Lock COMPLIANCE, EKS Pod Identity, Karpenter, CloudTrail, Cost Explorer) rather than letting "cloud-agnostic" cover both.

**ADR-0175.** States the estate is `eu-north-1` — nothing did. Resolves three contradictions:
1. `openbank-infra/aws/README.md` attributes a `eu-central-1` production pin to "ADR-0027's GDPR condition". **ADR-0027 contains no such condition** (verified: 0 occurrences).
2. `openbank-document-service` defaults to `region: ${OBJECTSTORE_S3_REGION:eu-central-1}` while the whole estate is `eu-north-1` — and it holds customer documents.
3. Prompt data reaches a US LLM **today** from a customer-facing assistant, with a YAML comment ("synthetic data only") as the only control.

**ADR-0007.** Its delivery note claimed dynamic DB credentials were `⬜ Pending — services consume static credentials; database secrets engine not yet wired`. **False since ADR-0099 Tier 1 landed**: seven components (accounts, audit, balances, fx-service, ledger, notifications, payments) run on the OpenBao database engine with 24h leases. Also splits the PKI claim into its two halves — the engine *is* live and issuing (300s document-signing leaves, agent identity); only the cert-manager↔OpenBao integration is deferred — and notes the deployed engine is **OpenBao**, not HashiCorp Vault.

## Definition of Done

- [x] Hexagonal layering — N/A (docs).
- [ ] Unit / integration / contract tests — N/A (docs).
- [x] `check-adr-registry` green — 168 ADRs, index regenerated and staged.
- [x] `check-adr-status` green.
- [x] **Every ADR cross-link verified to resolve** — scripted check; caught one invented filename (`0089-ai-customer-copilot.md` → `0089-customer-facing-ai-assistant.md`) before commit.
- [x] Every factual claim verified against the code, not from memory.
- [ ] OpenAPI / Flyway / Avro — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII. The ADRs name **key aliases and roles**, never key material; the AWS account id is already public throughout the repo.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code changed — no code changed. But **ADR-0172 documents crypto posture** and **#1280 is a real governance-data integrity issue**, hence the `security-review-required` label.
- [ ] PII path changed — no. ADR-0175 documents a PII **egress exposure** that already exists.
- [ ] Cardholder data — no.

## Compliance impact

- [x] DORA — Art. 9 (capacity: **first artifact mapping it**; key management), Art. 28-30 (register, concentration, exit)
- [x] GDPR — Chapter V transfers (LLM egress), Art. 5(1)(f)/32 (residency), Art. 30 named as still-absent
- [ ] PCI DSS / PSD2 / AML / CNB / None

## Rollout / Rollback

- **Deployment strategy:** none — documentation only, no runtime artifact.
- **Rollback plan:** revert. The four domains return to undocumented and ADR-0007's note returns to being wrong.
- **Data migration reversible:** N/A.

## Reviewer notes

**These are disclosure documents, and that is the decision to review.** They state in public that: two crown-jewel keys are not in IaC; the platform has no measured capacity evidence; there is no tested exit for anything; and a customer-facing assistant sends prompts to a US provider with no DPA. All four are true, all four are findable in under an hour by anyone who looks, and the repo's whole value proposition is that its ADRs are honest about delivery status. **If you would rather any of this stayed unwritten, that is a legitimate call — but the audit already found them, so the choice is documented-or-known, not documented-or-hidden.**

**19 pending decisions across the four ADRs.** These make the gaps trackable; they do not close them. The three I would rank first:
1. **ADR-0172 D2** — the PAdES fail-open. It is the only one that is currently producing a *wrong result* (invalid signatures, silently) rather than a missing control.
2. **#1280 / ADR-0174 D1** — the OPA policy-data correction. The platform asserting a residency control it does not run is the kind of thing that survives right up until someone relies on it.
3. **ADR-0173 D1** — the NodePool saturation alert. #809 already happened once; the failure mode is still unmonitored.

**One judgement call worth challenging:** ADR-0175 §2 refuses to adopt the README's `eu-central-1` production pin by inference, on the grounds that ADR-0027 does not contain the condition the README cites. ADR-0027 is itself a 2026-06-14 reconstruction of a lost original, so the pin *may* have been real. I chose to make it a decision to re-take rather than a fact to inherit — if you know the history, you can settle it in one line.
