### PR TITLE
feat(interest): post the ADR-0033 split so capitalization actually credits the customer

### DIFF
--- a/openbank-infra/docker-compose.yml
+++ b/openbank-infra/docker-compose.yml
@@ -1012,6 +1012,10 @@ services:
       QUARKUS_REDIS_HOSTS: redis://:${VALKEY_PASSWORD}@valkey:6379
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       MP_MESSAGING_CONNECTOR_SMALLRYE_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      # ADR-0033 §D: capitalization posts its credit leg to the ledger. The application.yaml
+      # default is localhost, which resolves to the container itself here.
+      LEDGER_SERVICE_URL: http://ledger-service:8101
+      TRANSACTION_SERVICE_URL: http://transaction-service:8102
     ports:
       - "8125:8125"
     depends_on:

--- a/openbank-interest-service/build.gradle.kts
+++ b/openbank-interest-service/build.gradle.kts
@@ -48,6 +48,12 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
+
+    // Consumer-driven contract for the ledger-service postJournal call the ADR-0033 §D
+    // capitalization credit leg makes (ADR-0063). interest-service is the fifth ledger-posting
+    // consumer; every other one already has a pact with openbank-ledger-service as provider.
+    testImplementation(libs.rest.assured.kotlin)
+    testImplementation(libs.pact.consumer)
 }
 
 kover {
@@ -63,4 +69,23 @@ kover {
             }
         }
     }
+}
+
+// Pact: write the generated consumer contract to pacts/ and forward broker config, matching
+// transaction-service/lending-service/billing-service/settlement-service's tasks.withType<Test>
+// block (ADR-0063 P1/P2). Without pact.rootDir the pact lands in the module's build/pacts and
+// .github/workflows/pact-drift-check.yml never sees it.
+tasks.withType<Test> {
+    systemProperty("pact.rootDir", "${rootProject.projectDir}/pacts")
+    listOf(
+        "pactbroker.url",
+        "pactbroker.auth.username",
+        "pactbroker.auth.password",
+        "pactbroker.enablePending",
+        "pactbroker.providerBranch",
+        "pact.verifier.publishResults",
+        "pact.provider.version",
+        "pact.provider.branch",
+        "pact.provider.tag",
+    ).forEach { key -> System.getProperty(key)?.let { systemProperty(key, it) } }
 }

--- a/openbank-interest-service/ktlint-baseline.xml
+++ b/openbank-interest-service/ktlint-baseline.xml
@@ -143,106 +143,108 @@
         <error line="45" column="29" source="standard:annotation" />
         <error line="45" column="58" source="standard:annotation" />
         <error line="46" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="46" column="37" source="standard:annotation" />
+        <error line="46" column="40" source="standard:annotation" />
         <error line="47" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="47" column="33" source="standard:annotation" />
-        <error line="50" column="8" source="standard:annotation" />
-        <error line="52" column="8" source="standard:annotation" />
-        <error line="52" column="43" source="standard:annotation" />
-        <error line="53" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="53" column="60" source="standard:annotation" />
+        <error line="47" column="37" source="standard:annotation" />
+        <error line="48" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="48" column="33" source="standard:annotation" />
+        <error line="51" column="8" source="standard:annotation" />
+        <error line="53" column="8" source="standard:annotation" />
+        <error line="53" column="43" source="standard:annotation" />
         <error line="54" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="54" column="33" source="standard:annotation" />
+        <error line="54" column="60" source="standard:annotation" />
         <error line="55" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="55" column="34" source="standard:annotation" />
+        <error line="55" column="33" source="standard:annotation" />
         <error line="56" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="56" column="32" source="standard:annotation" />
+        <error line="56" column="34" source="standard:annotation" />
         <error line="57" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="57" column="63" source="standard:annotation" />
+        <error line="57" column="32" source="standard:annotation" />
         <error line="58" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="58" column="68" source="standard:annotation" />
+        <error line="58" column="63" source="standard:annotation" />
         <error line="59" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="59" column="62" source="standard:annotation" />
+        <error line="59" column="68" source="standard:annotation" />
         <error line="60" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="60" column="60" source="standard:annotation" />
+        <error line="60" column="62" source="standard:annotation" />
         <error line="61" column="1" source="standard:spacing-between-declarations-with-annotations" />
         <error line="61" column="60" source="standard:annotation" />
         <error line="62" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="62" column="43" source="standard:annotation" />
+        <error line="62" column="60" source="standard:annotation" />
         <error line="63" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="63" column="65" source="standard:annotation" />
+        <error line="63" column="43" source="standard:annotation" />
         <error line="64" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="64" column="33" source="standard:annotation" />
-        <error line="67" column="8" source="standard:annotation" />
-        <error line="69" column="8" source="standard:annotation" />
-        <error line="69" column="43" source="standard:annotation" />
-        <error line="70" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="70" column="67" source="standard:annotation" />
+        <error line="64" column="65" source="standard:annotation" />
+        <error line="65" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="65" column="33" source="standard:annotation" />
+        <error line="68" column="8" source="standard:annotation" />
+        <error line="70" column="8" source="standard:annotation" />
+        <error line="70" column="43" source="standard:annotation" />
         <error line="71" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="71" column="60" source="standard:annotation" />
+        <error line="71" column="67" source="standard:annotation" />
         <error line="72" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="72" column="32" source="standard:annotation" />
+        <error line="72" column="60" source="standard:annotation" />
         <error line="73" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="73" column="34" source="standard:annotation" />
+        <error line="73" column="32" source="standard:annotation" />
         <error line="74" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="74" column="32" source="standard:annotation" />
+        <error line="74" column="34" source="standard:annotation" />
         <error line="75" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="75" column="62" source="standard:annotation" />
+        <error line="75" column="32" source="standard:annotation" />
         <error line="76" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="76" column="53" source="standard:annotation" />
+        <error line="76" column="62" source="standard:annotation" />
         <error line="77" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="77" column="60" source="standard:annotation" />
+        <error line="77" column="53" source="standard:annotation" />
         <error line="78" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="78" column="43" source="standard:annotation" />
+        <error line="78" column="60" source="standard:annotation" />
         <error line="79" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="79" column="13" source="standard:argument-list-wrapping" />
-        <error line="79" column="31" source="standard:argument-list-wrapping" />
-        <error line="79" column="32" source="standard:annotation" />
-        <error line="79" column="45" source="standard:argument-list-wrapping" />
-        <error line="79" column="60" source="standard:argument-list-wrapping" />
-        <error line="79" column="61" source="standard:annotation" />
-        <error line="79" column="121" source="standard:max-line-length" />
+        <error line="79" column="43" source="standard:annotation" />
         <error line="80" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="80" column="34" source="standard:annotation" />
+        <error line="80" column="13" source="standard:argument-list-wrapping" />
+        <error line="80" column="31" source="standard:argument-list-wrapping" />
+        <error line="80" column="32" source="standard:annotation" />
+        <error line="80" column="45" source="standard:argument-list-wrapping" />
+        <error line="80" column="60" source="standard:argument-list-wrapping" />
+        <error line="80" column="61" source="standard:annotation" />
+        <error line="80" column="121" source="standard:max-line-length" />
         <error line="81" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="81" column="13" source="standard:argument-list-wrapping" />
-        <error line="81" column="28" source="standard:argument-list-wrapping" />
-        <error line="81" column="29" source="standard:annotation" />
-        <error line="81" column="42" source="standard:argument-list-wrapping" />
-        <error line="81" column="57" source="standard:argument-list-wrapping" />
-        <error line="81" column="58" source="standard:annotation" />
-        <error line="81" column="121" source="standard:max-line-length" />
+        <error line="81" column="34" source="standard:annotation" />
         <error line="82" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="82" column="63" source="standard:annotation" />
+        <error line="82" column="13" source="standard:argument-list-wrapping" />
+        <error line="82" column="28" source="standard:argument-list-wrapping" />
+        <error line="82" column="29" source="standard:annotation" />
+        <error line="82" column="42" source="standard:argument-list-wrapping" />
+        <error line="82" column="57" source="standard:argument-list-wrapping" />
+        <error line="82" column="58" source="standard:annotation" />
+        <error line="82" column="121" source="standard:max-line-length" />
         <error line="83" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="83" column="33" source="standard:annotation" />
-        <error line="86" column="8" source="standard:annotation" />
-        <error line="88" column="8" source="standard:annotation" />
-        <error line="88" column="43" source="standard:annotation" />
-        <error line="89" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="89" column="34" source="standard:annotation" />
+        <error line="83" column="63" source="standard:annotation" />
+        <error line="84" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="84" column="33" source="standard:annotation" />
+        <error line="87" column="8" source="standard:annotation" />
+        <error line="89" column="8" source="standard:annotation" />
+        <error line="89" column="43" source="standard:annotation" />
         <error line="90" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="90" column="35" source="standard:annotation" />
+        <error line="90" column="34" source="standard:annotation" />
         <error line="91" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="91" column="32" source="standard:annotation" />
+        <error line="91" column="35" source="standard:annotation" />
         <error line="92" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="92" column="43" source="standard:annotation" />
+        <error line="92" column="32" source="standard:annotation" />
         <error line="93" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="93" column="66" source="standard:annotation" />
+        <error line="93" column="43" source="standard:annotation" />
         <error line="94" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="94" column="33" source="standard:annotation" />
+        <error line="94" column="66" source="standard:annotation" />
         <error line="95" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="95" column="31" source="standard:annotation" />
+        <error line="95" column="33" source="standard:annotation" />
         <error line="96" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="96" column="13" source="standard:argument-list-wrapping" />
-        <error line="96" column="28" source="standard:argument-list-wrapping" />
-        <error line="96" column="29" source="standard:annotation" />
-        <error line="96" column="42" source="standard:argument-list-wrapping" />
-        <error line="96" column="57" source="standard:argument-list-wrapping" />
-        <error line="96" column="58" source="standard:annotation" />
-        <error line="96" column="121" source="standard:max-line-length" />
+        <error line="96" column="31" source="standard:annotation" />
         <error line="97" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="97" column="33" source="standard:annotation" />
+        <error line="97" column="13" source="standard:argument-list-wrapping" />
+        <error line="97" column="28" source="standard:argument-list-wrapping" />
+        <error line="97" column="29" source="standard:annotation" />
+        <error line="97" column="42" source="standard:argument-list-wrapping" />
+        <error line="97" column="57" source="standard:argument-list-wrapping" />
+        <error line="97" column="58" source="standard:annotation" />
+        <error line="97" column="121" source="standard:max-line-length" />
+        <error line="98" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="98" column="33" source="standard:annotation" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/infrastructure/persistence/mapper/InterestMapper.kt">
         <error line="7" column="1" source="standard:no-wildcard-imports" />

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/InterestPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/InterestPorts.kt
@@ -37,6 +37,33 @@ interface InterestAccrualRepository {
      * product's accruals into this capitalization would credit them against the wrong product.
      */
     fun findPendingCapitalization(accountId: UUID, productId: String, toDate: LocalDate): Uni<List<InterestAccrual>>
+
+    /**
+     * The accruals of one `(account, product)` already **claimed** by an in-flight capitalization
+     * (`CAPITALIZING`), regardless of date.
+     *
+     * Deliberately NOT bounded by a period: the caller must be able to see a claim made for a
+     * *different* `periodTo` and refuse rather than silently re-capitalize the same accruals under a
+     * second ledger idempotency key — see `InterestService.capitalize`. Each row carries the period
+     * it was claimed for in [InterestAccrual.claimedPeriodTo].
+     */
+    fun findClaimedForCapitalization(accountId: UUID, productId: String): Uni<List<InterestAccrual>>
+
+    /**
+     * Claims [accrualIds] for the capitalization of [periodTo]: flips them `ACCRUING → CAPITALIZING`
+     * and stamps `claimed_period_to`, in ONE status-guarded transaction of its own.
+     *
+     * This is what pins the amount the ledger is about to be told to the amount that will be
+     * recorded. Without it, the ledger post and the capitalization row each re-derive the accrual
+     * set independently, and a backfilled accrual landing between them makes interest-service claim
+     * a credit the GL never booked — silently, because the ledger's idempotent replay returns the
+     * FIRST journal without comparing amounts.
+     *
+     * Fails (and rolls back) unless every id flipped: a partial match means a concurrent run claimed
+     * or capitalized some of them.
+     */
+    fun claimForCapitalization(accrualIds: List<UUID>, periodTo: LocalDate): Uni<Unit>
+
     fun sumAccrued(accountId: UUID, from: LocalDate, to: LocalDate): Uni<BigDecimal>
 }
 
@@ -47,14 +74,15 @@ interface InterestCapitalizationRepository {
 
     /**
      * Persists the capitalization, its paired withholding-tax liability and the outbox event, and
-     * flips the source accruals `ACCRUING → CAPITALIZED`, all in ONE database transaction (same
+     * flips the source accruals `CAPITALIZING → CAPITALIZED`, all in ONE database transaction (same
      * atomic shape as statement-service's `saveWithOutbox`). A crash or failure anywhere rolls the
      * whole write set back, so a retry re-runs from a clean slate instead of re-crediting
      * already-capitalized accruals (duplicate interest + duplicate withholding).
      *
-     * The accrual flip is status-guarded (`AND status = 'ACCRUING'`): if any of [accrualIds] was
-     * capitalized by a concurrent run, the row count mismatches and the transaction fails — no
-     * partial rows survive.
+     * The accrual flip is status-guarded (`AND status = 'CAPITALIZING'`): the rows must still be the
+     * ones this attempt claimed via [InterestAccrualRepository.claimForCapitalization]. If a
+     * concurrent run capitalized or reversed any of them, the row count mismatches and the
+     * transaction fails — no partial rows survive.
      */
     fun saveWithOutbox(
         cap: InterestCapitalization,

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/LedgerPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/LedgerPorts.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.application.port.out
+
+import io.smallrye.mutiny.Uni
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * The customer credit leg of a capitalization (ADR-0033 §D) — the accounting fact that interest was
+ * credited, expressed in the interest domain's own terms and left for the adapter to turn into a
+ * balanced journal.
+ *
+ * This is an **accounting event, not a payment**: nothing is instructed, cleared or settled, so it
+ * follows `openbank-lending-service`'s `LedgerPostingPort` shape (hand the ledger a journal) rather
+ * than the withholding *remittance* path's `TransactionServiceClient.initiateTransaction` (instruct
+ * a real payment to the finanční úřad). The two are easy to confuse because both touch tax money;
+ * the remittance moves the bank's cash out, this only records that the customer is owed the net and
+ * the state is owed the tax.
+ *
+ * [grossAmount] must equal [netAmount] + [taxAmount] — [WithholdingTaxPolicy][com.openbank.interest
+ * .domain.tax.WithholdingTaxPolicy] guarantees it by construction (`net = gross − tax`), and it is
+ * what makes the resulting three-leg entry balance within [currency].
+ */
+data class CapitalizationPosting(
+    /** The customer account whose pocket is credited — the sub-ledger dimension of the deposit leg. */
+    val accountId: UUID,
+    val productId: String,
+    /** Period end = the §38d credit date; part of the business identity of this capitalization. */
+    val periodTo: LocalDate,
+    val currency: String,
+    /** Gross interest earned — the bank's expense. */
+    val grossAmount: BigDecimal,
+    /** Withholding tax retained at source; zero for NOT_WITHHELD / EXEMPT / DEFERRED_FX. */
+    val taxAmount: BigDecimal,
+    /** What the customer actually receives (`gross − tax`). */
+    val netAmount: BigDecimal,
+)
+
+/**
+ * Posts the capitalization split to `openbank-ledger-service`.
+ *
+ * Implementations MUST be idempotent on the posting's **business identity**
+ * (`account, product, period end`) so that a retry after a crash collapses onto the already-booked
+ * journal instead of crediting the customer twice — see
+ * [CapitalizationJournalFactory][com.openbank.interest.infrastructure.client.CapitalizationJournalFactory].
+ */
+interface LedgerPostingPort {
+    fun post(posting: CapitalizationPosting): Uni<Unit>
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/LedgerPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/LedgerPorts.kt
@@ -4,8 +4,8 @@
 
 package com.openbank.interest.application.port.out
 
+import com.openbank.libs.domain.money.Money
 import io.smallrye.mutiny.Uni
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 
@@ -21,9 +21,19 @@ import java.util.UUID
  * the remittance moves the bank's cash out, this only records that the customer is owed the net and
  * the state is owed the tax.
  *
- * [grossAmount] must equal [netAmount] + [taxAmount] — [WithholdingTaxPolicy][com.openbank.interest
- * .domain.tax.WithholdingTaxPolicy] guarantees it by construction (`net = gross − tax`), and it is
- * what makes the resulting three-leg entry balance within [currency].
+ * ### Why the amounts are [Money] and not `BigDecimal`
+ *
+ * `LedgerService` re-wraps every incoming line as `Money.of(amount, currencyCode)`, and `Money`
+ * refuses an amount whose scale exceeds the currency's minor units (CZK/EUR/USD/GBP = 2). A posting
+ * carrying a raw `BigDecimal` therefore pushes that invariant across a network boundary, where it
+ * surfaces as an opaque HTTP 400 on **every** capitalization instead of a compile-time obligation —
+ * which is exactly what happened when this port was first written with three bare `BigDecimal`s at
+ * scale 4. lending's `LendingJournalFactory` and transaction-service's `PaymentJournalFactory` are
+ * immune by type (both read `.amount` off a `Money`); this port now is too. Rounding to the
+ * currency's scale happens ONCE, at the source in `InterestService`, before this type is built.
+ *
+ * [gross] must equal [net] + [tax] and all three must share one currency — enforced here, in the
+ * constructor, so an unbalanced or mixed-currency split cannot exist as a value at all.
  */
 data class CapitalizationPosting(
     /** The customer account whose pocket is credited — the sub-ledger dimension of the deposit leg. */
@@ -31,14 +41,28 @@ data class CapitalizationPosting(
     val productId: String,
     /** Period end = the §38d credit date; part of the business identity of this capitalization. */
     val periodTo: LocalDate,
-    val currency: String,
     /** Gross interest earned — the bank's expense. */
-    val grossAmount: BigDecimal,
+    val gross: Money,
     /** Withholding tax retained at source; zero for NOT_WITHHELD / EXEMPT / DEFERRED_FX. */
-    val taxAmount: BigDecimal,
+    val tax: Money,
     /** What the customer actually receives (`gross − tax`). */
-    val netAmount: BigDecimal,
-)
+    val net: Money,
+) {
+    init {
+        require(gross.currency == net.currency && gross.currency == tax.currency) {
+            "Refusing a mixed-currency interest capitalization for account=$accountId " +
+                "product=$productId period=$periodTo: gross=$gross net=$net tax=$tax"
+        }
+        require(gross.amount.compareTo(net.amount.add(tax.amount)) == 0) {
+            "Refusing to post an unbalanced interest capitalization for account=$accountId " +
+                "product=$productId period=$periodTo: gross=${gross.amount} != " +
+                "net=${net.amount} + tax=${tax.amount}"
+        }
+    }
+
+    /** The single ISO-4217 code all three legs are denominated in. */
+    val currency: String get() = gross.currency.code
+}
 
 /**
  * Posts the capitalization split to `openbank-ledger-service`.

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -9,6 +9,8 @@ import com.openbank.interest.application.port.out.*
 import com.openbank.interest.domain.model.*
 import com.openbank.interest.domain.tax.WithholdingTax
 import com.openbank.interest.domain.tax.WithholdingTaxPolicy
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
 import com.openbank.libs.persistence.outbox.OutboxMessage
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
@@ -89,17 +91,84 @@ class InterestService(
         return Uni.createFrom().item(0)
     }
 
+    /**
+     * Capitalizes one `(account, product)` period (ADR-0033 §B/§D): claim → post to the GL → commit.
+     *
+     * ### The claim, and why it exists
+     *
+     * The ledger idempotency key is the capitalization's business identity
+     * (`account, product, periodTo`) and carries **no amount** — on purpose: a key that varied with
+     * the amount would not collide on a retry, it would post a SECOND journal and double-credit the
+     * customer. That makes the key amount-blind, so the accrual set the ledger is told about and the
+     * accrual set the capitalization row records MUST be pinned to be the same set. Reading it twice
+     * is not enough: `findPendingCapitalization` has no lower date bound, so an accrual backfilled
+     * for an earlier date between the two reads silently enlarges the second one. The ledger would
+     * then replay the first journal (100) while this service committed the second amount (120), and
+     * the withholding remittance would pay real cash on 20 CZK the customer never received.
+     *
+     * So the set is **claimed** — flipped `ACCRUING → CAPITALIZING` in its own committed transaction
+     * — before anything is posted, and only a claimed set is ever credited.
+     *
+     * ### Crash recovery
+     *
+     * A crash at any point after the claim leaves the set `CAPITALIZING`. A **plain retry of
+     * `capitalize(accountId, productId, toDate)` recovers it**: this method looks for a claimed set
+     * first, finds that exact one, re-derives the identical gross/net/tax and therefore the identical
+     * idempotency key, and the ledger collapses the replay onto the journal it already booked (or
+     * books it now, if the crash preceded the post). Nothing needs an operator, and there is no way
+     * to wedge: a claimed set is always completable. An accrual backfilled after the claim is
+     * `ACCRUING`, outside it, and falls into the next period — which is the right answer, because it
+     * is not part of the credit the ledger booked.
+     *
+     * The one case that is refused rather than guessed is a claim held for a *different* period end:
+     * completing it under this `toDate` would mint a second key and post a second journal. See
+     * [inFlightClaimFailure].
+     */
     override fun capitalize(accountId: UUID, productId: String, toDate: LocalDate): Uni<InterestCapitalization> =
-        accrualRepo.findPendingCapitalization(accountId, productId, toDate).flatMap { accruals ->
-            // Normalized so a "czk"/"CZK" mix is one currency, not two.
-            val currencies = accruals.map { it.currency.uppercase() }.distinct()
+        accrualRepo.findClaimedForCapitalization(accountId, productId).flatMap { claimed ->
             when {
-                accruals.isEmpty() ->
-                    Uni.createFrom().failure(IllegalStateException("No pending accruals to capitalize"))
-                currencies.size > 1 -> Uni.createFrom().failure(mixedCurrencyFailure(accountId, productId, currencies))
-                else -> capitalizePending(accountId, productId, toDate, accruals, currencies.single())
+                claimed.isEmpty() -> claimAndCapitalize(accountId, productId, toDate)
+                claimed.all { it.claimedPeriodTo == toDate } ->
+                    capitalizeSet(accountId, productId, toDate, claimed, alreadyClaimed = true)
+                else -> Uni.createFrom().failure(inFlightClaimFailure(accountId, productId, toDate, claimed))
             }
         }
+
+    /** No claim outstanding: take a fresh `ACCRUING` set and claim it for [toDate]. */
+    private fun claimAndCapitalize(
+        accountId: UUID,
+        productId: String,
+        toDate: LocalDate,
+    ): Uni<InterestCapitalization> =
+        accrualRepo.findPendingCapitalization(accountId, productId, toDate).flatMap { accruals ->
+            if (accruals.isEmpty()) {
+                Uni.createFrom().failure(IllegalStateException("No pending accruals to capitalize"))
+            } else {
+                capitalizeSet(accountId, productId, toDate, accruals, alreadyClaimed = false)
+            }
+        }
+
+    /**
+     * A `CAPITALIZING` set claimed for another period end. Capitalizing it to [toDate] would derive a
+     * different idempotency key from the one the interrupted attempt used, so the ledger would not
+     * recognise the replay and would post a SECOND journal — for accruals the first journal may
+     * already have credited. There is no safe guess, so refuse and name the retry that fixes it.
+     */
+    private fun inFlightClaimFailure(
+        accountId: UUID,
+        productId: String,
+        toDate: LocalDate,
+        claimed: List<InterestAccrual>,
+    ): IllegalStateException {
+        val periods = claimed.mapNotNull { it.claimedPeriodTo }.distinct().sorted()
+        return IllegalStateException(
+            "Refusing to capitalize account=$accountId product=$productId to periodTo=$toDate: " +
+                "${claimed.size} accrual(s) are already CAPITALIZING, claimed for $periods. Complete that " +
+                "capitalization first by retrying capitalize(account, product, ${periods.firstOrNull()}) — " +
+                "it is idempotent and will collapse onto the journal the interrupted attempt booked. " +
+                "Capitalizing the same accruals to a different period end would post a SECOND journal.",
+        )
+    }
 
     /**
      * A pending set spanning several currencies has no single correct capitalization: the accrued
@@ -116,22 +185,73 @@ class InterestService(
                 "several currencies.",
         )
 
-    /** Capitalizes one single-currency pending set (ADR-0033 §B/§D). See [capitalize] for the guards. */
-    private fun capitalizePending(
+    /**
+     * A negative gross is refused outright, and nothing is claimed, posted or committed.
+     *
+     * It is reachable: `interest_rate_configs.annual_rate` has no CHECK and `createConfig` does not
+     * validate, so a negative rate accrues negative interest. The old code *skipped the ledger* for
+     * a non-positive gross, which committed a capitalization row saying the customer had been
+     * charged while the GL recorded nothing at all — the exact interest-service-vs-GL divergence
+     * this class now exists to prevent. Its KDoc cited V6's `WHERE total_accrued <> 0` as authority,
+     * but V6 excludes only ZERO: it treats a negative capitalization as money-bearing and constrains
+     * it. A negative credit would be `Dr 2100 / Cr 401x` — a debit of the customer's pocket — which
+     * nothing in this service builds and which is a product decision, not a rounding detail.
+     */
+    private fun negativeGrossFailure(
+        accountId: UUID,
+        productId: String,
+        toDate: LocalDate,
+        gross: BigDecimal,
+        currency: String,
+    ) = IllegalStateException(
+        "Refusing to capitalize a NEGATIVE gross for account=$accountId product=$productId " +
+            "periodTo=$toDate: gross=$gross $currency. Charging a customer via the interest " +
+            "capitalization path is not modelled (it would reverse the ADR-0033 §D split to " +
+            "Dr deposit-control / Cr interest-expense); nothing is credited, nothing is withheld " +
+            "and the accruals stay ACCRUING. Check interest_rate_configs.annual_rate for this " +
+            "product — a negative rate is accepted by createConfig today.",
+    )
+
+    /**
+     * Capitalizes one claimed-or-claimable single-currency set (ADR-0033 §B/§D).
+     *
+     * Rounding happens exactly ONCE, here, and to the **currency's** scale — not scale 4. This is
+     * the source: `Money` (and therefore ledger-service, which re-wraps every incoming line as
+     * `Money.of(amount, currencyCode)`) rejects an amount whose scale exceeds the currency's minor
+     * units, so a scale-4 gross 400s every single money-bearing capitalization at the boundary.
+     * Daily accruals stay at scale 6 — `totalAccrued` below is the raw sum — because an accrual is a
+     * running measurement, not money. The capitalization is the actual credit, so it is money, and
+     * it is rounded here rather than at the port so the capitalization row and the GL carry the
+     * identical figures; rounding at the adapter would leave the row and the journal up to 0.005
+     * apart.
+     *
+     * Rounding gross and net independently is safe: [WithholdingTaxPolicy] assesses tax at scale 0
+     * (whole CZK, DOWN), so `round(gross) == round(gross − tax) + tax` exactly and the
+     * `gross = net + tax` invariant [CapitalizationPosting] enforces survives.
+     */
+    private fun capitalizeSet(
         accountId: UUID,
         productId: String,
         toDate: LocalDate,
         accruals: List<InterestAccrual>,
-        currency: String,
+        alreadyClaimed: Boolean,
     ): Uni<InterestCapitalization> {
+        // Normalized so a "czk"/"CZK" mix is one currency, not two.
+        val currencies = accruals.map { it.currency.uppercase() }.distinct()
+        if (currencies.size > 1) return Uni.createFrom().failure(mixedCurrencyFailure(accountId, productId, currencies))
+        val ccy = CurrencyCode.of(currencies.single())
         val total = accruals.fold(BigDecimal.ZERO) { acc, a -> acc + a.accruedAmount }
-        val gross = total.setScale(4, RoundingMode.HALF_UP)
+        val gross = total.setScale(ccy.defaultFractionDigits, RoundingMode.HALF_UP)
+        // Before the claim, so a refusal leaves every accrual ACCRUING and nothing to unwind.
+        if (gross.signum() < 0) {
+            return Uni.createFrom().failure(negativeGrossFailure(accountId, productId, toDate, gross, ccy.code))
+        }
         val periodFrom = accruals.minOf { it.accrualDate }
         val now = OffsetDateTime.now(clock)
         // ADR-0033: withhold at the credit (capitalization), crediting net; record the liability.
         return taxProfilePort.resolve(accountId).flatMap { profile ->
-            val tax = WithholdingTaxPolicy.compute(gross, currency, profile, toDate)
-            val net = tax.netAmount.setScale(4, RoundingMode.HALF_UP)
+            val tax = WithholdingTaxPolicy.compute(gross, ccy.code, profile, toDate)
+            val net = tax.netAmount.setScale(ccy.defaultFractionDigits, RoundingMode.HALF_UP)
             val cap = InterestCapitalization(
                 accountId = accountId,
                 productId = productId,
@@ -142,7 +262,7 @@ class InterestService(
                 grossAmount = gross,
                 taxAmount = tax.taxAmount,
                 netAmount = net,
-                currency = currency,
+                currency = ccy.code,
                 createdAt = now,
             )
             val withholding = WithholdingTax(
@@ -153,37 +273,49 @@ class InterestService(
                 taxableBase = tax.taxableBase,
                 rate = tax.rate,
                 taxAmount = tax.taxAmount,
-                currency = currency,
+                currency = ccy.code,
                 treatment = tax.treatment,
                 exemptCode = tax.exemptCode,
                 createdAt = now,
             )
-            // Ledger FIRST, own rows second (ADR-0033 §D) — see [postCreditLeg].
-            postCreditLeg(cap).flatMap {
-                // ONE transaction for the whole credit: capitalization + withholding + outbox event +
-                // the status-guarded ACCRUING -> CAPITALIZED flip. Previously these were four separate
-                // transactions, so a crash between them could commit the capitalization while leaving
-                // the accruals ACCRUING — a retry then re-credited the customer AND re-booked the tax.
-                capitalizationRepo.saveWithOutbox(
-                    cap,
-                    withholding,
-                    withholdingRecordedEvent(cap, withholding),
-                    accruals.map { it.id },
-                    now,
-                )
-            }
+            claim(accruals, toDate, alreadyClaimed)
+                // Ledger SECOND, own rows THIRD (ADR-0033 §D) — see [postCreditLeg].
+                .flatMap { postCreditLeg(cap, ccy) }
+                .flatMap {
+                    // ONE transaction for the whole credit: capitalization + withholding + outbox
+                    // event + the status-guarded CAPITALIZING -> CAPITALIZED flip. Previously these
+                    // were four separate transactions, so a crash between them could commit the
+                    // capitalization while leaving the accruals claimable — a retry then re-credited
+                    // the customer AND re-booked the tax.
+                    capitalizationRepo.saveWithOutbox(
+                        cap,
+                        withholding,
+                        withholdingRecordedEvent(cap, withholding),
+                        accruals.map { it.id },
+                        now,
+                    )
+                }
         }
     }
+
+    /** Freezes the accrual set for [toDate]; a set recovered from a previous attempt is already frozen. */
+    private fun claim(accruals: List<InterestAccrual>, toDate: LocalDate, alreadyClaimed: Boolean): Uni<Unit> =
+        if (alreadyClaimed) {
+            Uni.createFrom().item(Unit)
+        } else {
+            accrualRepo.claimForCapitalization(accruals.map { it.id }, toDate)
+        }
 
     /**
      * Posts the ADR-0033 §D split to the ledger — DEBIT interest expense (gross), CREDIT the
      * customer's deposit-control pocket (net, sub-ledger = accountId), CREDIT withholding-tax
-     * payable (tax) — **before** the local write set commits.
+     * payable (tax) — **after** the accrual set is claimed and **before** the local write set
+     * commits.
      *
      * Ordering is deliberate and mirrors `LendingService.accrueOne`'s post-then-mark. A crash
-     * between the two leaves the accruals `ACCRUING` and no capitalization row, so the retry
-     * re-runs the whole period and replays the SAME business-derived idempotency key
-     * (`CapitalizationJournalFactory.idempotencyKey` — account + product + period end, never
+     * between the post and the commit leaves the accruals `CAPITALIZING`, so the retry re-derives
+     * the SAME amounts from the SAME claimed set and replays the SAME business-derived idempotency
+     * key (`CapitalizationJournalFactory.idempotencyKey` — account + product + period end, never
      * `cap.id`, which is a fresh UUID per attempt); the ledger collapses that onto the journal it
      * already booked. The result is exactly-once on money. The reverse order — commit, then post —
      * would strand a customer credit that exists in interest-service and nowhere in the GL, which
@@ -197,19 +329,21 @@ class InterestService(
      * no tax: there is nothing to recognize, so no journal is posted — every leg would be zero and
      * the ledger requires ≥2 lines each with `amount > 0`. The capitalization row is still written,
      * which is what V6's partial unique index (`WHERE total_accrued <> 0`) already anticipates as
-     * inert bookkeeping. Same branch as lending's zero-interest installment.
+     * inert bookkeeping. Same branch as lending's zero-interest installment. A NEGATIVE gross is a
+     * different matter entirely and never reaches here — [capitalizeSet] refuses it before the claim
+     * (see [negativeGrossFailure]).
      */
-    private fun postCreditLeg(cap: InterestCapitalization): Uni<Unit> {
-        if (cap.grossAmount.signum() <= 0) return Uni.createFrom().item(Unit)
+    private fun postCreditLeg(cap: InterestCapitalization, ccy: CurrencyCode): Uni<Unit> {
+        val gross = Money(cap.grossAmount, ccy)
+        if (gross.isZero()) return Uni.createFrom().item(Unit)
         return ledgerPostingPort.post(
             CapitalizationPosting(
                 accountId = cap.accountId,
                 productId = cap.productId,
                 periodTo = cap.periodTo,
-                currency = cap.currency,
-                grossAmount = cap.grossAmount,
-                taxAmount = cap.taxAmount,
-                netAmount = cap.netAmount,
+                gross = gross,
+                tax = Money(cap.taxAmount, ccy),
+                net = Money(cap.netAmount, ccy),
             ),
         )
     }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -28,6 +28,7 @@ class InterestService(
     private val accrualRepo: InterestAccrualRepository,
     private val capitalizationRepo: InterestCapitalizationRepository,
     private val taxProfilePort: TaxProfilePort,
+    private val ledgerPostingPort: LedgerPostingPort,
     @ConfigProperty(name = "openbank.interest.day-count-convention", defaultValue = "ACT_365")
     private val defaultDayCount: String,
     private val clock: Clock,
@@ -42,6 +43,7 @@ class InterestService(
         accrualRepo: InterestAccrualRepository,
         capitalizationRepo: InterestCapitalizationRepository,
         taxProfilePort: TaxProfilePort,
+        ledgerPostingPort: LedgerPostingPort,
         @ConfigProperty(name = "openbank.interest.day-count-convention", defaultValue = "ACT_365")
         defaultDayCount: String,
     ) : this(
@@ -49,6 +51,7 @@ class InterestService(
         accrualRepo,
         capitalizationRepo,
         taxProfilePort,
+        ledgerPostingPort,
         defaultDayCount,
         Clock.systemUTC(),
     )
@@ -155,18 +158,60 @@ class InterestService(
                 exemptCode = tax.exemptCode,
                 createdAt = now,
             )
-            // ONE transaction for the whole credit: capitalization + withholding + outbox event +
-            // the status-guarded ACCRUING -> CAPITALIZED flip. Previously these were four separate
-            // transactions, so a crash between them could commit the capitalization while leaving
-            // the accruals ACCRUING — a retry then re-credited the customer AND re-booked the tax.
-            capitalizationRepo.saveWithOutbox(
-                cap,
-                withholding,
-                withholdingRecordedEvent(cap, withholding),
-                accruals.map { it.id },
-                now,
-            )
+            // Ledger FIRST, own rows second (ADR-0033 §D) — see [postCreditLeg].
+            postCreditLeg(cap).flatMap {
+                // ONE transaction for the whole credit: capitalization + withholding + outbox event +
+                // the status-guarded ACCRUING -> CAPITALIZED flip. Previously these were four separate
+                // transactions, so a crash between them could commit the capitalization while leaving
+                // the accruals ACCRUING — a retry then re-credited the customer AND re-booked the tax.
+                capitalizationRepo.saveWithOutbox(
+                    cap,
+                    withholding,
+                    withholdingRecordedEvent(cap, withholding),
+                    accruals.map { it.id },
+                    now,
+                )
+            }
         }
+    }
+
+    /**
+     * Posts the ADR-0033 §D split to the ledger — DEBIT interest expense (gross), CREDIT the
+     * customer's deposit-control pocket (net, sub-ledger = accountId), CREDIT withholding-tax
+     * payable (tax) — **before** the local write set commits.
+     *
+     * Ordering is deliberate and mirrors `LendingService.accrueOne`'s post-then-mark. A crash
+     * between the two leaves the accruals `ACCRUING` and no capitalization row, so the retry
+     * re-runs the whole period and replays the SAME business-derived idempotency key
+     * (`CapitalizationJournalFactory.idempotencyKey` — account + product + period end, never
+     * `cap.id`, which is a fresh UUID per attempt); the ledger collapses that onto the journal it
+     * already booked. The result is exactly-once on money. The reverse order — commit, then post —
+     * would strand a customer credit that exists in interest-service and nowhere in the GL, which
+     * no retry can repair because the accruals are already `CAPITALIZED`.
+     *
+     * The REST call is intentionally OUTSIDE `saveWithOutbox`'s transaction: a network call inside
+     * an open DB transaction holds a connection for the ledger's whole round-trip (and its retries),
+     * and a ledger timeout would then be indistinguishable from a rolled-back write.
+     *
+     * A zero-gross period (a zero-balance account still runs the accrual pass) carries no money and
+     * no tax: there is nothing to recognize, so no journal is posted — every leg would be zero and
+     * the ledger requires ≥2 lines each with `amount > 0`. The capitalization row is still written,
+     * which is what V6's partial unique index (`WHERE total_accrued <> 0`) already anticipates as
+     * inert bookkeeping. Same branch as lending's zero-interest installment.
+     */
+    private fun postCreditLeg(cap: InterestCapitalization): Uni<Unit> {
+        if (cap.grossAmount.signum() <= 0) return Uni.createFrom().item(Unit)
+        return ledgerPostingPort.post(
+            CapitalizationPosting(
+                accountId = cap.accountId,
+                productId = cap.productId,
+                periodTo = cap.periodTo,
+                currency = cap.currency,
+                grossAmount = cap.grossAmount,
+                taxAmount = cap.taxAmount,
+                netAmount = cap.netAmount,
+            ),
+        )
     }
 
     /** Builds the versioned `interest.withholding.recorded` outbox event (ADR-0033 §F). */

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/domain/model/InterestModels.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/domain/model/InterestModels.kt
@@ -10,7 +10,18 @@ import java.time.OffsetDateTime
 import java.util.UUID
 
 enum class InterestRateType { FIXED, VARIABLE, TIERED }
-enum class AccrualStatus { ACCRUING, CAPITALIZED, REVERSED, SUSPENDED }
+
+/**
+ * Lifecycle of one daily accrual.
+ *
+ * `ACCRUING` → `CAPITALIZING` → `CAPITALIZED` is the money path. `CAPITALIZING` is the **claim**:
+ * `InterestService.capitalize` freezes the exact set of accruals it is about to credit BEFORE it
+ * posts to the ledger, so the amount the ledger books and the amount the capitalization row records
+ * can never diverge — see `InterestService.capitalize` for the crash/recovery argument.
+ *
+ * `REVERSED`/`SUSPENDED` are declared but have no writer yet.
+ */
+enum class AccrualStatus { ACCRUING, CAPITALIZING, CAPITALIZED, REVERSED, SUSPENDED }
 enum class DayCount { ACT_365, ACT_360, ACT_ACT, THIRTY_360 }
 
 data class InterestRateConfig(
@@ -39,6 +50,16 @@ data class InterestAccrual(
     val accruedAmount: BigDecimal,
     val currency: String = "EUR",
     val status: AccrualStatus = AccrualStatus.ACCRUING,
+    /**
+     * The `periodTo` this accrual was claimed for when it went `CAPITALIZING`, and null otherwise.
+     *
+     * It is what makes a claim recoverable: `capitalize(account, product, toDate)` completes an
+     * in-flight claim only when [claimedPeriodTo] equals the requested `toDate`, because the period
+     * end is part of the ledger idempotency key. Capitalizing a claimed set to a *different* period
+     * end would mint a second key and post a SECOND journal for interest the first attempt may
+     * already have booked.
+     */
+    val claimedPeriodTo: LocalDate? = null,
     val capitalizedAt: OffsetDateTime? = null,
     val createdAt: OffsetDateTime,
 )
@@ -80,5 +101,5 @@ data class AccrualSummary(
     val currency: String,
     val fromDate: LocalDate,
     val toDate: LocalDate,
-    val accrualCount: Int
+    val accrualCount: Int,
 )

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactory.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactory.kt
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import com.openbank.interest.application.port.out.CapitalizationPosting
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Turns a [CapitalizationPosting] into a balanced double-entry [PostJournalRequest] for
+ * ledger-service (ADR-0033 §D). Pure and side-effect-free so the accounting is fully unit-tested
+ * without any HTTP — the same shape as lending's `LendingJournalFactory`.
+ *
+ * The split, per capitalization:
+ * ```
+ *   DEBIT  4010/4011/4012/4013  Interest Expense <ccy>          gross
+ *   CREDIT 2100/2101/2102/2103  Customer Deposit Control <ccy>  net    (subAccountId = accountId)
+ *   CREDIT 2200                 Withholding Tax Payable          tax
+ * ```
+ * `gross = net + tax` (guaranteed by `WithholdingTaxPolicy`), so the entry balances within the
+ * single currency it is denominated in — every leg carries the same `baseCurrencyCode`, which is
+ * also each account's declared currency, as `LedgerService` requires.
+ *
+ * **Zero-amount legs are omitted, never posted.** A zero tax is the common, legitimate case: the
+ * statutory whole-CZK DOWN rounding (daňový řád) means any gross below 7.00 CZK yields
+ * `floor(gross) × 0.15 = 0` while the interest is still *withheld* in treatment, and
+ * NOT_WITHHELD / EXEMPT / DEFERRED_FX are zero by definition. The ledger both requires ≥2 lines and
+ * enforces `CHECK (amount > 0)` on every line, so emitting the tax leg at zero would fail the whole
+ * entry — the customer's credit included.
+ */
+object CapitalizationJournalFactory {
+
+    /**
+     * Customer deposit-control leaf accounts, per currency — the customer's liability pocket
+     * (2100=CZK, 2101=EUR, 2102=USD, 2103=GBP). These are the *same* stable ids
+     * `openbank-transaction-service`'s `PaymentJournalFactory` posts against, deliberately: a
+     * customer's booked balance is the sum of their payments AND their interest over one
+     * sub-ledger, so interest must not land on a control account of its own. They are also the only
+     * account class the ledger accepts a `subAccountId` on (ADR-0039 Phase B).
+     */
+    private val DEPOSIT_CONTROL: Map<String, UUID> = mapOf(
+        "CZK" to UUID.fromString("a0000000-0000-0000-0000-000000000002"),
+        "EUR" to UUID.fromString("a0000000-0000-0000-0000-000000002101"),
+        "USD" to UUID.fromString("a0000000-0000-0000-0000-000000002102"),
+        "GBP" to UUID.fromString("a0000000-0000-0000-0000-000000002103"),
+    )
+
+    /**
+     * The ledger idempotency key for a capitalization, derived from its **business identity** —
+     * `(account, product, period end)` — and NOT from `InterestCapitalization.id`.
+     *
+     * This is the difference between exactly-once and double-crediting real money. `cap.id` defaults
+     * to a fresh UUID on every construction, so a crash between the ledger post and the local commit
+     * would, on retry, build a new capitalization with a new id, mint a new key, and post the credit
+     * a SECOND time. A business-derived key replays onto the same journal and the ledger collapses
+     * it (`findByIdempotencyKey` returns the original entry before any work is done).
+     *
+     * The identity matches interest-service's own DB backstop — the V6 unique index on
+     * `(account_id, product_id, period_to)` — on purpose: the two must agree on what "the same
+     * capitalization" means, or one of them is wrong. Mirrors lending's business-derived
+     * `loan:{id}:inst:{n}:accrual`.
+     */
+    fun idempotencyKey(posting: CapitalizationPosting): String =
+        "interest-capitalization-${posting.accountId}-${posting.productId}-${posting.periodTo}"
+
+    fun buildRequest(posting: CapitalizationPosting, config: InterestLedgerConfig): PostJournalRequest {
+        val key = idempotencyKey(posting)
+        return PostJournalRequest(
+            idempotencyKey = key,
+            // Deterministic in the same business identity as the key: a retry must not mint a new
+            // transactionId, or the replayed entry would look like a different economic event.
+            transactionId = UUID.nameUUIDFromBytes(key.toByteArray(Charsets.UTF_8)),
+            entryDate = posting.periodTo.toString(),
+            valueDate = posting.periodTo.toString(),
+            description = "Interest capitalization ${posting.productId} to ${posting.periodTo}",
+            lines = buildLines(posting, config),
+            createdBy = config.systemActorId(),
+        )
+    }
+
+    fun buildLines(posting: CapitalizationPosting, config: InterestLedgerConfig): List<JournalLineRequest> {
+        val ccy = posting.currency.uppercase()
+        require(posting.grossAmount.compareTo(posting.netAmount.add(posting.taxAmount)) == 0) {
+            "Refusing to post an unbalanced interest capitalization for account=${posting.accountId} " +
+                "product=${posting.productId} period=${posting.periodTo}: gross=${posting.grossAmount} != " +
+                "net=${posting.netAmount} + tax=${posting.taxAmount}"
+        }
+        val expenseGl = interestExpense(ccy, config)
+        val depositGl = depositControl(ccy)
+        // Only money-bearing legs. See the class note: a zero leg is DB-rejected, and zero tax is
+        // the normal case for sub-7-CZK gross and for every non-withheld treatment.
+        return listOfNotNull(
+            line(expenseGl, "DEBIT", posting.grossAmount, ccy),
+            line(depositGl, "CREDIT", posting.netAmount, ccy, subAccountId = posting.accountId),
+            line(config.gl().withholdingTaxPayable(), "CREDIT", posting.taxAmount, ccy),
+        )
+    }
+
+    private fun line(
+        glAccountId: UUID,
+        side: String,
+        amount: BigDecimal,
+        ccy: String,
+        subAccountId: UUID? = null,
+    ): JournalLineRequest? {
+        if (amount.signum() <= 0) return null
+        return JournalLineRequest(
+            glAccountId = glAccountId,
+            side = side,
+            amount = amount,
+            currencyCode = ccy,
+            // Single-currency entry: no conversion, so the base amount is the leg's own amount and
+            // the ledger balances it within `ccy` (ADR-0025).
+            fxRate = null,
+            baseAmount = amount,
+            baseCurrencyCode = ccy,
+            subAccountId = subAccountId,
+        )
+    }
+
+    /**
+     * The interest-expense GL is per currency because `LedgerService` rejects a line whose base
+     * currency differs from its GL account's declared currency (422) — the V14 cash-clearing bug.
+     */
+    private fun interestExpense(currency: String, config: InterestLedgerConfig): UUID = when (currency) {
+        "CZK" -> config.gl().interestExpenseCzk()
+        "EUR" -> config.gl().interestExpenseEur()
+        "USD" -> config.gl().interestExpenseUsd()
+        "GBP" -> config.gl().interestExpenseGbp()
+        // Refuse rather than guess: posting a foreign credit against a CZK expense account would be
+        // rejected by the ledger anyway, and picking "some" account would misstate the P&L.
+        else -> error("No interest-expense GL account seeded for currency $currency")
+    }
+
+    private fun depositControl(currency: String): UUID = DEPOSIT_CONTROL[currency]
+        ?: error("No deposit-control GL account seeded for currency $currency")
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactory.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactory.kt
@@ -81,20 +81,18 @@ object CapitalizationJournalFactory {
     }
 
     fun buildLines(posting: CapitalizationPosting, config: InterestLedgerConfig): List<JournalLineRequest> {
-        val ccy = posting.currency.uppercase()
-        require(posting.grossAmount.compareTo(posting.netAmount.add(posting.taxAmount)) == 0) {
-            "Refusing to post an unbalanced interest capitalization for account=${posting.accountId} " +
-                "product=${posting.productId} period=${posting.periodTo}: gross=${posting.grossAmount} != " +
-                "net=${posting.netAmount} + tax=${posting.taxAmount}"
-        }
+        // Single currency and `gross == net + tax` are guaranteed by CapitalizationPosting's own
+        // constructor, and every amount is already at the currency's scale because it is a Money —
+        // there is nothing left for this factory to re-check or re-round.
+        val ccy = posting.currency
         val expenseGl = interestExpense(ccy, config)
         val depositGl = depositControl(ccy)
         // Only money-bearing legs. See the class note: a zero leg is DB-rejected, and zero tax is
         // the normal case for sub-7-CZK gross and for every non-withheld treatment.
         return listOfNotNull(
-            line(expenseGl, "DEBIT", posting.grossAmount, ccy),
-            line(depositGl, "CREDIT", posting.netAmount, ccy, subAccountId = posting.accountId),
-            line(config.gl().withholdingTaxPayable(), "CREDIT", posting.taxAmount, ccy),
+            line(expenseGl, "DEBIT", posting.gross.amount, ccy),
+            line(depositGl, "CREDIT", posting.net.amount, ccy, subAccountId = posting.accountId),
+            line(config.gl().withholdingTaxPayable(), "CREDIT", posting.tax.amount, ccy),
         )
     }
 

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/InterestLedgerConfig.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/InterestLedgerConfig.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import io.smallrye.config.ConfigMapping
+import io.smallrye.config.WithDefault
+import java.util.UUID
+
+/**
+ * Ledger-posting configuration for interest capitalization (ADR-0033 §D): the system actor recorded
+ * as the journal author, and the leaf GL accounts the capitalization split debits/credits. Defaults
+ * are the stable `a0000000-…` UUIDs the ledger seeds; operators override them per environment to the
+ * real chart of accounts. Same convention as `openbank-billing-service`'s `BillingLedgerConfig`.
+ *
+ * Deposit-control accounts are NOT configured here: they are picked per currency by
+ * [CapitalizationJournalFactory] from the same stable ids `openbank-transaction-service`'s
+ * `PaymentJournalFactory` posts against, because both must land on the *same* sub-ledger for a
+ * customer's booked balance to be the sum of their payments and their interest.
+ */
+@ConfigMapping(prefix = "interest.ledger")
+interface InterestLedgerConfig {
+
+    /** The interest service's own system-actor id, recorded as the journal's `createdBy`. */
+    @WithDefault("00000000-0000-0000-0000-0000000000cc")
+    fun systemActorId(): UUID
+
+    fun gl(): Gl
+
+    interface Gl {
+        /**
+         * DEBIT (gross) — the bank's interest-expense GL for CZK. Default is the seeded
+         * "4010 Interest Expense CZK" row (`V17__interest_capitalization_accounts.sql`), NOT the
+         * older "4000 Interest Expense" row from `V1__init_ledger.sql`: V1 seeded that one with
+         * `gen_random_uuid()`, so no fixed UUID can ever reference it (issue #468's defect — every
+         * posting would 422 "GL account not found"), and it is CZK-only, so it could not carry a
+         * non-CZK expense leg either.
+         */
+        @WithDefault("a0000000-0000-0000-0000-000000004010")
+        fun interestExpenseCzk(): UUID
+
+        /** DEBIT (gross) — interest-expense GL for EUR ("4011", V17). */
+        @WithDefault("a0000000-0000-0000-0000-000000004011")
+        fun interestExpenseEur(): UUID
+
+        /** DEBIT (gross) — interest-expense GL for USD ("4012", V17). */
+        @WithDefault("a0000000-0000-0000-0000-000000004012")
+        fun interestExpenseUsd(): UUID
+
+        /** DEBIT (gross) — interest-expense GL for GBP ("4013", V17). */
+        @WithDefault("a0000000-0000-0000-0000-000000004013")
+        fun interestExpenseGbp(): UUID
+
+        /**
+         * CREDIT (tax) — the withholding-tax liability owed to the finanční úřad ("2200", V17).
+         * CZK-only by construction: ADR-0033 §E withholds only CZK-denominated interest, so this
+         * leg never appears on a foreign-currency entry.
+         */
+        @WithDefault("a0000000-0000-0000-0000-000000002200")
+        fun withholdingTaxPayable(): UUID
+    }
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/LedgerCallGuard.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/LedgerCallGuard.kt
@@ -18,8 +18,10 @@ import org.eclipse.microprofile.rest.client.inject.RestClient
  * ledger collapses them onto the already-booked journal. The circuit breaker stops hammering a
  * degraded ledger and lets the caller fail fast (DORA Art. 11 operational resilience).
  *
- * Failing fast is the correct outcome here: capitalize() posts BEFORE it commits its own rows, so a
- * ledger outage leaves the accruals `ACCRUING` and the period simply capitalizes on the next run.
+ * Failing fast is the correct outcome here: capitalize() claims the accrual set (`ACCRUING` ->
+ * `CAPITALIZING`) BEFORE this call, so a ledger outage leaves the accruals `CAPITALIZING`, not
+ * `ACCRUING` — a retry of the same request finds the same claimed set and the period simply
+ * capitalizes on the next run.
  */
 @ApplicationScoped
 class LedgerCallGuard(@RestClient private val ledgerClient: LedgerRestClient) {

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/LedgerCallGuard.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/LedgerCallGuard.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker
+import org.eclipse.microprofile.faulttolerance.Retry
+import org.eclipse.microprofile.faulttolerance.Timeout
+import org.eclipse.microprofile.rest.client.inject.RestClient
+
+/**
+ * Resilience boundary around the ledger-service call (mirrors lending's and transaction-service's
+ * guard). The journal POST is idempotent on `idempotencyKey` — and this caller's key is derived from
+ * the capitalization's *business* identity, not a per-attempt row id — so retries are safe: the
+ * ledger collapses them onto the already-booked journal. The circuit breaker stops hammering a
+ * degraded ledger and lets the caller fail fast (DORA Art. 11 operational resilience).
+ *
+ * Failing fast is the correct outcome here: capitalize() posts BEFORE it commits its own rows, so a
+ * ledger outage leaves the accruals `ACCRUING` and the period simply capitalizes on the next run.
+ */
+@ApplicationScoped
+class LedgerCallGuard(@RestClient private val ledgerClient: LedgerRestClient) {
+
+    @Retry(maxRetries = 3, delay = 500, jitter = 100)
+    @Timeout(value = 2000)
+    @CircuitBreaker(requestVolumeThreshold = 5, failureRatio = 0.5, delay = 10000)
+    fun postJournal(request: PostJournalRequest): Uni<JournalResponse> = ledgerClient.postJournal(request)
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/LedgerRestClient.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/LedgerRestClient.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Typed client for the ledger-service journal API (ADR-0033 §D). Interest-service never mutates
+ * balances itself: it hands the ledger a balanced double-entry journal and the ledger is the single
+ * system of record for money movements. `POST /api/v1/journals` is the platform's only ledger
+ * ingestion surface — the same contract transaction-service, billing-service and lending-service use.
+ *
+ * A service bearer token is injected by [OidcClientRequestReactiveFilter]; the call is guarded by
+ * [LedgerCallGuard] (retry/timeout/circuit-breaker).
+ */
+@RegisterRestClient(configKey = "ledger-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/journals")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface LedgerRestClient {
+
+    @POST
+    fun postJournal(request: PostJournalRequest): Uni<JournalResponse>
+}
+
+data class PostJournalRequest(
+    val idempotencyKey: String,
+    val transactionId: UUID,
+    val entryDate: String,
+    val valueDate: String,
+    val description: String?,
+    val lines: List<JournalLineRequest>,
+    val createdBy: UUID,
+)
+
+/**
+ * One leg. [subAccountId] is the sub-ledger (analytická evidence) dimension and is accepted by the
+ * ledger **only** on deposit-control legs (ADR-0039 Phase B); it must be null everywhere else or
+ * `LedgerService` rejects the whole entry.
+ */
+data class JournalLineRequest(
+    val glAccountId: UUID,
+    val side: String,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val fxRate: BigDecimal?,
+    val baseAmount: BigDecimal,
+    val baseCurrencyCode: String,
+    val subAccountId: UUID? = null,
+)
+
+data class JournalResponse(val id: UUID, val transactionId: UUID, val status: String)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/RestLedgerPostingAdapter.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/RestLedgerPostingAdapter.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import com.openbank.interest.application.port.out.CapitalizationPosting
+import com.openbank.interest.application.port.out.LedgerPostingPort
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+
+/**
+ * Binds [LedgerPostingPort] to `openbank-ledger-service` over REST (ADR-0033 §D): builds the
+ * balanced capitalization journal with [CapitalizationJournalFactory] and posts it through
+ * [LedgerCallGuard].
+ *
+ * Bound unconditionally rather than behind a `backend=none` no-op default (lending's pattern): the
+ * ledger post is what makes a capitalization economically real, so a silent no-op binding would
+ * reproduce the very defect this closes — recording the withholding liability, remitting cash for
+ * it, and never crediting the customer. Interest-service already carries a hard REST dependency on
+ * transaction-service for the remittance leg, so there is no offline-build story to protect; the
+ * rest-client is lazy and the service still boots with the ledger unreachable.
+ */
+@ApplicationScoped
+class RestLedgerPostingAdapter(private val guard: LedgerCallGuard, private val config: InterestLedgerConfig) :
+    LedgerPostingPort {
+
+    override fun post(posting: CapitalizationPosting): Uni<Unit> =
+        guard.postJournal(CapitalizationJournalFactory.buildRequest(posting, config)).replaceWith(Unit)
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
@@ -15,84 +15,222 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-@Entity @Table(name = "interest_rate_configs")
+@Entity
+@Table(name = "interest_rate_configs")
 class InterestRateConfigEntity : PanacheEntityBase() {
-    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
-    @Column(name = "product_id") var productId: String = ""
-    @Column(name = "rate_type") @Enumerated(EnumType.STRING) var rateType: InterestRateType = InterestRateType.FIXED
-    @Column(name = "annual_rate", precision = 10, scale = 6) var annualRate: BigDecimal = BigDecimal.ZERO
-    @Column(name = "min_balance", precision = 20, scale = 4) var minBalance: BigDecimal = BigDecimal.ZERO
-    @Column(name = "max_balance", precision = 20, scale = 4) var maxBalance: BigDecimal? = null
-    @Column(name = "day_count") @Enumerated(EnumType.STRING) var dayCount: DayCount = DayCount.ACT_365
-    @Column(name = "effective_from") var effectiveFrom: LocalDate = LocalDate.EPOCH
-    @Column(name = "effective_to") var effectiveTo: LocalDate? = null
-    @Column(name = "active") var active: Boolean = true
-    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
-    @Column(name = "updated_at") var updatedAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id
+    @Column(columnDefinition = "uuid")
+    var id: UUID = UUID.randomUUID()
+
+    @Column(name = "product_id")
+    var productId: String = ""
+
+    @Column(name = "rate_type")
+    @Enumerated(EnumType.STRING)
+    var rateType: InterestRateType = InterestRateType.FIXED
+
+    @Column(name = "annual_rate", precision = 10, scale = 6)
+    var annualRate: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "min_balance", precision = 20, scale = 4)
+    var minBalance: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "max_balance", precision = 20, scale = 4)
+    var maxBalance: BigDecimal? = null
+
+    @Column(name = "day_count")
+    @Enumerated(EnumType.STRING)
+    var dayCount: DayCount = DayCount.ACT_365
+
+    @Column(name = "effective_from")
+    var effectiveFrom: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "effective_to")
+    var effectiveTo: LocalDate? = null
+
+    @Column(name = "active")
+    var active: Boolean = true
+
+    @Column(name = "created_at")
+    var createdAt: OffsetDateTime = OffsetDateTime.MIN
+
+    @Column(name = "updated_at")
+    var updatedAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity @Table(name = "interest_accruals")
+@Entity
+@Table(name = "interest_accruals")
 class InterestAccrualEntity : PanacheEntityBase() {
-    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
-    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID = UUID.randomUUID()
-    @Column(name = "product_id") var productId: String = ""
-    @Column(name = "config_id", columnDefinition = "uuid") var configId: UUID = UUID.randomUUID()
-    @Column(name = "accrual_date") var accrualDate: LocalDate = LocalDate.EPOCH
-    @Column(name = "balance", precision = 20, scale = 4) var balance: BigDecimal = BigDecimal.ZERO
-    @Column(name = "daily_rate", precision = 14, scale = 10) var dailyRate: BigDecimal = BigDecimal.ZERO
-    @Column(name = "accrued_amount", precision = 20, scale = 6) var accruedAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "currency", length = 3) var currency: String = "EUR"
-    @Column(name = "status") @Enumerated(EnumType.STRING) var status: AccrualStatus = AccrualStatus.ACCRUING
-    @Column(name = "capitalized_at") var capitalizedAt: OffsetDateTime? = null
-    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id
+    @Column(columnDefinition = "uuid")
+    var id: UUID = UUID.randomUUID()
+
+    @Column(name = "account_id", columnDefinition = "uuid")
+    var accountId: UUID = UUID.randomUUID()
+
+    @Column(name = "product_id")
+    var productId: String = ""
+
+    @Column(name = "config_id", columnDefinition = "uuid")
+    var configId: UUID = UUID.randomUUID()
+
+    @Column(name = "accrual_date")
+    var accrualDate: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "balance", precision = 20, scale = 4)
+    var balance: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "daily_rate", precision = 14, scale = 10)
+    var dailyRate: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "accrued_amount", precision = 20, scale = 6)
+    var accruedAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "currency", length = 3)
+    var currency: String = "EUR"
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    var status: AccrualStatus = AccrualStatus.ACCRUING
+
+    @Column(name = "claimed_period_to")
+    var claimedPeriodTo: LocalDate? = null
+
+    @Column(name = "capitalized_at")
+    var capitalizedAt: OffsetDateTime? = null
+
+    @Column(name = "created_at")
+    var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity @Table(name = "interest_capitalizations")
+@Entity
+@Table(name = "interest_capitalizations")
 class InterestCapitalizationEntity : PanacheEntityBase() {
-    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
-    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID = UUID.randomUUID()
-    @Column(name = "product_id") var productId: String = ""
-    @Column(name = "period_from") var periodFrom: LocalDate = LocalDate.EPOCH
-    @Column(name = "period_to") var periodTo: LocalDate = LocalDate.EPOCH
-    @Column(name = "total_accrued", precision = 20, scale = 6) var totalAccrued: BigDecimal = BigDecimal.ZERO
-    @Column(name = "capitalized_amount", precision = 20, scale = 4) var capitalizedAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "gross_amount", precision = 20, scale = 4) var grossAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "tax_amount", precision = 20, scale = 4) var taxAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "net_amount", precision = 20, scale = 4) var netAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "currency", length = 3) var currency: String = "EUR"
-    @Column(name = "ledger_entry_id", columnDefinition = "uuid") var ledgerEntryId: UUID? = null
-    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id
+    @Column(columnDefinition = "uuid")
+    var id: UUID = UUID.randomUUID()
+
+    @Column(name = "account_id", columnDefinition = "uuid")
+    var accountId: UUID = UUID.randomUUID()
+
+    @Column(name = "product_id")
+    var productId: String = ""
+
+    @Column(name = "period_from")
+    var periodFrom: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "period_to")
+    var periodTo: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "total_accrued", precision = 20, scale = 6)
+    var totalAccrued: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "capitalized_amount", precision = 20, scale = 4)
+    var capitalizedAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "gross_amount", precision = 20, scale = 4)
+    var grossAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "tax_amount", precision = 20, scale = 4)
+    var taxAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "net_amount", precision = 20, scale = 4)
+    var netAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "currency", length = 3)
+    var currency: String = "EUR"
+
+    @Column(name = "ledger_entry_id", columnDefinition = "uuid")
+    var ledgerEntryId: UUID? = null
+
+    @Column(name = "created_at")
+    var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity @Table(name = "withholding_tax")
+@Entity
+@Table(name = "withholding_tax")
 class WithholdingTaxEntity : PanacheEntityBase() {
-    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
-    @Column(name = "capitalization_id", columnDefinition = "uuid") var capitalizationId: UUID = UUID.randomUUID()
-    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID = UUID.randomUUID()
-    @Column(name = "party_ref") var partyRef: String? = null
-    @Column(name = "period_from") var periodFrom: LocalDate = LocalDate.EPOCH
-    @Column(name = "period_to") var periodTo: LocalDate = LocalDate.EPOCH
-    @Column(name = "taxable_base", precision = 20, scale = 4) var taxableBase: BigDecimal = BigDecimal.ZERO
-    @Column(name = "rate", precision = 6, scale = 4) var rate: BigDecimal = BigDecimal.ZERO
-    @Column(name = "tax_amount", precision = 20, scale = 4) var taxAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "currency", length = 3) var currency: String = "CZK"
-    @Column(name = "treatment") @Enumerated(EnumType.STRING) var treatment: WithholdingTreatment = WithholdingTreatment.WITHHELD
-    @Column(name = "exempt_code") var exemptCode: String? = null
-    @Column(name = "status") @Enumerated(EnumType.STRING) var status: WithholdingTaxStatus = WithholdingTaxStatus.RECORDED
-    @Column(name = "remittance_id", columnDefinition = "uuid") var remittanceId: UUID? = null
-    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id
+    @Column(columnDefinition = "uuid")
+    var id: UUID = UUID.randomUUID()
+
+    @Column(name = "capitalization_id", columnDefinition = "uuid")
+    var capitalizationId: UUID = UUID.randomUUID()
+
+    @Column(name = "account_id", columnDefinition = "uuid")
+    var accountId: UUID = UUID.randomUUID()
+
+    @Column(name = "party_ref")
+    var partyRef: String? = null
+
+    @Column(name = "period_from")
+    var periodFrom: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "period_to")
+    var periodTo: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "taxable_base", precision = 20, scale = 4)
+    var taxableBase: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "rate", precision = 6, scale = 4)
+    var rate: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "tax_amount", precision = 20, scale = 4)
+    var taxAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "currency", length = 3)
+    var currency: String = "CZK"
+
+    @Column(name = "treatment")
+    @Enumerated(EnumType.STRING)
+    var treatment: WithholdingTreatment = WithholdingTreatment.WITHHELD
+
+    @Column(name = "exempt_code")
+    var exemptCode: String? = null
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    var status: WithholdingTaxStatus = WithholdingTaxStatus.RECORDED
+
+    @Column(name = "remittance_id", columnDefinition = "uuid")
+    var remittanceId: UUID? = null
+
+    @Column(name = "created_at")
+    var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity @Table(name = "withholding_remittance")
+@Entity
+@Table(name = "withholding_remittance")
 class WithholdingRemittanceEntity : PanacheEntityBase() {
-    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
-    @Column(name = "period_year") var periodYear: Int = 0
-    @Column(name = "period_month") var periodMonth: Int = 0
-    @Column(name = "authority") var authority: String = ""
-    @Column(name = "currency", length = 3) var currency: String = "CZK"
-    @Column(name = "total_tax_amount", precision = 20, scale = 4) var totalTaxAmount: BigDecimal = BigDecimal.ZERO
-    @Column(name = "item_count") var itemCount: Int = 0
-    @Column(name = "due_date") var dueDate: LocalDate = LocalDate.EPOCH
-    @Column(name = "status") @Enumerated(EnumType.STRING) var status: WithholdingRemittanceStatus = WithholdingRemittanceStatus.PENDING
-    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id
+    @Column(columnDefinition = "uuid")
+    var id: UUID = UUID.randomUUID()
+
+    @Column(name = "period_year")
+    var periodYear: Int = 0
+
+    @Column(name = "period_month")
+    var periodMonth: Int = 0
+
+    @Column(name = "authority")
+    var authority: String = ""
+
+    @Column(name = "currency", length = 3)
+    var currency: String = "CZK"
+
+    @Column(name = "total_tax_amount", precision = 20, scale = 4)
+    var totalTaxAmount: BigDecimal = BigDecimal.ZERO
+
+    @Column(name = "item_count")
+    var itemCount: Int = 0
+
+    @Column(name = "due_date")
+    var dueDate: LocalDate = LocalDate.EPOCH
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    var status: WithholdingRemittanceStatus = WithholdingRemittanceStatus.PENDING
+
+    @Column(name = "created_at")
+    var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
@@ -15,222 +15,85 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
 
-@Entity
-@Table(name = "interest_rate_configs")
+@Entity @Table(name = "interest_rate_configs")
 class InterestRateConfigEntity : PanacheEntityBase() {
-    @Id
-    @Column(columnDefinition = "uuid")
-    var id: UUID = UUID.randomUUID()
-
-    @Column(name = "product_id")
-    var productId: String = ""
-
-    @Column(name = "rate_type")
-    @Enumerated(EnumType.STRING)
-    var rateType: InterestRateType = InterestRateType.FIXED
-
-    @Column(name = "annual_rate", precision = 10, scale = 6)
-    var annualRate: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "min_balance", precision = 20, scale = 4)
-    var minBalance: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "max_balance", precision = 20, scale = 4)
-    var maxBalance: BigDecimal? = null
-
-    @Column(name = "day_count")
-    @Enumerated(EnumType.STRING)
-    var dayCount: DayCount = DayCount.ACT_365
-
-    @Column(name = "effective_from")
-    var effectiveFrom: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "effective_to")
-    var effectiveTo: LocalDate? = null
-
-    @Column(name = "active")
-    var active: Boolean = true
-
-    @Column(name = "created_at")
-    var createdAt: OffsetDateTime = OffsetDateTime.MIN
-
-    @Column(name = "updated_at")
-    var updatedAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
+    @Column(name = "product_id") var productId: String = ""
+    @Column(name = "rate_type") @Enumerated(EnumType.STRING) var rateType: InterestRateType = InterestRateType.FIXED
+    @Column(name = "annual_rate", precision = 10, scale = 6) var annualRate: BigDecimal = BigDecimal.ZERO
+    @Column(name = "min_balance", precision = 20, scale = 4) var minBalance: BigDecimal = BigDecimal.ZERO
+    @Column(name = "max_balance", precision = 20, scale = 4) var maxBalance: BigDecimal? = null
+    @Column(name = "day_count") @Enumerated(EnumType.STRING) var dayCount: DayCount = DayCount.ACT_365
+    @Column(name = "effective_from") var effectiveFrom: LocalDate = LocalDate.EPOCH
+    @Column(name = "effective_to") var effectiveTo: LocalDate? = null
+    @Column(name = "active") var active: Boolean = true
+    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Column(name = "updated_at") var updatedAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity
-@Table(name = "interest_accruals")
+@Entity @Table(name = "interest_accruals")
 class InterestAccrualEntity : PanacheEntityBase() {
-    @Id
-    @Column(columnDefinition = "uuid")
-    var id: UUID = UUID.randomUUID()
-
-    @Column(name = "account_id", columnDefinition = "uuid")
-    var accountId: UUID = UUID.randomUUID()
-
-    @Column(name = "product_id")
-    var productId: String = ""
-
-    @Column(name = "config_id", columnDefinition = "uuid")
-    var configId: UUID = UUID.randomUUID()
-
-    @Column(name = "accrual_date")
-    var accrualDate: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "balance", precision = 20, scale = 4)
-    var balance: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "daily_rate", precision = 14, scale = 10)
-    var dailyRate: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "accrued_amount", precision = 20, scale = 6)
-    var accruedAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "currency", length = 3)
-    var currency: String = "EUR"
-
-    @Column(name = "status")
-    @Enumerated(EnumType.STRING)
-    var status: AccrualStatus = AccrualStatus.ACCRUING
-
-    @Column(name = "claimed_period_to")
-    var claimedPeriodTo: LocalDate? = null
-
-    @Column(name = "capitalized_at")
-    var capitalizedAt: OffsetDateTime? = null
-
-    @Column(name = "created_at")
-    var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
+    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID = UUID.randomUUID()
+    @Column(name = "product_id") var productId: String = ""
+    @Column(name = "config_id", columnDefinition = "uuid") var configId: UUID = UUID.randomUUID()
+    @Column(name = "accrual_date") var accrualDate: LocalDate = LocalDate.EPOCH
+    @Column(name = "balance", precision = 20, scale = 4) var balance: BigDecimal = BigDecimal.ZERO
+    @Column(name = "daily_rate", precision = 14, scale = 10) var dailyRate: BigDecimal = BigDecimal.ZERO
+    @Column(name = "accrued_amount", precision = 20, scale = 6) var accruedAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "currency", length = 3) var currency: String = "EUR"
+    @Column(name = "status") @Enumerated(EnumType.STRING) var status: AccrualStatus = AccrualStatus.ACCRUING
+    @Column(name = "claimed_period_to") var claimedPeriodTo: LocalDate? = null
+    @Column(name = "capitalized_at") var capitalizedAt: OffsetDateTime? = null
+    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity
-@Table(name = "interest_capitalizations")
+@Entity @Table(name = "interest_capitalizations")
 class InterestCapitalizationEntity : PanacheEntityBase() {
-    @Id
-    @Column(columnDefinition = "uuid")
-    var id: UUID = UUID.randomUUID()
-
-    @Column(name = "account_id", columnDefinition = "uuid")
-    var accountId: UUID = UUID.randomUUID()
-
-    @Column(name = "product_id")
-    var productId: String = ""
-
-    @Column(name = "period_from")
-    var periodFrom: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "period_to")
-    var periodTo: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "total_accrued", precision = 20, scale = 6)
-    var totalAccrued: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "capitalized_amount", precision = 20, scale = 4)
-    var capitalizedAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "gross_amount", precision = 20, scale = 4)
-    var grossAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "tax_amount", precision = 20, scale = 4)
-    var taxAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "net_amount", precision = 20, scale = 4)
-    var netAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "currency", length = 3)
-    var currency: String = "EUR"
-
-    @Column(name = "ledger_entry_id", columnDefinition = "uuid")
-    var ledgerEntryId: UUID? = null
-
-    @Column(name = "created_at")
-    var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
+    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID = UUID.randomUUID()
+    @Column(name = "product_id") var productId: String = ""
+    @Column(name = "period_from") var periodFrom: LocalDate = LocalDate.EPOCH
+    @Column(name = "period_to") var periodTo: LocalDate = LocalDate.EPOCH
+    @Column(name = "total_accrued", precision = 20, scale = 6) var totalAccrued: BigDecimal = BigDecimal.ZERO
+    @Column(name = "capitalized_amount", precision = 20, scale = 4) var capitalizedAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "gross_amount", precision = 20, scale = 4) var grossAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "tax_amount", precision = 20, scale = 4) var taxAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "net_amount", precision = 20, scale = 4) var netAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "currency", length = 3) var currency: String = "EUR"
+    @Column(name = "ledger_entry_id", columnDefinition = "uuid") var ledgerEntryId: UUID? = null
+    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity
-@Table(name = "withholding_tax")
+@Entity @Table(name = "withholding_tax")
 class WithholdingTaxEntity : PanacheEntityBase() {
-    @Id
-    @Column(columnDefinition = "uuid")
-    var id: UUID = UUID.randomUUID()
-
-    @Column(name = "capitalization_id", columnDefinition = "uuid")
-    var capitalizationId: UUID = UUID.randomUUID()
-
-    @Column(name = "account_id", columnDefinition = "uuid")
-    var accountId: UUID = UUID.randomUUID()
-
-    @Column(name = "party_ref")
-    var partyRef: String? = null
-
-    @Column(name = "period_from")
-    var periodFrom: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "period_to")
-    var periodTo: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "taxable_base", precision = 20, scale = 4)
-    var taxableBase: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "rate", precision = 6, scale = 4)
-    var rate: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "tax_amount", precision = 20, scale = 4)
-    var taxAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "currency", length = 3)
-    var currency: String = "CZK"
-
-    @Column(name = "treatment")
-    @Enumerated(EnumType.STRING)
-    var treatment: WithholdingTreatment = WithholdingTreatment.WITHHELD
-
-    @Column(name = "exempt_code")
-    var exemptCode: String? = null
-
-    @Column(name = "status")
-    @Enumerated(EnumType.STRING)
-    var status: WithholdingTaxStatus = WithholdingTaxStatus.RECORDED
-
-    @Column(name = "remittance_id", columnDefinition = "uuid")
-    var remittanceId: UUID? = null
-
-    @Column(name = "created_at")
-    var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
+    @Column(name = "capitalization_id", columnDefinition = "uuid") var capitalizationId: UUID = UUID.randomUUID()
+    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID = UUID.randomUUID()
+    @Column(name = "party_ref") var partyRef: String? = null
+    @Column(name = "period_from") var periodFrom: LocalDate = LocalDate.EPOCH
+    @Column(name = "period_to") var periodTo: LocalDate = LocalDate.EPOCH
+    @Column(name = "taxable_base", precision = 20, scale = 4) var taxableBase: BigDecimal = BigDecimal.ZERO
+    @Column(name = "rate", precision = 6, scale = 4) var rate: BigDecimal = BigDecimal.ZERO
+    @Column(name = "tax_amount", precision = 20, scale = 4) var taxAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "currency", length = 3) var currency: String = "CZK"
+    @Column(name = "treatment") @Enumerated(EnumType.STRING) var treatment: WithholdingTreatment = WithholdingTreatment.WITHHELD
+    @Column(name = "exempt_code") var exemptCode: String? = null
+    @Column(name = "status") @Enumerated(EnumType.STRING) var status: WithholdingTaxStatus = WithholdingTaxStatus.RECORDED
+    @Column(name = "remittance_id", columnDefinition = "uuid") var remittanceId: UUID? = null
+    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }
 
-@Entity
-@Table(name = "withholding_remittance")
+@Entity @Table(name = "withholding_remittance")
 class WithholdingRemittanceEntity : PanacheEntityBase() {
-    @Id
-    @Column(columnDefinition = "uuid")
-    var id: UUID = UUID.randomUUID()
-
-    @Column(name = "period_year")
-    var periodYear: Int = 0
-
-    @Column(name = "period_month")
-    var periodMonth: Int = 0
-
-    @Column(name = "authority")
-    var authority: String = ""
-
-    @Column(name = "currency", length = 3)
-    var currency: String = "CZK"
-
-    @Column(name = "total_tax_amount", precision = 20, scale = 4)
-    var totalTaxAmount: BigDecimal = BigDecimal.ZERO
-
-    @Column(name = "item_count")
-    var itemCount: Int = 0
-
-    @Column(name = "due_date")
-    var dueDate: LocalDate = LocalDate.EPOCH
-
-    @Column(name = "status")
-    @Enumerated(EnumType.STRING)
-    var status: WithholdingRemittanceStatus = WithholdingRemittanceStatus.PENDING
-
-    @Column(name = "created_at")
-    var createdAt: OffsetDateTime = OffsetDateTime.MIN
+    @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
+    @Column(name = "period_year") var periodYear: Int = 0
+    @Column(name = "period_month") var periodMonth: Int = 0
+    @Column(name = "authority") var authority: String = ""
+    @Column(name = "currency", length = 3) var currency: String = "CZK"
+    @Column(name = "total_tax_amount", precision = 20, scale = 4) var totalTaxAmount: BigDecimal = BigDecimal.ZERO
+    @Column(name = "item_count") var itemCount: Int = 0
+    @Column(name = "due_date") var dueDate: LocalDate = LocalDate.EPOCH
+    @Column(name = "status") @Enumerated(EnumType.STRING) var status: WithholdingRemittanceStatus = WithholdingRemittanceStatus.PENDING
+    @Column(name = "created_at") var createdAt: OffsetDateTime = OffsetDateTime.MIN
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/mapper/InterestMapper.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/mapper/InterestMapper.kt
@@ -13,67 +13,109 @@ import jakarta.enterprise.context.ApplicationScoped
 @ApplicationScoped
 class InterestMapper {
     fun toEntity(c: InterestRateConfig) = InterestRateConfigEntity().also {
-        it.id = c.id; it.productId = c.productId; it.rateType = c.rateType
-        it.annualRate = c.annualRate; it.minBalance = c.minBalance; it.maxBalance = c.maxBalance
-        it.dayCount = c.dayCount; it.effectiveFrom = c.effectiveFrom; it.effectiveTo = c.effectiveTo
-        it.active = c.active; it.createdAt = c.createdAt; it.updatedAt = c.updatedAt
+        it.id = c.id
+        it.productId = c.productId
+        it.rateType = c.rateType
+        it.annualRate = c.annualRate
+        it.minBalance = c.minBalance
+        it.maxBalance = c.maxBalance
+        it.dayCount = c.dayCount
+        it.effectiveFrom = c.effectiveFrom
+        it.effectiveTo = c.effectiveTo
+        it.active = c.active
+        it.createdAt = c.createdAt
+        it.updatedAt = c.updatedAt
     }
     fun toDomain(e: InterestRateConfigEntity) = InterestRateConfig(
         id = e.id, productId = e.productId, rateType = e.rateType,
         annualRate = e.annualRate, minBalance = e.minBalance, maxBalance = e.maxBalance,
         dayCount = e.dayCount, effectiveFrom = e.effectiveFrom, effectiveTo = e.effectiveTo,
-        active = e.active, createdAt = e.createdAt, updatedAt = e.updatedAt
+        active = e.active, createdAt = e.createdAt, updatedAt = e.updatedAt,
     )
     fun toEntity(a: InterestAccrual) = InterestAccrualEntity().also {
-        it.id = a.id; it.accountId = a.accountId; it.productId = a.productId
-        it.configId = a.configId; it.accrualDate = a.accrualDate; it.balance = a.balance
-        it.dailyRate = a.dailyRate; it.accruedAmount = a.accruedAmount; it.currency = a.currency
-        it.status = a.status; it.capitalizedAt = a.capitalizedAt; it.createdAt = a.createdAt
+        it.id = a.id
+        it.accountId = a.accountId
+        it.productId = a.productId
+        it.configId = a.configId
+        it.accrualDate = a.accrualDate
+        it.balance = a.balance
+        it.dailyRate = a.dailyRate
+        it.accruedAmount = a.accruedAmount
+        it.currency = a.currency
+        it.status = a.status
+        it.claimedPeriodTo = a.claimedPeriodTo
+        it.capitalizedAt = a.capitalizedAt
+        it.createdAt = a.createdAt
     }
     fun toDomain(e: InterestAccrualEntity) = InterestAccrual(
         id = e.id, accountId = e.accountId, productId = e.productId,
         configId = e.configId, accrualDate = e.accrualDate, balance = e.balance,
         dailyRate = e.dailyRate, accruedAmount = e.accruedAmount, currency = e.currency,
-        status = e.status, capitalizedAt = e.capitalizedAt, createdAt = e.createdAt
+        status = e.status, claimedPeriodTo = e.claimedPeriodTo,
+        capitalizedAt = e.capitalizedAt, createdAt = e.createdAt,
     )
     fun toEntity(c: InterestCapitalization) = InterestCapitalizationEntity().also {
-        it.id = c.id; it.accountId = c.accountId; it.productId = c.productId
-        it.periodFrom = c.periodFrom; it.periodTo = c.periodTo; it.totalAccrued = c.totalAccrued
-        it.capitalizedAmount = c.capitalizedAmount; it.grossAmount = c.grossAmount
-        it.taxAmount = c.taxAmount; it.netAmount = c.netAmount; it.currency = c.currency
-        it.ledgerEntryId = c.ledgerEntryId; it.createdAt = c.createdAt
+        it.id = c.id
+        it.accountId = c.accountId
+        it.productId = c.productId
+        it.periodFrom = c.periodFrom
+        it.periodTo = c.periodTo
+        it.totalAccrued = c.totalAccrued
+        it.capitalizedAmount = c.capitalizedAmount
+        it.grossAmount = c.grossAmount
+        it.taxAmount = c.taxAmount
+        it.netAmount = c.netAmount
+        it.currency = c.currency
+        it.ledgerEntryId = c.ledgerEntryId
+        it.createdAt = c.createdAt
     }
     fun toDomain(e: InterestCapitalizationEntity) = InterestCapitalization(
         id = e.id, accountId = e.accountId, productId = e.productId,
         periodFrom = e.periodFrom, periodTo = e.periodTo, totalAccrued = e.totalAccrued,
         capitalizedAmount = e.capitalizedAmount, grossAmount = e.grossAmount,
         taxAmount = e.taxAmount, netAmount = e.netAmount, currency = e.currency,
-        ledgerEntryId = e.ledgerEntryId, createdAt = e.createdAt
+        ledgerEntryId = e.ledgerEntryId, createdAt = e.createdAt,
     )
     fun toEntity(w: WithholdingTax) = WithholdingTaxEntity().also {
-        it.id = w.id; it.capitalizationId = w.capitalizationId; it.accountId = w.accountId
-        it.partyRef = w.partyRef; it.periodFrom = w.periodFrom; it.periodTo = w.periodTo
-        it.taxableBase = w.taxableBase; it.rate = w.rate; it.taxAmount = w.taxAmount
-        it.currency = w.currency; it.treatment = w.treatment; it.exemptCode = w.exemptCode
-        it.status = w.status; it.remittanceId = w.remittanceId; it.createdAt = w.createdAt
+        it.id = w.id
+        it.capitalizationId = w.capitalizationId
+        it.accountId = w.accountId
+        it.partyRef = w.partyRef
+        it.periodFrom = w.periodFrom
+        it.periodTo = w.periodTo
+        it.taxableBase = w.taxableBase
+        it.rate = w.rate
+        it.taxAmount = w.taxAmount
+        it.currency = w.currency
+        it.treatment = w.treatment
+        it.exemptCode = w.exemptCode
+        it.status = w.status
+        it.remittanceId = w.remittanceId
+        it.createdAt = w.createdAt
     }
     fun toDomain(e: WithholdingTaxEntity) = WithholdingTax(
         id = e.id, capitalizationId = e.capitalizationId, accountId = e.accountId,
         partyRef = e.partyRef, periodFrom = e.periodFrom, periodTo = e.periodTo,
         taxableBase = e.taxableBase, rate = e.rate, taxAmount = e.taxAmount,
         currency = e.currency, treatment = e.treatment, exemptCode = e.exemptCode,
-        status = e.status, remittanceId = e.remittanceId, createdAt = e.createdAt
+        status = e.status, remittanceId = e.remittanceId, createdAt = e.createdAt,
     )
     fun toEntity(r: WithholdingRemittance) = WithholdingRemittanceEntity().also {
-        it.id = r.id; it.periodYear = r.periodYear; it.periodMonth = r.periodMonth
-        it.authority = r.authority; it.currency = r.currency; it.totalTaxAmount = r.totalTaxAmount
-        it.itemCount = r.itemCount; it.dueDate = r.dueDate; it.status = r.status
+        it.id = r.id
+        it.periodYear = r.periodYear
+        it.periodMonth = r.periodMonth
+        it.authority = r.authority
+        it.currency = r.currency
+        it.totalTaxAmount = r.totalTaxAmount
+        it.itemCount = r.itemCount
+        it.dueDate = r.dueDate
+        it.status = r.status
         it.createdAt = r.createdAt
     }
     fun toDomain(e: WithholdingRemittanceEntity) = WithholdingRemittance(
         id = e.id, periodYear = e.periodYear, periodMonth = e.periodMonth,
         authority = e.authority, currency = e.currency, totalTaxAmount = e.totalTaxAmount,
         itemCount = e.itemCount, dueDate = e.dueDate, status = e.status,
-        withholdingIds = emptyList(), createdAt = e.createdAt
+        withholdingIds = emptyList(), createdAt = e.createdAt,
     )
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt
@@ -25,64 +25,164 @@ import java.util.UUID
 
 @ApplicationScoped
 class InterestRateConfigRepositoryImpl @Inject constructor(
-    private val sf: Mutiny.SessionFactory, private val mapper: InterestMapper
+    private val sf: Mutiny.SessionFactory,
+    private val mapper: InterestMapper,
 ) : InterestRateConfigRepository {
     @WithTransaction override fun save(config: InterestRateConfig): Uni<InterestRateConfig> {
         val e = mapper.toEntity(config)
         return sf.withTransaction { s -> s.persist(e).map { mapper.toDomain(e) } }
     }
+
     @WithSession override fun findById(id: UUID): Uni<InterestRateConfig?> =
         sf.withSession { s -> s.find(InterestRateConfigEntity::class.java, id) }.map { it?.let(mapper::toDomain) }
-    @WithSession override fun findByProductId(productId: String): Uni<List<InterestRateConfig>> =
-        sf.withSession { s -> s.createQuery("FROM InterestRateConfigEntity WHERE productId = :p ORDER BY effectiveFrom DESC", InterestRateConfigEntity::class.java).setParameter("p", productId).resultList }.map { it.map(mapper::toDomain) }
-    @WithSession override fun findAll(): Uni<List<InterestRateConfig>> =
-        sf.withSession { s -> s.createQuery("FROM InterestRateConfigEntity ORDER BY productId, effectiveFrom DESC", InterestRateConfigEntity::class.java).resultList }.map { it.map(mapper::toDomain) }
+
+    @WithSession override fun findByProductId(productId: String): Uni<List<InterestRateConfig>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM InterestRateConfigEntity WHERE productId = :p ORDER BY effectiveFrom DESC",
+            InterestRateConfigEntity::class.java,
+        ).setParameter("p", productId).resultList
+    }.map { it.map(mapper::toDomain) }
+
+    @WithSession override fun findAll(): Uni<List<InterestRateConfig>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM InterestRateConfigEntity ORDER BY productId, effectiveFrom DESC",
+            InterestRateConfigEntity::class.java,
+        ).resultList
+    }.map { it.map(mapper::toDomain) }
+
     @WithSession override fun findActiveForProduct(productId: String, date: LocalDate): Uni<InterestRateConfig?> =
-        sf.withSession { s -> s.createQuery("FROM InterestRateConfigEntity WHERE productId = :p AND active = true AND effectiveFrom <= :d AND (effectiveTo IS NULL OR effectiveTo >= :d) ORDER BY effectiveFrom DESC", InterestRateConfigEntity::class.java).setParameter("p", productId).setParameter("d", date).setMaxResults(1).singleResultOrNull }.map { it?.let(mapper::toDomain) }
-    @WithTransaction override fun update(config: InterestRateConfig): Uni<InterestRateConfig> =
-        sf.withTransaction { s -> s.find(InterestRateConfigEntity::class.java, config.id).flatMap { e -> e!!.active = config.active; e.updatedAt = config.updatedAt; s.persist(e).map { mapper.toDomain(e) } } }
+        sf.withSession { s ->
+            s.createQuery(
+                "FROM InterestRateConfigEntity WHERE productId = :p AND active = true AND effectiveFrom <= :d AND (effectiveTo IS NULL OR effectiveTo >= :d) ORDER BY effectiveFrom DESC",
+                InterestRateConfigEntity::class.java,
+            ).setParameter("p", productId).setParameter("d", date).setMaxResults(1).singleResultOrNull
+        }.map { it?.let(mapper::toDomain) }
+
+    @WithTransaction
+    override fun update(config: InterestRateConfig): Uni<InterestRateConfig> = sf.withTransaction { s ->
+        s.find(InterestRateConfigEntity::class.java, config.id).flatMap { e ->
+            e!!.active =
+                config.active
+            e.updatedAt = config.updatedAt
+            s.persist(e).map { mapper.toDomain(e) }
+        }
+    }
 }
 
 @ApplicationScoped
 class InterestAccrualRepositoryImpl @Inject constructor(
-    private val sf: Mutiny.SessionFactory, private val mapper: InterestMapper
+    private val sf: Mutiny.SessionFactory,
+    private val mapper: InterestMapper,
 ) : InterestAccrualRepository {
     @WithTransaction override fun save(accrual: InterestAccrual): Uni<InterestAccrual> {
         val e = mapper.toEntity(accrual)
         return sf.withTransaction { s -> s.persist(e).map { mapper.toDomain(e) } }
     }
-    @WithSession override fun findAll(): Uni<List<InterestAccrual>> =
-        sf.withSession { s ->
-            s.createQuery("FROM InterestAccrualEntity ORDER BY accrualDate DESC, createdAt DESC", InterestAccrualEntity::class.java).resultList
-        }.map { it.map(mapper::toDomain) }
-    @WithSession override fun findByAccountId(accountId: UUID, from: LocalDate?, to: LocalDate?): Uni<List<InterestAccrual>> {
-        val q = if (from != null && to != null)
-            sf.withSession { s -> s.createQuery("FROM InterestAccrualEntity WHERE accountId = :a AND accrualDate >= :f AND accrualDate <= :t ORDER BY accrualDate DESC", InterestAccrualEntity::class.java).setParameter("a", accountId).setParameter("f", from).setParameter("t", to).resultList }
-        else
-            sf.withSession { s -> s.createQuery("FROM InterestAccrualEntity WHERE accountId = :a ORDER BY accrualDate DESC", InterestAccrualEntity::class.java).setParameter("a", accountId).resultList }
+
+    @WithSession override fun findAll(): Uni<List<InterestAccrual>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM InterestAccrualEntity ORDER BY accrualDate DESC, createdAt DESC",
+            InterestAccrualEntity::class.java,
+        ).resultList
+    }.map { it.map(mapper::toDomain) }
+
+    @WithSession
+    override fun findByAccountId(accountId: UUID, from: LocalDate?, to: LocalDate?): Uni<List<InterestAccrual>> {
+        val q = if (from != null && to != null) {
+            sf.withSession { s ->
+                s.createQuery(
+                    "FROM InterestAccrualEntity WHERE accountId = :a AND accrualDate >= :f AND accrualDate <= :t ORDER BY accrualDate DESC",
+                    InterestAccrualEntity::class.java,
+                ).setParameter("a", accountId).setParameter("f", from).setParameter("t", to).resultList
+            }
+        } else {
+            sf.withSession { s ->
+                s.createQuery(
+                    "FROM InterestAccrualEntity WHERE accountId = :a ORDER BY accrualDate DESC",
+                    InterestAccrualEntity::class.java,
+                ).setParameter("a", accountId).resultList
+            }
+        }
         return q.map { it.map(mapper::toDomain) }
     }
-    @WithSession override fun findPendingCapitalization(accountId: UUID, productId: String, toDate: LocalDate): Uni<List<InterestAccrual>> =
-        sf.withSession { s -> s.createQuery("FROM InterestAccrualEntity WHERE accountId = :a AND productId = :p AND status = 'ACCRUING' AND accrualDate <= :d ORDER BY accrualDate ASC", InterestAccrualEntity::class.java).setParameter("a", accountId).setParameter("p", productId).setParameter("d", toDate).resultList }.map { it.map(mapper::toDomain) }
-    @WithSession override fun sumAccrued(accountId: UUID, from: LocalDate, to: LocalDate): Uni<BigDecimal> =
-        sf.withSession { s -> s.createQuery("SELECT COALESCE(SUM(accruedAmount), 0) FROM InterestAccrualEntity WHERE accountId = :a AND accrualDate >= :f AND accrualDate <= :t AND status = 'ACCRUING'", BigDecimal::class.java).setParameter("a", accountId).setParameter("f", from).setParameter("t", to).singleResult }
+
+    @WithSession override fun findPendingCapitalization(
+        accountId: UUID,
+        productId: String,
+        toDate: LocalDate,
+    ): Uni<List<InterestAccrual>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM InterestAccrualEntity WHERE accountId = :a AND productId = :p AND status = 'ACCRUING' AND accrualDate <= :d ORDER BY accrualDate ASC",
+            InterestAccrualEntity::class.java,
+        ).setParameter("a", accountId).setParameter("p", productId).setParameter("d", toDate).resultList
+    }.map { it.map(mapper::toDomain) }
+
+    @WithSession
+    override fun findClaimedForCapitalization(accountId: UUID, productId: String): Uni<List<InterestAccrual>> =
+        sf.withSession { s ->
+            s.createQuery(
+                "FROM InterestAccrualEntity WHERE accountId = :a AND productId = :p AND status = 'CAPITALIZING' ORDER BY accrualDate ASC",
+                InterestAccrualEntity::class.java,
+            ).setParameter("a", accountId).setParameter("p", productId).resultList
+        }.map { it.map(mapper::toDomain) }
+
+    // Own transaction, committed BEFORE the ledger post: the claim must survive a crash, or the
+    // retry would re-derive a different accrual set and diverge from the journal already booked.
+    @WithTransaction override fun claimForCapitalization(accrualIds: List<UUID>, periodTo: LocalDate): Uni<Unit> =
+        sf.withTransaction { s ->
+            s.createMutationQuery(
+                "UPDATE InterestAccrualEntity SET status = 'CAPITALIZING', claimedPeriodTo = :t " +
+                    "WHERE id IN :ids AND status = 'ACCRUING'",
+            ).setParameter("t", periodTo).setParameter("ids", accrualIds).executeUpdate()
+                .flatMap { claimed ->
+                    if (claimed != accrualIds.size) {
+                        Uni.createFrom().failure(
+                            IllegalStateException(
+                                "Capitalization claim aborted: expected to claim ${accrualIds.size} ACCRUING " +
+                                    "accruals for periodTo=$periodTo, matched $claimed — concurrent capitalization " +
+                                    "or reversed accruals; rolled back, nothing was posted",
+                            ),
+                        )
+                    } else {
+                        Uni.createFrom().item(Unit)
+                    }
+                }
+        }
+
+    @WithSession
+    override fun sumAccrued(accountId: UUID, from: LocalDate, to: LocalDate): Uni<BigDecimal> = sf.withSession { s ->
+        s.createQuery(
+            "SELECT COALESCE(SUM(accruedAmount), 0) FROM InterestAccrualEntity WHERE accountId = :a AND accrualDate >= :f AND accrualDate <= :t AND status = 'ACCRUING'",
+            BigDecimal::class.java,
+        ).setParameter("a", accountId).setParameter("f", from).setParameter("t", to).singleResult
+    }
 }
 
 @ApplicationScoped
 class InterestCapitalizationRepositoryImpl @Inject constructor(
-    private val sf: Mutiny.SessionFactory, private val mapper: InterestMapper, private val clock: Clock
+    private val sf: Mutiny.SessionFactory,
+    private val mapper: InterestMapper,
+    private val clock: Clock,
 ) : InterestCapitalizationRepository {
     @WithTransaction override fun save(cap: InterestCapitalization): Uni<InterestCapitalization> {
         val e = mapper.toEntity(cap)
         return sf.withTransaction { s -> s.persist(e).map { mapper.toDomain(e) } }
     }
-    @WithSession override fun findByAccountId(accountId: UUID): Uni<List<InterestCapitalization>> =
-        sf.withSession { s -> s.createQuery("FROM InterestCapitalizationEntity WHERE accountId = :a ORDER BY createdAt DESC", InterestCapitalizationEntity::class.java).setParameter("a", accountId).resultList }.map { it.map(mapper::toDomain) }
+
+    @WithSession
+    override fun findByAccountId(accountId: UUID): Uni<List<InterestCapitalization>> = sf.withSession { s ->
+        s.createQuery(
+            "FROM InterestCapitalizationEntity WHERE accountId = :a ORDER BY createdAt DESC",
+            InterestCapitalizationEntity::class.java,
+        ).setParameter("a", accountId).resultList
+    }.map { it.map(mapper::toDomain) }
 
     // All four writes of a capitalization share ONE transaction (same shape as statement-service's
     // saveWithOutbox): capitalization + withholding + outbox event + the guarded accrual flip. A
     // failure anywhere — including the row-count guard below — rolls the whole set back, so a retry
-    // never re-credits accruals that a previous partial run already capitalized.
+    // never re-credits accruals that a previous partial run already capitalized. The accruals are
+    // expected to be CAPITALIZING here: InterestAccrualRepository.claimForCapitalization put them
+    // there before the ledger was told anything.
     @WithTransaction
     override fun saveWithOutbox(
         cap: InterestCapitalization,
@@ -108,18 +208,19 @@ class InterestCapitalizationRepositoryImpl @Inject constructor(
                 .chain { _ -> s.persist(whtEntity) }
                 .chain { _ -> s.persist(outboxEntity) }
                 .chain { _ ->
-                    // Status guard: only rows still ACCRUING flip. A count mismatch means another
-                    // writer capitalized (or reversed) some of them meanwhile — abort + roll back.
+                    // Status guard: only rows still CAPITALIZING — i.e. the exact set THIS attempt
+                    // claimed before it posted — flip. A count mismatch means another writer
+                    // capitalized (or reversed) some of them meanwhile: abort + roll back.
                     s.createMutationQuery(
                         "UPDATE InterestAccrualEntity SET status = 'CAPITALIZED', capitalizedAt = :t " +
-                            "WHERE id IN :ids AND status = 'ACCRUING'",
+                            "WHERE id IN :ids AND status = 'CAPITALIZING'",
                     ).setParameter("t", capitalizedAt).setParameter("ids", accrualIds).executeUpdate()
                 }
                 .flatMap { updated ->
                     if (updated != accrualIds.size) {
                         Uni.createFrom().failure(
                             IllegalStateException(
-                                "Capitalization aborted: expected to flip ${accrualIds.size} ACCRUING accruals, " +
+                                "Capitalization aborted: expected to flip ${accrualIds.size} CAPITALIZING accruals, " +
                                     "matched $updated (account=${cap.accountId}, product=${cap.productId}, " +
                                     "periodTo=${cap.periodTo}) — concurrent capitalization or reversed accruals; rolled back",
                             ),

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -47,9 +47,9 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
-  # Outbound service-to-service token (#999): the transaction-service rest-client mints an
-  # openbank-services M2M token via this oidc-client. Disabled under %test (units call the
-  # consumer directly; the boot IT never books a remittance payment).
+  # Outbound service-to-service token (#999): the transaction-service and ledger-service
+  # rest-clients mint an openbank-services M2M token via this oidc-client. Disabled under %test
+  # (units call the consumer directly; the boot IT never books a remittance payment).
   oidc-client:
     auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
     client-id: openbank-services
@@ -60,6 +60,14 @@ quarkus:
   rest-client:
     transaction-service:
       url: ${TRANSACTION_SERVICE_URL:http://localhost:8102}
+      scope: jakarta.inject.Singleton
+    # ADR-0033 §D: the capitalization credit leg (DEBIT interest expense / CREDIT the customer's
+    # deposit-control pocket / CREDIT withholding-tax payable). The default resolves only on
+    # localhost — a deployment MUST set LEDGER_SERVICE_URL or every capitalization fails at the
+    # ledger post and leaves its accruals ACCRUING (loud, not silent: nothing is credited and
+    # nothing is withheld, so the period simply retries).
+    ledger-service:
+      url: ${LEDGER_SERVICE_URL:http://localhost:8101}
       scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
@@ -129,6 +137,23 @@ authz:
     # dispatchScheduledBatch() explicitly and never races the assertions.
     scheduler:
       enabled: false
+# ADR-0033 §D — the GL accounts the capitalization split posts against (InterestLedgerConfig).
+# Defaults are the stable `a0000000-…` rows seeded by the ledger's
+# V17__interest_capitalization_accounts.sql; operators repoint them at the real chart per
+# environment. Interest expense is per currency because the ledger rejects a line whose currency
+# differs from its GL account's (the V14 cash-clearing bug); withholding-tax payable is CZK-only
+# because ADR-0033 §E withholds only CZK interest.
+interest:
+  ledger:
+    system-actor-id: ${INTEREST_LEDGER_SYSTEM_ACTOR_ID:00000000-0000-0000-0000-0000000000cc}
+    gl:
+      # NOT V1's '4000 Interest Expense': that row was seeded with gen_random_uuid(), so no fixed
+      # UUID can reference it (issue #468's defect, cf. V15/'4003 Fee Income'), and it is CZK-only.
+      interest-expense-czk: ${INTEREST_GL_INTEREST_EXPENSE_CZK:a0000000-0000-0000-0000-000000004010}
+      interest-expense-eur: ${INTEREST_GL_INTEREST_EXPENSE_EUR:a0000000-0000-0000-0000-000000004011}
+      interest-expense-usd: ${INTEREST_GL_INTEREST_EXPENSE_USD:a0000000-0000-0000-0000-000000004012}
+      interest-expense-gbp: ${INTEREST_GL_INTEREST_EXPENSE_GBP:a0000000-0000-0000-0000-000000004013}
+      withholding-tax-payable: ${INTEREST_GL_WITHHOLDING_TAX_PAYABLE:a0000000-0000-0000-0000-000000002200}
 openbank:
   interest:
     accrual-cron: "0 0 1 * * ?"

--- a/openbank-interest-service/src/main/resources/db/migration/V7__accrual_capitalizing_claim.sql
+++ b/openbank-interest-service/src/main/resources/db/migration/V7__accrual_capitalizing_claim.sql
@@ -1,0 +1,54 @@
+-- ADR-0033 §D: the CAPITALIZING *claim* — the state that keeps interest-service and the GL from
+-- disagreeing about how much interest a period actually credited.
+--
+-- The defect this closes. `InterestService.capitalize` posts the credit to ledger-service and only
+-- then commits its own capitalization row (deliberately: the reverse order strands a credit the GL
+-- never saw). The ledger idempotency key is the capitalization's business identity —
+-- `interest-capitalization-{account}-{product}-{periodTo}` — and carries NO amount, because a key
+-- that changed with the amount would simply post a SECOND journal instead of colliding.
+--
+-- So, before this migration:
+--   1. capitalize() reads the ACCRUING accruals <= periodTo   -> gross 100
+--   2. ledger books journal J(key, 100)
+--   3. the pod dies before saveWithOutbox commits             -> accruals still ACCRUING, no cap row
+--   4. a missed-day accrual for an earlier date is backfilled -> ACCRUING, also <= periodTo
+--   5. the retry re-reads the set                             -> gross 120, SAME key
+--   6. the ledger returns J(key, 100) from findByIdempotencyKey without looking at the amount
+--   7. interest-service commits a cap row for 120 and flips everything CAPITALIZED
+-- The customer and the GL moved 100; interest-service says 120; the withholding remittance then
+-- pays real cash to the finanční úřad on 20 CZK that was never credited. Nothing reconciles the two
+-- sides, so the break is permanent and silent.
+--
+-- The fix is to make step 1 a *claim* rather than a read: the selected accruals flip
+-- ACCRUING -> CAPITALIZING in their own committed transaction BEFORE the ledger is told anything.
+--   * A crash anywhere after the claim leaves the set CAPITALIZING. The retry finds THAT set
+--     (InterestAccrualRepository.findClaimedForCapitalization), so it derives the identical amount
+--     and the identical key, and the ledger collapses the replay onto the journal it already has.
+--     A stuck CAPITALIZING set is therefore recoverable by a plain retry of capitalize(...) with the
+--     same periodTo — no operator surgery, no manual status edit.
+--   * The backfilled accrual of step 4 lands ACCRUING, outside the claim, and falls into the next
+--     period. That is the correct answer: it was not part of the credit the ledger booked.
+--
+-- claimed_period_to records which periodTo the claim was made for. It is the guard against the one
+-- remaining way to mint a second key: completing an in-flight claim under a DIFFERENT period end.
+-- capitalize() refuses that combination loudly instead (see InterestService.inFlightClaimFailure).
+--
+-- 'CAPITALIZING' is appended AFTER 'ACCRUING' to keep the enum in lifecycle order. REVERSED and
+-- SUSPENDED (V1) still have no writer and are deliberately left untouched.
+--
+-- PostgreSQL note: ALTER TYPE ... ADD VALUE is allowed inside Flyway's transaction on PG 12+ (this
+-- fleet runs 16) as long as the new value is not USED in the same transaction. It is not — the
+-- statements below only declare it and add a nullable column. For that reason there is deliberately
+-- no partial index `WHERE status = 'CAPITALIZING'` here: that index expression would use the value
+-- and fail the migration. idx_accruals_account already serves the claim lookup, which is rare
+-- (one row set per in-flight capitalization) and always account+product scoped.
+--
+-- Rollback note (only safe while no row is CAPITALIZING; the value itself cannot be dropped from a
+-- PG enum, which is harmless — it simply becomes unused again):
+--   ALTER TABLE interest_accruals DROP COLUMN IF EXISTS claimed_period_to;
+ALTER TYPE accrual_status ADD VALUE IF NOT EXISTS 'CAPITALIZING' AFTER 'ACCRUING';
+
+ALTER TABLE interest_accruals ADD COLUMN IF NOT EXISTS claimed_period_to DATE;
+
+COMMENT ON COLUMN interest_accruals.claimed_period_to IS
+    'The capitalization periodTo this accrual was claimed for while status = CAPITALIZING; NULL otherwise.';

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
@@ -27,6 +27,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.mockk.verifyOrder
 import io.smallrye.mutiny.Uni
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -66,12 +67,29 @@ class InterestServiceTest {
     /** Captures the ADR-0033 §D credit leg handed to the ledger, filled by stubCapitalization(). */
     private val postingSlot: CapturingSlot<CapitalizationPosting> = slot()
 
+    /** Captures the ACCRUING -> CAPITALIZING claim the use case takes before it posts. */
+    private val claimIdsSlot: CapturingSlot<List<UUID>> = slot()
+    private val claimPeriodSlot: CapturingSlot<LocalDate> = slot()
+
+    /**
+     * The default world: nothing is CAPITALIZING, so capitalize() takes a fresh ACCRUING set and
+     * claims it. The claim is the finding-2 fix — it freezes the exact accrual set the ledger is
+     * about to be told about, because the idempotency key carries no amount.
+     */
+    private fun stubNoClaimOutstanding() {
+        every { accrualRepo.findClaimedForCapitalization(any(), any()) } returns Uni.createFrom().item(emptyList())
+        every {
+            accrualRepo.claimForCapitalization(capture(claimIdsSlot), capture(claimPeriodSlot))
+        } returns Uni.createFrom().item(Unit)
+    }
+
     /**
      * Stubs the profile lookup, the ledger credit leg, and the ONE atomic write the use case
      * performs: capitalization + withholding + outbox event + the guarded accrual flip all land
      * through `saveWithOutbox`, so there is nothing else for the service to call.
      */
     private fun stubCapitalization(profile: TaxProfile = TaxProfile.FAIL_SAFE_DEFAULT) {
+        stubNoClaimOutstanding()
         every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(profile)
         every { ledgerPostingPort.post(capture(postingSlot)) } returns Uni.createFrom().item(Unit)
         every {
@@ -226,6 +244,7 @@ class InterestServiceTest {
             sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("60.00"), currency = "CZK"),
         )
 
+        stubNoClaimOutstanding()
         every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(TaxProfile.FAIL_SAFE_DEFAULT)
         every { ledgerPostingPort.post(any()) } returns Uni.createFrom().item(Unit)
         every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
@@ -260,12 +279,18 @@ class InterestServiceTest {
         verify(exactly = 1) { ledgerPostingPort.post(any()) }
         assertThat(postingSlot.captured.accountId).isEqualTo(accountId)
         assertThat(postingSlot.captured.currency).isEqualTo("CZK")
-        assertThat(postingSlot.captured.grossAmount).isEqualByComparingTo(BigDecimal("100.0000"))
-        assertThat(postingSlot.captured.taxAmount).isEqualByComparingTo(BigDecimal("15"))
-        assertThat(postingSlot.captured.netAmount).isEqualByComparingTo(BigDecimal("85.0000"))
+        assertThat(postingSlot.captured.gross.amount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(postingSlot.captured.tax.amount).isEqualByComparingTo(BigDecimal("15"))
+        assertThat(postingSlot.captured.net.amount).isEqualByComparingTo(BigDecimal("85.00"))
         // gross = net + tax, so the three-leg entry balances within CZK.
-        assertThat(postingSlot.captured.grossAmount)
-            .isEqualByComparingTo(postingSlot.captured.netAmount.add(postingSlot.captured.taxAmount))
+        assertThat(postingSlot.captured.gross.amount)
+            .isEqualByComparingTo(postingSlot.captured.net.amount.add(postingSlot.captured.tax.amount))
+        // NOT isEqualByComparingTo: scale IS the property that broke (finding 1). The ledger wraps
+        // every line in Money.of(amount, currencyCode) and Money refuses scale > the currency's
+        // minor units, so a scale-4 gross 400s the whole capitalization. isEqualByComparingTo
+        // ignores scale by construction, which is precisely why the old suite could not see it.
+        assertThat(postingSlot.captured.gross.amount.scale()).isEqualTo(2)
+        assertThat(postingSlot.captured.net.amount.scale()).isEqualTo(2)
     }
 
     @Test
@@ -277,6 +302,7 @@ class InterestServiceTest {
             sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("100.00"), currency = "CZK"),
         )
 
+        stubNoClaimOutstanding()
         every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(TaxProfile.FAIL_SAFE_DEFAULT)
         every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
             Uni.createFrom().item(accruals)
@@ -289,8 +315,10 @@ class InterestServiceTest {
 
         // The whole point of posting BEFORE the local write: a capitalization row that the GL knows
         // nothing about is unrepairable (its accruals are already CAPITALIZED, so no retry revisits
-        // them). Failing here leaves the accruals ACCRUING and the period simply retries.
+        // them). Failing here leaves the accruals CAPITALIZING — claimed, so the retry re-derives
+        // the identical amount and key, and simply completes.
         verify(exactly = 0) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { accrualRepo.claimForCapitalization(accruals.map { it.id }, toDate) }
     }
 
     @Test
@@ -326,6 +354,7 @@ class InterestServiceTest {
             sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 19), BigDecimal("5.00"), currency = "EUR"),
         )
 
+        stubNoClaimOutstanding()
         every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
             Uni.createFrom().item(accruals)
 
@@ -333,8 +362,10 @@ class InterestServiceTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("mixed-currency")
             .hasMessageContaining("[CZK, EUR]")
-        // Nothing is credited, nothing is withheld, and the accruals stay ACCRUING for an operator.
+        // Nothing is credited, nothing is withheld, and the accruals stay ACCRUING for an operator:
+        // the currency check runs BEFORE the claim, so there is nothing to unwind.
         verify(exactly = 0) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { accrualRepo.claimForCapitalization(any(), any()) }
         verify(exactly = 0) { taxProfilePort.resolve(any()) }
     }
 
@@ -367,6 +398,7 @@ class InterestServiceTest {
         val productId = "SAVINGS"
         val toDate = LocalDate.of(2026, 1, 20)
 
+        stubNoClaimOutstanding()
         every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
             Uni.createFrom().item(emptyList())
 
@@ -374,6 +406,153 @@ class InterestServiceTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("No pending accruals to capitalize")
         verify(exactly = 0) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+    }
+
+    // --- The claim (finding 2: the idempotency key is amount-blind) ----------------------------
+
+    @Test
+    fun `capitalize claims the accrual set BEFORE it tells the ledger anything`() {
+        val accountId = UUID.fromString("12121212-1212-1212-1212-121212121212")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        val accruals = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("100.00"), currency = "CZK"),
+        )
+        stubCapitalization()
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(accruals)
+
+        service.capitalize(accountId, productId, toDate).await().indefinitely()
+
+        // Order is the whole fix: the ledger's idempotency key carries no amount, so the set the
+        // ledger is told about must be frozen before it is told. Claiming after the post would
+        // leave the same window open.
+        verifyOrder {
+            accrualRepo.claimForCapitalization(any(), any())
+            ledgerPostingPort.post(any())
+            capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any())
+        }
+        assertThat(claimIdsSlot.captured).containsExactlyElementsOf(accruals.map { it.id })
+        assertThat(claimPeriodSlot.captured).isEqualTo(toDate)
+    }
+
+    @Test
+    fun `a crashed attempt is recovered by a plain retry, on the SAME claimed set and amount`() {
+        // The finding-2 scenario. First attempt: gross 100, ledger posts J(key, 100), the pod dies
+        // before saveWithOutbox commits. A missed-day accrual for an EARLIER date is then
+        // backfilled. Before the claim, the retry re-read `ACCRUING AND accrualDate <= toDate`
+        // (no lower bound), summed 120, replayed the SAME amount-blind key, got J(100) back from
+        // findByIdempotencyKey without any amount check, and committed a cap row for 120. The GL
+        // moved 100. The remittance then paid real cash on 20 CZK nobody was credited.
+        val accountId = UUID.fromString("13131313-1313-1313-1313-131313131313")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        val claimed = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("100.00"), currency = "CZK")
+                .copy(status = AccrualStatus.CAPITALIZING, claimedPeriodTo = toDate),
+        )
+        stubCapitalization()
+        every { accrualRepo.findClaimedForCapitalization(accountId, productId) } returns
+            Uni.createFrom().item(claimed)
+
+        val result = service.capitalize(accountId, productId, toDate).await().indefinitely()
+
+        // The retry credits the CLAIMED 100, not 100 + the backfill: the claimed set is the only
+        // thing it looks at, so the amount matches the journal the interrupted attempt booked.
+        assertThat(result.grossAmount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(postingSlot.captured.gross.amount).isEqualByComparingTo(BigDecimal("100.00"))
+        // The pending query is never even reached, so the backfilled accrual cannot leak in. It
+        // stays ACCRUING and falls into the next period — which is the correct answer.
+        verify(exactly = 0) { accrualRepo.findPendingCapitalization(any(), any(), any()) }
+        // Already claimed: re-claiming would trip the ACCRUING guard and wedge the recovery.
+        verify(exactly = 0) { accrualRepo.claimForCapitalization(any(), any()) }
+        // ...and the credit still completes. A claimed set is never a wedge.
+        verify(exactly = 1) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a claim held for a different period end is refused, not silently re-keyed`() {
+        val accountId = UUID.fromString("14141414-1414-1414-1414-141414141414")
+        val productId = "SAVINGS_CZK"
+        val claimed = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("100.00"), currency = "CZK")
+                .copy(status = AccrualStatus.CAPITALIZING, claimedPeriodTo = LocalDate.of(2026, 1, 20)),
+        )
+        every { accrualRepo.findClaimedForCapitalization(accountId, productId) } returns
+            Uni.createFrom().item(claimed)
+
+        // periodTo is part of the idempotency key, so completing this claim to 2026-02-20 would
+        // mint a SECOND key and post a SECOND journal for interest the first attempt may already
+        // have credited.
+        assertThatThrownBy {
+            service.capitalize(accountId, productId, LocalDate.of(2026, 2, 20)).await().indefinitely()
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("already CAPITALIZING")
+            .hasMessageContaining("2026-01-20")
+
+        verify(exactly = 0) { ledgerPostingPort.post(any()) }
+        verify(exactly = 0) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+    }
+
+    // --- Negative gross (finding 3) --------------------------------------------------------------
+
+    @Test
+    fun `a negative gross is refused loudly instead of silently skipping the GL`() {
+        val accountId = UUID.fromString("15151515-1515-1515-1515-151515151515")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        // Reachable: interest_rate_configs.annual_rate has no CHECK and createConfig does not
+        // validate, so a negative rate accrues negative interest.
+        val accruals = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("-10.00"), currency = "CZK"),
+        )
+        stubNoClaimOutstanding()
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(accruals)
+
+        assertThatThrownBy { service.capitalize(accountId, productId, toDate).await().indefinitely() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("NEGATIVE gross")
+            .hasMessageContaining("-10.00 CZK")
+
+        // The old code returned Unit here and committed the capitalization anyway: the row said the
+        // customer had been CHARGED while the GL recorded nothing. Nothing may commit, and the
+        // accruals must stay claimable so an operator can fix the rate and re-run.
+        verify(exactly = 0) { ledgerPostingPort.post(any()) }
+        verify(exactly = 0) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { accrualRepo.claimForCapitalization(any(), any()) }
+        verify(exactly = 0) { taxProfilePort.resolve(any()) }
+    }
+
+    @Test
+    fun `gross is rounded to the currency's minor units, not to scale 4`() {
+        val accountId = UUID.fromString("16161616-1616-1616-1616-161616161616")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        // Accruals carry scale-6 daily amounts; their sum is 100.004999, which used to reach the
+        // ledger as 100.0050 (scale 4) and 400 every time.
+        val accruals = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("60.002500"), currency = "CZK"),
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 19), BigDecimal("40.002499"), currency = "CZK"),
+        )
+        stubCapitalization()
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(accruals)
+
+        val result = service.capitalize(accountId, productId, toDate).await().indefinitely()
+
+        // Scale asserted explicitly — isEqualByComparingTo would pass on 100.0050 too.
+        assertThat(result.grossAmount.scale()).isEqualTo(2)
+        assertThat(result.grossAmount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(result.netAmount.scale()).isEqualTo(2)
+        // The raw accrual sum is preserved at full precision: it is a measurement, not money, and
+        // V6's partial index keys on it.
+        assertThat(capSlot.captured.totalAccrued).isEqualByComparingTo(BigDecimal("100.004999"))
+        // The cap row and the ledger MUST carry the identical figures — rounding once, here, is
+        // what guarantees it. Rounding at the adapter would leave them up to 0.005 apart.
+        assertThat(postingSlot.captured.gross.amount).isEqualTo(capSlot.captured.grossAmount)
+        assertThat(postingSlot.captured.net.amount).isEqualTo(capSlot.captured.netAmount)
+        assertThat(postingSlot.captured.tax.amount).isEqualTo(capSlot.captured.taxAmount)
     }
 
     @Test

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
@@ -4,9 +4,11 @@
 
 package com.openbank.interest.application.usecase
 
+import com.openbank.interest.application.port.out.CapitalizationPosting
 import com.openbank.interest.application.port.out.InterestAccrualRepository
 import com.openbank.interest.application.port.out.InterestCapitalizationRepository
 import com.openbank.interest.application.port.out.InterestRateConfigRepository
+import com.openbank.interest.application.port.out.LedgerPostingPort
 import com.openbank.interest.application.port.out.TaxProfilePort
 import com.openbank.interest.domain.model.AccrualRequest
 import com.openbank.interest.domain.model.AccrualStatus
@@ -44,11 +46,13 @@ class InterestServiceTest {
     private val accrualRepo = mockk<InterestAccrualRepository>()
     private val capitalizationRepo = mockk<InterestCapitalizationRepository>()
     private val taxProfilePort = mockk<TaxProfilePort>()
+    private val ledgerPostingPort = mockk<LedgerPostingPort>()
     private val service = InterestService(
         configRepo,
         accrualRepo,
         capitalizationRepo,
         taxProfilePort,
+        ledgerPostingPort,
         "ACT_365",
         clock,
     )
@@ -59,13 +63,17 @@ class InterestServiceTest {
     private val eventSlot: CapturingSlot<OutboxMessage> = slot()
     private val accrualIdsSlot: CapturingSlot<List<UUID>> = slot()
 
+    /** Captures the ADR-0033 §D credit leg handed to the ledger, filled by stubCapitalization(). */
+    private val postingSlot: CapturingSlot<CapitalizationPosting> = slot()
+
     /**
-     * Stubs the profile lookup and the ONE atomic write the use case now performs: capitalization +
-     * withholding + outbox event + the guarded accrual flip all land through `saveWithOutbox`, so
-     * there is nothing else for the service to call.
+     * Stubs the profile lookup, the ledger credit leg, and the ONE atomic write the use case
+     * performs: capitalization + withholding + outbox event + the guarded accrual flip all land
+     * through `saveWithOutbox`, so there is nothing else for the service to call.
      */
     private fun stubCapitalization(profile: TaxProfile = TaxProfile.FAIL_SAFE_DEFAULT) {
         every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(profile)
+        every { ledgerPostingPort.post(capture(postingSlot)) } returns Uni.createFrom().item(Unit)
         every {
             capitalizationRepo.saveWithOutbox(
                 capture(capSlot),
@@ -219,6 +227,7 @@ class InterestServiceTest {
         )
 
         every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(TaxProfile.FAIL_SAFE_DEFAULT)
+        every { ledgerPostingPort.post(any()) } returns Uni.createFrom().item(Unit)
         every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
             Uni.createFrom().item(accruals)
         // Mirrors the repo's status guard tripping (a concurrent run flipped the accruals first):
@@ -229,6 +238,81 @@ class InterestServiceTest {
         assertThatThrownBy { service.capitalize(accountId, productId, toDate).await().indefinitely() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Capitalization aborted")
+    }
+
+    @Test
+    fun `the ledger credit leg carries gross-net-tax and the customer sub-ledger`() {
+        val accountId = UUID.fromString("77777777-7777-7777-7777-777777777777")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        val accruals = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("100.00"), currency = "CZK"),
+        )
+        stubCapitalization()
+
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(accruals)
+
+        service.capitalize(accountId, productId, toDate).await().indefinitely()
+
+        // Without this the bank remits withholding tax on interest it never credited (the ADR-0033
+        // §D hole): the split must reach the ledger, not just interest-service's own tables.
+        verify(exactly = 1) { ledgerPostingPort.post(any()) }
+        assertThat(postingSlot.captured.accountId).isEqualTo(accountId)
+        assertThat(postingSlot.captured.currency).isEqualTo("CZK")
+        assertThat(postingSlot.captured.grossAmount).isEqualByComparingTo(BigDecimal("100.0000"))
+        assertThat(postingSlot.captured.taxAmount).isEqualByComparingTo(BigDecimal("15"))
+        assertThat(postingSlot.captured.netAmount).isEqualByComparingTo(BigDecimal("85.0000"))
+        // gross = net + tax, so the three-leg entry balances within CZK.
+        assertThat(postingSlot.captured.grossAmount)
+            .isEqualByComparingTo(postingSlot.captured.netAmount.add(postingSlot.captured.taxAmount))
+    }
+
+    @Test
+    fun `a ledger failure leaves NO capitalization row (post before transaction)`() {
+        val accountId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        val accruals = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("100.00"), currency = "CZK"),
+        )
+
+        every { taxProfilePort.resolve(any()) } returns Uni.createFrom().item(TaxProfile.FAIL_SAFE_DEFAULT)
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(accruals)
+        every { ledgerPostingPort.post(any()) } returns
+            Uni.createFrom().failure(IllegalStateException("ledger unavailable"))
+
+        assertThatThrownBy { service.capitalize(accountId, productId, toDate).await().indefinitely() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("ledger unavailable")
+
+        // The whole point of posting BEFORE the local write: a capitalization row that the GL knows
+        // nothing about is unrepairable (its accruals are already CAPITALIZED, so no retry revisits
+        // them). Failing here leaves the accruals ACCRUING and the period simply retries.
+        verify(exactly = 0) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a zero-gross period books no journal but still records the capitalization`() {
+        val accountId = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        val productId = "SAVINGS_CZK"
+        val toDate = LocalDate.of(2026, 1, 20)
+        // A zero-balance account still runs the accrual pass; it accrues nothing worth crediting.
+        val accruals = listOf(
+            sampleAccrual(accountId, productId, LocalDate.of(2026, 1, 18), BigDecimal("0.00"), currency = "CZK"),
+        )
+        stubCapitalization()
+
+        every { accrualRepo.findPendingCapitalization(accountId, productId, toDate) } returns
+            Uni.createFrom().item(accruals)
+
+        service.capitalize(accountId, productId, toDate).await().indefinitely()
+
+        // Every leg would be zero, and the ledger requires >=2 lines each with amount > 0.
+        verify(exactly = 0) { ledgerPostingPort.post(any()) }
+        verify(exactly = 1) { capitalizationRepo.saveWithOutbox(any(), any(), any(), any(), any()) }
+        assertThat(capSlot.captured.grossAmount).isEqualByComparingTo(BigDecimal.ZERO)
     }
 
     @Test

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/InterestLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/contract/InterestLedgerPostJournalPactConsumerTest.kt
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.contract
+
+import au.com.dius.pact.consumer.MockServer
+import au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt
+import au.com.dius.pact.consumer.junit5.PactTestFor
+import au.com.dius.pact.core.model.PactSpecVersion
+import au.com.dius.pact.core.model.RequestResponsePact
+import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.interest.application.port.out.CapitalizationPosting
+import com.openbank.interest.domain.tax.TaxProfile
+import com.openbank.interest.domain.tax.WithholdingTaxPolicy
+import com.openbank.interest.domain.tax.WithholdingTreatment
+import com.openbank.interest.infrastructure.client.CapitalizationJournalFactory
+import com.openbank.interest.infrastructure.client.InterestLedgerConfig
+import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.domain.money.Money
+import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Consumer-driven contract for the journal posting `openbank-interest-service` makes when it
+ * capitalizes credit interest (ADR-0033 §D: `InterestService.capitalize` → [LedgerPostingPort]
+ * [com.openbank.interest.application.port.out.LedgerPostingPort] →
+ * [com.openbank.interest.infrastructure.client.RestLedgerPostingAdapter] →
+ * `LedgerRestClient.postJournal`). Interest-service is the fifth ledger-posting consumer, after
+ * transaction-, lending-, billing- and settlement-service, and it uses the same single ingestion
+ * surface: `POST /api/v1/journals` → 201 `{id, transactionId, status}`.
+ *
+ * ### Why this test does not look like the other four
+ *
+ * The existing `*LedgerPostJournalPactConsumerTest`s hand-write their request body as a JSON string
+ * literal and POST *that* with RestAssured; their journal factory is never invoked, so the contract
+ * pins **what the test author typed**, not what the service emits. That is not a contract on the
+ * consumer — a factory defect (wrong GL account, missing `subAccountId`, an over-scaled amount)
+ * passes provider verification untouched and ships. Issue #1347 tracks retro-fitting them.
+ *
+ * This test derives the body from the REAL [CapitalizationJournalFactory] instead: it builds a
+ * domain [CapitalizationPosting] the way `InterestService.capitalizeSet` builds one (raw accrual sum
+ * → gross at the currency's scale → [WithholdingTaxPolicy] → net), calls the production factory, and
+ * serializes THAT `PostJournalRequest` as the pact's request body. Nothing about the JSON is retyped
+ * — if the factory changes what it emits, the pact changes with it and
+ * `.github/workflows/pact-drift-check.yml` fails until the committed pact is regenerated and the
+ * ledger re-verifies it.
+ *
+ * This is not theoretical for this service: the credit leg's first cut handed the port three bare
+ * `BigDecimal`s at scale 4, and ledger-service re-wraps every incoming line as
+ * `Money.of(amount, currencyCode)` — which rejects scale > the currency's minor units. Every
+ * money-bearing capitalization would have 400'd at the boundary. A hand-written `"amount": 100.00`
+ * body would have recorded a green contract for a service that could not post a single journal.
+ *
+ * ### Provider state
+ *
+ * "the standard chart of accounts is seeded" — the SAME state the transaction-/lending-/billing-/
+ * settlement-service pacts already use, and it is already implemented (as a no-op, correctly: the
+ * Flyway migrations seed the chart into the fresh Testcontainer DB) on **both** ledger-side
+ * verification classes, `LedgerPactProviderVerificationTest` (git-pact/`@PactFolder`) and
+ * `LedgerPactBrokerProviderVerificationTest` (broker). No new state is introduced, so there is
+ * nothing that could end up on only one of them (#1198). The four GL accounts these interactions
+ * post against are seeded by `V17__interest_capitalization_accounts.sql`, which is part of the same
+ * ledger migration set and therefore part of the same "standard chart".
+ *
+ * ### Regenerating
+ *
+ * `./gradlew :openbank-interest-service:test --tests "*InterestLedgerPostJournalPactConsumerTest*"`
+ * rewrites `pacts/openbank-interest-service-openbank-ledger-service.json`; commit it in the same PR.
+ */
+@ExtendWith(PactConsumerTestExt::class)
+@PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
+class InterestLedgerPostJournalPactConsumerTest {
+
+    /**
+     * The three-leg case: a CZ-resident individual's CZK savings interest, withheld at 15 %.
+     * Dr 4010 interest expense (gross) / Cr 2100 deposit control (net, `subAccountId` = the
+     * customer's account) / Cr 2200 withholding-tax payable (tax).
+     */
+    private val withheldPosting = posting(accruedSum = "100.004321", accountId = WITHHELD_ACCOUNT_ID)
+
+    /**
+     * The two-leg case, and a real one rather than a contrivance: the statutory whole-CZK DOWN
+     * rounding (daňový řád) means any gross below 7.00 CZK assesses `floor(gross) × 0.15 = 0` while
+     * the treatment is still `WITHHELD`. The ledger enforces `CHECK (amount > 0)` per line, so
+     * emitting the tax leg at zero would fail the whole entry — including the customer's legitimate
+     * credit. The factory omits it; this contract records that it does.
+     *
+     * A DIFFERENT customer to the withheld case on purpose. The factory derives both the idempotency
+     * key and the `transactionId` from the business identity (account, product, period end), so two
+     * fixtures sharing an account would ship two interactions carrying the same key — and the
+     * provider would replay the second onto the journal the first already booked, verifying the
+     * three-leg entry twice and the two-leg entry never.
+     */
+    private val zeroTaxPosting = posting(accruedSum = "6.994321", accountId = ZERO_TAX_ACCOUNT_ID)
+
+    private val withheldCzkBody = bodyOf(withheldPosting)
+    private val zeroTaxCzkBody = bodyOf(zeroTaxPosting)
+
+    @Pact(consumer = "openbank-interest-service", provider = "openbank-ledger-service")
+    fun postWithheldCapitalizationJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the standard chart of accounts is seeded")
+        .uponReceiving("POST a balanced three-line CZK interest-capitalization journal with withholding tax")
+        .path("/api/v1/journals")
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(withheldCzkBody)
+        .willRespondWith()
+        .status(201)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.uuid("id")
+                o.uuid("transactionId")
+                o.stringType("status", "POSTED")
+            }.build(),
+        )
+        .toPact()
+
+    @Pact(consumer = "openbank-interest-service", provider = "openbank-ledger-service")
+    fun postZeroTaxCapitalizationJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder
+        .given("the standard chart of accounts is seeded")
+        .uponReceiving("POST a balanced two-line CZK interest-capitalization journal with no withholding-tax leg")
+        .path("/api/v1/journals")
+        .method("POST")
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(zeroTaxCzkBody)
+        .willRespondWith()
+        .status(201)
+        .headers(mapOf("Content-Type" to "application/json"))
+        .body(
+            newJsonBody { o ->
+                o.uuid("id")
+                o.uuid("transactionId")
+                o.stringType("status", "POSTED")
+            }.build(),
+        )
+        .toPact()
+
+    @Test
+    @PactTestFor(pactMethod = "postWithheldCapitalizationJournalPact")
+    fun `postJournal accepts the withheld three-leg split and returns the created journal`(mockServer: MockServer) {
+        // Pins the fixture as the case it claims to be: a fixture that silently stopped exercising
+        // withholding would keep this contract green while contracting nothing.
+        assertThat(CapitalizationJournalFactory.buildLines(withheldPosting, LedgerConfigFixture)).hasSize(3)
+
+        val body = postJournal(mockServer, withheldCzkBody)
+
+        assertThat(body.getString("id")).isNotBlank()
+        assertThat(body.getString("transactionId")).isNotBlank()
+        assertThat(body.getString("status")).isNotBlank()
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "postZeroTaxCapitalizationJournalPact")
+    fun `postJournal accepts the zero-tax two-leg split and returns the created journal`(mockServer: MockServer) {
+        // The tax is zero, but the treatment is still WITHHELD — floor(6.99) * 0.15 simply rounds
+        // to 0 — and the factory must drop the leg rather than post it at zero.
+        val assessed = WithholdingTaxPolicy.compute(BigDecimal("6.99"), "CZK", TAX_PROFILE, PERIOD_TO)
+        assertThat(assessed.treatment).isEqualTo(WithholdingTreatment.WITHHELD)
+        assertThat(assessed.taxAmount).isEqualByComparingTo(BigDecimal.ZERO)
+
+        val lines = CapitalizationJournalFactory.buildLines(zeroTaxPosting, LedgerConfigFixture)
+        assertThat(lines).hasSize(2)
+        assertThat(lines).`as`("a zero leg must never be emitted").allMatch { it.amount.signum() > 0 }
+
+        val body = postJournal(mockServer, zeroTaxCzkBody)
+
+        assertThat(body.getString("id")).isNotBlank()
+        assertThat(body.getString("transactionId")).isNotBlank()
+        assertThat(body.getString("status")).isNotBlank()
+    }
+
+    private fun postJournal(mockServer: MockServer, body: String) = given()
+        .baseUri(mockServer.getUrl())
+        .contentType("application/json")
+        .body(body)
+        .post("/api/v1/journals")
+        .then()
+        .statusCode(201)
+        .extract().jsonPath()
+
+    /**
+     * Builds the posting the way `InterestService.capitalizeSet` does — from a raw scale-6 accrual
+     * sum, rounded ONCE to the currency's scale, with tax and net derived by the real
+     * [WithholdingTaxPolicy]. Retyping `gross`/`tax`/`net` here would reintroduce, one layer down,
+     * exactly the "the author typed it" defect this test exists to avoid.
+     */
+    private fun posting(accruedSum: String, accountId: UUID, currency: String = "CZK"): CapitalizationPosting {
+        val ccy = CurrencyCode.of(currency)
+        val gross = BigDecimal(accruedSum).setScale(ccy.defaultFractionDigits, RoundingMode.HALF_UP)
+        val assessed = WithholdingTaxPolicy.compute(gross, ccy.code, TAX_PROFILE, PERIOD_TO)
+        return CapitalizationPosting(
+            accountId = accountId,
+            productId = PRODUCT_ID,
+            periodTo = PERIOD_TO,
+            gross = Money(gross, ccy),
+            // Whole CZK by statute (scale 0), so the wire carries `15`, not `15.00`.
+            tax = Money(assessed.taxAmount, ccy),
+            net = Money(assessed.netAmount.setScale(ccy.defaultFractionDigits, RoundingMode.HALF_UP), ccy),
+        )
+    }
+
+    /**
+     * The exact bytes `LedgerRestClient.postJournal` puts on the wire: the production factory's
+     * `PostJournalRequest`, serialized by Jackson with the Kotlin module — the same combination
+     * Quarkus REST Client Reactive uses for this DTO (plain scalars only: String/UUID/BigDecimal/
+     * List, no dates, so no Quarkus-specific ObjectMapper customization applies).
+     * `WRITE_BIGDECIMAL_AS_PLAIN` keeps the amounts' scale visible on the wire as the ledger's
+     * `Money.of` will read it.
+     */
+    private fun bodyOf(posting: CapitalizationPosting): String =
+        MAPPER.writeValueAsString(CapitalizationJournalFactory.buildRequest(posting, LedgerConfigFixture))
+
+    private companion object {
+        private val WITHHELD_ACCOUNT_ID: UUID = UUID.fromString("11111111-1111-1111-1111-111111111111")
+        private val ZERO_TAX_ACCOUNT_ID: UUID = UUID.fromString("22222222-2222-2222-2222-222222222222")
+        private const val PRODUCT_ID = "SAVINGS_CZK"
+        private val PERIOD_TO: LocalDate = LocalDate.of(2026, 1, 20)
+
+        /** ADR-0033 §C: the fiscally conservative default — a CZ-resident individual, withheld 15 %. */
+        private val TAX_PROFILE = TaxProfile.FAIL_SAFE_DEFAULT
+
+        private val MAPPER = jacksonObjectMapper().enable(SerializationFeature.WRITE_BIGDECIMAL_AS_PLAIN)
+    }
+
+    /**
+     * `InterestLedgerConfig`'s `@WithDefault` values, restated: a `@ConfigMapping` cannot be
+     * instantiated outside Quarkus, and this test is deliberately HTTP-free apart from the pact mock
+     * server. Drift between these and the real defaults is caught where it matters rather than here
+     * — the pact body pins these ids, and ledger-service's provider verification replays it against
+     * a Testcontainer DB with `V17__interest_capitalization_accounts.sql` applied, so a wrong id is
+     * a failed verification, not a green test.
+     */
+    private object LedgerConfigFixture : InterestLedgerConfig {
+        override fun systemActorId(): UUID = UUID.fromString("00000000-0000-0000-0000-0000000000cc")
+        override fun gl(): InterestLedgerConfig.Gl = GlFixture
+
+        object GlFixture : InterestLedgerConfig.Gl {
+            override fun interestExpenseCzk(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004010")
+            override fun interestExpenseEur(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004011")
+            override fun interestExpenseUsd(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004012")
+            override fun interestExpenseGbp(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004013")
+            override fun withholdingTaxPayable(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000002200")
+        }
+    }
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactoryTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactoryTest.kt
@@ -8,6 +8,7 @@ import com.openbank.interest.application.port.out.CapitalizationPosting
 import com.openbank.interest.domain.model.InterestCapitalization
 import com.openbank.interest.domain.tax.TaxProfile
 import com.openbank.interest.domain.tax.WithholdingTaxPolicy
+import com.openbank.libs.domain.money.Money
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -38,21 +39,21 @@ class CapitalizationJournalFactoryTest {
     fun `a withheld CZK capitalization splits into three balanced legs`() {
         // gross 100 CZK, resident individual -> base 100, tax 15, net 85 (WithholdingTaxPolicy).
         val lines = CapitalizationJournalFactory.buildLines(
-            posting(gross = "100.0000", tax = "15", net = "85.0000"),
+            posting(gross = "100.00", tax = "15", net = "85.00"),
             config,
         )
 
         assertThat(lines).hasSize(3)
         val debit = lines.single { it.side == "DEBIT" }
         assertThat(debit.glAccountId).isEqualTo(interestExpenseCzk)
-        assertThat(debit.amount).isEqualByComparingTo("100.0000")
+        assertThat(debit.amount).isEqualByComparingTo("100.00")
         // The bank's expense is the GROSS: the customer's tax is still the bank's interest cost,
         // it is merely paid to the state instead of to the customer.
         assertThat(debit.subAccountId).isNull()
 
         val deposit = lines.single { it.glAccountId == depositControlCzk }
         assertThat(deposit.side).isEqualTo("CREDIT")
-        assertThat(deposit.amount).isEqualByComparingTo("85.0000")
+        assertThat(deposit.amount).isEqualByComparingTo("85.00")
 
         val tax = lines.single { it.glAccountId == withholdingTaxPayable }
         assertThat(tax.side).isEqualTo("CREDIT")
@@ -65,7 +66,7 @@ class CapitalizationJournalFactoryTest {
     @Test
     fun `the deposit leg names the customer sub-ledger and no other leg does`() {
         val lines = CapitalizationJournalFactory.buildLines(
-            posting(gross = "100.0000", tax = "15", net = "85.0000"),
+            posting(gross = "100.00", tax = "15", net = "85.00"),
             config,
         )
 
@@ -86,11 +87,11 @@ class CapitalizationJournalFactoryTest {
     fun `a zero-tax capitalization emits two legs, never a zero-amount third`() {
         // Real case, not a contrivance: the statutory whole-CZK DOWN rounding means any gross below
         // 7.00 CZK yields floor(gross) * 0.15 = 0 while the interest is still WITHHELD.
-        val result = WithholdingTaxPolicy.compute(BigDecimal("6.9900"), "CZK", TaxProfile.FAIL_SAFE_DEFAULT, PERIOD_TO)
+        val result = WithholdingTaxPolicy.compute(BigDecimal("6.99"), "CZK", TaxProfile.FAIL_SAFE_DEFAULT, PERIOD_TO)
         assertThat(result.taxAmount).isEqualByComparingTo(BigDecimal.ZERO)
 
         val lines = CapitalizationJournalFactory.buildLines(
-            posting(gross = "6.9900", tax = result.taxAmount.toPlainString(), net = result.netAmount.toPlainString()),
+            posting(gross = "6.99", tax = result.taxAmount.toPlainString(), net = result.netAmount.toPlainString()),
             config,
         )
 
@@ -105,12 +106,12 @@ class CapitalizationJournalFactoryTest {
     @Test
     fun `a not-withheld legal entity is credited gross in two legs`() {
         val lines = CapitalizationJournalFactory.buildLines(
-            posting(gross = "100.0000", tax = "0", net = "100.0000"),
+            posting(gross = "100.00", tax = "0", net = "100.00"),
             config,
         )
 
         assertThat(lines).hasSize(2)
-        assertThat(lines.single { it.side == "CREDIT" }.amount).isEqualByComparingTo("100.0000")
+        assertThat(lines.single { it.side == "CREDIT" }.amount).isEqualByComparingTo("100.00")
         assertBalanced(lines)
     }
 
@@ -119,11 +120,11 @@ class CapitalizationJournalFactoryTest {
     @Test
     fun `non-CZK interest routes to the currency's own control and expense accounts`() {
         // §E: only CZK is withheld in v1; EUR interest is DEFERRED_FX, tax 0, credited gross.
-        val result = WithholdingTaxPolicy.compute(BigDecimal("50.0000"), "EUR", TaxProfile.FAIL_SAFE_DEFAULT, PERIOD_TO)
+        val result = WithholdingTaxPolicy.compute(BigDecimal("50.00"), "EUR", TaxProfile.FAIL_SAFE_DEFAULT, PERIOD_TO)
         assertThat(result.taxAmount).isEqualByComparingTo(BigDecimal.ZERO)
 
         val lines = CapitalizationJournalFactory.buildLines(
-            posting(gross = "50.0000", tax = "0", net = "50.0000", currency = "EUR"),
+            posting(gross = "50.00", tax = "0", net = "50.00", currency = "EUR"),
             config,
         )
 
@@ -143,7 +144,7 @@ class CapitalizationJournalFactoryTest {
     fun `an unseeded currency is refused rather than posted to a guessed account`() {
         assertThatThrownBy {
             CapitalizationJournalFactory.buildLines(
-                posting(gross = "10.0000", tax = "0", net = "10.0000", currency = "PLN"),
+                posting(gross = "10.00", tax = "0", net = "10.00", currency = "PLN"),
                 config,
             )
         }.isInstanceOf(IllegalStateException::class.java)
@@ -179,9 +180,9 @@ class CapitalizationJournalFactoryTest {
 
     @Test
     fun `a different period is a different capitalization`() {
-        val january = CapitalizationJournalFactory.idempotencyKey(posting(gross = "1.0000", tax = "0", net = "1.0000"))
+        val january = CapitalizationJournalFactory.idempotencyKey(posting(gross = "1.00", tax = "0", net = "1.00"))
         val february = CapitalizationJournalFactory.idempotencyKey(
-            posting(gross = "1.0000", tax = "0", net = "1.0000", periodTo = LocalDate.of(2026, 2, 20)),
+            posting(gross = "1.00", tax = "0", net = "1.00", periodTo = LocalDate.of(2026, 2, 20)),
         )
         assertThat(january).isNotEqualTo(february)
     }
@@ -189,17 +190,47 @@ class CapitalizationJournalFactoryTest {
     // --- Guards --------------------------------------------------------------------------------
 
     @Test
-    fun `an unbalanced posting is refused before it reaches the ledger`() {
+    fun `an unbalanced posting cannot even be constructed, let alone reach the ledger`() {
+        // The guard moved from this factory into CapitalizationPosting's own constructor: an
+        // unbalanced split can no longer exist as a value, so no future call site can route around
+        // the check by building its own request.
+        assertThatThrownBy { posting(gross = "100.00", tax = "15", net = "80.00") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("gross=100.00 != net=80.00 + tax=15")
+    }
+
+    @Test
+    fun `a posting cannot carry an amount the ledger would reject as over-scaled`() {
+        // THE finding-1 defect, pinned at the type. InterestService rounded to scale 4 and handed
+        // three bare BigDecimals to this port; ledger-service re-wraps every line as
+        // Money.of(amount, currencyCode), and Money refuses scale > the currency's minor units.
+        // Every money-bearing capitalization therefore 400'd at the boundary — in every currency,
+        // under every treatment. CapitalizationPosting carries Money now, so the same mistake is a
+        // construction failure here instead of an opaque HTTP 400 in production.
+        assertThatThrownBy { Money.of(BigDecimal("100.0000"), "CZK") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Amount scale 4 exceeds currency CZK fraction digits 2")
+    }
+
+    @Test
+    fun `a mixed-currency posting cannot be constructed`() {
         assertThatThrownBy {
-            CapitalizationJournalFactory.buildLines(posting(gross = "100.0000", tax = "15", net = "80.0000"), config)
+            CapitalizationPosting(
+                accountId = accountId,
+                productId = "SAVINGS_CZK",
+                periodTo = PERIOD_TO,
+                gross = Money.of(BigDecimal("100.00"), "CZK"),
+                tax = Money.of(BigDecimal("15"), "CZK"),
+                net = Money.of(BigDecimal("85.00"), "EUR"),
+            )
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("gross=100.0000 != net=80.0000 + tax=15")
+            .hasMessageContaining("mixed-currency")
     }
 
     @Test
     fun `the request dates and author come from the period end and the configured system actor`() {
         val request = CapitalizationJournalFactory.buildRequest(
-            posting(gross = "100.0000", tax = "15", net = "85.0000"),
+            posting(gross = "100.00", tax = "15", net = "85.00"),
             config,
         )
 
@@ -211,7 +242,23 @@ class CapitalizationJournalFactoryTest {
 
     // --- Helpers -------------------------------------------------------------------------------
 
+    /**
+     * Asserts what `LedgerService.postJournal` will actually do with these lines.
+     *
+     * The first block is the part the original version of this helper omitted, and it is why a
+     * 100%-of-the-path defect shipped: the ledger re-wraps every line as
+     * `Money.of(req.amount, req.currencyCode)` / `Money.of(req.baseAmount, req.baseCurrencyCode)`,
+     * and `Money`'s init rejects an over-scaled amount. That is the REAL production class from
+     * openbank-libs-domain, not a restatement of its rule — a hand-written `assertBalanced` can only
+     * ever check the rules its author remembered, and every amount assertion in this file uses
+     * `isEqualByComparingTo`, which ignores scale by construction. So the one property that broke
+     * was invisible to both.
+     */
     private fun assertBalanced(lines: List<JournalLineRequest>) {
+        lines.forEach { l ->
+            Money.of(l.amount, l.currencyCode)
+            Money.of(l.baseAmount, l.baseCurrencyCode)
+        }
         lines.map { it.baseCurrencyCode }.distinct().forEach { ccy ->
             val debits = lines.filter { it.side == "DEBIT" && it.baseCurrencyCode == ccy }
                 .fold(BigDecimal.ZERO) { acc, l -> acc + l.baseAmount }
@@ -233,10 +280,9 @@ class CapitalizationJournalFactoryTest {
         accountId = accountId,
         productId = "SAVINGS_CZK",
         periodTo = periodTo,
-        currency = currency,
-        grossAmount = BigDecimal(gross),
-        taxAmount = BigDecimal(tax),
-        netAmount = BigDecimal(net),
+        gross = Money.of(BigDecimal(gross), currency),
+        tax = Money.of(BigDecimal(tax), currency),
+        net = Money.of(BigDecimal(net), currency),
     )
 
     /** A capitalization built the way `InterestService` builds it — a FRESH `id` every time. */
@@ -246,10 +292,10 @@ class CapitalizationJournalFactoryTest {
         periodFrom = LocalDate.of(2026, 1, 18),
         periodTo = PERIOD_TO,
         totalAccrued = BigDecimal("100.00"),
-        capitalizedAmount = BigDecimal("85.0000"),
-        grossAmount = BigDecimal("100.0000"),
+        capitalizedAmount = BigDecimal("85.00"),
+        grossAmount = BigDecimal("100.00"),
         taxAmount = BigDecimal("15"),
-        netAmount = BigDecimal("85.0000"),
+        netAmount = BigDecimal("85.00"),
         currency = "CZK",
         createdAt = OffsetDateTime.parse("2026-01-20T00:00:00Z"),
     )
@@ -258,10 +304,9 @@ class CapitalizationJournalFactoryTest {
         accountId = cap.accountId,
         productId = cap.productId,
         periodTo = cap.periodTo,
-        currency = cap.currency,
-        grossAmount = cap.grossAmount,
-        taxAmount = cap.taxAmount,
-        netAmount = cap.netAmount,
+        gross = Money.of(cap.grossAmount, cap.currency),
+        tax = Money.of(cap.taxAmount, cap.currency),
+        net = Money.of(cap.netAmount, cap.currency),
     )
 
     private companion object {

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactoryTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactoryTest.kt
@@ -271,9 +271,9 @@ class CapitalizationJournalFactoryTest {
     /** The seeded defaults from `V17__interest_capitalization_accounts.sql`. */
     private object TestLedgerConfig : InterestLedgerConfig {
         override fun systemActorId(): UUID = UUID.fromString("00000000-0000-0000-0000-0000000000cc")
-        override fun gl(): InterestLedgerConfig.Gl = Gl
+        override fun gl(): InterestLedgerConfig.Gl = TestGl
 
-        object Gl : InterestLedgerConfig.Gl {
+        object TestGl : InterestLedgerConfig.Gl {
             override fun interestExpenseCzk(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004010")
             override fun interestExpenseEur(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004011")
             override fun interestExpenseUsd(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004012")

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactoryTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/infrastructure/client/CapitalizationJournalFactoryTest.kt
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import com.openbank.interest.application.port.out.CapitalizationPosting
+import com.openbank.interest.domain.model.InterestCapitalization
+import com.openbank.interest.domain.tax.TaxProfile
+import com.openbank.interest.domain.tax.WithholdingTaxPolicy
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * The ADR-0033 §D capitalization split (`InterestService.capitalize` → ledger). This is a money
+ * path: a wrong account, a missing sub-ledger dimension or an unstable idempotency key each
+ * misstate real customer balances, so the accounting is asserted here in full, with no HTTP.
+ */
+class CapitalizationJournalFactoryTest {
+
+    private val accountId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val config = TestLedgerConfig
+
+    private val interestExpenseCzk = UUID.fromString("a0000000-0000-0000-0000-000000004010")
+    private val interestExpenseEur = UUID.fromString("a0000000-0000-0000-0000-000000004011")
+    private val depositControlCzk = UUID.fromString("a0000000-0000-0000-0000-000000000002")
+    private val depositControlEur = UUID.fromString("a0000000-0000-0000-0000-000000002101")
+    private val withholdingTaxPayable = UUID.fromString("a0000000-0000-0000-0000-000000002200")
+
+    // --- The three-leg split ------------------------------------------------------------------
+
+    @Test
+    fun `a withheld CZK capitalization splits into three balanced legs`() {
+        // gross 100 CZK, resident individual -> base 100, tax 15, net 85 (WithholdingTaxPolicy).
+        val lines = CapitalizationJournalFactory.buildLines(
+            posting(gross = "100.0000", tax = "15", net = "85.0000"),
+            config,
+        )
+
+        assertThat(lines).hasSize(3)
+        val debit = lines.single { it.side == "DEBIT" }
+        assertThat(debit.glAccountId).isEqualTo(interestExpenseCzk)
+        assertThat(debit.amount).isEqualByComparingTo("100.0000")
+        // The bank's expense is the GROSS: the customer's tax is still the bank's interest cost,
+        // it is merely paid to the state instead of to the customer.
+        assertThat(debit.subAccountId).isNull()
+
+        val deposit = lines.single { it.glAccountId == depositControlCzk }
+        assertThat(deposit.side).isEqualTo("CREDIT")
+        assertThat(deposit.amount).isEqualByComparingTo("85.0000")
+
+        val tax = lines.single { it.glAccountId == withholdingTaxPayable }
+        assertThat(tax.side).isEqualTo("CREDIT")
+        assertThat(tax.amount).isEqualByComparingTo("15")
+        assertThat(tax.subAccountId).isNull()
+
+        assertBalanced(lines)
+    }
+
+    @Test
+    fun `the deposit leg names the customer sub-ledger and no other leg does`() {
+        val lines = CapitalizationJournalFactory.buildLines(
+            posting(gross = "100.0000", tax = "15", net = "85.0000"),
+            config,
+        )
+
+        // subAccountId is what ties the GL control account out against the per-customer analytical
+        // sub-ledger (CNB 563/1991 + 501/2002). The ledger does NOT require it on a control leg, so
+        // omitting it would post silently and break the next tie-out run instead of failing here.
+        val withSub = lines.filter { it.subAccountId != null }
+        assertThat(withSub).hasSize(1)
+        assertThat(withSub.single().glAccountId).isEqualTo(depositControlCzk)
+        assertThat(withSub.single().subAccountId).isEqualTo(accountId)
+        // ...and the ledger rejects the whole entry if a non-deposit-control leg carries one.
+        assertThat(lines.filter { it.glAccountId != depositControlCzk }).allMatch { it.subAccountId == null }
+    }
+
+    // --- Zero tax ----------------------------------------------------------------------------
+
+    @Test
+    fun `a zero-tax capitalization emits two legs, never a zero-amount third`() {
+        // Real case, not a contrivance: the statutory whole-CZK DOWN rounding means any gross below
+        // 7.00 CZK yields floor(gross) * 0.15 = 0 while the interest is still WITHHELD.
+        val result = WithholdingTaxPolicy.compute(BigDecimal("6.9900"), "CZK", TaxProfile.FAIL_SAFE_DEFAULT, PERIOD_TO)
+        assertThat(result.taxAmount).isEqualByComparingTo(BigDecimal.ZERO)
+
+        val lines = CapitalizationJournalFactory.buildLines(
+            posting(gross = "6.9900", tax = result.taxAmount.toPlainString(), net = result.netAmount.toPlainString()),
+            config,
+        )
+
+        // The ledger enforces CHECK (amount > 0) per line, so a zero tax leg would fail the whole
+        // entry — taking the customer's legitimate credit down with it.
+        assertThat(lines).hasSize(2)
+        assertThat(lines).noneMatch { it.amount.signum() == 0 }
+        assertThat(lines.map { it.glAccountId }).containsExactlyInAnyOrder(interestExpenseCzk, depositControlCzk)
+        assertBalanced(lines)
+    }
+
+    @Test
+    fun `a not-withheld legal entity is credited gross in two legs`() {
+        val lines = CapitalizationJournalFactory.buildLines(
+            posting(gross = "100.0000", tax = "0", net = "100.0000"),
+            config,
+        )
+
+        assertThat(lines).hasSize(2)
+        assertThat(lines.single { it.side == "CREDIT" }.amount).isEqualByComparingTo("100.0000")
+        assertBalanced(lines)
+    }
+
+    // --- Non-CZK -----------------------------------------------------------------------------
+
+    @Test
+    fun `non-CZK interest routes to the currency's own control and expense accounts`() {
+        // §E: only CZK is withheld in v1; EUR interest is DEFERRED_FX, tax 0, credited gross.
+        val result = WithholdingTaxPolicy.compute(BigDecimal("50.0000"), "EUR", TaxProfile.FAIL_SAFE_DEFAULT, PERIOD_TO)
+        assertThat(result.taxAmount).isEqualByComparingTo(BigDecimal.ZERO)
+
+        val lines = CapitalizationJournalFactory.buildLines(
+            posting(gross = "50.0000", tax = "0", net = "50.0000", currency = "EUR"),
+            config,
+        )
+
+        assertThat(lines).hasSize(2)
+        // Both legs must be EUR accounts: the ledger rejects a line whose base currency differs
+        // from its GL account's declared currency (422 — the V14 cash-clearing bug).
+        assertThat(lines.single { it.side == "DEBIT" }.glAccountId).isEqualTo(interestExpenseEur)
+        assertThat(lines.single { it.side == "CREDIT" }.glAccountId).isEqualTo(depositControlEur)
+        assertThat(lines.single { it.side == "CREDIT" }.subAccountId).isEqualTo(accountId)
+        assertThat(lines).allMatch { it.currencyCode == "EUR" && it.baseCurrencyCode == "EUR" }
+        // The CZK-only withholding-tax-payable account must never appear on a foreign entry.
+        assertThat(lines.map { it.glAccountId }).doesNotContain(withholdingTaxPayable)
+        assertBalanced(lines)
+    }
+
+    @Test
+    fun `an unseeded currency is refused rather than posted to a guessed account`() {
+        assertThatThrownBy {
+            CapitalizationJournalFactory.buildLines(
+                posting(gross = "10.0000", tax = "0", net = "10.0000", currency = "PLN"),
+                config,
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("PLN")
+    }
+
+    // --- Idempotency ---------------------------------------------------------------------------
+
+    @Test
+    fun `the idempotency key is identical across two attempts with different capitalization ids`() {
+        // The defect this guards: cap.id defaults to a fresh UUID per construction, so keying the
+        // ledger on it would let a crash-then-retry mint a new key and credit the customer TWICE.
+        val first = capitalization()
+        val second = capitalization()
+        assertThat(first.id).isNotEqualTo(second.id)
+
+        val keyOne = CapitalizationJournalFactory.idempotencyKey(postingOf(first))
+        val keyTwo = CapitalizationJournalFactory.idempotencyKey(postingOf(second))
+
+        assertThat(keyOne).isEqualTo(keyTwo)
+        // Business identity == the V6 unique index on (account_id, product_id, period_to).
+        assertThat(keyOne).isEqualTo("interest-capitalization-$accountId-SAVINGS_CZK-2026-01-20")
+    }
+
+    @Test
+    fun `the transaction id is derived from the same business identity, so a retry reuses it`() {
+        val one = CapitalizationJournalFactory.buildRequest(postingOf(capitalization()), config)
+        val two = CapitalizationJournalFactory.buildRequest(postingOf(capitalization()), config)
+
+        assertThat(one.transactionId).isEqualTo(two.transactionId)
+        assertThat(one.idempotencyKey).isEqualTo(two.idempotencyKey)
+    }
+
+    @Test
+    fun `a different period is a different capitalization`() {
+        val january = CapitalizationJournalFactory.idempotencyKey(posting(gross = "1.0000", tax = "0", net = "1.0000"))
+        val february = CapitalizationJournalFactory.idempotencyKey(
+            posting(gross = "1.0000", tax = "0", net = "1.0000", periodTo = LocalDate.of(2026, 2, 20)),
+        )
+        assertThat(january).isNotEqualTo(february)
+    }
+
+    // --- Guards --------------------------------------------------------------------------------
+
+    @Test
+    fun `an unbalanced posting is refused before it reaches the ledger`() {
+        assertThatThrownBy {
+            CapitalizationJournalFactory.buildLines(posting(gross = "100.0000", tax = "15", net = "80.0000"), config)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("gross=100.0000 != net=80.0000 + tax=15")
+    }
+
+    @Test
+    fun `the request dates and author come from the period end and the configured system actor`() {
+        val request = CapitalizationJournalFactory.buildRequest(
+            posting(gross = "100.0000", tax = "15", net = "85.0000"),
+            config,
+        )
+
+        // §38d ties the withholding to the credit date, which is the period end.
+        assertThat(request.entryDate).isEqualTo("2026-01-20")
+        assertThat(request.valueDate).isEqualTo("2026-01-20")
+        assertThat(request.createdBy).isEqualTo(TestLedgerConfig.systemActorId())
+    }
+
+    // --- Helpers -------------------------------------------------------------------------------
+
+    private fun assertBalanced(lines: List<JournalLineRequest>) {
+        lines.map { it.baseCurrencyCode }.distinct().forEach { ccy ->
+            val debits = lines.filter { it.side == "DEBIT" && it.baseCurrencyCode == ccy }
+                .fold(BigDecimal.ZERO) { acc, l -> acc + l.baseAmount }
+            val credits = lines.filter { it.side == "CREDIT" && it.baseCurrencyCode == ccy }
+                .fold(BigDecimal.ZERO) { acc, l -> acc + l.baseAmount }
+            assertThat(debits).`as`("debits == credits within %s", ccy).isEqualByComparingTo(credits)
+        }
+        assertThat(lines.size).`as`("the ledger requires at least 2 lines").isGreaterThanOrEqualTo(2)
+        assertThat(lines).`as`("the ledger enforces amount > 0 per line").allMatch { it.amount.signum() > 0 }
+    }
+
+    private fun posting(
+        gross: String,
+        tax: String,
+        net: String,
+        currency: String = "CZK",
+        periodTo: LocalDate = PERIOD_TO,
+    ) = CapitalizationPosting(
+        accountId = accountId,
+        productId = "SAVINGS_CZK",
+        periodTo = periodTo,
+        currency = currency,
+        grossAmount = BigDecimal(gross),
+        taxAmount = BigDecimal(tax),
+        netAmount = BigDecimal(net),
+    )
+
+    /** A capitalization built the way `InterestService` builds it — a FRESH `id` every time. */
+    private fun capitalization() = InterestCapitalization(
+        accountId = accountId,
+        productId = "SAVINGS_CZK",
+        periodFrom = LocalDate.of(2026, 1, 18),
+        periodTo = PERIOD_TO,
+        totalAccrued = BigDecimal("100.00"),
+        capitalizedAmount = BigDecimal("85.0000"),
+        grossAmount = BigDecimal("100.0000"),
+        taxAmount = BigDecimal("15"),
+        netAmount = BigDecimal("85.0000"),
+        currency = "CZK",
+        createdAt = OffsetDateTime.parse("2026-01-20T00:00:00Z"),
+    )
+
+    private fun postingOf(cap: InterestCapitalization) = CapitalizationPosting(
+        accountId = cap.accountId,
+        productId = cap.productId,
+        periodTo = cap.periodTo,
+        currency = cap.currency,
+        grossAmount = cap.grossAmount,
+        taxAmount = cap.taxAmount,
+        netAmount = cap.netAmount,
+    )
+
+    private companion object {
+        private val PERIOD_TO: LocalDate = LocalDate.of(2026, 1, 20)
+    }
+
+    /** The seeded defaults from `V17__interest_capitalization_accounts.sql`. */
+    private object TestLedgerConfig : InterestLedgerConfig {
+        override fun systemActorId(): UUID = UUID.fromString("00000000-0000-0000-0000-0000000000cc")
+        override fun gl(): InterestLedgerConfig.Gl = Gl
+
+        object Gl : InterestLedgerConfig.Gl {
+            override fun interestExpenseCzk(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004010")
+            override fun interestExpenseEur(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004011")
+            override fun interestExpenseUsd(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004012")
+            override fun interestExpenseGbp(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004013")
+            override fun withholdingTaxPayable(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000002200")
+        }
+    }
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/CapitalizationLedgerBoundaryIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/CapitalizationLedgerBoundaryIT.kt
@@ -111,8 +111,24 @@ class CapitalizationLedgerBoundaryIT {
         assertThat(cap.totalAccrued).isEqualByComparingTo(BigDecimal("100.004999"))
 
         // ...and the row that was actually committed to Postgres says the same thing.
-        assertThat(persistedCap(cap.id).grossAmount).isEqualByComparingTo(cap.grossAmount)
-        assertThat(persistedCap(cap.id).netAmount).isEqualByComparingTo(cap.netAmount)
+        //
+        // isEqualByComparingTo is the right comparator for the VALUE here (unlike the scale-4-vs-2
+        // bug this suite exists to catch, there is no rounding step between "cap" and "persisted" —
+        // both are the same in-memory BigDecimal before and after the round-trip, so a numeric
+        // comparison genuinely proves the row is faithful). It is NOT the whole story: this table's
+        // gross_amount/net_amount columns are NUMERIC(20,4) (V3__withholding_tax.sql), so Postgres
+        // always returns scale 4 regardless of what was written — "100.00" round-trips as "100.0000".
+        // That is a representation gap from what was actually posted to the ledger at currency scale,
+        // even though the value is numerically identical. Asserting the scale explicitly here, rather
+        // than silently normalizing it away, is what makes that gap visible instead of hidden — see
+        // the linked issue for narrowing the column to currency scale.
+        val persisted = persistedCap(cap.id)
+        assertThat(persisted.grossAmount).isEqualByComparingTo(cap.grossAmount)
+        assertThat(persisted.netAmount).isEqualByComparingTo(cap.netAmount)
+        val scaleGapNote =
+            "interest_capitalizations.gross_amount is NUMERIC(20,4); this is scale 4 even though " +
+                "the ledger was posted at currency scale (2) -- a known representation gap, not a value bug"
+        assertThat(persisted.grossAmount.scale()).`as`(scaleGapNote).isEqualTo(4)
     }
 
     // --- Finding 2: the idempotency key is amount-blind -----------------------------------------

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/CapitalizationLedgerBoundaryIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/CapitalizationLedgerBoundaryIT.kt
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.interest.integration
+
+import com.openbank.interest.application.port.`in`.AccrueInterestUseCase
+import com.openbank.interest.application.port.`in`.CapitalizeInterestUseCase
+import com.openbank.interest.application.port.out.InterestRateConfigRepository
+import com.openbank.interest.domain.model.AccrualRequest
+import com.openbank.interest.domain.model.AccrualStatus
+import com.openbank.interest.domain.model.InterestCapitalization
+import com.openbank.interest.domain.model.InterestRateConfig
+import com.openbank.interest.infrastructure.persistence.entity.InterestAccrualEntity
+import com.openbank.interest.infrastructure.persistence.entity.InterestCapitalizationEntity
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.hibernate.reactive.mutiny.Mutiny
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Drives the REAL [CapitalizeInterestUseCase] — real Postgres, real repositories, real
+ * `CapitalizationJournalFactory` — across the ledger boundary ([LedgerBoundary], which constructs
+ * every line through the production [com.openbank.libs.domain.money.Money] exactly as
+ * `LedgerService.postJournal` does, and replays an idempotency key exactly as it does).
+ *
+ * This test exists because the PR's original suite could not see a defect that broke **every**
+ * money-bearing capitalization: `CapitalizationJournalFactoryTest` stopped at the DTO,
+ * `InterestServiceTest` mocked `LedgerPostingPort`, and `CapitalizationTransactionIT` injected the
+ * repository rather than the use case. Nothing joined the two ends, so nothing asked the one
+ * question that matters on a money path: **does the amount the GL booked equal the amount the
+ * capitalization row claims?**
+ *
+ * See [LedgerBoundary]'s KDoc for exactly what is real here and what is not.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.interest.it.PostgresRedisTestResource::class)
+class CapitalizationLedgerBoundaryIT {
+
+    @Inject
+    lateinit var service: CapitalizeInterestUseCase
+
+    @Inject
+    lateinit var accrualService: AccrueInterestUseCase
+
+    @Inject
+    lateinit var configRepo: InterestRateConfigRepository
+
+    @Inject
+    lateinit var ledger: LedgerBoundary
+
+    @Inject
+    lateinit var sf: Mutiny.SessionFactory
+
+    private val periodTo: LocalDate = LocalDate.of(2026, 1, 20)
+
+    @BeforeEach
+    fun clearLedger() {
+        ledger.reset()
+    }
+
+    // --- Finding 1: every posting 400'd, in every currency, under every treatment ---------------
+
+    @Test
+    fun `capitalize posts a journal the ledger can actually book, and its legs match the row`() {
+        val accountId = UUID.randomUUID()
+        // 60.002500 + 40.002499 = 100.004999 — a scale-6 accrual sum, the normal case. The old code
+        // rounded it to 100.0050 (scale 4) and handed that to the port as a bare BigDecimal;
+        // Money.of("100.0050", CZK) throws, so the ledger 400'd and NO capitalization ever
+        // completed. Rounding now happens once, at the source, to the currency's minor units.
+        persistAccrual(accountId, "60.002500", LocalDate.of(2026, 1, 18))
+        persistAccrual(accountId, "40.002499", LocalDate.of(2026, 1, 19))
+
+        val cap = capitalize(accountId)
+
+        val journal = ledger.journalFor("interest-capitalization-$accountId-$PRODUCT-$periodTo")
+        assertThat(journal).`as`("the credit reached the GL at all").isNotNull
+        assertThat(ledger.booked()).hasSize(1)
+
+        // THE assertion this whole test exists for: the GL and the capitalization row agree, to the
+        // digit. Not isEqualByComparingTo — scale is the property that broke, and comparing by value
+        // ignores it by construction.
+        val debit = journal!!.debits().single()
+        assertThat(debit.glAccountId).isEqualTo(TestInterestLedgerConfig.interestExpenseCzk)
+        assertThat(debit.amount.amount).isEqualTo(cap.grossAmount)
+        assertThat(debit.amount.amount.scale()).isEqualTo(2)
+
+        val deposit = journal.credits().single { it.glAccountId == TestInterestLedgerConfig.depositControlCzk }
+        assertThat(deposit.amount.amount).isEqualTo(cap.netAmount)
+        assertThat(deposit.amount.amount.scale()).isEqualTo(2)
+        // The sub-ledger dimension, or the next tie-out run breaks instead.
+        assertThat(deposit.subAccountId).isEqualTo(accountId)
+
+        val tax = journal.credits().single { it.glAccountId == TestInterestLedgerConfig.withholdingTaxPayableCzk }
+        assertThat(tax.amount.amount).isEqualTo(cap.taxAmount)
+
+        // gross 100.00 -> base 100, tax 15, net 85.00 (WithholdingTaxPolicy, whole-CZK DOWN).
+        assertThat(cap.grossAmount).isEqualTo(BigDecimal("100.00"))
+        assertThat(cap.taxAmount).isEqualByComparingTo(BigDecimal("15"))
+        assertThat(cap.netAmount).isEqualTo(BigDecimal("85.00"))
+        // The raw accrual sum survives at full precision: an accrual is a measurement, not money,
+        // and V6's partial unique index keys on `total_accrued <> 0`.
+        assertThat(cap.totalAccrued).isEqualByComparingTo(BigDecimal("100.004999"))
+
+        // ...and the row that was actually committed to Postgres says the same thing.
+        assertThat(persistedCap(cap.id).grossAmount).isEqualByComparingTo(cap.grossAmount)
+        assertThat(persistedCap(cap.id).netAmount).isEqualByComparingTo(cap.netAmount)
+    }
+
+    // --- Finding 2: the idempotency key is amount-blind -----------------------------------------
+
+    @Test
+    fun `an accrual backfilled after a crashed post cannot make the row and the GL disagree`() {
+        val accountId = UUID.randomUUID()
+        persistAccrual(accountId, "100.000000", LocalDate.of(2026, 1, 18))
+
+        // Attempt 1: the ledger books J(key, 100) and the pod dies before saveWithOutbox commits.
+        ledger.crashAfterNextBooking("simulated crash after the ledger booked, before the local commit")
+        assertThatThrownBy { capitalize(accountId) }.hasMessageContaining("simulated crash")
+
+        val key = "interest-capitalization-$accountId-$PRODUCT-$periodTo"
+        assertThat(ledger.journalFor(key)!!.debits().single().amount.amount).isEqualTo(BigDecimal("100.00"))
+        assertThat(capRowCount(accountId)).`as`("nothing committed locally").isZero()
+        // The claim survived the crash — that is what pins the retry to the same 100.
+        assertThat(statusesOf(accountId)).containsOnly(AccrualStatus.CAPITALIZING)
+
+        // A missed day is backfilled for an EARLIER date. findPendingCapitalization has no lower
+        // bound, so before the claim this accrual silently joined the retry's set and made it 120.
+        persistAccrual(accountId, "20.000000", LocalDate.of(2026, 1, 17))
+
+        // Attempt 2: a plain retry, same arguments. No operator, no manual status surgery.
+        val cap = capitalize(accountId)
+
+        // The divergence that used to happen here: interest-service committed 120 / tax 18 / net 102
+        // while the GL and the customer had moved 100 — the ledger returns the first journal from
+        // findByIdempotencyKey without ever looking at the amount. The remittance then paid 18 CZK
+        // of real cash on 20 CZK the customer never got. Nothing reconciles the two sides, so it was
+        // permanent and silent.
+        assertThat(cap.grossAmount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(cap.taxAmount).isEqualByComparingTo(BigDecimal("15"))
+        assertThat(cap.netAmount).isEqualByComparingTo(BigDecimal("85.00"))
+        assertThat(ledger.journalFor(key)!!.debits().single().amount.amount).isEqualByComparingTo(cap.grossAmount)
+
+        // And exactly ONE journal — putting the amount in the key would have posted a second one and
+        // turned a silent understatement into a double credit (85 + 102 for 120 owed).
+        assertThat(ledger.booked()).`as`("no double credit").hasSize(1)
+        assertThat(capRowCount(accountId)).isEqualTo(1)
+
+        // The backfilled accrual is untouched and falls into the next period — the right answer: it
+        // was not part of the credit the ledger booked.
+        val byDate = accrualsOf(accountId).associate { it.accrualDate to it.status }
+        assertThat(byDate[LocalDate.of(2026, 1, 18)]).isEqualTo(AccrualStatus.CAPITALIZED)
+        assertThat(byDate[LocalDate.of(2026, 1, 17)]).isEqualTo(AccrualStatus.ACCRUING)
+    }
+
+    @Test
+    fun `a claim stuck by a ledger outage is recovered by a plain retry, with no double credit`() {
+        val accountId = UUID.randomUUID()
+        persistAccrual(accountId, "100.000000", LocalDate.of(2026, 1, 18))
+
+        // The ledger is down: the post fails with NOTHING booked, leaving the set claimed and no
+        // journal at all — the state an operator would find. It must not be a wedge.
+        ledger.failNextPost("ledger unavailable")
+        assertThatThrownBy { capitalize(accountId) }.hasMessageContaining("ledger unavailable")
+        assertThat(statusesOf(accountId)).containsOnly(AccrualStatus.CAPITALIZING)
+        assertThat(ledger.booked()).isEmpty()
+
+        val cap = capitalize(accountId)
+
+        assertThat(cap.grossAmount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(ledger.booked()).hasSize(1)
+        assertThat(statusesOf(accountId)).containsOnly(AccrualStatus.CAPITALIZED)
+    }
+
+    @Test
+    fun `a claim held for another period end is refused instead of minting a second key`() {
+        val accountId = UUID.randomUUID()
+        persistAccrual(accountId, "100.000000", LocalDate.of(2026, 1, 18))
+        ledger.crashAfterNextBooking("simulated crash")
+        assertThatThrownBy { capitalize(accountId) }.hasMessageContaining("simulated crash")
+
+        // periodTo is part of the idempotency key. Completing this claim to February would derive a
+        // DIFFERENT key, so the ledger would not recognise the replay and would book a SECOND
+        // journal for interest January's journal already credited.
+        assertThatThrownBy { capitalize(accountId, LocalDate.of(2026, 2, 20)) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("already CAPITALIZING")
+            .hasMessageContaining("2026-01-20")
+
+        assertThat(ledger.booked()).hasSize(1)
+        assertThat(capRowCount(accountId)).isZero()
+        // ...and the documented recovery — retry with the period it was claimed for — still works.
+        assertThat(capitalize(accountId).grossAmount).isEqualByComparingTo(BigDecimal("100.00"))
+        assertThat(ledger.booked()).hasSize(1)
+    }
+
+    // --- Finding 3: negative gross ---------------------------------------------------------------
+
+    @Test
+    fun `a negative rate is refused loudly - no capitalization row, no journal`() {
+        val accountId = UUID.randomUUID()
+        // Reachable end-to-end, not contrived: annual_rate is NUMERIC(10,6) with no CHECK, the DTO
+        // has no @DecimalMin, and createConfig passes it straight through.
+        val configId = persistConfig(NEGATIVE_PRODUCT, BigDecimal("-0.365000"))
+        val accrual = accrue(accountId, NEGATIVE_PRODUCT, BigDecimal("1000.00"))
+        assertThat(accrual.accruedAmount.signum()).`as`("a negative rate really does accrue negative interest")
+            .isNegative()
+        assertThat(configId).isNotNull
+
+        assertThatThrownBy {
+            VertxContextSupport.subscribeAndAwait<InterestCapitalization> {
+                service.capitalize(accountId, NEGATIVE_PRODUCT, periodTo)
+            }
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("NEGATIVE gross")
+
+        // The old guard (`if (gross.signum() <= 0) return Uni.item(Unit)`) skipped the GL and let the
+        // capitalization row commit anyway: the row said the customer had been CHARGED while the GL
+        // recorded nothing at all. Its KDoc cited V6's `WHERE total_accrued <> 0` as authority, but
+        // V6 excludes only ZERO — it treats a negative capitalization as money-bearing and
+        // constrains it, i.e. it refutes the guard rather than justifying it.
+        assertThat(ledger.booked()).isEmpty()
+        assertThat(capRowCount(accountId)).isZero()
+        // Refused before the claim, so the accruals stay claimable: fix the rate, re-run.
+        assertThat(statusesOf(accountId)).containsOnly(AccrualStatus.ACCRUING)
+    }
+
+    @Test
+    fun `a zero-gross period books no journal but still records the capitalization`() {
+        val accountId = UUID.randomUUID()
+        persistAccrual(accountId, "0.000000", LocalDate.of(2026, 1, 18))
+
+        val cap = capitalize(accountId)
+
+        // Zero is NOT negative: there is simply nothing to recognize, and every leg would be zero
+        // while the ledger requires >=2 lines each with amount > 0.
+        assertThat(ledger.booked()).isEmpty()
+        assertThat(cap.grossAmount).isEqualByComparingTo(BigDecimal.ZERO)
+        assertThat(capRowCount(accountId)).isEqualTo(1)
+        assertThat(statusesOf(accountId)).containsOnly(AccrualStatus.CAPITALIZED)
+    }
+
+    // --- Helpers ---------------------------------------------------------------------------------
+
+    // Every reactive call below runs through VertxContextSupport, never `await().indefinitely()`:
+    // capitalize() reaches reactive Panache, which needs a Vert.x duplicated context. Blocking the
+    // JUnit thread on the Uni instead fails with "No current Vertx context found" before the code
+    // under test is ever exercised — the same reason CapitalizationTransactionIT uses this wrapper.
+    private fun capitalize(accountId: UUID, to: LocalDate = periodTo): InterestCapitalization =
+        VertxContextSupport.subscribeAndAwait { service.capitalize(accountId, PRODUCT, to) }!!
+
+    private fun accrue(accountId: UUID, productId: String, balance: BigDecimal) =
+        VertxContextSupport.subscribeAndAwait {
+            accrualService.accrue(
+                AccrualRequest(
+                    accountId = accountId,
+                    productId = productId,
+                    balance = balance,
+                    currency = "CZK",
+                    accrualDate = LocalDate.of(2026, 1, 18),
+                ),
+            )
+        }
+
+    private fun persistConfig(productId: String, annualRate: BigDecimal): UUID = VertxContextSupport.subscribeAndAwait {
+        configRepo.save(
+            InterestRateConfig(
+                productId = productId,
+                annualRate = annualRate,
+                effectiveFrom = LocalDate.of(2026, 1, 1),
+                createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+                updatedAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+            ),
+        )
+    }!!.id
+
+    /** interest_accruals.config_id is a real FK, so every accrual needs a rate config to point at. */
+    private fun persistAccrual(accountId: UUID, accrued: String, date: LocalDate) {
+        val config = persistConfig(PRODUCT, BigDecimal("0.365000"))
+        val entity = InterestAccrualEntity().apply {
+            id = UUID.randomUUID()
+            this.accountId = accountId
+            productId = PRODUCT
+            configId = config
+            accrualDate = date
+            balance = BigDecimal("1000.00")
+            dailyRate = BigDecimal("0.0010000000")
+            accruedAmount = BigDecimal(accrued)
+            currency = "CZK"
+            status = AccrualStatus.ACCRUING
+            createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z")
+        }
+        VertxContextSupport.subscribeAndAwait { sf.withTransaction { s -> s.persist(entity) } }
+    }
+
+    private fun accrualsOf(accountId: UUID): List<InterestAccrualEntity> = VertxContextSupport.subscribeAndAwait {
+        sf.withSession { s ->
+            s.createQuery("FROM InterestAccrualEntity WHERE accountId = :a", InterestAccrualEntity::class.java)
+                .setParameter("a", accountId).resultList
+        }
+    }!!
+
+    private fun statusesOf(accountId: UUID): List<AccrualStatus> = accrualsOf(accountId).map { it.status }
+
+    private fun capRowsOf(accountId: UUID): List<InterestCapitalizationEntity> = VertxContextSupport.subscribeAndAwait {
+        sf.withSession { s ->
+            s.createQuery(
+                "FROM InterestCapitalizationEntity WHERE accountId = :a",
+                InterestCapitalizationEntity::class.java,
+            ).setParameter("a", accountId).resultList
+        }
+    }!!
+
+    private fun capRowCount(accountId: UUID): Int = capRowsOf(accountId).size
+
+    private fun persistedCap(id: UUID): InterestCapitalizationEntity = VertxContextSupport.subscribeAndAwait {
+        sf.withSession { s -> s.find(InterestCapitalizationEntity::class.java, id) }
+    }!!
+
+    private companion object {
+        private const val PRODUCT = "SAVINGS_CZK"
+        private const val NEGATIVE_PRODUCT = "SAVINGS_CZK_NEGATIVE_RATE"
+    }
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/CapitalizationTransactionIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/CapitalizationTransactionIT.kt
@@ -28,11 +28,16 @@ import java.util.UUID
  * Proves the ADR-0033 capitalization atomicity claim against a REAL Postgres — the thing the mocked
  * use-case tests structurally cannot show. `InterestCapitalizationRepositoryImpl.saveWithOutbox`
  * asserts that the capitalization, the withholding liability, the outbox event and the
- * `ACCRUING → CAPITALIZED` flip either all commit or all roll back; only a live transaction can
+ * `CAPITALIZING → CAPITALIZED` flip either all commit or all roll back; only a live transaction can
  * demonstrate that no partial rows survive a mid-way failure.
  *
+ * The accruals arrive here already `CAPITALIZING` because `InterestService.capitalize` claims the
+ * set (`ACCRUING → CAPITALIZING`, its own committed transaction) BEFORE it posts to the ledger —
+ * see `InterestAccrualRepository.claimForCapitalization`. This IT covers the last leg of that
+ * lifecycle; `CapitalizationLedgerBoundaryIT` covers the whole of it through the use case.
+ *
  * Why this matters concretely: the pre-refactor code ran these as four separate transactions, so a
- * crash after the capitalization commit but before the accrual flip left the accruals `ACCRUING`
+ * crash after the capitalization commit but before the accrual flip left the accruals claimable
  * next to a committed capitalization. The retry then re-credited the customer AND re-booked the
  * withholding tax — a double credit and a double tax liability from one period's interest.
  *
@@ -99,10 +104,10 @@ class CapitalizationTransactionIT {
             periodFrom = LocalDate.of(2026, 1, 18),
             periodTo = periodTo,
             totalAccrued = BigDecimal("100.000000"),
-            capitalizedAmount = BigDecimal("85.0000"),
-            grossAmount = BigDecimal("100.0000"),
-            taxAmount = BigDecimal("15.0000"),
-            netAmount = BigDecimal("85.0000"),
+            capitalizedAmount = BigDecimal("85.00"),
+            grossAmount = BigDecimal("100.00"),
+            taxAmount = BigDecimal("15"),
+            netAmount = BigDecimal("85.00"),
             currency = czk,
             createdAt = OffsetDateTime.parse("2026-01-20T00:00:00Z"),
         )
@@ -112,9 +117,9 @@ class CapitalizationTransactionIT {
         accountId = cap.accountId,
         periodFrom = cap.periodFrom,
         periodTo = cap.periodTo,
-        taxableBase = BigDecimal("100.0000"),
+        taxableBase = BigDecimal("100"),
         rate = BigDecimal("0.1500"),
-        taxAmount = BigDecimal("15.0000"),
+        taxAmount = BigDecimal("15"),
         currency = czk,
         treatment = WithholdingTreatment.WITHHELD,
         createdAt = cap.createdAt,
@@ -166,7 +171,7 @@ class CapitalizationTransactionIT {
     @Test
     fun `commits the capitalization, withholding, event and accrual flip together`() {
         val accountId = UUID.randomUUID()
-        val accrualId = persistAccrual(accountId, "SAVINGS_CZK", AccrualStatus.ACCRUING)
+        val accrualId = persistAccrual(accountId, "SAVINGS_CZK", AccrualStatus.CAPITALIZING)
         val cap = capitalizationOf(accountId)
 
         saveCapitalization(cap, listOf(accrualId))
@@ -188,10 +193,10 @@ class CapitalizationTransactionIT {
         assertThatThrownBy { saveCapitalization(cap, listOf(accrualId)) }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Capitalization aborted")
-            .hasMessageContaining("expected to flip 1 ACCRUING accruals, matched 0")
+            .hasMessageContaining("expected to flip 1 CAPITALIZING accruals, matched 0")
 
         // THE point of this test: the failure left NOTHING behind. A committed capitalization here
-        // would mean the customer was credited for interest whose accruals are still ACCRUING —
+        // would mean the customer was credited for interest whose accruals are still claimable —
         // ready to be capitalized (and credited, and taxed) a second time.
         assertThat(capRows(cap.id)).isZero()
         assertThat(whtRows(cap.id)).isZero()
@@ -201,8 +206,8 @@ class CapitalizationTransactionIT {
     @Test
     fun `V6 index rejects a second money-bearing capitalization for the same account, product and period`() {
         val accountId = UUID.randomUUID()
-        val first = persistAccrual(accountId, "SAVINGS_CZK", AccrualStatus.ACCRUING)
-        val second = persistAccrual(accountId, "SAVINGS_CZK", AccrualStatus.ACCRUING, LocalDate.of(2026, 1, 19))
+        val first = persistAccrual(accountId, "SAVINGS_CZK", AccrualStatus.CAPITALIZING)
+        val second = persistAccrual(accountId, "SAVINGS_CZK", AccrualStatus.CAPITALIZING, LocalDate.of(2026, 1, 19))
         val cap1 = capitalizationOf(accountId)
 
         saveCapitalization(cap1, listOf(first))
@@ -214,6 +219,6 @@ class CapitalizationTransactionIT {
             .hasMessageContaining("uq_interest_capitalizations_period")
 
         assertThat(capRows(cap2.id)).isZero()
-        assertThat(accrualStatus(second)).isEqualTo(AccrualStatus.ACCRUING)
+        assertThat(accrualStatus(second)).isEqualTo(AccrualStatus.CAPITALIZING)
     }
 }

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/LedgerBoundary.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/LedgerBoundary.kt
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.interest.integration
+
+import com.openbank.interest.application.port.out.CapitalizationPosting
+import com.openbank.interest.application.port.out.LedgerPostingPort
+import com.openbank.interest.infrastructure.client.CapitalizationJournalFactory
+import com.openbank.interest.infrastructure.client.InterestLedgerConfig
+import com.openbank.interest.infrastructure.client.JournalLineRequest
+import com.openbank.interest.infrastructure.client.PostJournalRequest
+import com.openbank.libs.domain.money.Money
+import io.quarkus.test.Mock
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A booked journal, as ledger-service would hold it: every line already re-wrapped as [Money], which
+ * is the form the amounts must survive to be booked at all.
+ */
+data class BookedJournal(val idempotencyKey: String, val transactionId: UUID, val lines: List<BookedLine>) {
+    fun debits(): List<BookedLine> = lines.filter { it.side == "DEBIT" }
+    fun credits(): List<BookedLine> = lines.filter { it.side == "CREDIT" }
+}
+
+data class BookedLine(val glAccountId: UUID, val side: String, val amount: Money, val subAccountId: UUID?)
+
+/**
+ * The ledger boundary, in-process — the thing every existing test in this module stops one step
+ * short of, which is why a defect that broke **100 %** of money-bearing capitalizations shipped
+ * green.
+ *
+ * ### What is real here, and what is not
+ *
+ * Real, because the defect lived in exactly these two places:
+ * - the production [CapitalizationJournalFactory] builds the request (no re-modelling of the split);
+ * - **[Money] is the real production class** from `openbank-libs-domain`, and [book] constructs every
+ *   line through `Money.of(amount, currencyCode)` / `Money.of(baseAmount, baseCurrencyCode)` — the
+ *   exact two calls `LedgerService.postJournal` makes (`LedgerService.kt:95,97`). `Money`'s init
+ *   requires `amount.scale() <= currency.defaultFractionDigits`; a scale-4 CZK amount throws there
+ *   and `CommonExceptionMappers` turns it into an HTTP 400. This is NOT a hand-rolled restatement of
+ *   the ledger's rule — `CapitalizationJournalFactoryTest.assertBalanced` used to be one, and it
+ *   omitted precisely this rule. It is the same object doing the same check.
+ * - [book] also reproduces `LedgerService.postJournal`'s **idempotent replay verbatim**: a repeated
+ *   key returns the already-booked entry *before any validation and without comparing amounts*
+ *   (`LedgerService.kt:78`). That indifference to the amount is what makes finding 2's divergence
+ *   silent, so a stand-in that "helpfully" compared amounts would test a ledger that does not exist.
+ *
+ * Not real: this is not the `LedgerService` CDI bean over HTTP. `openbank-interest-service` cannot
+ * put `openbank-ledger-service` on its classpath — both ship `db/migration/V1__*.sql`, so Flyway
+ * would refuse to boot ("more than one migration with version 1"), and Quarkus would bean-scan the
+ * ledger's entities into this application. A cross-service test needs a harness that runs both
+ * containers, which does not exist in this repo. Consequently the ledger's GL-account existence and
+ * per-account currency checks (its 422s) are NOT exercised here; they are ledger-service's own tests.
+ * The scale invariant, the balance rule, the line count and the replay semantics — the four things
+ * this PR can break — are.
+ */
+@Mock
+@ApplicationScoped
+class LedgerBoundary : LedgerPostingPort {
+
+    private val journals = LinkedHashMap<String, BookedJournal>()
+
+    /** Set to fail the post AFTER the journal is booked — the crash window this PR argues about. */
+    private val crashAfterBooking = AtomicReference<String?>(null)
+
+    /** Set to fail the post BEFORE anything is booked — a plain ledger outage. */
+    private val failBeforeBooking = AtomicReference<String?>(null)
+
+    /** Every journal booked, in order. More than one per period is a double credit. */
+    fun booked(): List<BookedJournal> = journals.values.toList()
+
+    fun journalFor(key: String): BookedJournal? = journals[key]
+
+    /**
+     * Makes the next post book its journal and then fail, exactly as a pod dying between the ledger
+     * commit and `saveWithOutbox` looks from interest-service: the money moved, the local write set
+     * did not.
+     */
+    fun crashAfterNextBooking(reason: String) = crashAfterBooking.set(reason)
+
+    /** Fails the next post without booking anything — the ledger is simply unreachable. */
+    fun failNextPost(reason: String) = failBeforeBooking.set(reason)
+
+    fun reset() {
+        journals.clear()
+        crashAfterBooking.set(null)
+        failBeforeBooking.set(null)
+    }
+
+    override fun post(posting: CapitalizationPosting): Uni<Unit> {
+        failBeforeBooking.getAndSet(null)?.let { return Uni.createFrom().failure(IllegalStateException(it)) }
+        return runCatching {
+            book(CapitalizationJournalFactory.buildRequest(posting, TestInterestLedgerConfig))
+        }.fold(
+            onSuccess = {
+                val crash = crashAfterBooking.getAndSet(null)
+                if (crash != null) {
+                    Uni.createFrom().failure(IllegalStateException(crash))
+                } else {
+                    Uni.createFrom().item(Unit)
+                }
+            },
+            onFailure = { Uni.createFrom().failure(it) },
+        )
+    }
+
+    /**
+     * `LedgerService.postJournal`, in the two respects that can break here.
+     *
+     * Replay first (before any validation, no amount comparison), then `Money`-construct every line,
+     * then the `JournalEntry` init rules: at least two lines, `amount > 0` per line, and debits ==
+     * credits per currency.
+     */
+    private fun book(request: PostJournalRequest): BookedJournal {
+        journals[request.idempotencyKey]?.let { return it }
+
+        val lines = request.lines.map { l: JournalLineRequest ->
+            // The invariant that 400'd every capitalization. Real Money, real init, real throw.
+            val amount = Money.of(l.amount, l.currencyCode)
+            Money.of(l.baseAmount, l.baseCurrencyCode)
+            BookedLine(l.glAccountId, l.side, amount, l.subAccountId)
+        }
+        require(lines.size >= 2) { "A journal entry requires at least 2 lines, got ${lines.size}" }
+        require(lines.all { it.amount.isPositive() }) { "Every journal line requires amount > 0" }
+        lines.map { it.amount.currency }.distinct().forEach { ccy ->
+            val debits = lines.filter { it.side == "DEBIT" && it.amount.currency == ccy }
+                .fold(Money.zero(ccy.code)) { acc, l -> acc + l.amount }
+            val credits = lines.filter { it.side == "CREDIT" && it.amount.currency == ccy }
+                .fold(Money.zero(ccy.code)) { acc, l -> acc + l.amount }
+            require(debits.amount.compareTo(credits.amount) == 0) {
+                "Journal entry does not balance in $ccy: debits=$debits credits=$credits"
+            }
+        }
+        val journal = BookedJournal(request.idempotencyKey, request.transactionId, lines)
+        journals[request.idempotencyKey] = journal
+        return journal
+    }
+}
+
+/** The seeded defaults from `V17__interest_capitalization_accounts.sql`. */
+object TestInterestLedgerConfig : InterestLedgerConfig {
+    val depositControlCzk: UUID = UUID.fromString("a0000000-0000-0000-0000-000000000002")
+    val interestExpenseCzk: UUID = UUID.fromString("a0000000-0000-0000-0000-000000004010")
+    val withholdingTaxPayableCzk: UUID = UUID.fromString("a0000000-0000-0000-0000-000000002200")
+
+    override fun systemActorId(): UUID = UUID.fromString("00000000-0000-0000-0000-0000000000cc")
+    override fun gl(): InterestLedgerConfig.Gl = TestGl
+
+    object TestGl : InterestLedgerConfig.Gl {
+        override fun interestExpenseCzk(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004010")
+        override fun interestExpenseEur(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004011")
+        override fun interestExpenseUsd(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004012")
+        override fun interestExpenseGbp(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004013")
+        override fun withholdingTaxPayable(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000002200")
+    }
+}

--- a/openbank-ledger-service/src/main/resources/db/migration/V17__interest_capitalization_accounts.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V17__interest_capitalization_accounts.sql
@@ -1,0 +1,62 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- ADR-0033 §D — the GL accounts the credit-interest capitalization split posts against.
+--
+-- openbank-interest-service records a capitalization + a withholding-tax liability in its own
+-- tables but posts NOTHING to the ledger, while WithholdingRemittanceSettlementConsumer already
+-- moves real money to the finanční úřad. The bank therefore remits withholding tax on interest it
+-- never credited to anyone, with no GL record of either the expense or the customer liability.
+-- The split that closes this is:
+--
+--     DEBIT  Interest Expense           (gross)
+--     CREDIT Customer Deposit Control   (net, subAccountId = customer account)
+--     CREDIT Withholding Tax Payable    (tax, omitted when nothing was withheld)
+--
+-- Two of those three legs have no usable account today.
+--
+-- 1. Withholding Tax Payable did not exist at all. Seeded below as '2200' (LIABILITY, CZK) — CZK
+--    only, because ADR-0033 §E withholds only CZK-denominated interest (foreign interest records
+--    treatment = DEFERRED_FX and tax = 0), so a per-currency family would seed three accounts that
+--    can never be posted against.
+--
+-- 2. Interest Expense DOES exist as '4000' (V1__init_ledger.sql) but is unusable twice over:
+--
+--    a. V1 seeded it with gen_random_uuid(), so its id differs per deployment and no consuming
+--       service can hardcode a working reference — the exact defect issue #468 hit with '4001 Fee
+--       Income', which V15__stable_fee_income_account.sql fixed by seeding a NEW stable-UUID row
+--       ('4003') rather than mutating V1's. Every real posting against the random id 422s with
+--       "GL account not found" (see BillingLedgerConfig.Gl.feeIncome's note). Same remedy here:
+--       V1's '4000' row is left untouched (an applied migration is never edited, and UPDATEing a
+--       primary key risks orphaning journal_lines), and the unique constraint on `code` means the
+--       replacement needs a free code — hence the '401x' family below rather than '4000'.
+--
+--    b. It is declared CZK. LedgerService.postJournal rejects a line whose baseCurrencyCode does
+--       not match its GL account's declared currency (422), so a CZK-only expense account cannot
+--       carry the DEBIT leg of a EUR/USD/GBP interest capitalization — the entry would fail whole,
+--       taking the (untaxed, but still real) foreign-currency credit with it. This is exactly the
+--       bug V14__cash_clearing_accounts_per_currency.sql fixed for cash-clearing ("confirmed live,
+--       a EUR CREDIT transaction failed where CZK succeeded"). Interest expense is the same shape,
+--       so it gets the same per-currency treatment.
+--
+-- Numbering follows the V5/V14 convention (base + XX01/XX02/XX03 = EUR/USD/GBP) and the stable-UUID
+-- chart convention (last UUID segment = account code). The paired deposit-control accounts these
+-- entries credit already exist and are already stable: '2100' CZK (V3, id …0002) and '2101'/'2102'/
+-- '2103' EUR/USD/GBP (V5).
+
+INSERT INTO gl_accounts (id, code, name, type, currency_code, is_leaf, is_enabled) VALUES
+    ('a0000000-0000-0000-0000-000000002200', '2200', 'Withholding Tax Payable', 'LIABILITY', 'CZK', true, true),
+    ('a0000000-0000-0000-0000-000000004010', '4010', 'Interest Expense CZK', 'EXPENSE', 'CZK', true, true),
+    ('a0000000-0000-0000-0000-000000004011', '4011', 'Interest Expense EUR', 'EXPENSE', 'EUR', true, true),
+    ('a0000000-0000-0000-0000-000000004012', '4012', 'Interest Expense USD', 'EXPENSE', 'USD', true, true),
+    ('a0000000-0000-0000-0000-000000004013', '4013', 'Interest Expense GBP', 'EXPENSE', 'GBP', true, true);
+
+-- Rollback:
+--   DELETE FROM gl_accounts WHERE id IN (
+--       'a0000000-0000-0000-0000-000000002200',
+--       'a0000000-0000-0000-0000-000000004010',
+--       'a0000000-0000-0000-0000-000000004011',
+--       'a0000000-0000-0000-0000-000000004012',
+--       'a0000000-0000-0000-0000-000000004013');
+-- Safe to roll back only before any journal_lines reference these accounts (the FK would block the
+-- DELETE otherwise) — i.e. before openbank-interest-service capitalizes in a live environment.

--- a/pacts/openbank-interest-service-openbank-ledger-service.json
+++ b/pacts/openbank-interest-service-openbank-ledger-service.json
@@ -1,0 +1,220 @@
+{
+  "consumer": {
+    "name": "openbank-interest-service"
+  },
+  "interactions": [
+    {
+      "description": "POST a balanced three-line CZK interest-capitalization journal with withholding tax",
+      "providerStates": [
+        {
+          "name": "the standard chart of accounts is seeded"
+        }
+      ],
+      "request": {
+        "body": {
+          "createdBy": "00000000-0000-0000-0000-0000000000cc",
+          "description": "Interest capitalization SAVINGS_CZK to 2026-01-20",
+          "entryDate": "2026-01-20",
+          "idempotencyKey": "interest-capitalization-11111111-1111-1111-1111-111111111111-SAVINGS_CZK-2026-01-20",
+          "lines": [
+            {
+              "amount": 100.00,
+              "baseAmount": 100.00,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000004010",
+              "side": "DEBIT",
+              "subAccountId": null
+            },
+            {
+              "amount": 85.00,
+              "baseAmount": 85.00,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000000002",
+              "side": "CREDIT",
+              "subAccountId": "11111111-1111-1111-1111-111111111111"
+            },
+            {
+              "amount": 15,
+              "baseAmount": 15,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000002200",
+              "side": "CREDIT",
+              "subAccountId": null
+            }
+          ],
+          "transactionId": "ed038eb6-817f-36e4-af3b-01a53bca2274",
+          "valueDate": "2026-01-20"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/journals"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "POSTED",
+          "transactionId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            },
+            "$.transactionId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transactionId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    },
+    {
+      "description": "POST a balanced two-line CZK interest-capitalization journal with no withholding-tax leg",
+      "providerStates": [
+        {
+          "name": "the standard chart of accounts is seeded"
+        }
+      ],
+      "request": {
+        "body": {
+          "createdBy": "00000000-0000-0000-0000-0000000000cc",
+          "description": "Interest capitalization SAVINGS_CZK to 2026-01-20",
+          "entryDate": "2026-01-20",
+          "idempotencyKey": "interest-capitalization-22222222-2222-2222-2222-222222222222-SAVINGS_CZK-2026-01-20",
+          "lines": [
+            {
+              "amount": 6.99,
+              "baseAmount": 6.99,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000004010",
+              "side": "DEBIT",
+              "subAccountId": null
+            },
+            {
+              "amount": 6.99,
+              "baseAmount": 6.99,
+              "baseCurrencyCode": "CZK",
+              "currencyCode": "CZK",
+              "fxRate": null,
+              "glAccountId": "a0000000-0000-0000-0000-000000000002",
+              "side": "CREDIT",
+              "subAccountId": "22222222-2222-2222-2222-222222222222"
+            }
+          ],
+          "transactionId": "c2c8edbe-77ac-3ac6-9546-0f528a84572a",
+          "valueDate": "2026-01-20"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api/v1/journals"
+      },
+      "response": {
+        "body": {
+          "id": "e2490de5-5bd3-43d5-b7c4-526e33f71304",
+          "status": "POSTED",
+          "transactionId": "e2490de5-5bd3-43d5-b7c4-526e33f71304"
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "type": "Uuid"
+            },
+            "$.transactionId": {
+              "type": "Uuid"
+            }
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            },
+            "$.status": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.transactionId": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                }
+              ]
+            }
+          }
+        },
+        "status": 201
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.7.3"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "openbank-ledger-service"
+  }
+}


### PR DESCRIPTION
Implements ADR-0033 §D. Prerequisite for ever enabling the interest crons (#999, `docs/audits/2026-07-16-closing-audit.md` finding I-7).

## Why this had to come first

`capitalize()` recorded the capitalization + withholding rows in interest-service's own tables and posted **nothing** to the ledger — verified: no ledger reference anywhere in `InterestService`, and **nothing consumes `interest.withholding.recorded.v1`**. Meanwhile `WithholdingRemittanceSettlementConsumer` **does** move real money (`transactionClient.initiateTransaction`).

So turning on the accrual/capitalization crons in that state would have made **the bank pay real withholding tax to the finanční úřad on interest it never credited to anyone**, with the GL recording neither the expense nor the customer liability. Dead code at least moves no money. That is why this PR exists and why the crons remain stubs.

## The split

```
DEBIT  4010/4011/4012/4013  Interest Expense <ccy>          gross
CREDIT 2100/2101/2102/2103  Customer Deposit Control <ccy>  net    (subAccountId = accountId)
CREDIT 2200                 Withholding Tax Payable         tax
```

`gross = net + tax` is asserted before the request is built, so the entry balances per currency.

| case | legs |
| --- | --- |
| gross 100.00 CZK, resident individual 15% | Dr `4010` 100.00 · Cr `2100` 85.00 (sub) · Cr `2200` 15 |
| gross 6.99 CZK — `floor(6) × 0.15 = 0`, still `WITHHELD` | **two** legs: Dr `4010` 6.99 · Cr `2100` 6.99 |
| EUR 50.00, `DEFERRED_FX` | Dr `4011` 50.00 · Cr `2101` 50.00 — no 2200 leg |
| zero gross | **no journal**; the capitalization row is still written (matches V6's partial index `WHERE total_accrued <> 0`) |

Zero-amount legs are dropped, never sent. Whole-CZK `DOWN` assessment (daňový řád) makes `taxAmount = 0` the *normal* case below 7.00 CZK — the same reachable state that #1264 had to fix on the remittance side.

## Ledger first, own rows second

`postCreditLeg(cap).flatMap { saveWithOutbox(...) }`, mirroring `LendingService.accrueOne`, and deliberately **outside** `saveWithOutbox`'s `sf.withTransaction` (no network call inside a DB transaction).

A crash between the two leaves the accruals `ACCRUING` and **no** capitalization row, so the retry re-runs the period and replays the **same business-derived idempotency key** — `interest-capitalization-{accountId}-{productId}-{periodTo}`, never `cap.id`, which is a fresh UUID per attempt and would **double-post real money**. The ledger collapses the replay. Exactly-once.

Commit-then-post would strand a credit that exists in interest-service and nowhere in the GL, which no retry can repair because the accruals would already be `CAPITALIZED`.

## V17: two GL findings that contradict the ADR

ADR-0033 §D opens with *"Capitalization currently posts one gross leg"* — **false**; there was no posting to convert.

1. **`2200 Withholding Tax Payable` did not exist at all.**
2. **`4000 Interest Expense` exists but is unusable.** V1 seeds it with `gen_random_uuid()`, so its id differs per deployment and nothing can reference it. This is **issue #468 verbatim** — V15 hit it on `4001 Fee Income` (its own comment: *"every real fee-charge posting 422'd with 'GL account not found'"*) and fixed it by seeding a **new stable-UUID code** rather than editing an applied migration. Same remedy: a new `401x` family.
3. **Interest expense must be per-currency.** `LedgerService` (`:270`) rejects a line whose base currency ≠ its GL account's currency, and `4000` is CZK-only — one shared expense account would 422 the entire EUR entry, killing the customer credit with it. V14 hit exactly this on cash clearing (#747, *"confirmed live: a EUR CREDIT transaction fails there"*).

`2100` (V3, id `…0002`) and `2101`/`2102`/`2103` (V5) already carry stable ids — reused, not re-seeded. V1's `4000` row is left untouched.

## Verified independently, not taken on trust

I re-ran everything myself rather than accept the implementation report:

- **`subAccountId` = the capitalization's `accountId`** — confirmed against four independent precedents (`PaymentJournalFactory.depositLeg`, `BillingJournalFactory`, the ledger's own `JournalEntry.bookedDeltas()` projecting `subAccountId → AccountBookedDelta(accountId, …)`, and `InterestAccrualScenario` in the simulation). Not assumed. This matters because `LedgerService:278` rejects `subAccountId` on non-control legs but **never requires it on control legs** (closing-audit finding L-2) — nothing would have stopped a sub-ledger-blind posting, and the result is a tie-out break at the next 06:00 run.
- **Mutation-tested the two decisive properties**: setting the deposit leg's `subAccountId = null` fails 2 tests; moving the ledger post after `saveWithOutbox` fails 3, including `a ledger failure leaves NO capitalization row`. Green tests are not evidence on their own — that lesson is from #1236 (reverted) and #1246 (self-inflicted, fixed in #1264) earlier today.
- `./gradlew :openbank-interest-service:{test,ktlintCheck,detekt} :openbank-ledger-service:{test,ktlintCheck,detekt}` — **BUILD SUCCESSFUL** (JDK 25), 26 interest tests, 0 failures.
- Diff scope confirmed: only the intended files (an earlier `ktlintFormat` had silently reformatted 12 unrelated baselined files; all reverted).

## Judgement calls worth challenging

1. **The `401x` family instead of `4000`** — forced by #468 + the currency check, but it does leave V1's `4000` as a dead row in the chart. Cleaning that up is a separate concern (nothing references it by UUID; only finrep test fixtures use the code string).
2. **Non-CZK is credited gross** (`DEFERRED_FX`, ADR-0033 §E). The alternative — refuse non-CZK capitalization entirely until the FX withholding design lands — is defensible and would be a smaller surface.
3. **The adapter is bound unconditionally**, not behind a `backend=none` no-op like lending's. A silent no-op default is what produced this very defect. Cost: a deployment without `LEDGER_SERVICE_URL` fails every capitalization — loudly, leaving accruals `ACCRUING` (nothing credited, nothing withheld), which I judge strictly better than silence.
4. **interest-service has no gitops Deployment** (docker-compose only), so there was no manifest to wire. Worth confirming that is expected before this can run in-cluster.
5. `docker-compose.yml` also gained `TRANSACTION_SERVICE_URL`, which was missing — the existing remittance path was pointing at localhost.

## Still out of scope

`accrueAll`/`capitalizeAll` remain stubs; no `@Scheduled` is enabled. This PR makes capitalization *correct*; turning it on additionally needs account enumeration and a balance port — **interest-service has neither**, and neither is designed anywhere. That remains the open product decision behind #999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
