### PR TITLE
fix(account): restore @PactBroker on provider verification (unblocks auto-deploy)

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountEventPactProviderVerificationTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/contract/AccountEventPactProviderVerificationTest.kt
@@ -11,13 +11,14 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
-import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.openbank.account.domain.event.AccountCreatedEvent
 import com.openbank.account.domain.model.AccountType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.UUID
 
@@ -32,12 +33,23 @@ import java.util.UUID
  * emit, and Pact checks it against the consumer contract. Messages are built from real domain
  * types and serialized with the same Jackson modules so the contract verifies the real wire shape.
  *
- * Reads the consumer pact from the git-pact folder (`@PactFolder`, resolved relative to this
- * module's working directory at `../pacts` = the monorepo-root `pacts/` dir) and replays each
- * interaction. This always runs — no broker, no gate, no CI secret required (ADR-0063 chose
- * git-pact over a Pact Broker for exactly this reason: zero new infra dependency), matching the
- * pattern already applied to `LedgerPactProviderVerificationTest` (openbank-ledger-service) and
- * `PartyEventPactProviderVerificationTest` (openbank-party-service).
+ * `@PactBroker` (not `@PactFolder`) — the same fix #1166 applied to party-service, for the same
+ * reason. `_service-ci.yml` publishes every consumer's pacts to the broker on a main push, but
+ * #372 (2026-07-07) had switched this class to `@PactFolder("../pacts")`, so nothing ever pulled
+ * those pacts BACK OUT of the broker to verify them and publish a result. `can-i-deploy` reads the
+ * broker and nothing else, so it permanently saw "no verified pact" for every consumer of
+ * account-service and blocked their deploys — confirmed live: notification-service #1180 and #1303
+ * both merged clean, built green, then failed the gate with "There is no verified pact between
+ * openbank-notification-service and openbank-account-service".
+ *
+ * `@EnabledIfSystemProperty` keeps it a no-op locally and on the PR lane, where no broker is
+ * configured — matching every other broker-based provider test in the fleet.
+ *
+ * A [MessageTestTarget] alone is correct here: both pacts naming account-service as provider are
+ * message-only (balance-service's AccountCreated, notification-service's TRANSACTION_COMPLETED),
+ * so unlike `PartyEventPactProviderVerificationTest` there is no HTTP interaction to dispatch to
+ * and no Quarkus instance to boot. If an HTTP consumer contract against account-service is ever
+ * added, this needs party-service's per-interaction target dispatch.
  *
  * IMPORTANT: if `AccountCreatedMessagePactConsumerTest` (openbank-balance-service) changes the
  * contract, regenerate the pact JSON (`./gradlew :openbank-balance-service:test --tests
@@ -45,12 +57,12 @@ import java.util.UUID
  * service-openbank-account-service.json` in the same PR, or this test will fail against a stale
  * contract.
  *
- * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact file a skip, not a
- * failure — relevant if the folder is ever emptied ahead of a broker migration.
+ * `@IgnoreNoPactsToVerify(ignoreIoErrors)` makes a missing/unreadable pact a skip, not a failure.
  */
 @Provider("openbank-account-service")
-@PactFolder("../pacts")
+@PactBroker(enablePendingPacts = "true")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class AccountEventPactProviderVerificationTest {
 
     private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())


### PR DESCRIPTION
notification-service #1180 (OTP / password-reset body redaction — a security fix) and #1303 both merged clean and built green today, then failed the deploy gate:

```
There is no verified pact between the latest version of openbank-notification-service
with tag main (2bc51585) and the version of openbank-account-service currently in
sandbox (dae215b5)
```

Both are still undeployed.

## Root cause

`_service-ci.yml` publishes every consumer's pacts to the broker on a main push. But #372 (2026-07-07) switched `AccountEventPactProviderVerificationTest` to `@PactFolder("../pacts")`, so nothing ever pulled those pacts back **out** of the broker to verify them and publish a result. `can-i-deploy` reads the broker and nothing else — so it permanently saw "no verified pact" for every consumer of account-service.

The contract itself is fine. `@PactVerifyProvider("a TRANSACTION_COMPLETED notification request")` and its `@State` already verify that exact message against the git-committed pact, and pass. This was never a real incompatibility — only a missing verification record in the one place the gate looks.

This is the same fix #1166 applied to party-service, which #372's sibling #371 had broken identically. Precedent for the whole shape is #1009 (ledger-service).

## The change

`@PactFolder("../pacts")` → `@PactBroker(enablePendingPacts = "true")` + `@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")`, mirroring party-service exactly.

`MessageTestTarget` alone stays correct here. Both pacts naming account-service as provider are message-only — balance-service's `AccountCreated` and notification-service's `TRANSACTION_COMPLETED` (verified: `msgs=1 http=0` for each). So unlike party-service there is no HTTP interaction to dispatch to and no Quarkus instance to boot. The docstring notes this needs party's per-interaction dispatch if an HTTP consumer contract is ever added.

## Trade-off, stated plainly

Swapping to `@PactBroker` means this class no longer runs locally or on the PR lane (no broker configured there) — it becomes CI-main-only. That is a real reduction in feedback speed versus ADR-0063's git-pact intent, and it is the same trade-off #1166 accepted for party-service.

Keeping both classes (as ledger-service does) is **not** an option here: ledger's docstring is explicit that two `@Provider` classes are safe there only because both use `HttpTestTarget`. account-service is message-based, so a second class would hit the "one @Provider test per provider" collision CLAUDE.md warns about.

## This does not deploy notification by itself

`can-i-deploy` compares against the account-service version **currently in sandbox** (`dae215b5`, from 2026-07-12). Merging this publishes a verification for the *new* account-service SHA, not for `dae215b5`. The full chain is: merge → account-service CI publishes a verification on the main push → account-service auto-deploys → sandbox carries a version that has a verification → notification's gate passes.

Per #1273's gotcha, only a genuine push to `main` sets `pact.verifier.publishResults=true`; a `workflow_dispatch` re-run looks green without publishing. Merging this PR is that push.

## Verification

- `:openbank-account-service:compileTestKotlin` + `:openbank-account-service:ktlintCheck` pass. This is the repo's prescribed local gate for broker-gated provider tests — real Pact verification only runs in CI, where the broker exists.
- Confirmed the class is a no-op locally exactly as the merged party-service one is: `--tests "*AccountEventPactProviderVerificationTest*"` reports "No tests found", and so does `--tests "*PartyEventPactProviderVerificationTest*"` against unmodified `main`. A test that does run (`AccountToBalancePactConsumerTest`) still reports BUILD SUCCESSFUL, so the filter itself is not lying.

## Note for reviewers

account-service is money-path (`rules.yaml: money_path_services`), so this needs 2 approvals. It is a test-only annotation change — no `src/main` code, no API, no schema. `docs/threat-models/openbank-account-service.md` already exists and is unaffected.

## Linked issues

Refs #1332