### PR TITLE
fix(document): warn about the DEV-ONLY seal identity at startup, not at first use

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PdfBoxPadesSealAdapter.kt
@@ -6,6 +6,7 @@ package com.openbank.document.infrastructure.render
 
 import com.openbank.document.application.port.out.SignatureSealPort
 import com.openbank.document.domain.model.SignatureCeremony
+import io.quarkus.runtime.Startup
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -38,6 +39,13 @@ import java.util.Optional
  * neither requires that sign-off — and its key custody model (file-based PKCS12, or an ephemeral
  * in-memory cert) is explicitly *not* HSM-backed.
  */
+// @Startup, not merely @ApplicationScoped: this bean's init decides whether the seal identity is a
+// real organizational one or a DEV-ONLY ephemeral throwaway, and says so in a loud warning. A
+// CDI-lazy bean would defer that decision — and the warning — to the FIRST signature ceremony, which
+// is the one moment it is too late to be a warning: until then the log is clean and the service
+// reports UP, so nothing tells an operator the seals it is about to apply are worthless as evidence.
+// It is also what makes require-trusted-issuer a boot gate rather than a first-request gate.
+@Startup
 @ApplicationScoped
 class PdfBoxPadesSealAdapter(
     @ConfigProperty(name = "openbank.signature.keystore-path")


### PR DESCRIPTION
`PdfBoxPadesSealAdapter`'s `init` decides whether the PAdES seal identity is a real organizational one or a DEV-ONLY ephemeral throwaway, and warns loudly that

> every PAdES seal applied while this warning fires is worthless as evidence (the private key vanishes on restart and was never issued by any trusted CA)

The class carried only `@ApplicationScoped`. Quarkus creates such beans lazily via a client proxy, so that `init` — and the warning — did not run until the **first signature ceremony**.

## Observed

document-service is currently running on the sandbox with **no signing keystore** — its OpenBao KV key `document-service-signing-seal` is unpopulated (#1284). Its entire startup log, on two consecutive pods:

```
$ kubectl -n documents logs <pod> -c document-service | grep -ci "ephemeral|DEV-ONLY|worthless"
0        # out of 23 log lines
```

An operator sees a clean log and `status: UP`. Nothing suggests the service will seal with a throwaway certificate. The warning arrives at the first real ceremony — the one moment it is too late to be a warning.

## The gate was quietly weakened too

`require-trusted-issuer` is documented as *"the service refuses to start with a DEV-ONLY ephemeral seal identity — better to fail boot than to apply seals that are worthless as evidence"*. But a lazily-created bean throws its `check()` on the **first request**, not at boot — so once that flag is flipped, the deploy would go green and the failure would surface later, on a request, rather than as a failed rollout.

`@Startup` makes both promises true: the identity decision, the warning, and the gate all happen at boot.

## Scope

One import, one annotation, and a comment recording why it must not be dropped back to plain `@ApplicationScoped`. No behaviour changes when a real keystore is present.

Deliberately **not** in this PR:
- Populating the Vault key — that is signing key material and a human decision (#1284).
- Setting `OPENBANK_SIGNATURE_REQUIRE_TRUSTED_ISSUER=true` — belongs with the key, and would be wrong to set while the key is still missing.
- Removing `optional: true` from the gitops secret refs — that is deliberate and documented; removing it would reintroduce exactly the crash-loop the design prevents. See my correction on #1284.

## Verification

- `:openbank-document-service:test --tests '*PdfBoxPadesSealAdapterTest*' ktlintCheck detekt` — green.
- `quarkusBuild` passes, so ArC accepts the wiring (CDI failures only surface there, not in unit tests).
- The existing unit tests construct the adapter directly and already cover `requireTrustedIssuer`, so they are unaffected — `@Startup` only governs *when* CDI instantiates it.

**Being straight about the limit:** eager instantiation is a CDI runtime behaviour, and I could not prove it locally — no unit test can observe it, and document-service has no boot-smoke IT. The real acceptance check is post-deploy: a rolled pod must log the ephemeral-identity warning at startup. That is exactly the condition that is failing today, so it is a clean before/after.

Refs #1284