### PR TITLE
fix(authz): let the customer-edge record a signing decision (sign 403)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "52d3d516388a8aa2"
+    openbank.tech/policy-checksum: "f87aa3de385e106d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "52d3d516388a8aa2"
+        openbank.tech/policy-checksum: "f87aa3de385e106d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "2cbc9cde8543e4a1"
+    openbank.tech/policy-checksum: "bc9f41ec9fbab063"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2cbc9cde8543e4a1"
+        openbank.tech/policy-checksum: "bc9f41ec9fbab063"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "72fda6f42cfb7b83"
+    openbank.tech/policy-checksum: "f8c19af7052cc471"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "72fda6f42cfb7b83"
+        openbank.tech/policy-checksum: "f8c19af7052cc471"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "14ac5fa809334b85"
+    openbank.tech/policy-checksum: "4d8314c02444237a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "14ac5fa809334b85"
+        openbank.tech/policy-checksum: "4d8314c02444237a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "ef7b8cfc9be67a5f"
+    openbank.tech/policy-checksum: "b2e6efd4384f0d78"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ef7b8cfc9be67a5f"
+        openbank.tech/policy-checksum: "b2e6efd4384f0d78"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "2b21caba745cbbb4"
+    openbank.tech/policy-checksum: "fa1e397030feac5d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2b21caba745cbbb4"
+        openbank.tech/policy-checksum: "fa1e397030feac5d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "af09ffc9e5cf7957"
+    openbank.tech/policy-checksum: "f7d985ec75528070"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -198,10 +198,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af09ffc9e5cf7957"
+        openbank.tech/policy-checksum: "f7d985ec75528070"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "af09ffc9e5cf7957"
+    openbank.tech/policy-checksum: "f7d985ec75528070"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -198,10 +198,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af09ffc9e5cf7957"
+        openbank.tech/policy-checksum: "f7d985ec75528070"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "be5ea67c66f93643"
+    openbank.tech/policy-checksum: "44d5fc9ad95570d0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "be5ea67c66f93643"
+        openbank.tech/policy-checksum: "44d5fc9ad95570d0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "fcb7c8952e6a56f7"
+    openbank.tech/policy-checksum: "c2890c2f0f24471b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fcb7c8952e6a56f7"
+        openbank.tech/policy-checksum: "c2890c2f0f24471b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "6b5d16372cae64d9"
+    openbank.tech/policy-checksum: "cb39de827ba381aa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6b5d16372cae64d9"
+        openbank.tech/policy-checksum: "cb39de827ba381aa"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "9e3772dc2474a162"
+    openbank.tech/policy-checksum: "9a70365cc430aa4f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9e3772dc2474a162"
+        openbank.tech/policy-checksum: "9a70365cc430aa4f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "da10ebbf6e956ba1"
+    openbank.tech/policy-checksum: "9d65979b9e6f884b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "da10ebbf6e956ba1"
+        openbank.tech/policy-checksum: "9d65979b9e6f884b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "af09ffc9e5cf7957"
+    openbank.tech/policy-checksum: "f7d985ec75528070"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -198,10 +198,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "af09ffc9e5cf7957"
+        openbank.tech/policy-checksum: "f7d985ec75528070"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "911c7ef8b7cc3c0f"
+    openbank.tech/policy-checksum: "01cf400de3666f0c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "59be22abfc45954b"
+    openbank.tech/policy-checksum: "0eb8cb2e15f98f23"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5085f6a228c29cd8"
+    openbank.tech/policy-checksum: "42823e41f720981f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "243bf9baa4bbfc6a" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "485cce4e95561032" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7b3b3f1044c0f34a"
+        openbank.tech/policy-checksum: "feeadda01e417d4d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5085f6a228c29cd8" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "42823e41f720981f" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ec47c88e419effa1"
+        openbank.tech/policy-checksum: "335c2029a5cf56e7"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "59be22abfc45954b" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "0eb8cb2e15f98f23" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "911c7ef8b7cc3c0f"
+        openbank.tech/policy-checksum: "01cf400de3666f0c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "6041fa687eb3ee63" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "88cbe6b3afb6d501" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "232b256f9840ab4e"
+        openbank.tech/policy-checksum: "8b362d086d369d16"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0e97c5254fce1aa7"
+        openbank.tech/policy-checksum: "a5a854d83d45fd2e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ec47c88e419effa1"
+    openbank.tech/policy-checksum: "335c2029a5cf56e7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7b3b3f1044c0f34a"
+    openbank.tech/policy-checksum: "feeadda01e417d4d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6041fa687eb3ee63"
+    openbank.tech/policy-checksum: "88cbe6b3afb6d501"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "232b256f9840ab4e"
+    openbank.tech/policy-checksum: "8b362d086d369d16"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "243bf9baa4bbfc6a"
+    openbank.tech/policy-checksum: "485cce4e95561032"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0e97c5254fce1aa7"
+    openbank.tech/policy-checksum: "a5a854d83d45fd2e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "ede831b5ea8f64cb"
+    openbank.tech/policy-checksum: "47e4a797af43c8cd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ede831b5ea8f64cb"
+        openbank.tech/policy-checksum: "47e4a797af43c8cd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "96cc884f415effbc"
+    openbank.tech/policy-checksum: "e7820afafe717723"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "96cc884f415effbc"
+        openbank.tech/policy-checksum: "e7820afafe717723"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "aabb5970ba5cccaf"
+    openbank.tech/policy-checksum: "06cf2e3093f20e46"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -197,10 +197,18 @@ data:
     # Keycloak service-account token is deterministically "service-account-<clientId>"
     # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
     # — not forgeable by a human session, which authenticates through a different client.
+    #
+    # `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+    # agreement is read AND signed through the edge, and recordDecision's verb sits outside
+    # operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+    # It is not an account-takeover primitive the way device.enroll is: document-service verifies
+    # the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+    # forces partyRef from the caller's token and rejects a caller who is not one of the
+    # ceremony's signers, so this grant cannot sign on someone else's behalf.
     allowed_reasons contains "edge-service-notification" if {
     	input.principal.type == "HUMAN"
     	input.principal.id == "service-account-openbank-edge"
-    	some family in {"notification.", "device.", "document."}
+    	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
     }
 

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "aabb5970ba5cccaf"
+        openbank.tech/policy-checksum: "06cf2e3093f20e46"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -183,10 +183,18 @@ allowed_reasons contains "customer-self-action" if {
 # Keycloak service-account token is deterministically "service-account-<clientId>"
 # (verified against a live token from the openbank-edge client, ADR-0065/0034 issue #266)
 # — not forgeable by a human session, which authenticates through a different client.
+#
+# `signatureCeremony.` is here for the same reason `document.` is (#1249): the onboarding
+# agreement is read AND signed through the edge, and recordDecision's verb sits outside
+# operator-read-any's {list, read} set, so signing 403'd while reading the ceremony passed.
+# It is not an account-takeover primitive the way device.enroll is: document-service verifies
+# the signer's evidenceRef against sca-service (SignerVerificationPort, ADR-0021), the edge
+# forces partyRef from the caller's token and rejects a caller who is not one of the
+# ceremony's signers, so this grant cannot sign on someone else's behalf.
 allowed_reasons contains "edge-service-notification" if {
 	input.principal.type == "HUMAN"
 	input.principal.id == "service-account-openbank-edge"
-	some family in {"notification.", "device.", "document."}
+	some family in {"notification.", "device.", "document.", "signatureCeremony."}
 	startswith(input.action, family)
 }
 

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -538,6 +538,36 @@ test_deny_operator_document_read_content if {
 	}
 }
 
+# signatureCeremony.recordDecision — the "Sign with biometrics" tap (ADR-0169 D3). Exactly
+# the document.readContent shape one endpoint further on: the verb is outside
+# operator-read-any's {list, read}, so reading the ceremony passed (signatureCeremony.read
+# slipped through on its name) while signing it 403'd, leaving the sign screen stuck with
+# every tap silently failing. Adding only the document. family in #1249 fixed the read leg
+# and left this one denied.
+test_allow_service_signature_ceremony_record_decision if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "signatureCeremony.recordDecision",
+		"resource": {"type": "signatureCeremony", "id": "c-1"},
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "edge-service-notification"
+}
+
+# The same containment as document.readContent: staff carrying ROLE_OPERATOR must not be
+# able to record a signing decision on a customer's agreement. Signing is the customer's
+# act — this rule is pinned to the edge's client_credentials identity, and a human operator
+# session authenticates through a different client, so it can never match.
+test_deny_operator_signature_ceremony_record_decision if {
+	not rest.allow with input as {
+		"principal": {"id": "alice.operator", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "signatureCeremony.recordDecision",
+		"resource": {"type": "signatureCeremony", "id": "c-1"},
+	}
+}
+
 # The rule must NOT open other action families to the edge M2M caller (deny-by-default
 # holds) — operator-read-any also does not cover a write like party.update.
 test_deny_service_outside_notification_family if {


### PR DESCRIPTION
## Problem

"Sign with biometrics" on the onboarding agreement does nothing — every tap runs the full SCA ceremony and then dies silently. Live, 2026-07-16 13:08, three taps in a row:

```
POST /customer/v1/sca/challenges                      -> 201
POST /customer/v1/sca/challenges/{id}/decision        -> 200
POST /customer/v1/signature-ceremonies/{id}/decisions -> 403   <-- 
```

Confirmed straight against the live OPA sidecar:

```
signatureCeremony.read           -> allow=true   reason=operator-read-any
signatureCeremony.recordDecision -> allow=false  allowed_reasons=[]
```

## Root cause

**Exactly the `document.readContent` shape from #1249, one endpoint further on.**

`edge-service-notification` scopes the edge's M2M identity to the `notification.` / `device.` / `document.` families. `signatureCeremony.` was never among them. And `recordDecision`'s verb sits outside `operator-read-any`'s `{list, read}` set — so `signatureCeremony.read` slipped through **on its name**, while `recordDecision` was denied. Reading the ceremony worked; signing it never could.

#1249 fixed onboarding's *read* leg (the PDF bytes) and left the *sign* leg 403ing, so the same screen is stuck one step later.

## Why this grant is safe

The rule's own comment warns that its families include `device.enroll`, an account-takeover primitive. Signing is not that:

- document-service verifies the signer's `evidenceRef` (the SCA challenge id) against sca-service — `SignerVerificationPort`, ADR-0021;
- the edge forces `partyRef` from the caller's token and rejects a caller who is not one of the ceremony's signers (`CustomerDocumentResource.recordDecision`).

So the grant cannot sign on someone else's behalf. It stays pinned to the edge's `client_credentials` identity, so a real ROLE_OPERATOR staff session can never match — `test_deny_operator_signature_ceremony_record_decision` encodes that, mirroring the containment test #1249 added.

## Blast radius

`rest.rego` is fleet-wide, so all 27 bundles are regenerated (26 carry the rule; the `policy-checksum` annotations roll those pods). Same shape and size as #1249's 46-file diff. I verified the only substantive change across every bundle is the one family line:

```
26 - 	some family in {"notification.", "device.", "document."}
26 + 	some family in {"notification.", "device.", "document.", "signatureCeremony."}
```

Everything else is comments and checksums.

## Verification

- `opa test` — **124/124** (2 new: the allow case and the operator-denied containment case).
- Post-deploy, the real check is the app: tap "Sign with biometrics" and the ceremony records instead of 403ing. I'll confirm on the cluster.

Refs ADR-0169 D3, #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)