### PR TITLE
fix(card-issuance): grant card.block to ROLE_OPERATOR/ROLE_ADMIN in OPA policy

### DIFF
--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "01cf400de3666f0c"
+    openbank.tech/policy-checksum: "5b287c8999c190ac"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -315,7 +315,8 @@ data:
     #   card.list      — listAll, listByAccount (#accountId), listByParty (#partyId)
     #   card.read      — getCard (#id)
     #   card.activate  — activate (#id)
-    #   card.block     — block (#id) — also ROLE_COMPLIANCE at the Jakarta layer
+    #   card.block     — block (#id) — ROLE_OPERATOR/ROLE_ADMIN/ROLE_COMPLIANCE (@RolesAllowed is a
+    #                    disjunction: ROLE_COMPLIANCE widens the caller set, it does not narrow it)
     #   card.suspend   — suspend (#id) — customer-edge calls this on a customer's OWN card
     #                    (self-service freeze, /customer/v1/cards/{id}/freeze)
     #   card.resume    — resume (#id) — same, customer self-service unfreeze
@@ -335,17 +336,24 @@ data:
 
     import rego.v1
 
-    # Operators/admins may create, activate, suspend, or resume a card. Card.block is deliberately
-    # excluded here — it additionally requires ROLE_COMPLIANCE at the Jakarta layer, gated below.
+    # Operators/admins may create, activate, block, suspend, or resume a card — mirroring
+    # CardResource's @RolesAllowed on each method. block() is included: its
+    # @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE") is a disjunction (any one role
+    # admits the caller), so ROLE_COMPLIANCE is an ADDITIONAL grantee, not an extra requirement.
+    # Omitting card.block here made the policy strictly narrower than the resource it guards: every
+    # card.block by ROLE_OPERATOR/ROLE_ADMIN would 403 the moment AUTHZ_ENFORCE flips to true,
+    # disabling the fraud response for a lost/stolen card for the only admin identity in the realm
+    # (admin@openbank.local holds OPERATOR/ADMIN/VIEWER, not COMPLIANCE).
     allowed_reasons contains "operator-card-write" if {
     	input.principal.type == "HUMAN"
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
-    	input.action in {"card.create", "card.activate", "card.suspend", "card.resume"}
+    	input.action in {"card.create", "card.activate", "card.block", "card.suspend", "card.resume"}
     }
 
-    # Blocking a card (fraud/compliance hold) is also grantable to ROLE_COMPLIANCE, matching
-    # CardResource's @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE") on block().
+    # Blocking a card (fraud/compliance hold) is also grantable to ROLE_COMPLIANCE alone — a
+    # compliance officer who holds neither ROLE_OPERATOR nor ROLE_ADMIN can still block, matching the
+    # third role in CardResource's @RolesAllowed on block().
     allowed_reasons contains "compliance-card-block" if {
     	input.principal.type == "HUMAN"
     	"ROLE_COMPLIANCE" in input.principal.roles

--- a/openbank-infra/gitops/components/payments/gen-card-issuance-opa-bundle.sh
+++ b/openbank-infra/gitops/components/payments/gen-card-issuance-opa-bundle.sh
@@ -23,7 +23,8 @@ CARD_ISSUANCE_REST_EXT=$(cat << 'REGO'
 #   card.list      — listAll, listByAccount (#accountId), listByParty (#partyId)
 #   card.read      — getCard (#id)
 #   card.activate  — activate (#id)
-#   card.block     — block (#id) — also ROLE_COMPLIANCE at the Jakarta layer
+#   card.block     — block (#id) — ROLE_OPERATOR/ROLE_ADMIN/ROLE_COMPLIANCE (@RolesAllowed is a
+#                    disjunction: ROLE_COMPLIANCE widens the caller set, it does not narrow it)
 #   card.suspend   — suspend (#id) — customer-edge calls this on a customer's OWN card
 #                    (self-service freeze, /customer/v1/cards/{id}/freeze)
 #   card.resume    — resume (#id) — same, customer self-service unfreeze
@@ -43,17 +44,24 @@ package openbank.rest
 
 import rego.v1
 
-# Operators/admins may create, activate, suspend, or resume a card. Card.block is deliberately
-# excluded here — it additionally requires ROLE_COMPLIANCE at the Jakarta layer, gated below.
+# Operators/admins may create, activate, block, suspend, or resume a card — mirroring
+# CardResource's @RolesAllowed on each method. block() is included: its
+# @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE") is a disjunction (any one role
+# admits the caller), so ROLE_COMPLIANCE is an ADDITIONAL grantee, not an extra requirement.
+# Omitting card.block here made the policy strictly narrower than the resource it guards: every
+# card.block by ROLE_OPERATOR/ROLE_ADMIN would 403 the moment AUTHZ_ENFORCE flips to true,
+# disabling the fraud response for a lost/stolen card for the only admin identity in the realm
+# (admin@openbank.local holds OPERATOR/ADMIN/VIEWER, not COMPLIANCE).
 allowed_reasons contains "operator-card-write" if {
 	input.principal.type == "HUMAN"
 	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
 	role in input.principal.roles
-	input.action in {"card.create", "card.activate", "card.suspend", "card.resume"}
+	input.action in {"card.create", "card.activate", "card.block", "card.suspend", "card.resume"}
 }
 
-# Blocking a card (fraud/compliance hold) is also grantable to ROLE_COMPLIANCE, matching
-# CardResource's @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE") on block().
+# Blocking a card (fraud/compliance hold) is also grantable to ROLE_COMPLIANCE alone — a
+# compliance officer who holds neither ROLE_OPERATOR nor ROLE_ADMIN can still block, matching the
+# third role in CardResource's @RolesAllowed on block().
 allowed_reasons contains "compliance-card-block" if {
 	input.principal.type == "HUMAN"
 	"ROLE_COMPLIANCE" in input.principal.roles

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01cf400de3666f0c"
+        openbank.tech/policy-checksum: "5b287c8999c190ac"
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## What

`card.block` was grantable to `ROLE_COMPLIANCE` only, while `CardResource.block()` carries `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")`.

`@RolesAllowed` is a **disjunction** — any one listed role admits the caller. The extension's comment read it as a conjunction:

> Card.block is deliberately excluded here — it additionally requires ROLE_COMPLIANCE at the Jakarta layer

`ROLE_COMPLIANCE` *widens* the caller set there; it is not an extra requirement. So the policy was strictly narrower than the resource it guards.

## Why it matters

Once `AUTHZ_ENFORCE` flips to `true` for card-issuance-service, every `card.block` by `ROLE_OPERATOR`/`ROLE_ADMIN` would 403 — disabling the fraud response for a lost or stolen card for the **only** admin identity in the realm. Live role mappings (queried from the running Keycloak, not the template):

| identity | realm roles | card.block before | after |
|---|---|---|---|
| `admin@openbank.local` | OPERATOR, ADMIN, VIEWER | **DENY** | ALLOW |
| `demo@openbank.local` | OPERATOR, ADMIN, AUDITOR, COMPLIANCE, DEMO, PAYMENTS, VIEWER | ALLOW | ALLOW |
| `service-account-openbank-services` | OPERATOR | **DENY** | ALLOW |

`AUTHZ_ENFORCE` is still `false` for this service, so **no live request is affected today**. This unblocks that flip.

## Verification

`opa eval` against the regenerated bundle, every `@Authorize` action on `CardResource`:

- **admin** (OPERATOR/ADMIN/VIEWER) — all 7 allow; `card.block` via `operator-card-write`
- **compliance-only** (COMPLIANCE) — `card.block` + `card.read` allow; `card.create`/`.activate`/`.suspend`/`.resume` deny — matching `@RolesAllowed` exactly
- **anonymous** — all 7 deny (negative control; confirms the probe discriminates)

Generator re-run is idempotent; the diff touches only card-issuance's bundle and its own pod-template checksum annotation (`01cf400de3666f0c` -> `5b287c8999c190ac`). No fleet ripple — `rules.yaml` is untouched.

## Deliberate widening, called out

The shared `openbank-services` service account (ROLE_OPERATOR) now also resolves `card.block` to allow. This is intended and matches the Jakarta layer, which already admits it via `ROLE_OPERATOR` — the policy was the only stricter gate, and only in enforce mode, which is off. Per the documented fleet-wide limitation (`rules.yaml: authz_policy.principal_type_service_unreachable`), `AuthorizeInterceptor` cannot distinguish that M2M caller from a human operator, so granting the role necessarily covers both — the same stance consent-service takes with `service-consent-m2m`.

If compliance-only card blocking is wanted as a deliberate policy, that is the opposite change: narrow `@RolesAllowed` on `block()` to `ROLE_COMPLIANCE` and grant that role to `admin@openbank.local`. That is a policy decision plus a realm change, not a bug fix, so it is out of scope here.

## How this was missed

The extension exists only as a bash heredoc inside `gen-card-issuance-opa-bundle.sh`, so `opa test` has nothing to load — 22 of 27 generators share that shape, leaving every per-service extension unverified. Traffic evidence would not have caught it either: card-issuance is KEDA scale-to-zero with 2 calls in 7 days, so shadow-mode denial counts read as "low risk, flip it". Only a static enumeration of `@Authorize` actions against the live bundle surfaced it. Filed as #1322 with a proposed CI guard.

## Linked issues

Refs #1322 — this PR fixes the one instance; the fleet-wide gate and heredoc extraction stay open there.
Refs #266
