### PR TITLE
docs(infra): correct two stale NAT-cost claims that are steering decisions

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -209,10 +209,35 @@ resource "kubectl_manifest" "nodepool_default" {
         consolidationPolicy = "WhenEmptyOrUnderutilized"
         consolidateAfter    = "1m"
         # FinOps: freeze node replacement 20:00–07:00 UTC (overnight).
-        # Karpenter consolidation on idle nodes churn image pulls from ghcr.io /
-        # quay.io over NAT (~100 GB/night, $4-5) because containerd on a fresh
-        # node pulls DaemonSet images before Kyverno ECR-rewrite is active.
         # During the freeze window 0 nodes may be disrupted; outside it, up to 50%.
+        #
+        # ORIGINAL RATIONALE, NOW OBSOLETE — kept because the window is still here and
+        # someone will ask why. It read: "Karpenter consolidation on idle nodes churn
+        # image pulls from ghcr.io / quay.io over NAT (~100 GB/night, $4-5) because
+        # containerd on a fresh node pulls DaemonSet images before Kyverno ECR-rewrite
+        # is active." That was true when written (2026-06-26): a NAT *Gateway* charged
+        # $0.045/GB processed, in both directions.
+        #
+        # It stopped being true four days later. 2026-06-30 replaced the gateway with
+        # `openbank-sandbox-fck-nat`, a t4g.small NAT *instance* — see fck-nat in this
+        # stack. There is now no NAT Gateway in the account at all, so:
+        #   - the $0.045/GB processing charge does not exist;
+        #   - image pulls are INBOUND from the internet, which AWS does not charge.
+        # Measured 2026-07-16 over 14 days (Cost Explorer): NatGateway-Bytes absent
+        # entirely; EUN1-DataTransfer-Out-Bytes $0.63; the only material transfer line is
+        # EUN1-DataTransfer-Regional-Bytes at $32.64 (~$70/mo) — CROSS-AZ, because
+        # fck-nat sits in eu-north-1a while ~2/3 of nodes run in 1b/1c. That is a
+        # different cost with a different fix, and it is mostly pod-to-pod traffic, not
+        # image pulls.
+        #
+        # So this freeze now buys little and costs something: 11h/night of no
+        # consolidation means idle nodes are held until 07:00 UTC, and it is why the
+        # `default` NodePool limit above cannot be raised without a night-surge bill.
+        # DO NOT drop it on the strength of this comment alone — the remaining question
+        # is whether fck-nat (a single t4g.small, cross-AZ for most nodes) can absorb an
+        # unfrozen night's pull burst, which is a throughput question nobody has
+        # measured. Tracked in #1290 along with the last workloads that still need the
+        # NAT path at all (CNPG). Re-evaluate once those are pinned at ECR.
         budgets = [
           # Standard 5-field cron: no disruption 20:00–07:00 UTC daily
           { schedule = "0 20 * * *", duration = "11h", nodes = "0%" },

--- a/openbank-infra/gitops/components/kyverno/ecr-pull-through-rewrite.yaml
+++ b/openbank-infra/gitops/components/kyverno/ecr-pull-through-rewrite.yaml
@@ -18,8 +18,15 @@
 # Not covered here (separate mechanisms):
 #   docker.io  — in-cluster registry-cache via containerd hosts.toml (EC2NodeClass
 #                userData); transparent proxy, no prefix needed.
-#   ghcr.io    — needs GitHub PAT in Secrets Manager; see commented stub in
-#                ecr-pull-through-cache.tf. Left on NAT until creds available.
+#
+# STALE UNTIL 2026-07-16, corrected here: this list used to claim "ghcr.io — needs
+# GitHub PAT in Secrets Manager … Left on NAT until creds available." That has been
+# untrue since 2026-06-14, when the `ghcr` pull-through rule was created — the rule
+# below (rewrite-ghcr) has been rewriting ghcr.io refs ever since, and the cache is
+# populated (e.g. ghcr/jimmidyson/configmap-reload, ghcr/cloudnative-pg/postgresql).
+# #1259 pins alloy's config-reloader straight at ghcr/… and it runs. The note was not
+# harmless: it is the reason nobody moved CNPG off ghcr.io (#1290) — anyone reading it
+# concludes the path does not exist.
 #
 # Exclusion: images already referencing ECR (*.dkr.ecr.*.amazonaws.com) and
 # openbank internal images are never rewritten.
@@ -35,6 +42,13 @@
 # ref end-to-end; it pulls postgres from ghcr.io directly (one image, rarely, mostly
 # node-cached — negligible NAT cost). Applied to all rules: the incompatibility is
 # with image mutation per se, not any one registry.
+#
+# The "negligible" estimate held up when it was finally measured (2026-07-16) — but the
+# conclusion "must pull from ghcr.io directly" does NOT. CNPG owning its ref end-to-end
+# is satisfied by pointing Cluster.spec.imageName at the pull-through
+# (…/ghcr/cloudnative-pg/postgresql:<tag>): no mutation, no drift, no reconcile loop.
+# 70 instance pods x ~281 MB (246 MB postgres + 35 MB bootstrap-controller) still take
+# the NAT path today for no reason other than the stale ghcr note above. See #1290.
 #
 # failurePolicy: Ignore — if Kyverno webhook is down, pods still start (they
 # pull from origin over NAT rather than being blocked). Acceptable for sandbox.


### PR DESCRIPTION
## Linked issues

Refs #1259, #1263, #1290

## Why

Comments only — **no functional change** (every changed line is a comment; `tofu fmt` clean). But both
of these are load-bearing: people and agents read them and conclude the wrong thing. One of them
already blocked a real fix.

## 1. The Karpenter overnight freeze justifies itself with a price that no longer exists

`main.tf` says:

> Karpenter consolidation on idle nodes churn image pulls from ghcr.io / quay.io over NAT
> (~100 GB/night, **$4-5**) …

True when written **2026-06-26** — a NAT **Gateway** charged $0.045/GB processed. It stopped being
true **four days later**: 2026-06-30 replaced it with `openbank-sandbox-fck-nat`, a t4g.small NAT
**instance**. There is now **no NAT Gateway in the account at all**, and image pulls are *inbound*,
which AWS does not charge.

Measured 2026-07-16, 14 days of Cost Explorer:

| usage type | 14d |
|---|---|
| `NatGateway-Bytes` | **absent entirely** |
| `EUN1-DataTransfer-Out-Bytes` | $0.63 |
| `EUN1-DataTransfer-Regional-Bytes` | **$32.64** (~$70/mo) |

The only material line is **cross-AZ** — fck-nat sits in `eu-north-1a` while ~2/3 of nodes run in
1b/1c. Different cost, different fix, and mostly pod-to-pod traffic rather than image pulls.

**The freeze is not removed here.** It still buys something nobody has measured — whether a single
t4g.small absorbs an unfrozen night's pull burst — and its removal has preconditions (#1290). The point
is that the next person should re-derive from facts, not from a price that stopped applying three weeks
ago.

## 2. "ghcr.io is left on NAT" — untrue, and it blocked a fix

`ecr-pull-through-rewrite.yaml` claims:

> `ghcr.io` — needs GitHub PAT in Secrets Manager … Left on NAT until creds available.

Untrue since **2026-06-14**, when the `ghcr` pull-through rule was created. `rewrite-ghcr` has been
rewriting ghcr.io refs ever since, the cache is populated, and #1259 pins alloy's config-reloader
straight at `…/ghcr/jimmidyson/configmap-reload:v0.12.0` — running right now.

**This one was not harmless.** It is why nobody moved CNPG off ghcr.io: anyone reading it concludes the
path does not exist. 70 instance pods × ~281 MB still take the NAT path for that reason alone (#1290).

Also annotated the CNPG exclusion itself. Its *"negligible NAT cost"* estimate **survived
measurement** — but its conclusion, *"must pull from ghcr.io directly"*, does not: `spec.imageName`
satisfies "CNPG owns its ref end-to-end" with no mutation, no drift, and no reconcile loop. The
exclusion stays; only the dead end in its reasoning is corrected.