### PR TITLE
fix(customer-edge): ask document-service for the terms PDF with a wildcard accept

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/OnboardingResource.kt
@@ -245,7 +245,6 @@ class OnboardingResource(
      */
     @GET
     @Path("/terms/{code}/content")
-    @Produces("application/pdf")
     @PermitAll
     @Blocking
     fun onboardingTermsContent(@PathParam("code") code: String): Response {
@@ -296,10 +295,14 @@ class OnboardingResource(
                 .type(MediaType.APPLICATION_JSON).build()
         }
 
+        // Accept MUST be wildcard, not application/pdf: document-service's content route is
+        // @Produces(APPLICATION_OCTET_STREAM), so a narrow Accept makes RESTEasy fail method
+        // selection and answer 404 "Unable to find matching target resource method" instead of
+        // the bytes. Mirrors CustomerDocumentResource.documentContent, the working precedent.
         return upstream.getRaw(
             "$documentServiceUrl/api/v1/documents/$documentId/content",
             ONBOARDING_PARTY_PLACEHOLDER,
-            "application/pdf",
+            MediaType.WILDCARD,
         )
     }
 }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/OnboardingTermsTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/OnboardingTermsTest.kt
@@ -11,6 +11,7 @@ import com.openbank.customeredge.infrastructure.webauthn.EnrollmentTicketService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -98,6 +99,25 @@ class OnboardingTermsTest {
 
         // Immutable published version ⇒ rendered once, not once per view.
         verify(exactly = 1) { upstream.post(match { it.contains("/render") }, any(), any()) }
+    }
+
+    // document-service's content route is @Produces(APPLICATION_OCTET_STREAM). Asking it for
+    // application/pdf makes RESTEasy fail method selection and answer 404 "Unable to find
+    // matching target resource method" — which the edge then could not serialise either, so the
+    // app saw a bare 406 instead of the terms. Found on a live pod; pinned here.
+    @Test
+    fun `content asks the upstream with a wildcard accept, never a narrow pdf accept`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(match { it.contains("/templates") }, any()) } returns
+            templates(Triple("VOP_CS", "PUBLISHED", "Všeobecné obchodní podmínky"))
+        every { upstream.post(match { it.contains("/render") }, any(), any()) } returns
+            Response.status(201).entity("""{"id":"doc-1"}""").build()
+        every { upstream.getRaw(any(), any(), any()) } returns
+            Response.ok("%PDF-1.4".toByteArray()).build()
+
+        resource(upstream).onboardingTermsContent("VOP_CS")
+
+        verify { upstream.getRaw(any(), any(), MediaType.WILDCARD) }
     }
 
     @Test


### PR DESCRIPTION
## Symptom

Živý pod vracel na `/onboarding/terms/VOP_CS/content` holé **406**, přestože render sám fungoval — v `documents` je přesně **jeden** VOP_CS PDF, takže i cache podle verze je správně.

## Root cause

Upstream fetch žádal `Accept: application/pdf`, ale content route v document-service je `@Produces(APPLICATION_OCTET_STREAM)`. RESTEasy pro takový Accept nevybral metodu a odpověděl **404 „Unable to find matching target resource method"**. Edge pak tuhle JSON chybu zkusil vrátit metodou deklarující `@Produces(application/pdf)` → **406**, což appka viděla.

`CustomerDocumentResource` (funkční cesta podpisového kroku) se ptá s `MediaType.WILDCARD` — sjednoceno podle něj + zahozeno úzké method-level `@Produces`, ať jde zpět content type z upstreamu.

## Proč to testy nechytily

Unit testy volají resource metodu **přímo** — nikdy neprojdou JAX-RS content negotiation ani reálný upstream. Přidán test, který wildcard accept pinuje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)