### PR TITLE
feat(observability): alert when the cluster hits its capacity ceiling (ADR-0173 D1)

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-forecast.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-forecast.yaml
@@ -93,3 +93,70 @@ spec:
           annotations:
             summary: "Traffic on {{ $labels.service }} dropped far below trend"
             description: "Request rate is >3σ below the last hour's mean for >10m — possible silent upstream outage or wedged consumer."
+    # ADR-0173 D1 — cluster capacity saturation. The gap this closes: the NodePool
+    # `limits` (cpu: 48 / memory: 128Gi, aws/envs/sandbox-platform/main.tf) are both
+    # the FinOps cost control AND the fleet capacity ceiling, and when they bind
+    # Karpenter simply stops provisioning — pods go Pending, nothing alerts. That is
+    # exactly issue #809's second-order failure ("raising requests pinned the pool at
+    # its limits"), and until now the only rules here forecast disk and PVC fill.
+    #
+    # NOT alerting directly on the NodePool cap, deliberately: Karpenter's metrics are
+    # not scraped (`karpenter_nodepools_limit` returns 0 series — verified against the
+    # live Prometheus 2026-07-16), so a `karpenter_*` rule would be a rule that can
+    # never fire. Scraping Karpenter is the better fix and is worth doing; these rules
+    # work with what is actually collected today.
+    - name: openbank.capacity.saturation
+      rules:
+        # THE #809 SIGNAL. When the NodePool cap binds, this is what the cluster looks
+        # like — Karpenter refuses to provision and pods sit Pending indefinitely. A
+        # short spike is normal during a rollout or a scale-from-zero, hence 15m.
+        #
+        # Uses kube_pod_status_phase{phase="Pending"} and NOT
+        # kube_pod_status_unschedulable: the latter's metric NAME is in Prometheus's
+        # label index but it has 0 series even unfiltered (verified live) — an alert on
+        # it would look correct, pass review, and never fire.
+        - alert: PodsPendingSustained
+          expr: sum(kube_pod_status_phase{phase="Pending"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "{{ $value }} pod(s) Pending for >15m — cluster may be at its capacity ceiling"
+            description: >-
+              Karpenter is not satisfying these pods. First check the NodePool limits
+              (cpu/memory in aws/envs/sandbox-platform/main.tf): when they bind, provisioning
+              stops silently and pods queue — the issue #809 failure mode. Other causes: a
+              taint/affinity nothing satisfies, or the 20:00-07:00 UTC disruption freeze
+              interacting with a rollout. Raising the cap is a FinOps decision (ADR-0173), not
+              a reflex.
+        # Leading indicator: requests committed against what the current nodes can offer.
+        # Karpenter bin-packs by REQUESTS (ADR-0173 §2), so this is the number that decides
+        # whether the next pod fits — not actual usage. High commitment with the cap near
+        # means the next scale-up is the one that fails.
+        - alert: ClusterCpuCommitmentHigh
+          expr: |
+            sum(kube_pod_container_resource_requests{resource="cpu"})
+              / sum(kube_node_status_allocatable{resource="cpu"}) > 0.85
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cluster CPU requests at {{ $value | humanizePercentage }} of allocatable"
+            description: >-
+              Committed CPU is close to what the running nodes can offer. If the NodePool cpu
+              limit is also near, the next pod that needs a new node will go Pending instead
+              (see PodsPendingSustained). Baseline when this rule was written: ~68%.
+        - alert: ClusterMemoryCommitmentHigh
+          expr: |
+            sum(kube_pod_container_resource_requests{resource="memory"})
+              / sum(kube_node_status_allocatable{resource="memory"}) > 0.85
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cluster memory requests at {{ $value | humanizePercentage }} of allocatable"
+            description: >-
+              Memory is the axis that bit in #809 — and note allocatable already has the
+              kubelet eviction headroom subtracted (evictionHard 300Mi / evictionSoft 500Mi in
+              the EC2NodeClass), so this is honest bin-packing arithmetic, not a paper number.
+              Baseline when this rule was written: ~42%.


### PR DESCRIPTION
## Summary

The NodePool limits (`cpu: 48` / `memory: 128Gi`) are both the FinOps cost control **and** the fleet capacity ceiling. When they bind, Karpenter stops provisioning and pods sit Pending — **silently**. That is issue #809's second-order failure, and nothing alerted on it: the forecast rules cover disk and PVC fill only.

ADR-0173 D1.

## Type of change

- [x] feat (new functionality — alert rules)
- [ ] fix / refactor / perf / docs / chore / security / breaking

## Linked issues

Refs ADR-0173 D1, #809

## Changes

Three rules in a new `openbank.capacity.saturation` group:

| alert | signal | baseline today |
|---|---|---|
| `PodsPendingSustained` | the #809 failure mode itself | 0 pending |
| `ClusterCpuCommitmentHigh` | leading indicator (>0.85, 30m) | **0.68** |
| `ClusterMemoryCommitmentHigh` | leading indicator (>0.85, 30m) | **0.42** |

Commitment is measured against **requests**, because that is what Karpenter bin-packs by (ADR-0173 §2) — actual usage is not what decides whether the next pod fits. `allocatable` already nets off the kubelet eviction headroom (`evictionHard 300Mi` / `evictionSoft 500Mi` in the EC2NodeClass), so the arithmetic is honest rather than a paper number.

## What the verification changed

**Every expression was run against the live Prometheus before being written down.** Two of my first choices were wrong:

**1. Not alerting on `karpenter_nodepools_limit`** — which is literally what the cap is, and the obvious thing to alert on. Karpenter's metrics **are not scraped**: 0 series. That rule could never fire. Scraping Karpenter is the better fix and worth doing separately; these rules work with what is actually collected today.

**2. Not using `kube_pod_status_unschedulable`** — the textbook metric for "pods can't be placed". Its **name is in Prometheus's label index but it has 0 series even unfiltered**:

```
kube_pod_status_unschedulable            -> 0 series (raw, no filter)
kube_pod_status_phase{phase="Pending"}   -> 1 series, value=0
```

An alert on the first would look correct, pass review, and never fire — the worst kind, because it reads as coverage.

**Thresholds proven against a known-positive, not assumed:**

```
CPU rule @ 0.60 -> FIRES   (on today's real 0.68)
CPU rule @ 0.85 -> quiet
```

So the rule mechanically works, and 0.85 sits correctly above current load.

## Definition of Done

- [x] Hexagonal layering — N/A.
- [ ] Unit / integration / contract tests — N/A (alert rules); validated against live Prometheus instead.
- [x] YAML parses; `yamllint` clean.
- [x] Every expression returns real data (no phantom metrics).
- [x] Firing behaviour proven at a known-positive threshold.
- [ ] OpenAPI / Flyway / Avro — N/A.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new `@Suppress`.
- [x] No new third-party dependency.
- [ ] Auth / crypto / payment code — no.
- [ ] PII path — no.
- [ ] Cardholder data — no.

## Compliance impact

- [x] **DORA Art. 9** — capacity and performance management. ADR-0173 is the first artifact mapping capacity to Art. 9 (`docs/bcp/dora-ictrm.md` maps it to access control / encryption / patching only); this is its first actual control.
- [ ] PCI DSS / GDPR / PSD2 / AML / CNB / None

## Rollout / Rollback

- **Deployment strategy:** ArgoCD picks the PrometheusRule up automatically (`ruleSelectorNilUsesHelmValues=false`). No workload change.
- **Rollback plan:** revert. The #809 failure mode returns to being unmonitored.
- **Data migration reversible:** N/A.

## Reviewer notes

**Thresholds are heuristics and the file says so** — its own header calls these rules "heuristics — tune the windows/thresholds once you have a few weeks of baseline". 0.85 is a judgement call against a 0.68/0.42 baseline observed once. If these turn noisy, the annotation records the baseline so the next person knows what it was tuned against.

**The gap this does not close:** the cap itself is still invisible. `PodsPendingSustained` tells you the ceiling bound *after* it bound; a `karpenter_nodepools_limit` rule would warn *before*. That needs Karpenter's metrics scraped, which is its own change.
