### PR TITLE
fix(infra): regenerate 21 stale OPA bundles so four-eyes matches rules.yaml

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "f23d7e86bc3ae564"
+    openbank.tech/policy-checksum: "4a45c174e034e8ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -419,6 +421,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -854,6 +872,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1003,6 +1360,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1164,12 +1585,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1195,6 +1635,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1255,6 +1712,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1385,7 +1873,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1398,16 +1886,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f23d7e86bc3ae564"
+        openbank.tech/policy-checksum: "4a45c174e034e8ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "e3ebf01c1fd8716e"
+    openbank.tech/policy-checksum: "01b743303274e6cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -362,6 +364,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -797,6 +815,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -946,6 +1303,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1107,12 +1528,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1138,6 +1578,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1198,6 +1655,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1328,7 +1816,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1341,16 +1829,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e3ebf01c1fd8716e"
+        openbank.tech/policy-checksum: "01b743303274e6cb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "001169d06e2744a0"
+    openbank.tech/policy-checksum: "7c72db1d50fc03b4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -463,6 +465,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -898,6 +916,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1047,6 +1404,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1208,12 +1629,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1239,6 +1679,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1299,6 +1756,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1429,7 +1917,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1442,16 +1930,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "001169d06e2744a0"
+        openbank.tech/policy-checksum: "7c72db1d50fc03b4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "784fb21b0d5e46e3"
+    openbank.tech/policy-checksum: "2b6a9e5feb1fa1fb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -368,6 +370,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -803,6 +821,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -952,6 +1309,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1113,12 +1534,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1144,6 +1584,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1204,6 +1661,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1334,7 +1822,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1347,16 +1835,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "784fb21b0d5e46e3"
+        openbank.tech/policy-checksum: "2b6a9e5feb1fa1fb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "38cd3193efa28693"
+    openbank.tech/policy-checksum: "46910f4920421e0d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -402,6 +402,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -837,6 +853,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -999,16 +1354,56 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
@@ -1221,6 +1616,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1442,7 +1854,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1455,16 +1867,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "38cd3193efa28693"
+        openbank.tech/policy-checksum: "46910f4920421e0d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "9ce5bdce9bbab509"
+    openbank.tech/policy-checksum: "61fc22473f673876"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -203,9 +203,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -222,11 +223,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -331,6 +333,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -609,16 +627,56 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
@@ -781,12 +839,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -812,6 +889,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -872,6 +966,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1002,7 +1127,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1015,16 +1140,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
@@ -1810,5 +1947,344 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   manifest.json: |
     {"roots": ["openbank/agents", "openbank/copilot", "openbank/rest", "agents", "rules"]}

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9ce5bdce9bbab509"
+        openbank.tech/policy-checksum: "61fc22473f673876"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "f26ee191275191e9"
+    openbank.tech/policy-checksum: "37a700d8cdcffd79"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -379,6 +381,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -814,6 +832,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -963,6 +1320,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1124,12 +1545,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1155,6 +1595,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1215,6 +1672,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1345,7 +1833,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1358,16 +1846,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f26ee191275191e9"
+        openbank.tech/policy-checksum: "37a700d8cdcffd79"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "7586fafec5231bba"
+    openbank.tech/policy-checksum: "c65f42f08fa2d73a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -432,6 +432,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -867,6 +883,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1029,16 +1384,56 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
@@ -1251,6 +1646,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1472,7 +1884,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1485,16 +1897,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7586fafec5231bba"
+        openbank.tech/policy-checksum: "c65f42f08fa2d73a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "2706acf959b61427"
+    openbank.tech/policy-checksum: "1d261a3552b744b2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -364,6 +366,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -799,6 +817,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -948,6 +1305,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1109,12 +1530,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1140,6 +1580,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1200,6 +1657,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1330,7 +1818,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1343,16 +1831,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2706acf959b61427"
+        openbank.tech/policy-checksum: "1d261a3552b744b2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "75ddda455fdbab69"
+    openbank.tech/policy-checksum: "301792c1cf6ea0d1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -477,6 +479,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -912,6 +930,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1061,6 +1418,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1222,12 +1643,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1253,6 +1693,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1313,6 +1770,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1443,7 +1931,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1456,16 +1944,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "75ddda455fdbab69"
+        openbank.tech/policy-checksum: "301792c1cf6ea0d1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "f09136eaa0f32e68"
+    openbank.tech/policy-checksum: "f2906db2da7553e6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -432,6 +434,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -867,6 +885,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1016,6 +1373,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1177,12 +1598,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1208,6 +1648,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1268,6 +1725,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1398,7 +1886,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1411,16 +1899,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f09136eaa0f32e68"
+        openbank.tech/policy-checksum: "f2906db2da7553e6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "2def8bbead9b9e1c"
+    openbank.tech/policy-checksum: "838a6bb8c479033f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -377,6 +379,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -812,6 +830,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -961,6 +1318,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1122,12 +1543,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1153,6 +1593,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1213,6 +1670,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1343,7 +1831,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1356,16 +1844,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "caaacf5b02b50aae"
+    openbank.tech/policy-checksum: "605d9a810c0ac261"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -422,6 +424,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -857,6 +875,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1006,6 +1363,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1167,12 +1588,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1198,6 +1638,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1258,6 +1715,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1388,7 +1876,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1401,16 +1889,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "72c02de1f8e33e89"
+    openbank.tech/policy-checksum: "956e2ede512efe62"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -407,6 +409,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -842,6 +860,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -991,6 +1348,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1152,12 +1573,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1183,6 +1623,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1243,6 +1700,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1373,7 +1861,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1386,16 +1874,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "f88fd5107d94241d" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "b72730a3548afc0f" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -374,7 +374,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b0bea30249bb414"
+        openbank.tech/policy-checksum: "5b72d9728a185701"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -727,7 +727,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "72c02de1f8e33e89" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "956e2ede512efe62" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1050,7 +1050,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8e2e42f5b990936a"
+        openbank.tech/policy-checksum: "d939e7fb63bf7466"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1365,7 +1365,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "caaacf5b02b50aae" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "605d9a810c0ac261" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2036,7 +2036,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c899f3a01905dac9" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "c333cc79d9d3d0fd" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2436,7 +2436,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d181a833e54577b1"
+        openbank.tech/policy-checksum: "6f0d210c269ab3e9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8e2e42f5b990936a"
+    openbank.tech/policy-checksum: "d939e7fb63bf7466"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -380,6 +382,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -815,6 +833,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -964,6 +1321,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1125,12 +1546,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1156,6 +1596,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1216,6 +1673,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1346,7 +1834,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1359,16 +1847,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8b0bea30249bb414"
+    openbank.tech/policy-checksum: "5b72d9728a185701"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -401,6 +403,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -836,6 +854,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -985,6 +1342,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1146,12 +1567,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1177,6 +1617,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1237,6 +1694,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1367,7 +1855,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1380,16 +1868,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c899f3a01905dac9"
+    openbank.tech/policy-checksum: "c333cc79d9d3d0fd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -381,6 +383,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -816,6 +834,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -965,6 +1322,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1126,12 +1547,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1157,6 +1597,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1217,6 +1674,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1347,7 +1835,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1360,16 +1848,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d181a833e54577b1"
+    openbank.tech/policy-checksum: "6f0d210c269ab3e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -384,6 +386,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -819,6 +837,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -968,6 +1325,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1129,12 +1550,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1160,6 +1600,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1220,6 +1677,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1350,7 +1838,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1363,16 +1851,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f88fd5107d94241d"
+    openbank.tech/policy-checksum: "b72730a3548afc0f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -437,6 +439,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -872,6 +890,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -1021,6 +1378,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1182,12 +1603,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1213,6 +1653,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1273,6 +1730,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1403,7 +1891,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1416,16 +1904,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "a89814850a6e9403"
+    openbank.tech/policy-checksum: "9a054726a6fe3590"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -370,6 +370,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -805,6 +821,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -967,16 +1322,56 @@ data:
         require:
           - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
         gate: event-consumer-liveness
-        enforced: advisory
-        target_enforce_date: "2026-09-15"   # ADR-0144
-        # CI producer is LIVE (advisory): .github/scripts/check-event-consumer-liveness.py runs in
-        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), findings are
-        # ::warning annotations. First scan (2026-07-13): 19 producer-only topics found, ALL still
-        # unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved by fiat).
-        # Flip to enforced once triage brings unallowlisted violations to zero = pass --enforce to
-        # the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
-        blocked_on: "19 pre-existing producer-only topics need individual triage (real gap vs. legitimate allowlist entry) before this can graduate to enforce — tracked as a fleet-sweep issue, not yet filed"
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
         ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
         allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
@@ -1189,6 +1584,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1410,7 +1822,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1423,16 +1835,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a89814850a6e9403"
+        openbank.tech/policy-checksum: "9a054726a6fe3590"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "266f1233bb8be714"
+    openbank.tech/policy-checksum: "5451b8d472bfc50b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -202,9 +202,10 @@ data:
     # sanctions.create directly, once AUTHZ_ENFORCE=true.
     #
     # Deliberately action-scoped to sanctions.create ONLY, not a "sanctions." family prefix:
-    # sanctions.review (dismiss/confirm a hit) and the list-refresh actions are real operator
-    # judgment calls, not a service-to-service compliance check, and must stay behind a human
-    # session — widening this to the family would let any M2M caller self-clear a sanctions hit.
+    # sanctions.clear (renamed from sanctions.review, issue #938 follow-up — dismiss/confirm a
+    # hit) and the list-refresh actions are real operator judgment calls, not a service-to-service
+    # compliance check, and must stay behind a human session — widening this to the family would
+    # let any M2M caller self-clear a sanctions hit.
     #
     # Deliberately NOT scoped to one hardcoded client id (unlike edge-service-notification):
     # sanctions.create is "run a compliance check" — not an account-takeover primitive like
@@ -221,11 +222,12 @@ data:
     	input.action == "sanctions.create"
     }
 
-    # NOTE: sanctions.create is not the only resourceless M2M `*.create` action with this
-    # gap — ledger.create, fx.create, lending.create, settlement.create, and others share the
-    # same shape and have the same live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false
-    # exposure. Each needs its own case-by-case rule (some may not be safe for any M2M caller
-    # the way sanctions.create is) — tracked separately as issue #750, not folded in here.
+    # NOTE: sanctions.create is not the only resourceless M2M `*.create`-shaped action with
+    # this gap — ledger.create, fx.convert (renamed from fx.create, issue #938 follow-up),
+    # lending.create, settlement.create, and others share the same shape and have the same
+    # live "advisory: would DENY" masked-by-AUTHZ_ENFORCE=false exposure. Each needs its own
+    # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
+    # — tracked separately as issue #750, not folded in here.
 
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
@@ -404,6 +406,22 @@ data:
 
     # Every tools.allow / tools.deny pattern across the agent's charter(s) -- factored out so
     # charter_allowed and rest_action_allowed don't each re-walk `some a in charter` themselves.
+    #
+    # SCHEMA NOTE: this only matches charters whose tools.allow/deny are a flat list of pattern
+    # STRINGS (compliance-officer, ledger-domain-engineer, ui-assistant, rca-investigator,
+    # customer-copilot). The standalone background/control-plane agents (finops-agent, devops-agent,
+    # control-liveness-sentinel, governance-auditor, release-steward, docs-truth-agent,
+    # authz-policy-auditor, flaky-test-hunter) instead declare tools.allow as a list of
+    # `{tier, resources}` objects -- `some pattern in a.tools.allow` binds `pattern` to the whole
+    # object for those charters, which glob_match can never match against a string tool name, so
+    # charter_allowed is always false for them here. This is intentionally NOT a security gap
+    # (default-deny fails closed, not open) -- it is simply inert: none of those services call the
+    # MCP /tools/call endpoint this package gates at all (confirmed: no reference to it in any of
+    # their source trees). Their real, live authorization is the standard `@RolesAllowed` REST
+    # security on each service's own endpoints. Their `agents.yaml` charter today documents intent
+    # for governance/audit purposes, not a runtime-enforced grant -- same as every charter's
+    # `requires_human` block, which no code path reads either. Wiring the tier+resources shape into
+    # a live decision here is future work if/when these services are ever fronted by the MCP gateway.
     allowed_or_denied_patterns := {
     	"allow": {pattern |
     		some a in charter
@@ -839,6 +857,345 @@ data:
         compliance:
           eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
           dora: "ICT change management (Art. 8–10); operational resilience via proactive pipeline monitoring"
+
+      - id: control-liveness-sentinel
+        plane: control
+        charter: "ADR-0163"
+        description: >
+          Fleet-wide correlator for the ADR-0160 liveness/drift-detection mechanisms — watches
+          WorkflowLivenessWatchdog heartbeat gauges, the event-consumer-liveness and lineage-vs-code
+          CI gate reports, and reconciliation drift-SLA windows. Surfaces a stale-or-silent control
+          as a finding before it pages, and proposes a durable fix (a code/IaC PR wiring an
+          unmonitored job into the watchdog, or a tracking ticket) through the HITL queue. Never
+          writes to a control directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "03:00 UTC"
+          reactive: goalert-webhook       # triggered when a WorkflowLivenessWatchdog gauge itself pages
+        data_scope:
+          read:
+            - prometheus-query-readonly   # openbank_workflow_liveness_last_success_age_seconds gauges
+            - read.governance             # rules.yaml advisory allowlists (mechanisms 1/2), ADR-0160
+          pii: none                       # control-heartbeat / CI-gate metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [prometheus, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens code/IaC diff PRs or draft.ticket only; no write
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any control ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_control_or_pipeline_change  # HITL mandatory; a human merges every proposal
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 6
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - control_mechanism_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide correlator for ADR-0160's detection controls"
+
+      - id: governance-auditor
+        plane: control
+        charter: "ADR-0164"
+        description: >
+          Post-hoc auditor of merged-PR governance compliance. For every PR merged to main, re-verifies
+          via the GitHub API that rules.yaml's own review rules were actually followed: approval count
+          vs. the money-path/default requirement, docs/threat-models/<service>.md presence for a
+          money-path change, merge-commit GPG verification, a linked issue in the PR body, and
+          (best-effort) an admin/override-flag bypass. Proposes a compliance-incident ticket through
+          the HITL queue for a human to triage — a violation on an already-merged PR is a human
+          decision, not a diff. Never merges, approves or re-runs anything.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "04:30 UTC"
+          reactive: pr-merged-webhook     # triggered per PR merge to main — this agent's natural trigger,
+                                          # unlike the alert-driven goalert-webhook its siblings use
+        data_scope:
+          read:
+            - github-prs-readonly        # merged-PR metadata: reviews, merge-commit verification, body, labels
+            - read.governance            # rules.yaml review + money_path_services — the compliance bar itself
+          pii: none                       # PR/review metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [github, governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any PR/review/merge ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_compliance_incident       # HITL mandatory; a human triages every finding
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - approver_must_differ_from: author     # segregation of duties
+          - record: reason                         # approve/reject reason -> audit
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 24                # one per merge is common; daily catch-up sweep is one more
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - governance_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 governance and organisation — re-verifies the repo's own change-control governance was followed"
+
+      - id: release-steward
+        plane: control
+        charter: "ADR-0165"
+        description: >
+          Periodic guardian of the release-please / version-axis invariants. Checks
+          release-please-config.json vs .release-please-manifest.json lockstep, admin-ui
+          package.json vs version.txt sync, a fleet-wide scan for services that set
+          quarkus.application.version explicitly (proactively, ahead of the reactive
+          check-app-version-override.sh CI gate), and open-PR openapi.yaml:info.version
+          collision detection across every open PR touching a spec. Proposes a triage ticket
+          for judgment-call drift (manifest baseline, version-sync side, which racing PR
+          re-bumps) and, for the one mechanically fixable case (an explicit
+          quarkus.application.version key), a scaffold PR through the HITL queue. Never
+          edits version.txt, merges a release-please PR, or writes to openapi.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          daily: "05:00 UTC"
+          reactive: release-please-merge-webhook   # triggered by every release-please PR merge —
+                                                    # this agent's natural trigger, the moment
+                                                    # incidents 1/2 have historically been introduced
+        data_scope:
+          read:
+            - read.governance             # release-please-config.json, .release-please-manifest.json,
+                                           # per-service application.yaml (repo-checkout reads)
+            - github-prs-readonly         # open PRs touching any openapi.yaml, for the collision check
+          pii: none                       # release/version metadata only; no customer data in scope
+        tools:
+          allow:
+            - tier: read
+              resources: [governance, github]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a mechanical fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to version.txt/openapi.yaml/manifest ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_release_or_version_drift  # HITL mandatory; a human picks the correct baseline/side
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 12                # daily sweep + one per release-please merge is common
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - release_invariant_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 24 testing of ICT systems — fleet-wide re-verification for the repo's own release-engineering invariants"
+
+      - id: docs-truth-agent
+        plane: control
+        charter: "ADR-0166"
+        description: >
+          Periodic ADR-status-vs-code drift detector. On a weekly sweep plus reactively when any
+          docs/adr/*.md file changes, greps every ADR's Delivery-Status: line against the code/
+          service/class/config key it names: a Shipped/Complete ADR whose named artifact doesn't
+          exist or isn't wired up, a Planned/Partial ADR whose fully-built implementation already
+          exists unmentioned (the ADR-0139/ADR-0140 feature-store incident), and a mismatch between
+          an ADR's or doc's "enforced" claim and rules.yaml's own gate-graduation enforced flag.
+          Findings are almost always a tracking ticket — correcting an ADR's substantive content is
+          a human judgment call — with a rare mechanical PR reserved for the one unambiguous case:
+          flipping just the Delivery-Status: line, nothing else in the file. Never edits ADR
+          decision content, merges a PR, or writes to rules.yaml.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "06:00 UTC"
+          reactive: adr-merge-webhook       # triggered by any merged change under docs/adr/*.md
+        data_scope:
+          read:
+            - read.governance             # docs/adr/*.md Delivery-Status lines, rules.yaml enforced flags,
+                                           # and a grep-based existence check of the artifacts they name
+          pii: none                       # ADR prose and repo file/grep metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket (primary) or, rarely, a Delivery-Status-only fix PR
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any ADR's decision content or rules.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_adr_status_correction     # HITL mandatory; a human reads the ADR and the code to judge the correct status
+          - every: proposal               # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 4                 # weekly sweep + occasional ADR-merge reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - adr_status_drift_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection — fleet-wide re-verification that architectural decision records still match the code they describe"
+
+      - id: authz-policy-auditor
+        plane: control
+        charter: "ADR-0167"
+        description: >
+          Static analyzer for the fleet's OPA/Rego authorization policies (rest.rego, agents.rego,
+          copilot_tool.rego) and the agents.yaml charters that feed them. Cross-references every rule
+          condition against AuthorizeInterceptor's actual emitted principal-type/id vocabulary: a rule
+          gated on a classification value the interceptor never emits, an agent-id comparison missing
+          the trim_prefix normalization the REST bridge path needs, an agents.yaml charter's
+          tools.allow/deny drifting from the tool_tiers registry, and a REST rule bypassing
+          agents.allow by calling charter_allowed directly. Proposes a tracking ticket through the
+          HITL queue for every finding -- this agent never opens a fix PR, even for the fleet's usual
+          "one narrow mechanical case," because a wrong auto-fix on an authorization rule is a live
+          security exposure. Never writes to a .rego policy or agents.yaml directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "07:00 UTC"
+          reactive: policy-source-changed-webhook   # triggered when any .rego policy or agents.yaml changes
+        data_scope:
+          read:
+            - read.governance             # openbank-infra/opa/policies/*.rego, openbank-libs/governance/
+                                           # policies/*.rego, agents.yaml, and AuthorizeInterceptor.kt via
+                                           # a repo checkout
+          pii: none                       # policy source text and rule metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket ONLY -- never a fix PR (ADR-0167 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any .rego policy or agents.yaml ever
+            - tier: execute
+              resources: ["*"]
+        requires_human:
+          - any_authz_policy_finding      # HITL mandatory; a human reads the rego/charter diff and the
+                                           # code path it gates before anything changes
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+          - two_person_review: authz_policy_findings   # stricter than every sibling agent's single-
+                                           # approval HITL gate (mirrors rules.yaml review.
+                                           # money_path_approvals: 2): a wrong disposition of an
+                                           # authz-policy finding is a live security exposure, not a
+                                           # documentation/cost/release nit, so this charter asks for a
+                                           # second reviewer before a finding is closed out
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional policy-source-changed reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - authz_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that authorization-policy rules can actually fire as intended"
+
+      - id: flaky-test-hunter
+        plane: development
+        charter: "ADR-0168"
+        description: >
+          Static analyzer for fleet-wide silent-test-failure patterns in Kotlin test sources.
+          Generalizes the check-test-runblocking-unit.sh CI guard (expression-body test functions
+          using runBlocking/runTest/GlobalScope.launch/GlobalScope.async without an explicit ': Unit'
+          return type, which JUnit5 silently drops instead of running) beyond its one hardcoded
+          builder, flags Pact provider verification tests gated on pactbroker.url (always skipped by
+          a local './gradlew test' run) and any provider with two colliding @Provider test classes,
+          and cross-checks declared-vs-executed @Test counts per module. Proposes a tracking ticket
+          through the HITL queue for nearly every finding -- guessing wrong on a fix here (suspend fun
+          vs ': Unit', which @Provider class should own an interaction) risks silently masking a real
+          bug instead of fixing it. Never writes to a test file directly.
+        enabled: true
+        enforcement: block
+        schedule:
+          weekly: "08:00 UTC"
+          reactive: ci-test-suite-failure-webhook   # triggered when a CI test-suite run reports a failure
+        data_scope:
+          read:
+            - read.governance             # every module's src/test/kotlin tree, .github/scripts/*.sh CI
+                                           # guard scripts, and build/test-results/test/*.xml JUnit
+                                           # reports via a repo checkout
+          pii: none                       # test source text and JUnit report metadata only; no customer data
+        tools:
+          allow:
+            - tier: read
+              resources: [governance]
+            - tier: write_proposal
+              resources: [github-pr]      # opens draft.ticket by default; gh.pr.open stays wired but is
+                                           # rarely used (ADR-0168 Decision)
+          deny:
+            - tier: write
+              resources: ["*"]            # explicit: no direct write to any test file ever
+            - tier: execute
+              resources: ["*"]            # never invokes a build/test run itself
+        requires_human:
+          - any_flaky_test_finding        # HITL mandatory; a human reads the test's intent before a fix lands
+          - every: proposal                 # segregation of duties: agent proposes, human disposes
+        limits:
+          tokens_per_run: 50000
+          runs_per_day: 8                 # weekly sweep + occasional CI-test-suite-failure reactive runs
+          kill_switch: true
+        audit:
+          capture:
+            - model_id
+            - prompt_hash
+            - tool_calls
+            - policy_decision
+            - findings_detected
+            - flaky_test_check_type_impacted
+            - human_approved_by
+        compliance:
+          eu_ai_act: "Art. 9 — risk management; Art. 13 — transparency; proposal-only, not Annex III high-risk"
+          dora: "Art. 9 ICT risk detection; Art. 5 ICT risk management framework — fleet-wide static verification that a test suite's reported green state reflects tests that actually ran"
   rules-data.yaml: |
     # SPDX-License-Identifier: Apache-2.0
     # Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
@@ -988,6 +1345,70 @@ data:
         # (removed/renamed props, type changes, non-nullable-no-default additions = replay break,
         # eventType renames) and *.avsc files (field default rules). Flip to enforced = --enforce.
         ci_producer: ".github/scripts/check-event-schema-compat.py"
+      event_consumer_liveness:
+        # ADR-0160 mechanism 1. standing-order-service published standing-order.due.v1 every day
+        # for weeks with zero consumers anywhere in the fleet — full CRUD, passing tests, docs, a
+        # scheduler doc-comment claiming a downstream consumed it — and nothing checked the claim
+        # against the actual fleet (issue #889). This is a fleet-wide scan, not diff-scoped: any
+        # Kafka topic published by ANY service's mp.messaging.outgoing (or dispatched via an
+        # outbox to a declared topic) must have at least one @Incoming consumer somewhere in the
+        # fleet (a matching topic:/topics: declaration), or be explicitly allowlisted below with a
+        # one-line reason (external sink, deliberately audit-only, or a tracked future-work gap).
+        detect: ["any <service>/src/main/resources/application.yaml mp.messaging.outgoing topic"]
+        require:
+          - "topic has >=1 real @Incoming consumer fleet-wide, or an allowlist entry with a reason"
+        gate: event-consumer-liveness
+        # GRADUATED to enforce 2026-07-14 (ADR-0144): the #996 fleet-sweep triage that started with
+        # issue #889 brought unallowlisted violations to zero across three rounds (#1005 sca topic
+        # mismatch, #1007/#1032/#1050 audit-service fan-out, #1054 fx-service dead-stub producer fix,
+        # this PR's fx.conversion.completed/documents.document.event/payments.swift.event consumers)
+        # — same graduation path check-outbox-dispatch-enabled.sh proved out. check-event-consumer-
+        # liveness.py --root . --enforce reports 0 fleet-wide; ci.yml now passes --enforce.
+        enforced: enforce
+        # CI producer is LIVE and enforced: .github/scripts/check-event-consumer-liveness.py runs in
+        # the "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped). A new topic
+        # published with no consumer and no allowlist entry now fails the build.
+        ci_producer: ".github/scripts/check-event-consumer-liveness.py"
+        # #996 triage findings, classified LEGITIMATE_NO_CONSUMER (not the #889 failure class):
+        allowlist:
+          - topic: "openbank.psd2.events"
+            reason: "psd2-service docs consistently describe this as audit-trail + external TPP-webhook delivery, not an intra-fleet reaction — no OpenBank service is meant to consume it."
+          - topic: "openbank.tpp.registry.event"
+            reason: "tpp-registry-service's own docs say the publish side is dormant (\"no domain events are emitted yet\" — outbox transport exists but unused). Not the #889 pattern (a working publish going nowhere): nothing is actually published today. Re-triage once the publish side is wired."
+          - topic: "openbank.pid.events"
+            reason: "Confirmed dead code, not a live gap: PidOutboxRepository.persistInTransaction (the only writer for this channel) has zero callers across all 5 pid-service use cases — grep-verified. pid-service's real domain events flow through a separate, actually-used PartyEventPublisher to party.events instead. application.yaml even documents the emitter exists only so the unwired @Channel doesn't crash the app at boot. Candidate for future cleanup (remove the dead channel), not a #889-class gap."
+      lineage_code_audit:
+        # ADR-0160 mechanism 2. standing-order-service's governance.yaml declares a downstream edge to
+        # transaction-service (relationType: api) — copy-pasted boilerplate with no backing
+        # @RegisterRestClient anywhere in the service. Nothing checked the claim against the actual
+        # fleet, same root cause as issue #889 (a different unverified claim, same failure shape: prose
+        # describing runtime behaviour, never checked against code). Fleet-wide scan, not diff-scoped:
+        # every governance.yaml lineage.downstream edge (relationType api|topic) must be backed by
+        # grep-verifiable code in the SAME service (a matching @RegisterRestClient configKey for api;
+        # an actual topic produced/consumed in common with the target service for topic — a topic edge
+        # doesn't name the specific topic, just the service, so it's a service-level cross-reference),
+        # or be explicitly allowlisted below with a one-line reason (a REST call made through a
+        # shared/generic client this heuristic's exact-match can't see, or a genuinely-stale edge
+        # already tracked for cleanup elsewhere).
+        detect: ["any <service>/governance.yaml lineage.downstream edge"]
+        require:
+          - "api edge has a matching @RegisterRestClient(configKey) in the same service, or an allowlist entry with a reason"
+          - "topic edge has an actual topic overlap with the target service (per mechanism 1's producer/consumer map), or an allowlist entry with a reason"
+        gate: lineage-code-audit
+        enforced: advisory
+        target_enforce_date: "2026-10-15"   # ADR-0144 — later than mechanism 1's date: first scan found a much higher (34/48) violation rate, expect a longer triage
+        # CI producer is LIVE (advisory): .github/scripts/check-governance-lineage.py runs in the
+        # "Validate manifests" job on every PR — fleet-wide scan (not diff-scoped), reuses mechanism 1's
+        # topic map via importlib (check-event-consumer-liveness.py's build_topic_maps), findings are
+        # ::warning annotations. First scan (2026-07-13): 34 of 48 downstream edges have no backing code
+        # found — consistent with mechanism 1's own first-scan rate (13/18, ~72%), i.e. this fleet's
+        # governance.yaml lineage data really is this stale, not primarily a heuristic false-positive
+        # rate. ALL still unallowlisted below (real triage tracked as a fleet-sweep issue, not resolved
+        # by fiat). Flip to enforced once triage brings unallowlisted violations to zero = pass
+        # --enforce to the script in ci.yml (one-line change), same as every other ADR-0144 gate here.
+        blocked_on: "34 unallowlisted lineage edges found on first scan (2026-07-13) need individual triage (stale/wrong governance.yaml edge vs. a real dependency this heuristic's exact-match can't see) — tracked as a fleet-sweep issue, not yet filed"
+        ci_producer: ".github/scripts/check-governance-lineage.py"
+        allowlist: []
       service_code_change:
         detect: ["<service>/src/main/**"]
         require:
@@ -1149,12 +1570,31 @@ data:
       - openbank-swift-service
       - openbank-fx-service
       - openbank-lending-service
-      - openbank-sca-service
-      - openbank-consent-service
+      - openbank-sca-service                  # four-eyes assessed (issue #938 follow-up), NOT wired: device.enroll and
+                                               # scaChallenge.consume are both real-payment/self-service actions with a
+                                               # confirmed M2M automated caller (customer-edge) — gating either would brick
+                                               # production automation once enforcement is ever flipped on, not just close
+                                               # the risky operator-console gap. See the four_eyes.verbs guardrail note below.
+      - openbank-consent-service               # four-eyes wired (issue #938 follow-up) on consent.grant/consent.revoke —
+                                                # both confirmed human-operator-only (no M2M caller). consent.activate
+                                                # deliberately left ungated: its rego already reserves an M2M grant for a
+                                                # possible SCA-completion-callback caller.
       - openbank-fraud-service                # ADR-0084: v4 rule engine live; domestic-payment enforcement gate merged (issue #667, flag default-off pending risk-team threshold calibration)
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface today is a stateless
+                                               # POST /fraud/score (fraud.score) — no operator case-decision, rule-config, or manual
+                                               # override endpoint exists yet, so there is nothing real to maker-checker gate. Revisit
+                                               # once a fraud case-management endpoint ships (clearing a flag / disabling a rule /
+                                               # forcing a decision would need `clear`/`override`/`disable` verbs added here then).
       - openbank-billing-service              # ADR-0143: fee assess/post/reverse shipped (phases 1a-2e); real-env e2e verification + four-eyes enforcement flip still gate production go-live
-      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101)
-      - openbank-sanctions-service             # ADR-0116: real feed screening; already required by four_eyes below (issue #554)
+      - openbank-settlement-service           # issue #307: debit->credit->ledger-booking saga (ADR-0101), orchestrated by a real
+                                               # Temporal workflow (SettlementWorkflowImpl) — not a bespoke non-Temporal saga.
+                                               # four-eyes assessed (issue #938 follow-up): the only REST surface is
+                                               # POST /settlements (settlement.create), which starts the (self-healing, self-
+                                               # compensating) saga; there is no manual retry/force-complete/compensate endpoint to
+                                               # gate. Revisit if such an operator override endpoint is ever added.
+      - openbank-sanctions-service             # ADR-0116: real feed screening; four-eyes wired (issue #938 follow-up) on
+                                                # sanctions.clear (deciding a screening hit) — the highest-risk action in this
+                                                # service, since a wrongly-cleared true positive is a real sanctions violation.
 
     # ---------------------------------------------------------------------------------------
     # SLOs (issue #669 — operational evidence, scope item 3). Governed data: a single
@@ -1180,6 +1620,23 @@ data:
       # the SLO burn-rate should page before the blunter absolute-latency alert does.
       latency_threshold_seconds: 1
       latency_window: 30d
+
+    # ---------------------------------------------------------------------------------------
+    # Alert delivery (ADR-0082 / ADR-0088). Keep this section terse: rules.yaml is embedded
+    # verbatim into every OPA sidecar bundle ConfigMap. Full rationale lives in ci_producer.
+    # ---------------------------------------------------------------------------------------
+    alerting:
+      # At least one Alertmanager route matching severity=critical must end at a receiver that
+      # egresses the cluster (external integration, or a webhook with a literal non-cluster
+      # URL; a url_file counts as unprovable). In-perimeter paging (GoAlert -> ntfy, ADR-0088
+      # D1) may stay alongside it, but not as the only leg. Guards the "severity inversion":
+      # critical routed only to no-Ingress in-cluster receivers (ADR-0056) while warning
+      # reached Slack, so the most severe alerts were the least likely to be seen.
+      critical_alerts_must_egress: true
+      enforced: enforce
+      ci_producer: ".github/scripts/check-critical-alert-egress.py"
+      checked_manifest: "openbank-infra/gitops/apps/kube-prometheus-stack.yaml"
+
     review:
       default_approvals: 1
       money_path_approvals: 2               # CONTRIBUTING.md + branch protection
@@ -1240,6 +1697,37 @@ data:
         - credit                            # balance: direct ledger-balance credit adjustment (issue #395)
         - debit                             # balance: direct ledger-balance debit adjustment (issue #395)
         - collateralRegister                # lending: collateral registration/edit feeds IFRS 9 LGD (issue #621)
+        - convert                           # fx: execute a currency conversion at the current spot rate (issue #938 follow-up).
+                                             # Confirmed no M2M caller (fx-service's own rego: "fx.convert... has NO in-repo M2M
+                                             # caller today and stays human-only") — see the guardrail note below before adding
+                                             # any further verb here.
+        - grant                             # consent: create a new TPP<->customer data-access consent (renamed from consent.create,
+                                             # issue #938 follow-up). Confirmed no M2M caller (consent-service's own rego: "consent.grant
+                                             # and consent.revoke are NOT granted to M2M clients").
+        - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
+                                             # (same rego note as consent.grant above).
+        - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
+                                             # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
+                                             # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only
+                                             # ROLE_OPERATOR/ROLE_ADMIN, no ROLE_SERVICE).
+        # GUARDRAIL (issue #938 follow-up — found while wiring sca-service): four_eyes_required is
+        # computed by ACTION NAME ALONE (rest.rego money_path_scopes + endswith verb match), with NO
+        # awareness of the caller's identity. A verb is only safe to add here if EVERY real-world
+        # caller of that action across the WHOLE fleet is a human operator/admin session — if even one
+        # legitimate M2M/automated caller exists, four-eyes enforcement (once ever flipped on for that
+        # service) pauses that automated flow too, indistinguishably from the risky human path it was
+        # meant to gate. sca-service's device.enroll and scaChallenge.consume were both assessed and
+        # REJECTED for this reason: both are granted to customer-edge's M2M identity in base rest.rego
+        # (edge-service-notification's device.* family, sca's own service-sca-edge-m2m rule) for
+        # ordinary customer self-service device enrollment and — critically — scaChallenge.consume is
+        # the payment settlement gate every real payment passes through. Gating either would silently
+        # brick production automation the moment enforcement is ever turned on, not just close the
+        # risky operator-console gap. Before adding a new verb: grep every service's own
+        # gen-<service>-opa-bundle.sh for an M2M/SERVICE-identity rule granting that action; if one
+        # exists (or plausibly could — consent.activate was ALSO excluded for this reason, no confirmed
+        # caller found but the rego already reserves the grant), the risky path needs its own distinct
+        # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
+        # gated safely — do not reuse the shared customer/M2M-facing action.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
@@ -1370,7 +1858,7 @@ data:
     dependencies:
       license_allowlist: [Apache-2.0, MIT, BSD-2-Clause, BSD-3-Clause, EPL-2.0, MPL-2.0, ISC]
       license_denylist: [GPL-2.0, GPL-3.0, AGPL-3.0]   # copyleft -- denied for THIRD-PARTY deps of the Apache-2.0 platform
-      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the four AI agent
+      # Carve-out (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent
       # services are OpenBank's open-core component and are licensed AGPL-3.0-only + a parallel
       # commercial licence -- IN-REPO, not Apache-2.0. The denylist above governs the Apache-2.0
       # platform tree; AGPL-3.0-only is the intended licence of the agent services, so the gate
@@ -1383,16 +1871,28 @@ data:
             - openbank-copilot-service/
             - openbank-devops-agent/
             - openbank-finops-agent/
+            - openbank-control-liveness-sentinel/
+            - openbank-governance-auditor/
+            - openbank-release-steward/
+            - openbank-docs-truth-agent/
+            - openbank-authz-policy-auditor/
+            - openbank-flaky-test-hunter/
           reason: "open-core: AGPL-3.0-only + commercial dual-licensing of the AI agent services"
           adr: ADR-0136
       license_boundary_exceptions:
-        - description: "AGPL/Apache seam (in-repo). The four agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
+        - description: "AGPL/Apache seam (in-repo). The AI agent services are AGPL-3.0-only; no Apache-2.0 module may take a build/compile dependency on them (only network/HTTP use is allowed). They depend on openbank-libs (Apache-2.0), which is permitted -- copyleft may consume permissive code."
           agpl_modules:
             - openbank-agent-service
             - openbank-copilot-service
             - openbank-devops-agent
             - openbank-finops-agent
-          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent') as a dependency"
+            - openbank-control-liveness-sentinel
+            - openbank-governance-auditor
+            - openbank-release-steward
+            - openbank-docs-truth-agent
+            - openbank-authz-policy-auditor
+            - openbank-flaky-test-hunter
+          rule: "no Apache-2.0 module may declare project(':openbank-agent-service'|':openbank-copilot-service'|':openbank-devops-agent'|':openbank-finops-agent'|':openbank-control-liveness-sentinel'|':openbank-governance-auditor'|':openbank-release-steward'|':openbank-docs-truth-agent'|':openbank-authz-policy-auditor'|':openbank-flaky-test-hunter') as a dependency"
           license: "AGPL-3.0-only"
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "266f1233bb8be714"
+        openbank.tech/policy-checksum: "5451b8d472bfc50b"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What

Regenerates the 21 generated OPA bundles that have no CI coverage, plus their pod-roll checksum annotations. All 21 were stale on `main`.

`opa-policy.yml`'s "build + verify bundle" job regenerates and diffs only **5 of 26** bundles (`agent`, `pid`, `copilot`, `customer-edge`, `notifications`) from a hand-maintained list. The other 21 hash `rules.yaml` and `agents.yaml` as checksum inputs, but nothing ever re-ran them when those inputs changed. Every uncovered bundle had drifted; every covered one was clean.

**CI coverage is deliberately a follow-up PR** so this one stays reviewable as a pure policy correction.

## Drift is data-only — no rego rule changed

Every `.rego` key (`rest.rego`, `agents.rego`, and each per-service `*_rest_ext.rego`) is byte-identical modulo comments across all 21 bundles. No allow/deny rule differs. Two embedded data documents were behind.

**`rules-data.yaml`** — semantic YAML diff of every key rego reads:

| key | state |
|---|---|
| `money_path_services` | unchanged |
| `money_path_action_prefixes` | unchanged |
| `feature_flags` | unchanged |
| `value_bands` | unchanged |
| `four_eyes.verbs` | **missing `convert`, `grant`, `revoke`, `clear`** |

Those four are the actions renamed in the #938 follow-up. `rules.yaml` lists all four as four-eyes-gated, and the matching `@Authorize` actions are live: `fx.convert` ([FxResource.kt:75](openbank-fx-service/src/main/kotlin/com/openbank/fx/infrastructure/rest/FxResource.kt#L75)), `consent.grant` / `consent.revoke` ([ConsentResource.kt:65](openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt#L65), [:136](openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt#L136)), `sanctions.clear` ([SanctionsResource.kt:46](openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/rest/SanctionsResource.kt#L46)). The deployed bundles did not gate what governance says they gate.

**`agents-data.yaml`** — 6 charters added (`control-liveness-sentinel`, `governance-auditor`, `release-steward`, `docs-truth-agent`, `authz-policy-auditor`, `flaky-test-hunter`). Purely additive: 7 → 13, none removed, none altered.

## Impact: latent, not currently exploitable

Four-eyes enforcement is **off fleet-wide** — `AUTHZ_FOUR_EYES_ENFORCE` is set nowhere in gitops, Terraform, or env, and every service defaults it to `false`. `four_eyes_required` only pauses a call into a `PendingApproval` when `authz.four-eyes.enforce=true`, so the missing verbs gate nothing that would otherwise be gated today.

The exposure is the flip: turning `AUTHZ_FOUR_EYES_ENFORCE=true` on consent, sanctions or fx while trusting `rules.yaml` would silently leave those four actions ungated — a single operator could clear a sanctions hit or grant a TPP consent with no second approver. Landing this first makes that flip safe.

The 6 added charters are inert on the MCP path: they declare `tools.allow` as `{tier, resources}` objects, which `charter_allowed` cannot glob-match against a string tool name, and none of those services call `/tools/call`. Default-deny fails closed either way.

## Verification

- `openbank-infra/opa/build-bundle.sh` passes — `opa check` plus all decision assertions, including the four-eyes ones. 13 charters.
- Regenerated by running each `gen-*-opa-bundle.sh`; no file hand-edited.
- Every changed line attributed to its ConfigMap key to confirm zero non-comment rego changes.

## Review notes

Touches money-path services (ledger, sepa-payment, sepa-instant, domestic-payment, settlement, clearing, swift, transaction, card-issuance, balance, account, lending, fx, consent, sanctions, sca) — 2 approvals per ADR-0030. Threat models already exist for all affected services; no new service is introduced.

The diff is large but mechanical: it is generator output. The reviewable claims are the two tables above.

Refs #750