### PR TITLE
fix(document): refuse to seal with a throwaway cert (ADR-0172 D2)

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
@@ -30,11 +30,20 @@ import java.time.Instant
 import java.util.Calendar
 import java.util.Date
 
-/** A signing identity (private key + leaf cert + full chain) ready to produce a CMS signature. */
+/**
+ * A signing identity (private key + leaf cert + full chain) ready to produce a CMS signature.
+ *
+ * [ephemeral] marks a throwaway self-signed identity from [PadesSigning.generateEphemeralIdentity].
+ * It is carried on the identity rather than left implicit at the call site because the *only* thing
+ * separating a real seal from a legally worthless one is which identity produced it — and an
+ * adapter that has fallen back has no other way to tell downstream. Callers MUST refuse to sign with
+ * an ephemeral identity outside dev; see `PdfBoxPadesSealAdapter.sealPades`.
+ */
 data class SigningIdentity(
     val privateKey: PrivateKey,
     val certificate: X509Certificate,
     val certificateChain: List<X509Certificate>,
+    val ephemeral: Boolean = false,
 )
 
 /**
@@ -96,6 +105,7 @@ object PadesSigning {
             privateKey = keyPair.private,
             certificate = certificate,
             certificateChain = listOf(certificate),
+            ephemeral = true,
         )
     }
 

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
@@ -53,6 +53,24 @@ class PdfBoxPadesSealAdapter(
     // in the deployment env once it is.
     @ConfigProperty(name = "openbank.signature.require-trusted-issuer", defaultValue = "false")
     requireTrustedIssuer: Boolean,
+
+    // The seal-time half of the same gate (ADR-0172 D2), and the one that actually protects evidence.
+    //
+    // `require-trusted-issuer` is a BOOT gate and defaults off on purpose: the rollout order (gitops
+    // env/volume wiring vs. OpenBao KV seeding) must never be able to crash-loop this service. That
+    // is a good constraint — but it left the fallback with nothing stopping it, so a service whose
+    // keystore secret failed to materialise would boot fine, log one WARN, and then happily seal
+    // documents with a throwaway cert. A misconfiguration silently produced legally worthless
+    // evidence that looked successful.
+    //
+    // So this gate is seal-time, not boot-time: booting on an ephemeral identity stays allowed
+    // (rollout-safe), but SIGNING with one does not. Defaults to `false` — fail closed — and is
+    // overridden to `true` only in %dev/%test (application.yaml), so the service is still runnable
+    // out of the box. Any deployment that genuinely wants throwaway seals must say so out loud with
+    // OPENBANK_SIGNATURE_ALLOW_EPHEMERAL_SEALS=true, which is a reviewable line in gitops rather
+    // than an invisible code default.
+    @ConfigProperty(name = "openbank.signature.allow-ephemeral-seals", defaultValue = "false")
+    private val allowEphemeralSeals: Boolean,
 ) : SignatureSealPort {
 
     private val logger = Logger.getLogger(PdfBoxPadesSealAdapter::class.java)
@@ -91,6 +109,20 @@ class PdfBoxPadesSealAdapter(
 
     override suspend fun sealPades(pdf: ByteArray, ceremony: SignatureCeremony): ByteArray =
         withContext(Dispatchers.IO) {
+            // Fail CLOSED before touching the PDF (ADR-0172 D2). An ephemeral identity produces a
+            // signature that is cryptographically well-formed and legally worthless — the failure
+            // mode that matters, because the output looks exactly like success. Refusing here means
+            // the ceremony errors loudly and no false evidence is ever written; the alternative is a
+            // sealed PDF nobody can rely on and nobody noticed.
+            check(!identity.ephemeral || allowEphemeralSeals) {
+                "Refusing to apply an institutional PAdES seal with a DEV-ONLY ephemeral identity: " +
+                    "the resulting signature would be worthless as evidence (self-signed, never " +
+                    "issued by any trusted CA, private key gone on restart). Provision the real " +
+                    "organizational PKCS12 keystore at openbank.signature.keystore-path (seeded into " +
+                    "OpenBao KV per docs/runbooks/0008-openbao-document-signing-pki.md), or set " +
+                    "openbank.signature.allow-ephemeral-seals=true to accept throwaway seals in a " +
+                    "non-production environment. ceremonyId=${ceremony.id}"
+            }
             // Idempotent: don't re-apply the institutional seal if a retry re-enters after the seal
             // was already written but the ceremony's completion failed to persist.
             if (PadesSigning.hasSignatureNamed(pdf, ORGANIZATION_NAME)) {

--- a/openbank-document-service/src/main/resources/application.yaml
+++ b/openbank-document-service/src/main/resources/application.yaml
@@ -103,6 +103,11 @@ quarkus:
         json: false
     oidc:
       enabled: false
+  openbank:
+    signature:
+      # No organizational keystore locally, so the seal falls back to a throwaway cert. Allow it —
+      # a dev seal is not evidence of anything and nobody is relying on it (ADR-0172 D2).
+      allow-ephemeral-seals: true
 "%test":
   quarkus:
     oidc:
@@ -111,6 +116,9 @@ quarkus:
       enabled: false
     management:
       enabled: false
+  openbank:
+    signature:
+      allow-ephemeral-seals: true
 openbank:
   rate-limit:
     enabled: true
@@ -155,6 +163,20 @@ openbank:
     # that then cannot obtain a trusted certificate fails loud (fail-closed) rather than silently
     # producing evidence-worthless output, and the service refuses to boot without a real seal key.
     require-trusted-issuer: ${OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER:false}
+    # ADR-0172 D2 — the seal-time half of the same gate, and the one that protects evidence.
+    #
+    # `require-trusted-issuer` above is a BOOT gate and is off by default on purpose: the rollout
+    # order (gitops env/volume wiring vs. OpenBao KV seeding) must never crash-loop this service.
+    # That left the ephemeral fallback with nothing stopping it — a service whose keystore secret
+    # failed to materialise booted fine, logged one WARN, then sealed documents with a throwaway
+    # cert. Legally worthless output that looks exactly like success.
+    #
+    # So: booting on an ephemeral identity stays allowed; SIGNING with one does not. Fail closed by
+    # default. %dev/%test override to true below so the service is runnable out of the box. Any
+    # environment that genuinely wants throwaway seals must say so out loud with
+    # OPENBANK_SIGNATURE_ALLOW_EPHEMERAL_SEALS=true — a reviewable line in gitops, not an invisible
+    # code default.
+    allow-ephemeral-seals: ${OPENBANK_SIGNATURE_ALLOW_EPHEMERAL_SEALS:false}
 
 mp:
   messaging:

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapterTest.kt
@@ -20,19 +20,22 @@ import java.util.Optional
 import java.util.UUID
 
 /**
- * A configured-but-nonexistent keystore path must fall back to the ephemeral dev identity, not
- * crash boot — this is what makes the gitops rollout order (wiring the volume/env-var before the
- * OpenBao KV secret is actually populated) safe (ADR-0162 D4 continued).
+ * Two gates, deliberately at different points in the lifecycle (ADR-0162 D4, ADR-0172 D2):
+ *
+ *  - **Boot** — a configured-but-nonexistent keystore path falls back to the ephemeral dev identity
+ *    rather than crashing. This is what makes the gitops rollout order (wiring the volume/env-var
+ *    before the OpenBao KV secret is populated) safe, and it must stay that way.
+ *  - **Seal** — but SIGNING with that ephemeral identity fails closed unless explicitly allowed.
+ *    Booting on a throwaway cert is survivable; sealing with one produces legally worthless evidence
+ *    that looks exactly like success, which is the failure mode worth preventing.
  */
 class PdfBoxPadesSealAdapterTest {
 
+    // ---- boot: fallback must not crash (the rollout-order guarantee) -----------------------
+
     @Test
     fun `a nonexistent keystore path falls back to the ephemeral identity instead of throwing`(): Unit = runBlocking {
-        val adapter = PdfBoxPadesSealAdapter(
-            keystorePath = Optional.of("/nonexistent/path/keystore.p12"),
-            keystorePassword = Optional.of("irrelevant"),
-            requireTrustedIssuer = false,
-        )
+        val adapter = adapter(keystorePath = Optional.of("/nonexistent/path/keystore.p12"))
 
         val signed = adapter.sealPades(blankPdf(), ceremony())
 
@@ -43,31 +46,113 @@ class PdfBoxPadesSealAdapterTest {
 
     @Test
     fun `an absent keystore path also falls back to the ephemeral identity`(): Unit = runBlocking {
-        val adapter = PdfBoxPadesSealAdapter(
-            keystorePath = Optional.empty(),
-            keystorePassword = Optional.empty(),
-            requireTrustedIssuer = false,
+        val adapter = adapter(keystorePath = Optional.empty())
+
+        val signed = adapter.sealPades(blankPdf(), ceremony())
+
+        assertThat(Loader.loadPDF(signed).use { it.signatureDictionaries }).hasSize(1)
+    }
+
+    @Test
+    fun `with no usable keystore and the boot guard on, refuses to start (fail-closed)`() {
+        assertThatThrownBy {
+            adapter(keystorePath = Optional.empty(), requireTrustedIssuer = true)
+        }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("require-trusted-issuer")
+    }
+
+    // ---- seal: the gate that protects evidence (ADR-0172 D2) -------------------------------
+
+    @Test
+    fun `sealing with an ephemeral identity fails closed by default`(): Unit = runBlocking {
+        // The real-world shape of this: gitops sets the keystore path, the OpenBao KV was never
+        // seeded, the volume mounts empty. The service boots (above), then must NOT seal.
+        val adapter = adapter(
+            keystorePath = Optional.of("/nonexistent/path/keystore.p12"),
+            allowEphemeralSeals = false,
+        )
+
+        assertThatThrownBy { runBlocking { adapter.sealPades(blankPdf(), ceremony()) } }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("worthless as evidence")
+    }
+
+    @Test
+    fun `the failure names the ceremony and the fix, not just the symptom`(): Unit = runBlocking {
+        val c = ceremony()
+        val adapter = adapter(keystorePath = Optional.empty(), allowEphemeralSeals = false)
+
+        assertThatThrownBy { runBlocking { adapter.sealPades(blankPdf(), c) } }
+            // An operator reading this at 3am needs the ceremony to correlate and the runbook to act.
+            .hasMessageContaining(c.id.toString())
+            .hasMessageContaining("0008-openbao-document-signing-pki")
+    }
+
+    @Test
+    fun `it fails before touching the PDF — no half-sealed output`(): Unit = runBlocking {
+        val pdf = blankPdf()
+        val adapter = adapter(keystorePath = Optional.empty(), allowEphemeralSeals = false)
+
+        runCatching { adapter.sealPades(pdf, ceremony()) }
+
+        // The guard is the first statement in sealPades: a refused seal must leave nothing behind
+        // that a retry or a caller could mistake for a signed document.
+        assertThat(Loader.loadPDF(pdf).use { it.signatureDictionaries }).isEmpty()
+    }
+
+    @Test
+    fun `a real keystore seals regardless of the ephemeral flag`(): Unit = runBlocking {
+        // The gate keys on the IDENTITY being ephemeral, not on the flag alone — a provisioned
+        // keystore must never be blocked by a fail-closed default.
+        val keystore = writeThrowawayKeystore()
+        val adapter = adapter(
+            keystorePath = Optional.of(keystore.toString()),
+            keystorePassword = Optional.of(KEYSTORE_PASSWORD),
+            allowEphemeralSeals = false,
         )
 
         val signed = adapter.sealPades(blankPdf(), ceremony())
 
-        val signatures = Loader.loadPDF(signed).use { it.signatureDictionaries }
-        assertThat(signatures).hasSize(1)
+        assertThat(Loader.loadPDF(signed).use { it.signatureDictionaries }).hasSize(1)
     }
 
-    @Test
-    fun `with no usable keystore and the guard on, refuses to start (fail-closed)`() {
-        // Go-live gate: with require-trusted-issuer set and no real keystore, the bean must refuse
-        // to construct (fail boot) rather than seal with an evidence-worthless ephemeral identity.
-        assertThatThrownBy {
-            PdfBoxPadesSealAdapter(
-                keystorePath = Optional.empty(),
-                keystorePassword = Optional.empty(),
-                requireTrustedIssuer = true,
+    // ---- helpers ---------------------------------------------------------------------------
+
+    private fun adapter(
+        keystorePath: Optional<String>,
+        keystorePassword: Optional<String> = Optional.of("irrelevant"),
+        requireTrustedIssuer: Boolean = false,
+        // Default true so the boot-fallback tests above keep asserting what they were written for;
+        // the seal-gate tests opt out explicitly.
+        allowEphemeralSeals: Boolean = true,
+    ) = PdfBoxPadesSealAdapter(
+        keystorePath = keystorePath,
+        keystorePassword = keystorePassword,
+        requireTrustedIssuer = requireTrustedIssuer,
+        allowEphemeralSeals = allowEphemeralSeals,
+    )
+
+    /**
+     * A PKCS12 on disk holding a non-ephemeral identity. Cryptographically this is still
+     * self-signed — the point is only that it arrives via `loadFromKeystore`, which is what marks it
+     * as not-ephemeral, exactly as a real organizational keystore would.
+     */
+    private fun writeThrowawayKeystore(): java.nio.file.Path {
+        val identity = PadesSigning.generateEphemeralIdentity("Test Org Keystore")
+        val keyStore = java.security.KeyStore.getInstance("PKCS12").apply {
+            load(null, null)
+            setKeyEntry(
+                "seal",
+                identity.privateKey,
+                KEYSTORE_PASSWORD.toCharArray(),
+                identity.certificateChain.toTypedArray(),
             )
         }
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("require-trusted-issuer")
+        val path = java.nio.file.Files.createTempFile("seal-keystore", ".p12")
+        java.nio.file.Files.newOutputStream(path).use { keyStore.store(it, KEYSTORE_PASSWORD.toCharArray()) }
+        path.toFile().deleteOnExit()
+        return path
     }
 
     private fun ceremony() = SignatureCeremony(
@@ -86,5 +171,9 @@ class PdfBoxPadesSealAdapterTest {
             document.save(output)
             return output.toByteArray()
         }
+    }
+
+    private companion object {
+        const val KEYSTORE_PASSWORD = "test-password"
     }
 }

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -109,6 +109,23 @@ spec:
                   name: document-service-signing-keystore
                   key: keystore.password
                   optional: true
+            # ADR-0172 D2 — SANDBOX ONLY, and it is here because the seal is currently worthless.
+            #
+            # Verified live 2026-07-16: the `document-service-signing-keystore` ExternalSecret is
+            # SecretSyncedError / READY=False ("could not get secret data from provider") because the
+            # OpenBao KV path `openbank/document-service-signing-seal` has never been seeded, so
+            # /mnt/signing-keystore/ mounts empty and the adapter falls back to a throwaway
+            # self-signed cert. Every seal applied here is legally worthless.
+            #
+            # The code now fails closed at seal time rather than producing that silently. Without
+            # this opt-in, signature ceremonies in the sandbox would start erroring — which is
+            # CORRECT, but would take out the demo without warning. So the fail-open is kept, and
+            # moved from an invisible code default to this reviewable line.
+            #
+            # REMOVE THIS once the KV is seeded per docs/runbooks/0008-openbao-document-signing-pki.md.
+            # It is the only thing standing between the sandbox and real (self-signed org) seals.
+            - name: OPENBANK_SIGNATURE_ALLOW_EPHEMERAL_SEALS
+              value: "true"
             # Datasource: single document-service-db (document-service-db.yaml).
             # Reactive URL for the app (Panache); JDBC URL for Flyway. Both
             # username/password variants set, matching the billing-service pattern.


### PR DESCRIPTION
## Summary

`PdfBoxPadesSealAdapter` silently produced **legally worthless PAdES seals** whenever its keystore was missing: it fell back to an ephemeral self-signed cert, logged one `WARN`, and sealed happily. The output is cryptographically well-formed and evidentially void — the failure mode that matters, because it looks exactly like success.

**This is live, not hypothetical.** Verified against the sandbox (see below). ADR-0172 D2.

## Type of change

- [x] fix (bug fix)
- [x] security (a control that silently did not hold)
- [ ] feat / refactor / perf / docs / chore / breaking

## Linked issues

Refs #1296 (the actual fix: seed the OpenBao KV — this PR is the code half)
Refs ADR-0172 D2, ADR-0162 D4

## The evidence

```
$ kubectl get externalsecret document-service-signing-keystore -n documents
document-service-signing-keystore   vault-kv   1h   SecretSyncedError   False
                                                    "could not get secret data from provider"

$ kubectl exec -n documents document-service-... -- ls -la /mnt/signing-keystore/
total 0
```

The OpenBao KV path `openbank/document-service-signing-seal` has never been seeded (manual, out-of-band per runbook 0008). Secret never materialises → volume is `optional: true` → mounts empty → `Files.exists(...)` false → ephemeral fallback. The service is `2/2 Running`; the `WARN` has not fired only because the bean is `@ApplicationScoped` (lazy) and no ceremony has run since the pod started **37 minutes ago**.

## Why not just flip `require-trusted-issuer`

That is the obvious fix and it is wrong today: **it would crash-loop document-service**, because the KV is unseeded. And the default-off is deliberate — the adapter's own comment states the constraint:

> Rollout order (infra wiring vs. secret population) must never be able to crash-loop this service.

That constraint is right. The bug is that honouring it left the *seal* completely unguarded.

## What changed

**The gate moves from boot time to seal time.** Booting on an ephemeral identity stays allowed (rollout-safe, constraint honoured); **signing** with one does not.

- `SigningIdentity` carries `ephemeral`. Which identity produced a seal is the only thing separating real evidence from worthless evidence, and the adapter had no way to tell downstream.
- The check is the **first statement** in `sealPades`, so a refused seal leaves no half-written PDF a retry could mistake for signed output.
- Fails closed by default. `%dev`/`%test` opt in, so the service stays runnable out of the box.
- **Sandbox gets an explicit `OPENBANK_SIGNATURE_ALLOW_EPHEMERAL_SEALS=true` in gitops.** Without it, ceremonies there would start erroring — which is *correct*, but would take out the demo unannounced. The fail-open is preserved and **moved from an invisible code default to a reviewable line** that states why it exists and what removes it.

## Definition of Done

- [x] Hexagonal layering preserved — `check-domain-purity`: 0 new.
- [x] Unit tests added/updated — 7 in `PdfBoxPadesSealAdapterTest`, 0 failures.
- [ ] Integration / contract tests — N/A.
- [x] `:openbank-document-service:build` passes (ktlint + detekt + kover + test).
- [x] No new lint warnings.
- [ ] OpenAPI / Flyway / Avro — N/A, no API, schema or event change.
- [x] Docs — the rationale lives in the adapter and `application.yaml` next to the flags; ADR-0172 D2 already owns the decision.

## Security checklist

- [x] No secrets, tokens, passwords, or PII. The test writes a throwaway PKCS12 to a temp file with a literal test password; no real key material anywhere.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [x] **Crypto / signing code changed → `security-review-required`.**
- [ ] PII path changed — no.
- [ ] Cardholder data — no.

## Compliance impact

- [x] **eIDAS / ADR-0162** — this is the whole point. Seals were void; now they either hold or fail loudly. Note this closes the gap between *worthless* and *advanced* (AdES) — **not** between advanced and qualified. Per ADR-0172 §5 there is still no HSM, and the document-signing root is a self-generated in-cluster RSA-2048 with a 10y TTL and no CRL/OCSP.
- [x] DORA Art. 9 — a protection control that did not hold.
- [ ] PCI DSS / GDPR / PSD2 / AML / CNB / None

## Rollout / Rollback

- **Deployment strategy:** canary, as any document-service change. **No behaviour change in the sandbox** — the explicit gitops opt-in preserves today's (worthless-seal) behaviour deliberately, so the demo does not break on deploy.
- **Rollback plan:** revert. Seals return to silently-worthless.
- **Data migration reversible:** N/A.

## Reviewer notes

**The tests are proven, not assumed.** I neutered the guard (`check(true)`) and re-ran: **4 of 7 tests fail**. A test that passes whether or not the fix is present is worse than no test, and this class of guard is exactly where that happens.

**The judgement call worth challenging:** I kept the sandbox fail-open via an explicit env var rather than letting ceremonies start erroring. The argument for erroring is purity — the seals *are* worthless and arguably should fail. The argument for the opt-in, which I took, is that silently breaking a demo to make a point is a bad trade when the same protection lands with a visible line that names its own removal condition. If you would rather the sandbox fail closed now, delete that env block and #1296 becomes urgent rather than tracked.

**What this does not fix:** the KV is still unseeded. This PR stops the lie; #1296 makes the seals real.
