### PR TITLE
docs: state what actually triggers a release-please release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,14 @@ Before a change is "done", run the ship-checklist (`/ship-check` runs the same c
 ADR-0029):
 
 1. **Open a PR.** No direct commits to `main`. Branch `<type>/<scope>-<summary>`; squash-merge via PR.
-2. **Versioning is automatic.** A change under `<service>/src/main/**` is released by **release-please**
-   from your Conventional Commit — so the commit message *is* the changelog. Do **not** hand-edit
-   `version.txt`, `CHANGELOG.md`, or `quarkus.application.version` (it derives from `version.txt`).
+2. **Versioning is automatic.** A change to **any file under `<service>/`** — except the paths listed
+   in that package's `exclude-paths` (currently `src/test`) — is released by **release-please** from
+   your Conventional Commit, so the commit message *is* the changelog. That includes `governance.yaml`,
+   `Dockerfile`, `build.gradle.kts` and the lint baselines: touch one and the service ships a version.
+   release-please offers no include/allow-list (only `exclude-paths`, and only for **directories** —
+   a single file cannot be excluded), so "only `src/main` releases" is not expressible; treat any
+   package-root edit as release-triggering. Do **not** hand-edit `version.txt`, `CHANGELOG.md`, or
+   `quarkus.application.version` (it derives from `version.txt`).
    A module is a released component **iff** it has a `version.txt` (registered in
    [`release-please-config.json`](release-please-config.json) + [`.release-please-manifest.json`](.release-please-manifest.json)).
 3. **API change ⇒ `openapi.yaml` updated + contract test.** Two independent version axes (ADR-0048):


### PR DESCRIPTION
## Problem

[`CLAUDE.md`](CLAUDE.md) promises:

> A change under `<service>/src/main/**` is released by **release-please** from your Conventional Commit

That is not what happens, and it cannot be made to happen.

release-please has **no include/allow-list**. The only path mechanism is `exclude-paths`, and per [`commit-exclude.ts`](https://github.com/googleapis/release-please/blob/main/src/util/commit-exclude.ts) it matches a **directory prefix**:

```ts
private isRelevant(file: string, path: string) {
  return path === ROOT_PROJECT_PATH || file.indexOf(`${path}/`) === 0;
}
```

An entry pointing at a file (`openbank-devops-agent/governance.yaml`) is compared as `openbank-devops-agent/governance.yaml/` and never matches — it **fails silently**: config parses, CI stays green, the bump still happens. `normalizePaths()` only trims slashes; it does not help.

So "only `src/main` releases" is inexpressible. Today **318 files across all 50 packages** sit at a package root and every one of them cuts a release:

```
governance.yaml  Dockerfile  build.gradle.kts  detekt-baseline.xml
ktlint-baseline.xml  CLAUDE.md  LICENSE  gradlew  settings.gradle.kts  …
```

Touching a lint baseline ships a version of the service.

## Two live examples

- **account-service 0.15.2** shipped crediting `**party-service:** restore @PactBroker…` — [#1166](https://github.com/JiRaska/open-bank-oss/pull/1166) was test-only across four services and cut four releases ([#1219](https://github.com/JiRaska/open-bank-oss/issues/1219)).
- **devops-agent 0.3.2 → 0.4.0** (a *minor*) for a single `governance.yaml` edit in [#1195](https://github.com/JiRaska/open-bank-oss/pull/1195), captioned *"Features: add Verification of Payee backend; give control-plane agents episodic memory"* — a feature it never received.

## Change

Rewrites the rule to describe the tool we actually have: any file under `<service>/` releases it, except that package's `exclude-paths` (`src/test` once [#1277](https://github.com/JiRaska/open-bank-oss/pull/1277) lands), and notes explicitly that a single file cannot be excluded — so nobody tries and quietly gets nothing.

Docs-only. No behavior change. +8/-3 lines; CLAUDE.md stays lean at 240 lines.

## Why not "fix it properly" instead

The alternative was moving those 318 root files into excludable directories (`governance/governance.yaml` etc.) across 50 packages, and chasing every consumer of those paths — CI scripts, the governance manifest, Docker builds. That is a large, risky change driven by a tool limitation rather than by design. Rejected in favour of honest docs; reopen the question if the release noise gets worse.

## Test plan

- [x] Claim verified against release-please source, not inferred: `isRelevant()` requires a `/` boundary; `normalizePaths()` only trims slashes
- [x] Replayed the matching rule on real data — file-exclude → BUMP (no effect), directory-exclude → SKIP
- [x] 318 root files across 50 packages counted from the working tree
- [x] Markdown only; no config or code touched

Refs #1219, #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)
