### PR TITLE
fix(notification): correct openapi.yaml drift from the implemented contract

### DIFF
--- a/openbank-notification-service/src/main/resources/openapi.yaml
+++ b/openbank-notification-service/src/main/resources/openapi.yaml
@@ -3,13 +3,13 @@
 openapi: 3.1.0
 info:
   title: Notification Service API
-  version: 1.4.0
+  version: 1.5.0
   description: Notification delivery management — query sent/pending notifications, manage push device tokens.
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 servers:
-  - url: http://localhost:8125
+  - url: http://localhost:8112
     description: Local development
 tags:
   - name: Notifications
@@ -94,32 +94,39 @@ paths:
   /api/v1/notifications:
     get:
       tags: [Notifications]
-      summary: List notifications
+      summary: List notifications (paginated)
+      description: |
+        Page through notifications, optionally narrowed to one party. Items carry metadata
+        only — the rendered `body` is returned by `GET /api/v1/notifications/{id}`.
       operationId: listNotifications
       parameters:
         - name: partyId
           in: query
+          description: Narrow to a single party. Omit to page the whole store.
           schema:
             type: string
             format: uuid
-        - name: status
+        - name: page
           in: query
-          schema:
-            type: string
-            enum: [PENDING, SENT, FAILED, READ]
-        - name: limit
-          in: query
-          schema:
-            type: integer
-            default: 20
-        - name: offset
-          in: query
+          description: Zero-based page index.
           schema:
             type: integer
             default: 0
+        - name: size
+          in: query
+          description: Page size. Values outside 1..100 are clamped.
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
       responses:
         '200':
-          description: Notifications
+          description: A page of notifications
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPage'
 
   /api/v1/notifications/{id}:
     get:
@@ -302,8 +309,9 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
-    NotificationResponse:
+    NotificationSummary:
       type: object
+      description: Notification metadata, as returned by the list endpoint. Carries no rendered body.
       properties:
         id:
           type: string
@@ -311,22 +319,109 @@ components:
         partyId:
           type: string
           format: uuid
-        type:
+        channel:
+          $ref: '#/components/schemas/NotificationChannel'
+        template:
           type: string
-          enum: [EMAIL, SMS, PUSH]
-        status:
+          description: Template enum name the body was rendered from.
+        recipient:
           type: string
+          description: Email address, phone number, or — for PUSH — the party id (delivery is by registered device token).
         subject:
           type: string
-        body:
-          type: string
+          description: |
+            Rendered subject. Always present: every write path renders one, even though the
+            column and entity permit NULL. If a path ever yields NULL, that IS a breaking
+            contract change and takes the major bump — do not quietly add `nullable` here.
+        status:
+          $ref: '#/components/schemas/NotificationStatus'
         sentAt:
           type: string
           format: date-time
           nullable: true
+        readAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the customer marked it read. Null = unread.
         createdAt:
           type: string
           format: date-time
+
+    NotificationPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationSummary'
+        total:
+          type: integer
+          format: int64
+        page:
+          type: integer
+        size:
+          type: integer
+
+    NotificationResponse:
+      type: object
+      description: |
+        A single notification, including its rendered body. Same fields as
+        NotificationSummary plus `body` — kept flat rather than composed with `allOf`,
+        because oasdiff does not flatten composition and reports every inherited field
+        as removed, which makes the API-contract diff unreadable.
+      properties:
+        id:
+          type: string
+          format: uuid
+        partyId:
+          type: string
+          format: uuid
+        channel:
+          $ref: '#/components/schemas/NotificationChannel'
+        template:
+          type: string
+          description: Template enum name the body was rendered from.
+        recipient:
+          type: string
+          description: Email address, phone number, or — for PUSH — the party id (delivery is by registered device token).
+        subject:
+          type: string
+          description: |
+            Rendered subject. Always present: every write path renders one, even though the
+            column and entity permit NULL. If a path ever yields NULL, that IS a breaking
+            contract change and takes the major bump — do not quietly add `nullable` here.
+        body:
+          type: string
+          description: |
+            The rendered message body. For secret-bearing templates (OTP_CODE,
+            PASSWORD_RESET) this is a redaction placeholder, never the delivered
+            secret — the secret is sent to the customer but never stored.
+        status:
+          $ref: '#/components/schemas/NotificationStatus'
+        sentAt:
+          type: string
+          format: date-time
+          nullable: true
+        readAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the customer marked it read. Null = unread.
+        createdAt:
+          type: string
+          format: date-time
+
+    NotificationChannel:
+      type: string
+      enum: [EMAIL, SMS, PUSH, IN_APP]
+
+    NotificationStatus:
+      type: string
+      enum: [PENDING, SENT, FAILED, BOUNCED]
+      description: |
+        Delivery state. Read-state is tracked separately by `readAt`, not by this field.
+        BOUNCED is declared by the domain model but not currently assigned by any code path.
 
     ApiError:
       type: object


### PR DESCRIPTION
Refs #1179

PR-2 of the notification/messaging sequence (after #1180 security fix, #1181 ADR-0171). **Spec-only — no handler changed.** Every item is the spec catching up to long-standing code.

## The drift

**`GET /api/v1/notifications`**

| Documented | Reality |
|---|---|
| `limit` / `offset` params | resource takes `page` / `size` — a client following the spec silently got page 0, size 20 |
| `status` filter | not implemented at all |
| *(no response schema)* | returns `{items, total, page, size}` — now `NotificationPage` |

**`NotificationResponse`**

| Documented | Reality |
|---|---|
| `type`, enum `[EMAIL, SMS, PUSH]` | field is `channel`, and the domain has a fourth value `IN_APP` |
| — | `template`, `recipient`, `readAt` are returned but were undocumented |
| `status` enum `[PENDING, SENT, FAILED, READ]` | `READ` is not a status (read-state is the separate nullable `readAt`); `BOUNCED` is declared by the domain and was missing |

Also: declared server port `8125`; the service listens on `8112`.

## Classification

Ran the pinned CI version of the tool locally (oasdiff 1.22.0, the same the gate downloads):

```
api-contract gate: openbank-notification-service: additive change,
info.version 1.4.0 -> 1.5.0 — OK (required >= MINOR).
```

0 ERR-level changes, 8 WARN-level. D2 invariant holds: `major(1.5.0)` == `openbank.api.version: "1"` == URL `/api/v1`.

The only contract test in this service is `NotificationRequestMessagePactConsumerTest` — a *message* pact for the Kafka inbound contract, untouched by a REST-spec change.

## Two judgement calls worth your review

**`subject` left non-nullable.** The entity (`var subject: String? = null`) and the column (`VARCHAR(500)`, no NOT NULL) both permit NULL — but `renderTemplate` returns `Pair<String, String>`, so no write path can produce one. Declaring `nullable: true` would document the *possible* rather than the *actual*, and oasdiff rates that ERR-level breaking — which would force **`/api/v2` for a pure documentation fix**. The schema carries the rule inline: if a path ever yields NULL, that IS a breaking contract change and takes the major bump.

**`NotificationResponse` repeats `NotificationSummary`'s fields instead of `allOf` composition.** I wrote it with `allOf` first. oasdiff does not flatten composition — it reported `id`, `partyId`, `body`, `subject`, `sentAt`, `createdAt`, `status` and `type` as *removed properties*, which is false and would have made the contract diff actively misleading to a reviewer. Ten duplicated lines buy a legible diff; the reason is recorded in the schema description so nobody "fixes" it back.

## Spotted while here — not fixed

`rules.yaml: api_change` still declares `enforced: advisory` with `target_enforce_date: "2026-08-15"`, but `ci.yml` already passes `--enforce` to the gate. The flip happened in CI without `rules.yaml` catching up, so the authoritative source understates a gate that is live and blocking today. Worth its own one-liner; I did not touch it here to keep this PR spec-only.
