### PR TITLE
fix(gitops): unbreak pact-broker-db sync, pilot the CNPG ECR ref

### DIFF
--- a/openbank-infra/gitops/components/pact-broker/postgres.yaml
+++ b/openbank-infra/gitops/components/pact-broker/postgres.yaml
@@ -20,10 +20,27 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io — the ADR-0092 pilot for #1290. CNPG instance
+  # pods are (correctly) excluded from the Kyverno ecr-pull-through-rewrite policy: the
+  # operator reconciles the running pod's image against spec.imageName, so a mutating
+  # webhook makes the pod permanently drift and it recreates it every ~10s (that is what
+  # looped pact-broker-db and fraud-db when rewrite-ghcr landed). Setting the ref HERE is
+  # the mechanism the policy's own comment asks for — "CNPG must own its image ref
+  # end-to-end" — with no mutation and nothing to drift from.
+  # Tag stays 16.14 = what this cluster actually runs. The 18.1 that was declared here
+  # never applied (see the storage note below) and adopting it would be a Postgres MAJOR
+  # upgrade — a separate, deliberate decision, not a side effect of changing a registry.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:16.14
   storage:
     storageClass: gp3
-    size: 1Gi
+    # 5Gi = the live PVC. It was declared 1Gi in 343aef3f8 while the volume was already
+    # 5Gi, and CNPG's webhook refuses to shrink storage:
+    #   spec.storage: Invalid value: "1Gi": can't shrink existing storage from 5Gi to 1Gi
+    # Every sync of this Application has failed since 2026-06-30 as a result — 16 days,
+    # invisibly, because the workload stayed Healthy and only sync status went Unknown.
+    # That is also why the 18.1 above was never applied. Do not "tidy" this back down:
+    # the declared size must track the volume, which can grow but never shrink.
+    size: 5Gi
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Linked issues

Refs #1290 — pilot (step 2 of the suggested order).

## 1. This Application has been failing every sync for 16 days

`343aef3f8` declared `storage.size: 1Gi` while the volume was already `5Gi`. CNPG's webhook refuses to
shrink:

```
admission webhook "vcluster.cnpg.io" denied the request:
  spec.storage: Invalid value: "1Gi": can't shrink existing storage from 5Gi to 1Gi
```

Argo has been `sync=Unknown` with a `ComparisonError` since **2026-06-30**, while `health=Healthy` —
because the workload itself is fine. **83 of 84 Applications are Synced; this is the one.** Nothing
surfaced it.

Declared size now tracks the volume. It can grow, never shrink — do not tidy it back down.

## Why 18.1 → 16.14 is not a regression

The `imageName: …postgresql:18.1` declared here **never applied** — no sync ever landed. The live
cluster runs **16.14**.

Unblocking the sync without touching that line would push 18.1 at a live database: a Postgres **major**
version upgrade, 16 → 18, that nobody decided and that has been sitting undelivered for 16 days. That
belongs in its own PR with its own thinking, not as a side effect of fixing a storage field. The tag is
aligned to what actually runs.

## 2. The pilot (#1290)

CNPG instance pods are excluded from `ecr-pull-through-rewrite`, and **correctly so** — the operator
reconciles the running pod's image against `spec.imageName`, so a mutating webhook makes the pod
permanently drift and it gets recreated every ~10s. That is precisely what looped `pact-broker-db` and
`fraud-db` when `rewrite-ghcr` landed. **The exclusion is not being touched.**

Setting the ref in the spec is the mechanism the policy's own comment asks for — *"CNPG must own its
image ref end-to-end"* — with no mutation and nothing to drift from:

```yaml
imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:16.14
```

Same version, different registry, so this tests **one variable**: does CNPG accept an ECR ref and reach
Ready without the reconcile loop? If yes, the remaining ~70 instance pods can follow.

## Verified before pushing

Server-side dry-run against the **live** webhook — the one that has been rejecting this app:

```
$ kubectl apply --server-side --dry-run=server -f openbank-infra/gitops/components/pact-broker/postgres.yaml
cluster.postgresql.cnpg.io/pact-broker-db serverside-applied (server dry run)
```

The storage rejection is gone and the ECR ref is accepted. The `16.14` tag is cached in the
pull-through (246.2 MB, since 2026-06-15).

## Impact and rollback

One rolling restart of a **single-instance, non-money-path** contract-test database. Rollback is
reverting this commit.

**What to watch after merge** — the failure mode this class produces is loud and specific: if the pod
starts recreating every ~10s and the cluster never reaches Ready, that is the drift loop and the pilot
has failed. Revert immediately; do not try to fix it forward.