### PR TITLE
fix(customer-edge): unwedge ArgoCD — RollingUpdate maxSurge 0, not Recreate

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/redis.yaml
+++ b/openbank-infra/gitops/components/customer-edge/redis.yaml
@@ -27,10 +27,25 @@ metadata:
     app.kubernetes.io/part-of: customer-edge
 spec:
   replicas: 1
-  # Recreate, not the default RollingUpdate: the gp3 PVC below is ReadWriteOnce, so a new pod
-  # would block Pending forever waiting for a volume the outgoing pod still holds.
+  # The gp3 PVC below is ReadWriteOnce, so a replacement pod must never exist alongside the
+  # outgoing one — it would sit Pending forever waiting for a volume the old pod still holds.
+  # maxSurge: 0 enforces exactly that: terminate first, then start.
+  #
+  # `type: Recreate` (the textbook answer, and what reposilite/registry-cache use) is NOT
+  # usable here: this Deployment already exists with Kubernetes' defaulted
+  # `rollingUpdate: {maxSurge: 25%, maxUnavailable: 25%}`, and server-side apply keeps fields
+  # the manifest stops mentioning. The merged object then carries rollingUpdate AND
+  # type: Recreate, which the API server rejects —
+  #   spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
+  # — so ArgoCD cannot even diff, and the WHOLE customer-edge app wedges on ComparisonError
+  # (observed 2026-07-16: PVC stuck Pending, no pod roll, unrelated image bumps blocked).
+  # Recreate would need a manual field delete or Replace=true; staying on RollingUpdate keeps
+  # this purely declarative and is equivalent at replicas: 1.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: redis


### PR DESCRIPTION
## What happened

**My own #1270 wedged the entire customer-edge Application.** Not a subtle failure — everything in that app stopped syncing.

#1270 set `strategy.type: Recreate` on a Deployment that already carries Kubernetes' defaulted `rollingUpdate: {maxSurge: 25%, maxUnavailable: 25%}`. Server-side apply keeps fields a manifest stops mentioning, so the merged object had **both**, which the API server rejects:

```
ComparisonError: Failed to compare desired state to live state: failed to calculate diff:
error calculating server side diff: serverSideDiff error: error running server side apply in
dryrun mode for resource Deployment/redis: Deployment.apps "redis" is invalid:
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

ArgoCD could not compute a diff at all, so **nothing** in the app synced:

- PVC `redis-data` stuck `Pending` for 15+ minutes,
- Redis never rolled onto it (still the 84-minute-old `emptyDir` pod, so #1260 is still live),
- the unrelated customer-edge image bump blocked behind it — which is also why I misread the deploy state earlier.

## Why Recreate looked right

`reposilite` and `registry-cache` both use `type: Recreate` and are fine — because they were **created** with it and never had the defaulted field. Migrating an *existing* Deployment onto Recreate needs a manual field delete or `Replace=true`. I copied the precedent without noticing that difference.

## Fix

`maxSurge: 0` delivers the property that actually mattered: never two pods contending for a ReadWriteOnce volume — terminate first, then start. At `replicas: 1` that is equivalent to Recreate, and it stays purely declarative (no hand-patching the cluster, no `Replace=true` on every future sync).

## The verification gap that let this through

#1270 passed `kubectl apply --dry-run=server` — I checked. That is a **client-side** merge and does not reproduce ArgoCD's server-side apply, which is exactly where the conflict lives. The right check, now run:

```
$ kubectl apply --server-side --force-conflicts --dry-run=server --field-manager=argocd-controller -f redis.yaml
deployment.apps/redis serverside-applied (server dry run)
persistentvolumeclaim/redis-data serverside-applied (server dry run)
service/redis serverside-applied (server dry run)
```

For any app with `ServerSideApply=true`, `--server-side` is the dry-run that counts.

Refs #1260, #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)