### PR TITLE
fix(customer-edge): consent step serves only the terms, as a PDF

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
@@ -14,6 +14,7 @@ import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.QueryParam
 import jakarta.ws.rs.core.MediaType
@@ -64,11 +65,20 @@ class OnboardingResource(
         // The X-Customer-Party-Id header value for the pre-party terms call — document-service's
         // template routes don't scope by party, but UpstreamClient always sends the header.
         private const val ONBOARDING_PARTY_PLACEHOLDER = "onboarding-anonymous"
+
+        private const val STATUS_CREATED = 201
+        private const val STATUS_NOT_FOUND = 404
+
+        // Only the general terms are servable here — the framework agreement is per-party and
+        // signed one step later (ADR-0169/0170), never fetched anonymously.
+        private val SERVABLE_TERMS_CODES = setOf("VOP_CS", "VOP_EN")
     }
 
-    // Instance field (the resource is a Quarkus singleton): per-lang cache of the serialized
-    // /terms response so an anonymous burst can't fan out to document-service.
+    // Instance fields (the resource is a Quarkus singleton): per-lang cache of the serialized
+    // /terms response so an anonymous burst can't fan out to document-service, and the
+    // rendered-PDF document id per immutable (code, version) so the terms render once.
     private val termsCache = java.util.concurrent.ConcurrentHashMap<String, Pair<Long, String>>()
+    private val renderedTermsCache = java.util.concurrent.ConcurrentHashMap<String, String>()
 
     @Inject
     lateinit var jsonMapper: ObjectMapper
@@ -155,16 +165,21 @@ class OnboardingResource(
     fun registerParty(body: String): Response = customerEdge.registerParty(body)
 
     /**
-     * The PUBLISHED contractual documents shown on the onboarding consent step (framework
-     * agreement + general terms), before any credential exists — informed consent requires the
-     * text to be READABLE at the moment the user ticks "I agree", and at that point there is no
-     * account, no token and no personalised document yet (the personalised agreement is created
-     * and signed after `account.created`, ADR-0169/0170).
+     * The PUBLISHED general terms (VOP) the onboarding consent step asks the user to agree to.
+     * Informed consent requires the text to be READABLE at the moment the tick happens, and at
+     * that point there is no account, no token and no personalised document yet.
+     *
+     * Deliberately ONLY the terms — NOT the framework agreement. The agreement is a document the
+     * user *signs*, and it is created per-party and signed one step later, after `account.created`
+     * (ADR-0169/0170). Listing it here too made the consent step look like a second signing
+     * screen and duplicated what the sign step already shows.
+     *
+     * Metadata only (code/name/version/publishedAt) — the readable bytes come from
+     * [onboardingTermsContent] as a real PDF, the same artifact class the sign step renders.
      *
      * Same security class as [startOnboarding] above (the already-public onboarding surface,
      * behind the same ingress rate limit) — deliberately NOT a new exposure category: read-only,
-     * serves only PUBLISHED template text (a bank's public terms — no PII, no party data, no
-     * template internals beyond what every prospective customer must be able to read anyway).
+     * serves only PUBLISHED terms (a bank's public terms — no PII, no party data).
      *
      * Upstream call uses the edge M2M token against document-service's template list (the same
      * ROLE_OPERATOR-gated route the admin cockpit reads); responses are cached for [TERMS_TTL_MS]
@@ -183,7 +198,7 @@ class OnboardingResource(
             }
         }
 
-        val wanted = listOf("RAMCOVA_SMLOUVA_$l", "VOP_$l")
+        val wanted = "VOP_$l"
         val resp = upstream.get(
             "$documentServiceUrl/api/v1/documents/templates?limit=100",
             ONBOARDING_PARTY_PLACEHOLDER,
@@ -196,16 +211,13 @@ class OnboardingResource(
         }
         val docs = runCatching {
             jsonMapper.readTree(raw)
-                .filter { it.get("status")?.asText() == "PUBLISHED" && it.get("code")?.asText() in wanted }
-                // Stable order: agreement first, then terms — the consent screen renders in order.
-                .sortedBy { wanted.indexOf(it.get("code")?.asText()) }
+                .filter { it.get("status")?.asText() == "PUBLISHED" && it.get("code")?.asText() == wanted }
                 .map {
                     mapOf(
                         "code" to it.get("code")?.asText(),
                         "name" to it.get("name")?.asText(),
                         "version" to it.get("version")?.asText(),
                         "publishedAt" to it.get("createdAt")?.asText(),
-                        "html" to it.get("bodyHtml")?.asText(),
                     )
                 }
         }.getOrElse {
@@ -216,5 +228,78 @@ class OnboardingResource(
         val body = jsonMapper.writeValueAsString(mapOf("documents" to docs))
         termsCache[l] = now to body
         return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * The PUBLISHED terms as a real PDF — the same artifact class the sign step renders, minus
+     * any signature field (nothing is signed here; the user only reads before ticking consent).
+     *
+     * [code] is restricted to [SERVABLE_TERMS_CODES]: the framework agreement is per-party and
+     * belongs to the authenticated sign step, so it can never be pulled through this anonymous
+     * route even by guessing its template code.
+     *
+     * document-service has no stateless render — `POST /documents/render` always persists the
+     * rendered artifact. A published template version is immutable, so the render is cached by
+     * (code, version) and the rendered document id reused: one artifact per published version,
+     * not one per curious visitor.
+     */
+    @GET
+    @Path("/terms/{code}/content")
+    @Produces("application/pdf")
+    @PermitAll
+    @Blocking
+    fun onboardingTermsContent(@PathParam("code") code: String): Response {
+        val wanted = code.uppercase()
+        if (wanted !in SERVABLE_TERMS_CODES) {
+            return Response.status(STATUS_NOT_FOUND)
+                .entity("""{"error":"unknown terms document"}""")
+                .type(MediaType.APPLICATION_JSON).build()
+        }
+
+        val listResp = upstream.get(
+            "$documentServiceUrl/api/v1/documents/templates?limit=100",
+            ONBOARDING_PARTY_PLACEHOLDER,
+        )
+        if (listResp.status != STATUS_OK) {
+            return Response.status(STATUS_BAD_GATEWAY)
+                .entity("""{"error":"document templates unavailable"}""")
+                .type(MediaType.APPLICATION_JSON).build()
+        }
+        val version = runCatching {
+            jsonMapper.readTree((listResp.entity as? String).orEmpty())
+                .firstOrNull {
+                    it.get("code")?.asText() == wanted && it.get("status")?.asText() == "PUBLISHED"
+                }?.get("version")?.asText()
+        }.getOrNull()
+            ?: return Response.status(STATUS_NOT_FOUND)
+                .entity("""{"error":"no published version of this document"}""")
+                .type(MediaType.APPLICATION_JSON).build()
+
+        val documentId = renderedTermsCache.computeIfAbsent("$wanted@$version") {
+            val renderBody = jsonMapper.writeValueAsString(
+                mapOf("templateCode" to wanted, "contentType" to "application/pdf"),
+            )
+            val rendered = upstream.post(
+                "$documentServiceUrl/api/v1/documents/render",
+                ONBOARDING_PARTY_PLACEHOLDER,
+                renderBody,
+            )
+            if (rendered.status != STATUS_CREATED) return@computeIfAbsent ""
+            runCatching {
+                jsonMapper.readTree((rendered.entity as? String).orEmpty()).get("id")?.asText()
+            }.getOrNull().orEmpty()
+        }
+        if (documentId.isBlank()) {
+            renderedTermsCache.remove("$wanted@$version") // don't cache a failed render
+            return Response.status(STATUS_BAD_GATEWAY)
+                .entity("""{"error":"could not render the terms"}""")
+                .type(MediaType.APPLICATION_JSON).build()
+        }
+
+        return upstream.getRaw(
+            "$documentServiceUrl/api/v1/documents/$documentId/content",
+            ONBOARDING_PARTY_PLACEHOLDER,
+            "application/pdf",
+        )
     }
 }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/OnboardingTermsTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/OnboardingTermsTest.kt
@@ -10,6 +10,7 @@ import com.openbank.customeredge.infrastructure.rest.UpstreamClient
 import com.openbank.customeredge.infrastructure.webauthn.EnrollmentTicketService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.ws.rs.core.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -42,11 +43,12 @@ class OnboardingTermsTest {
     }
 
     @Test
-    fun `returns published agreement and terms in stable order`() {
+    fun `returns only the published terms — never the framework agreement`() {
         val upstream = mockk<UpstreamClient>()
         every { upstream.get(any(), any()) } returns templates(
             Triple("VOP_CS", "PUBLISHED", "Všeobecné obchodní podmínky"),
-            Triple("RAMCOVA_SMLOUVA_CS", "RETIRED", "stará"),
+            Triple("VOP_CS", "RETIRED", "staré VOP"),
+            // The agreement is signed one step later, per party — it must never be listed here.
             Triple("RAMCOVA_SMLOUVA_CS", "PUBLISHED", "Rámcová smlouva"),
             Triple("UCET_SMLOUVA_CS", "PUBLISHED", "jiný dokument"),
         )
@@ -55,27 +57,73 @@ class OnboardingTermsTest {
 
         assertThat(resp.status).isEqualTo(200)
         val docs = mapper.readTree(resp.entity as String).get("documents")
-        assertThat(docs.size()).isEqualTo(2)
-        assertThat(docs[0].get("code").asText()).isEqualTo("RAMCOVA_SMLOUVA_CS")
-        assertThat(docs[1].get("code").asText()).isEqualTo("VOP_CS")
-        assertThat(docs[0].get("html").asText()).contains("text RAMCOVA_SMLOUVA_CS")
+        assertThat(docs.size()).isEqualTo(1)
+        assertThat(docs[0].get("code").asText()).isEqualTo("VOP_CS")
         assertThat(docs[0].get("version").asText()).isEqualTo("1.1.0")
+        // Metadata only — the readable bytes come from /terms/{code}/content as a PDF.
+        assertThat(docs[0].has("html")).isFalse()
     }
 
     @Test
-    fun `lang en selects the english templates and anything else falls back to cs`() {
+    fun `lang en selects the english terms and anything else falls back to cs`() {
         val upstream = mockk<UpstreamClient>()
         every { upstream.get(any(), any()) } returns templates(
-            Triple("RAMCOVA_SMLOUVA_EN", "PUBLISHED", "Framework Agreement"),
             Triple("VOP_EN", "PUBLISHED", "General Terms"),
+            Triple("RAMCOVA_SMLOUVA_EN", "PUBLISHED", "Framework Agreement"),
         )
 
         val resp = resource(upstream).onboardingTerms("en")
 
         assertThat(resp.status).isEqualTo(200)
         val docs = mapper.readTree(resp.entity as String).get("documents")
-        assertThat(docs.size()).isEqualTo(2)
-        assertThat(docs[0].get("code").asText()).isEqualTo("RAMCOVA_SMLOUVA_EN")
+        assertThat(docs.size()).isEqualTo(1)
+        assertThat(docs[0].get("code").asText()).isEqualTo("VOP_EN")
+    }
+
+    // ---- /terms/{code}/content -------------------------------------------------
+
+    @Test
+    fun `content renders the published terms to pdf and reuses the render per version`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/templates") }, any()) } returns
+            templates(Triple("VOP_CS", "PUBLISHED", "Všeobecné obchodní podmínky"))
+        every { upstream.post(match { it.contains("/render") }, any(), any()) } returns
+            Response.status(201).entity("""{"id":"doc-1"}""").build()
+        every { upstream.getRaw(match { it.contains("/documents/doc-1/content") }, any(), any()) } returns
+            Response.ok("%PDF-1.4".toByteArray()).build()
+
+        val res = resource(upstream)
+        assertThat(res.onboardingTermsContent("VOP_CS").status).isEqualTo(200)
+        assertThat(res.onboardingTermsContent("vop_cs").status).isEqualTo(200)
+
+        // Immutable published version ⇒ rendered once, not once per view.
+        verify(exactly = 1) { upstream.post(match { it.contains("/render") }, any(), any()) }
+    }
+
+    @Test
+    fun `content refuses any code outside the terms allow-list`() {
+        val upstream = mockk<UpstreamClient>()
+
+        // The per-party agreement must not be reachable through the anonymous route.
+        val resp = resource(upstream).onboardingTermsContent("RAMCOVA_SMLOUVA_CS")
+
+        assertThat(resp.status).isEqualTo(404)
+        verify(exactly = 0) { upstream.post(any(), any(), any()) }
+    }
+
+    @Test
+    fun `content maps a failed render to 502 and does not cache the failure`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/templates") }, any()) } returns
+            templates(Triple("VOP_CS", "PUBLISHED", "Všeobecné obchodní podmínky"))
+        every { upstream.post(match { it.contains("/render") }, any(), any()) } returns
+            Response.status(500).entity("""{"internal":"boom"}""").build()
+
+        val res = resource(upstream)
+        assertThat(res.onboardingTermsContent("VOP_CS").status).isEqualTo(502)
+        // A failed render must be retried on the next request, never cached as a hole.
+        assertThat(res.onboardingTermsContent("VOP_CS").status).isEqualTo(502)
+        verify(exactly = 2) { upstream.post(match { it.contains("/render") }, any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Proč

Test na zařízení ukázal, že consent krok nabízel "dokumenty k nahlédnutí" = **rámcová smlouva + VOP**. Špatně v obou bodech:

- **Rámcovka se tam nenahlíží — podepisuje se o krok dál**, per party, po `account.created` (ADR-0169/0170). Její přítomnost dělala z consent kroku druhou podpisovou obrazovku a duplikovala sign screen.
- **VOP se nepodepisuje** — jen se čte před zaškrtnutím souhlasu.

## Co

- `GET /onboarding/terms` → jen **PUBLISHED VOP**, metadata (bez html)
- nový `GET /onboarding/terms/{code}/content` → **reálné PDF** (stejná třída artefaktu jako sign step, bez podpisových polí)

**Bezpečnost:** `code` je omezen allow-listem (`VOP_CS`/`VOP_EN`) — per-party rámcovku nelze přes anonymní route vytáhnout ani uhodnutím template kódu. Test to pinuje.

**Render:** document-service nemá stateless render (`POST /documents/render` vždy persistuje). Publikovaná verze šablony je neměnná, takže render cachuju podle `(code, version)` a přepoužívám document id — **jeden artefakt na publikovanou verzi**, ne jeden na každé zobrazení. Selhaný render se necachuje.

## Testy

5 unit testů: jen VOP (nikdy rámcovka), lang fallback, PDF render + reuse per verze, allow-list odmítne rámcovku (404, žádný upstream render), selhaný render → 502 bez leaku a bez cache.

Navazuje na #1254. App strana následuje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
