### PR TITLE
docs: correct the release trigger to both axes, record three footguns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,18 @@ Before a change is "done", run the ship-checklist (`/ship-check` runs the same c
 ADR-0029):
 
 1. **Open a PR.** No direct commits to `main`. Branch `<type>/<scope>-<summary>`; squash-merge via PR.
-2. **Versioning is automatic.** A change under `<service>/src/main/**` is released by **release-please**
-   from your Conventional Commit — so the commit message *is* the changelog. Do **not** hand-edit
-   `version.txt`, `CHANGELOG.md`, or `quarkus.application.version` (it derives from `version.txt`).
+2. **Versioning is automatic, and needs BOTH axes.** release-please cuts a release only when the
+   commit **type** releases (`feat`/`fix`/`perf`/`security`, or breaking) **and** it touches a file
+   under `<service>/` outside that package's `exclude-paths` (today `src/test`, plus `e2e` for
+   admin-ui). The commit message *is* the changelog. Neither axis alone is enough:
+   - A hidden type (`refactor` `docs` `test` `build` `ci` `chore`) **never** releases, at any path
+     — the lever when a PR doesn't change shipped code (`rules.yaml: release_scope_mismatch`).
+   - The path axis is broader than `src/main`: `governance.yaml`, `Dockerfile`, `build.gradle.kts`
+     and the lint baselines all count. There is no include/allow-list — only `exclude-paths`,
+     matching **directories** only, so a single file cannot be excluded.
+
+   Do **not** hand-edit `version.txt`, `CHANGELOG.md`, or `quarkus.application.version` (it derives
+   from `version.txt`).
    A module is a released component **iff** it has a `version.txt` (registered in
    [`release-please-config.json`](release-please-config.json) + [`.release-please-manifest.json`](.release-please-manifest.json)).
 3. **API change ⇒ `openapi.yaml` updated + contract test.** Two independent version axes (ADR-0048):
@@ -80,6 +89,15 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   set it `true` in `application.yaml`, or events never dispatch (no error, `attempt_count` stays 0).
 - **CDI wiring isn't validated by `ktlintCheck` + unit tests.** Add `:svc:quarkusBuild` to your
   pre-push gate; ArC/CDI failures only surface there.
+- **`@ApplicationScoped` is LAZY — an `init {}` guard or warning does not run at boot.** Quarkus
+  creates the bean via a client proxy on first use, so a constructor that logs "this config is
+  DEV-ONLY" or `check()`s a go-live flag stays silent until the first request that touches it — which
+  for a rarely-called path can be never, or worse, the exact moment it's too late. Found live in
+  `PdfBoxPadesSealAdapter` (#1299): it warns that every PAdES seal is "worthless as evidence" without
+  a real keystore, and that warning had never once appeared in a pod log, while
+  `require-trusted-issuer` — documented as "refuses to **start**" — would have thrown on a *request*,
+  long after the deploy went green. Add `@Startup` (`io.quarkus.runtime.Startup`) to any bean whose
+  `init` is a boot-time gate or a config-sanity warning.
 
 ### ktlint
 - Path-scoped CI only lints changed files, so a pre-existing wildcard import or a latent
@@ -123,6 +141,23 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   old, understated requests; after raising them Karpenter may refuse to provision
   ("all available instance types exceed limits for nodepool"), leaving pods Pending and stalling
   drift rolls. Whenever you raise requests or eviction headroom, re-check the pool's `limits`.
+- **`optional: true` on a secret ref is a deliberate trade, not a default — know which way you want
+  it.** Without it, a missing Secret pins the pod at `CreateContainerConfigError`: loud, impossible to
+  miss, fixed within the hour (vop-oidc, #1232). With it, Kubernetes silently drops the env/volume and
+  the pod runs `2/2` reporting `UP` while the feature it needed is quietly degraded — document-service
+  sealed PDFs with a throwaway cert for two days that way (#1284), and the ONLY signal was an ArgoCD
+  `Degraded` nobody acted on. `optional: true` is right when a rollout-order race must never
+  crash-loop the service (gitops wiring merges before the OpenBao KV secret is seeded) — but then the
+  fallback needs its own loud, *eager* alarm, or the silence is the bug.
+- **An Argo Rollout that never once succeeded deadlocks on a dead `stable`.** If revision 1 never
+  became healthy (image absent, Kyverno denial), `stableRS` stays pinned to it forever; the canary
+  can't scale because canary strategy holds replicas on a stable that can never schedule. The Rollout
+  loops `Progressing` → `Degraded` (`progressDeadlineSeconds`) while a *later* revision serves happily
+  — service up, Rollout permanently red. **Neither `kubectl argo rollouts retry` nor `promote --full`
+  fixes it** — promote skips steps and pauses, not a broken stable. Delete the dead ReplicaSet
+  (`kubectl -n <ns> delete rs <name>-<rev1-hash>`); Argo then adopts the current revision and goes
+  Healthy in ~90s. Verify it owns **zero** pods first (`kubectl get pods -l
+  rollouts-pod-template-hash=<hash>`). Seen on vop-service, 2026-07-16.
 - **`strategy.type: Recreate` + Server-Side Apply = HTTP 403.** Use `RollingUpdate` with
   `maxSurge: 0 / maxUnavailable: 1` for identical zero-concurrency behaviour.
 - **Use explicit registry prefixes for container images** (`docker.io/library/<image>` for official

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ ADR-0029):
    commit **type** releases (`feat`/`fix`/`perf`/`security`, or breaking) **and** it touches a file
    under `<service>/` outside that package's `exclude-paths` (today `src/test`, plus `e2e` for
    admin-ui). The commit message *is* the changelog. Neither axis alone is enough:
-   - A hidden type (`refactor` `docs` `test` `build` `ci` `chore`) **never** releases, at any path
-     — the lever when a PR doesn't change shipped code (`rules.yaml: release_scope_mismatch`).
+   - A hidden type (`refactor` `docs` `test` `build` `ci` `chore`) does not release at any path —
+     unless it carries a breaking marker, which renders a ⚠ section and so releases a major. That
+     is the lever when a PR doesn't change shipped code (`rules.yaml: release_scope_mismatch`).
    - The path axis is broader than `src/main`: `governance.yaml`, `Dockerfile`, `build.gradle.kts`
      and the lint baselines all count. There is no include/allow-list — only `exclude-paths`,
      matching **directories** only, so a single file cannot be excluded.

--- a/openbank-libs/governance/RELEASE.md
+++ b/openbank-libs/governance/RELEASE.md
@@ -44,10 +44,10 @@ touches** under that component's directory, regardless of the typed scope.
 
 **This means a `feat`/`fix`/`perf`/`security` PR that only touches a service directory *outside*
 `<service>/src/main/**`** — an `openapi.yaml`-only edit, a gitops/docs-only PR that happens to also
-add a file inside the service dir — **still proposes a release**, even though CLAUDE.md rule 2 says
-only `src/main/**` changes should. release-please sees "a file under this component's directory
-changed" + "what type is the commit"; it has no include/allow-list, so "only `src/main` releases" is
-not expressible.
+add a file inside the service dir — **still proposes a release**, even though
+`rules.yaml: change_requirements.release_scope_mismatch` says only `src/main/**` ought to.
+release-please sees "a file under this component's directory changed" + "what type is the commit";
+it has no include/allow-list, so "only `src/main` releases" is not expressible.
 
 What it *does* have is `exclude-paths` (per package, added in #1277): every package now excludes its
 own `src/test`, so a `src/test/**`-only change no longer proposes a release whatever its type.

--- a/openbank-libs/governance/RELEASE.md
+++ b/openbank-libs/governance/RELEASE.md
@@ -43,13 +43,21 @@ commit message *is* the changelog. release-please attributes a commit to a compo
 touches** under that component's directory, regardless of the typed scope.
 
 **This means a `feat`/`fix`/`perf`/`security` PR that only touches a service directory *outside*
-`<service>/src/main/**`** — a `src/test/**`-only change, an `openapi.yaml`-only edit, a
-gitops/docs-only PR that happens to also add a file inside the service dir — **still proposes a
-release**, even though CLAUDE.md rule 2 says only `src/main/**` changes should. release-please has no
-concept of a sub-path exclusion; it only sees "a file under this component's directory changed" +
-"what type is the commit". This surfaced live in PR #547/#551 (a `src/test/**`-only boot-smoke test
-inside a gitops-registration PR proposed `finrep-service 0.4.0` for an artifact that hadn't changed).
-It's harmless — the rebuilt image is byte-identical, just re-tagged — but noisy, so
+`<service>/src/main/**`** — an `openapi.yaml`-only edit, a gitops/docs-only PR that happens to also
+add a file inside the service dir — **still proposes a release**, even though CLAUDE.md rule 2 says
+only `src/main/**` changes should. release-please sees "a file under this component's directory
+changed" + "what type is the commit"; it has no include/allow-list, so "only `src/main` releases" is
+not expressible.
+
+What it *does* have is `exclude-paths` (per package, added in #1277): every package now excludes its
+own `src/test`, so a `src/test/**`-only change no longer proposes a release whatever its type.
+Exclusion matches **directory prefixes only** (`file.indexOf(path + '/') === 0`) — a single file
+cannot be excluded, and a commit touching `src/main` *and* `src/test` still releases (a commit is
+skipped only if **all** its files match an exclude).
+
+The gap surfaced live in PR #547/#551 (a `src/test/**`-only boot-smoke test inside a
+gitops-registration PR proposed `finrep-service 0.4.0` for an artifact that hadn't changed) — the
+case `exclude-paths` now covers. For the paths it doesn't cover the noise remains, so
 `check-release-scope-mismatch.py` flags it as an advisory PR-time warning
 (`rules.yaml: change_requirements.release_scope_mismatch`). When it fires and the PR genuinely doesn't
 change the service's shipped code, re-type the commit (`test:`/`docs:`/`chore:`/`refactor:`/`build:`/


### PR DESCRIPTION
Two documents that disagree with the code, and three footguns that each cost a session today.

Supersedes #1295, which set out to fix the same CLAUDE.md sentence — see the last section.

## 1. RELEASE.md was made false an hour ago

#1277 (`da6a734c3`) gave all 51 packages an `exclude-paths`. `RELEASE.md:49` still says:

> release-please has no concept of a sub-path exclusion

and that a `src/test/**`-only change "**still proposes a release**". Neither holds now. Corrected, plus the mechanics worth knowing: exclusion matches **directory prefixes only** (`file.indexOf(path + '/') === 0`), so a single file cannot be excluded, and a commit touching `src/main` **and** `src/test` still releases — a commit is skipped only if **all** its files match an exclude.

## 2. CLAUDE.md rule 2 was wrong in the other direction

> A change under `<service>/src/main/**` is released by release-please

Understates the path axis (`governance.yaml`, `Dockerfile`, `build.gradle.kts`, the lint baselines all release too) **and omits the type axis entirely**. The honest rule needs both:

> release ⟺ (type ∈ {feat, fix, perf, security} or breaking) **AND** (a changed file under `<service>/` outside that package's `exclude-paths`)

A hidden type (`refactor` `docs` `test` `build` `ci` `chore`) **never** releases, at any path. That matters because it is exactly the lever `rules.yaml: release_scope_mismatch` already advises — "use a non-releasing type when the PR doesn't touch the release-worthy subtree" — and the old text implied no such lever existed.

**Verified against the config, not asserted:**
- 51 packages, each excluding its own `src/test`; admin-ui also excludes `e2e`, and the text now says so (my first draft said just "`src/test`" — the config caught me).
- Live control: `chore(admin-ui): deploy …` commits have touched `openbank-admin-ui/` since tag `admin-ui-v0.49.0`, release-please has run since, and **no admin-ui release PR exists**. Only possible if the type gates the release.

## 3. Three footguns

- **`@ApplicationScoped` is lazy** — an `init {}` warning or go-live `check()` does not run at boot. `PdfBoxPadesSealAdapter`'s "every seal is worthless as evidence" warning had never once appeared in a pod log, and `require-trusted-issuer` — documented as "refuses to **start**" — would have thrown on a *request* instead. Fixed by #1299; the trap generalises. → Kotlin/Quarkus.
- **`optional: true` on a secret ref is a trade, not a default.** Without it: loud `CreateContainerConfigError`, fixed within the hour (vop-oidc, #1232). With it: pod runs `2/2` reporting `UP` while the feature is silently degraded — document-service sealed PDFs with a throwaway cert for two days (#1284). Legitimate when rollout order must never crash-loop the service, but then the fallback needs its own **eager** alarm. → GitOps.
- **An Argo Rollout whose revision 1 never succeeded deadlocks on a dead `stable`.** Neither `retry` nor `promote --full` fixes it — promote skips steps and pauses, not a broken stable. Delete the dead ReplicaSet (verify it owns zero pods first). Cost ~40 minutes on vop-service today. → GitOps.

## On #1295

#1295 aimed at the same CLAUDE.md sentence and got two things genuinely right, which I've kept: there is no include/allow-list, and exclusion is directory-only so a single file can't be excluded.

Where it goes wrong is *"touch one and the service ships a version"* — that asserts path alone triggers a release, which the admin-ui control above disproves. It also cites devops-agent 0.3.2→**0.4.0** as evidence; a *minor* is only ever produced by a `feat`, so that example shows the type deciding, not the path. Merging it would have put two false statements into the file every contributor and agent reads, and contradicted `rules.yaml` — which CLAUDE.md itself declares authoritative. Close it in favour of this, or take this as the rewrite it asked for.

Docs-only; no code or config changes.

Refs #1284, #1299