### PR TITLE
chore(ci): stop dependabot re-opening the two unbuildable admin-ui majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Majors the ecosystem cannot satisfy yet. Each PR can never go green, so
+    # dependabot would just re-open a red PR every Monday. Drop the entry once
+    # the unblock criterion in #1314 is met.
+    ignore:
+      # eslint 10 removed context.getFilename(); the eslint-plugin-react that
+      # eslint-config-next@16 bundles still calls it and peers on eslint <=9.
+      - dependency-name: "eslint"
+        versions: ["10.x"]
+      # The typescript-eslint parser does not support the TypeScript 7
+      # compiler API (crashes reading ModuleKind 'Cjs').
+      - dependency-name: "typescript"
+        versions: ["7.x"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Two dependabot PRs sit in the queue with a red Admin UI build. Neither is fixable here — both fail upstream of this repo, so they can never go green as filed.

## What actually fails

**#968 — eslint 9.39.4 -> 10.7.0**

```
TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function
    at resolveBasedir (.../eslint-config-next/node_modules/eslint-plugin-react/lib/util/version.js:31:100)
```

ESLint 10 removed `context.getFilename()`. `eslint-config-next@16.2.10` bundles an `eslint-plugin-react` that still calls it and peers on `^2 || ... || ^9`.

**#969 — typescript 6.0.3 -> 7.0.2**

```
ESLint: 9.39.4
TypeError: Cannot read properties of undefined (reading 'Cjs')
```

The typescript-eslint parser does not support the TypeScript 7 compiler API.

## The change

Adds an `ignore` block to the `/openbank-admin-ui` npm ecosystem pinning out `eslint 10.x` and `typescript 7.x` only. Without it dependabot re-opens both every Monday and the queue goes red again.

The pin is deliberately version-scoped rather than `update-types: semver-major`, so the next major after each still surfaces for review instead of being silently swallowed.

#968 and #969 are closed; #1314 tracks the unblock criteria and is the trigger to remove each entry.

## Verification

- `yaml.safe_load` parses the file; the `ignore` block lands on the npm block only, `next` / `react` / `ui-minor` groups unchanged.

## Linked issues

Refs #1314