### PR TITLE
fix(governance): stop the OPA bundles asserting an LLM topology that does not exist

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "f87aa3de385e106d"
+    openbank.tech/policy-checksum: "92074cfb9e487f57"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -619,14 +619,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -636,8 +649,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f87aa3de385e106d"
+        openbank.tech/policy-checksum: "92074cfb9e487f57"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/agent/agent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: agent-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "77bc4c895d60abaa"
+    openbank.tech/policy-checksum: "cdc2a157932c3d98"
 data:
   agents.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -237,14 +237,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -254,8 +267,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/agent/agent-service.yaml
+++ b/openbank-infra/gitops/components/agent/agent-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Roll the pod when the OPA policy bundle changes (subPath mounts don't hot-reload).
         # Must match agent-opa-bundle's openbank.tech/policy-checksum (CI verifies, no drift).
-        openbank.tech/policy-checksum: "77bc4c895d60abaa"
+        openbank.tech/policy-checksum: "cdc2a157932c3d98"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "bc9f41ec9fbab063"
+    openbank.tech/policy-checksum: "1374ce79526a2a85"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -562,14 +562,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -579,8 +592,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bc9f41ec9fbab063"
+        openbank.tech/policy-checksum: "1374ce79526a2a85"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "f8c19af7052cc471"
+    openbank.tech/policy-checksum: "5fd283ed0bfd22a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -663,14 +663,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -680,8 +693,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8c19af7052cc471"
+        openbank.tech/policy-checksum: "5fd283ed0bfd22a9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "4d8314c02444237a"
+    openbank.tech/policy-checksum: "91c821d61f67cd72"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -568,14 +568,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -585,8 +598,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d8314c02444237a"
+        openbank.tech/policy-checksum: "91c821d61f67cd72"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "b2e6efd4384f0d78"
+    openbank.tech/policy-checksum: "bdb3174420815353"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -600,14 +600,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -617,8 +630,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2e6efd4384f0d78"
+        openbank.tech/policy-checksum: "bdb3174420815353"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "fa1e397030feac5d"
+    openbank.tech/policy-checksum: "9becfeb96c18c264"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -651,14 +651,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -668,8 +681,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fa1e397030feac5d"
+        openbank.tech/policy-checksum: "9becfeb96c18c264"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "f7d985ec75528070"
+    openbank.tech/policy-checksum: "d3f2d00b953e0133"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1893,14 +1893,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -1910,8 +1923,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7d985ec75528070"
+        openbank.tech/policy-checksum: "d3f2d00b953e0133"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "f7d985ec75528070"
+    openbank.tech/policy-checksum: "d3f2d00b953e0133"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1893,14 +1893,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -1910,8 +1923,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7d985ec75528070"
+        openbank.tech/policy-checksum: "d3f2d00b953e0133"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "44d5fc9ad95570d0"
+    openbank.tech/policy-checksum: "7609de8301d92f1e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -579,14 +579,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -596,8 +609,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "44d5fc9ad95570d0"
+        openbank.tech/policy-checksum: "7609de8301d92f1e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "c2890c2f0f24471b"
+    openbank.tech/policy-checksum: "7c2f0b1f13bf42eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -630,14 +630,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -647,8 +660,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c2890c2f0f24471b"
+        openbank.tech/policy-checksum: "7c2f0b1f13bf42eb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "cb39de827ba381aa"
+    openbank.tech/policy-checksum: "c97c8e5bdffc95bf"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -564,14 +564,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -581,8 +594,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb39de827ba381aa"
+        openbank.tech/policy-checksum: "c97c8e5bdffc95bf"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "9a70365cc430aa4f"
+    openbank.tech/policy-checksum: "b3ff51c56f3967f3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -677,14 +677,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -694,8 +707,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9a70365cc430aa4f"
+        openbank.tech/policy-checksum: "b3ff51c56f3967f3"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9d65979b9e6f884b"
+    openbank.tech/policy-checksum: "f6e721b6270a31de"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -632,14 +632,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -649,8 +662,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9d65979b9e6f884b"
+        openbank.tech/policy-checksum: "f6e721b6270a31de"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "f7d985ec75528070"
+    openbank.tech/policy-checksum: "d3f2d00b953e0133"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1893,14 +1893,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -1910,8 +1923,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "f7d985ec75528070"
+        openbank.tech/policy-checksum: "d3f2d00b953e0133"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5b287c8999c190ac"
+    openbank.tech/policy-checksum: "3fb46e611ca95d73"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -585,14 +585,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -602,8 +615,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0eb8cb2e15f98f23"
+    openbank.tech/policy-checksum: "19a9ac806bfb0d40"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -622,14 +622,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -639,8 +652,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "42823e41f720981f"
+    openbank.tech/policy-checksum: "c77cc841a36be35b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -607,14 +607,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -624,8 +637,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "485cce4e95561032" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "56668ec48b4de096" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "feeadda01e417d4d"
+        openbank.tech/policy-checksum: "0848c6796656516a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "42823e41f720981f" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "c77cc841a36be35b" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "335c2029a5cf56e7"
+        openbank.tech/policy-checksum: "bf5c211cfcf5518d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "0eb8cb2e15f98f23" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "19a9ac806bfb0d40" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5b287c8999c190ac"
+        openbank.tech/policy-checksum: "3fb46e611ca95d73"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "88cbe6b3afb6d501" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "3133cd43f8eb6ac0" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b362d086d369d16"
+        openbank.tech/policy-checksum: "3f8546b73585d8b6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a5a854d83d45fd2e"
+        openbank.tech/policy-checksum: "7d504a1fe73829ba"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "335c2029a5cf56e7"
+    openbank.tech/policy-checksum: "bf5c211cfcf5518d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -580,14 +580,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -597,8 +610,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "feeadda01e417d4d"
+    openbank.tech/policy-checksum: "0848c6796656516a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -601,14 +601,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -618,8 +631,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "88cbe6b3afb6d501"
+    openbank.tech/policy-checksum: "3133cd43f8eb6ac0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -581,14 +581,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -598,8 +611,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8b362d086d369d16"
+    openbank.tech/policy-checksum: "3f8546b73585d8b6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -584,14 +584,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -601,8 +614,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "485cce4e95561032"
+    openbank.tech/policy-checksum: "56668ec48b4de096"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -637,14 +637,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -654,8 +667,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a5a854d83d45fd2e"
+    openbank.tech/policy-checksum: "7d504a1fe73829ba"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -588,14 +588,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -605,8 +618,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "47e4a797af43c8cd"
+    openbank.tech/policy-checksum: "cfcb970183d86e67"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -590,14 +590,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -607,8 +620,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "47e4a797af43c8cd"
+        openbank.tech/policy-checksum: "cfcb970183d86e67"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "e7820afafe717723"
+    openbank.tech/policy-checksum: "f876cea669403a20"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -568,14 +568,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -585,8 +598,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e7820afafe717723"
+        openbank.tech/policy-checksum: "f876cea669403a20"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "06cf2e3093f20e46"
+    openbank.tech/policy-checksum: "594b284c8d00fe52"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -604,14 +604,27 @@ data:
 
     # ---------------------------------------------------------------------------------------
     # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+    #
+    # ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+    #
+    # This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+    # anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+    # target therefore reads as a live control to anything consuming those bundles — which is exactly
+    # how the model_gateway block below came to assert a data-residency routing rule that has never
+    # run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+    # against gitops and the live sandbox:
     # ---------------------------------------------------------------------------------------
     runtime:
-      orchestration: temporal           # agent = durable, replayable workflow; full step history
-      reasoning:     langgraph          # state graph executed as Temporal activities
-      guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-      memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-      observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-      identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+      orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+      reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+      guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                        # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                        # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+      memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                        # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+      observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+      identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                        # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
     # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
     # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -621,8 +634,32 @@ data:
     # ---------------------------------------------------------------------------------------
     # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
     # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+    #
+    # ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+    # first — it is the one that describes the running system.
+    #
+    # Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+    # name this block was embedded into 34 OPA bundles as policy data asserting
+    # `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+    # data-residency control that has never existed. A false control claim is worse than an absent one:
+    # an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+    # must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
     # ---------------------------------------------------------------------------------------
-    model_gateway:
+    model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+      gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                       # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                       # agents and points at a Service that has never existed (#1280).
+      budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+      providers:
+        deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                       # pinning, no DPA. The single de-facto provider; chosen on cost.
+          hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                       # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+      routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+      fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                       # the agent degrades to a deterministic path (ADR-0174 §4).
+
+    model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
       tool: litellm                       # or equivalent open gateway in front of all models
       budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
       models:

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06cf2e3093f20e46"
+        openbank.tech/policy-checksum: "594b284c8d00fe52"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/agents.yaml
+++ b/openbank-libs/governance/agents.yaml
@@ -44,14 +44,27 @@ global_controls:
 
 # ---------------------------------------------------------------------------------------
 # Open runtime stack (ADR-0031 D6). No single-vendor agent SDK; all components in-cluster.
+#
+# ⚠ THIS BLOCK IS THE TARGET (ADR-0031 D6), NOT THE AS-BUILT. Read the `# as-built:` notes.
+#
+# This file is embedded VERBATIM into 34 OPA bundle ConfigMaps (rules.yaml: opa_bundle_sync), so
+# anything asserted here is replicated fleet-wide as machine-readable policy data. An unmarked
+# target therefore reads as a live control to anything consuming those bundles — which is exactly
+# how the model_gateway block below came to assert a data-residency routing rule that has never
+# run (issue #1280, ADR-0174 §2, ADR-0175 §4). Per-key as-built status, verified 2026-07-16
+# against gitops and the live sandbox:
 # ---------------------------------------------------------------------------------------
 runtime:
-  orchestration: temporal           # agent = durable, replayable workflow; full step history
-  reasoning:     langgraph          # state graph executed as Temporal activities
-  guardrails:    [llama-guard, prompt-injection-filter]   # read data is untrusted (instruction/data split)
-  memory_rag:    pgvector           # grounding in rules.yaml / ADRs / code (reuses Postgres)
-  observability: langfuse           # on top of OTel (ADR-0008); tracks approval-without-edit rate
-  identity:      spiffe-spire       # short-TTL SVID per run; signing root stays in Vault (ADR-0017)
+  orchestration: temporal           # as-built: LIVE. temporal namespace up; agents are Temporal workflows.
+  reasoning:     langgraph          # as-built: NOT DEPLOYED. Activities are hand-written Kotlin; no langgraph.
+  guardrails:    [llama-guard, prompt-injection-filter]   # as-built: PARTIAL. PromptInjectionGuard.kt is real
+                                    # (copilot-service). llama-guard is NOT deployed — its only occurrences are
+                                    # inside the OPA bundles' embedded copy of THIS file, which is not evidence.
+  memory_rag:    pgvector           # as-built: NOT DEPLOYED. No pgvector, no embeddings, no RAG. The copilot's
+                                    # HelpKnowledgeBase is deterministic keyword scoring, by explicit choice.
+  observability: langfuse           # as-built: NOT DEPLOYED. OTel only.
+  identity:      spiffe-spire       # as-built: PARTIAL. AgentSvidVerifier.kt is real, but no SPIRE deployment
+                                    # exists; the live agent identity is OpenBao's pki-agent CA (ADR-0031 D3b).
 
 # Licensing note (ADR-0136, supersedes the ADR-0031 D8 separate-repo plan): the AI agent SERVICES are
 # AGPL-3.0-only + a parallel commercial licence, IN-REPO (not a separate repo); the rest of the platform is
@@ -61,8 +74,32 @@ runtime:
 # ---------------------------------------------------------------------------------------
 # Model strategy -- hybrid, model-agnostic via an open LLM gateway (ADR-0031 D6).
 # No lock-in: tools via MCP, policy via Rego, models via the gateway.
+#
+# ⚠⚠ NONE OF THE `model_gateway_target` BLOCK BELOW IS DEPLOYED. Read `model_gateway_as_built`
+# first — it is the one that describes the running system.
+#
+# Renamed from `model_gateway` to `model_gateway_target` deliberately (issue #1280): under the old
+# name this block was embedded into 34 OPA bundles as policy data asserting
+# `routing: {sensitive_data: self_hosted}` — i.e. the platform machine-claimed a GDPR Chapter V
+# data-residency control that has never existed. A false control claim is worse than an absent one:
+# an absent control gets found, an asserted one gets relied on. Any consumer reading the bundles
+# must now hit `_target` / `_as_built` and cannot mistake the intent for the state.
 # ---------------------------------------------------------------------------------------
-model_gateway:
+model_gateway_as_built:            # verified 2026-07-16 against gitops + the live sandbox
+  gateway: none                    # no gateway. Agents call the provider endpoint directly.
+                                   # LLM_GATEWAY_URL=http://litellm.ai-platform.svc:4000 is set on 5
+                                   # agents and points at a Service that has never existed (#1280).
+  budgets_enforced_at: charter     # CharterRateLimiter in openbank-agent-service — NOT a gateway.
+  providers:
+    deepinfra:                     # api.deepinfra.com, deepseek-ai/DeepSeek-V3.2. US-hosted, no region
+                                   # pinning, no DPA. The single de-facto provider; chosen on cost.
+      hosted: true                 # prompt data LEAVES THE EU. Licensed for synthetic data only —
+                                   # see ADR-0175 §4/§5. There is NO technical control enforcing that.
+  routing: none                    # no sensitive_data routing exists. See ADR-0175 D3.
+  fallback: none                   # single provider. On failure LlmDiagnosisAdapter returns null and
+                                   # the agent degrades to a deterministic path (ADR-0174 §4).
+
+model_gateway_target:              # ADR-0031 D6 — the decision. NOT the state. Nothing here is deployed.
   tool: litellm                       # or equivalent open gateway in front of all models
   budgets_enforced_at: gateway        # tokens/run + runs/day from each charter
   models:


### PR DESCRIPTION
## Summary

`agents.yaml` is embedded **verbatim into 34 OPA bundle ConfigMaps**, so anything it asserts becomes machine-readable policy data fleet-wide. It asserted `routing: {sensitive_data: self_hosted}` — a **GDPR Chapter V data-residency control that has never existed**.

Fixed at the source, since that is what ripples to all 34 bundles.

## Type of change

- [x] fix (bug fix)
- [x] security (a control the platform claimed and does not have)
- [ ] feat / refactor / perf / docs / chore / breaking

## Linked issues

Closes #1280
Refs ADR-0031, ADR-0174 §2, ADR-0175 §4

## The problem

ADR-0031 D6 decides a hybrid topology: LiteLLM gateway, self-hosted vLLM for sensitive/residency work, Anthropic hosted, `sensitive_data → self_hosted` routing. **None of it is deployed** — verified against gitops *and* the live sandbox:

```
$ kubectl get ns ai-platform
Error from server (NotFound): namespaces "ai-platform" not found
$ kubectl get svc -A | grep -c litellm
0
```

The real dependency is one US provider (DeepInfra), no routing, no fallback. But because `agents.yaml` said otherwise, 34 bundles machine-asserted the residency control. **A false control claim is worse than an absent one: an absent control gets found, an asserted one gets relied on.**

## What changed

`model_gateway` is split and renamed so no consumer can mistake intent for state:

| key | says |
|---|---|
| `model_gateway_as_built` | `gateway: none`, `routing: none`, `fallback: none`, `deepinfra hosted: true` (prompt data leaves the EU) |
| `model_gateway_target` | ADR-0031 D6's decision, verbatim, marked NOT deployed |

The rename is safe — **nothing reads `model_gateway`** (no rego, no Kotlin, no script; checked).

The `runtime:` block had the same disease, and gets **per-key** as-built notes rather than a blanket warning, because it is genuinely mixed. Verified individually:

| key | as-built |
|---|---|
| `orchestration: temporal` | **LIVE** — namespace up 26d |
| `reasoning: langgraph` | NOT DEPLOYED |
| `memory_rag: pgvector` | NOT DEPLOYED |
| `observability: langfuse` | NOT DEPLOYED |
| `guardrails` | **PARTIAL** — `PromptInjectionGuard.kt` real; llama-guard not deployed |
| `identity: spiffe-spire` | **PARTIAL** — `AgentSvidVerifier.kt` real; no SPIRE. Live identity is OpenBao `pki-agent` |

Worth noting: **llama-guard's only occurrences in the repo are inside the bundles' own embedded copy of this file.** Circular evidence — the artifact citing itself.

## Definition of Done

- [x] Hexagonal layering — N/A (governance data).
- [ ] Unit / integration / contract tests — N/A; verified by `opa eval` instead (below).
- [x] `opa check` passes on the regenerated bundle.
- [x] **OPA decisions verified unchanged** — operator allow, anonymous deny, unregistered `AI_AGENT` tool deny. This is a data-truth fix, not a policy change; if a decision had moved, that would be a bug.
- [x] All 27 generators re-run; regeneration idempotent (46 files, stable across a second run).
- [x] `check-duplicate-yaml-keys` green.
- [ ] OpenAPI / Flyway / Avro — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [x] **Authorization policy data changed → `security-review-required`.** Decisions verified unchanged.
- [ ] PII path changed — no. It *documents* a PII egress exposure that already exists (ADR-0175 §4).
- [ ] Cardholder data — no.

## Compliance impact

- [x] **GDPR Chapter V** — the asserted `sensitive_data → self_hosted` routing was the thing that would keep personal data off a US endpoint. It does not run. This PR stops claiming it does; **ADR-0175 D3 is the control that would make it true.**
- [x] DORA Art. 28-30 — the machine-readable governance data now names the provider actually in use (ADR-0174 §1).
- [ ] PCI DSS / PSD2 / AML / CNB / None

## Rollout / Rollback

- **Deployment strategy:** the bundle checksums change, so every OPA sidecar pod rolls (that is the mechanism working — `subPath` mounts do not hot-reload). **No decision changes**, so no authorization behaviour changes.
- **Rollback plan:** revert. The bundles resume asserting a residency control that does not exist.
- **Data migration reversible:** N/A.

## Reviewer notes

**I corrected my own report while doing this** — see [#1280 comment](https://github.com/JiRaska/open-bank-oss/issues/1280#issuecomment-4993075109). I originally wrote "five agents point at a service that has never existed", which reads as *five agents are calling a ghost and failing*. They are not: all five `LlmDiagnosisAdapter`s are **stubs** (0 HTTP calls; they only *log* the URL and return a canned string with a `TODO(ADR-0164)`). `LLM_GATEWAY_URL` is config for an unbuilt integration, not a broken call path — cosmetic, not a defect. I overstated it, so I have not touched it here.

The OPA finding is the one that mattered, and it stands.

**What this does not fix:** the exposure itself. Prompt data still reaches DeepInfra; the only control remains a YAML comment saying "synthetic data only" (ADR-0175 §4). This PR makes the governance data honest about that — **ADR-0175 D3** is what closes it.
