### PR TITLE
feat(libs): meter every @Authorize decision so the AUTHZ_ENFORCE rollout has a signal

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
@@ -7,6 +7,7 @@ package com.openbank.libs.authz
 import com.openbank.libs.approval.ApprovalStatus
 import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.observability.DomainMetrics
 import io.quarkus.security.identity.SecurityIdentity
 import jakarta.annotation.Priority
 import jakarta.enterprise.inject.Instance
@@ -53,6 +54,14 @@ import kotlin.reflect.jvm.kotlinFunction
  *     so the CI audit can confirm the policy rejects the right calls before
  *     anyone flips enforce on. Advisory must never brick an endpoint when no
  *     sidecar is deployed yet.
+ *
+ * Every decision — either mode — increments `openbank.authz.decisions`
+ * (see [DomainMetrics.authzDecision]), tagged with the `enforced` value in
+ * effect. This is what makes each service's stated rollout precondition ("flip
+ * to true only after an observation window with a clean advisory report")
+ * actually evaluable: `outcome=deny, enforced=false` IS that report. Before
+ * this metric existed the only advisory signal was a WARN line on stdout, so
+ * the precondition could not be checked for any service in the fleet.
  *
  * Failure modes (enforce=true):
  *   - PDP returns `deny`  → `ForbiddenException` (HTTP 403) — the user is
@@ -117,6 +126,13 @@ class AuthorizeInterceptor {
     @Inject
     lateinit var clock: Clock
 
+    // Instance<> for the same reason as `pdp`/`securityContext` above. DomainMetrics ships in this
+    // same JAR and is itself no-op-safe without a MeterRegistry, so it is resolvable in practice —
+    // but a hard @Inject here would make this interceptor's validation depend on it in EVERY
+    // service, which is precisely the fleet-wide build hazard the comments above exist to avoid.
+    @Inject
+    lateinit var metrics: Instance<DomainMetrics>
+
     // Instance<> for the same reason as `pdp`/`securityContext` above: most services
     // never wire an ApprovalStore, so a hard @Inject would break their build.
     @Inject
@@ -145,24 +161,7 @@ class AuthorizeInterceptor {
             ?: return ctx.proceed()
 
         if (!pdp.isResolvable) {
-            // An @Authorize method exists but the service wired no PDP.
-            if (!enforce) {
-                log.warnf(
-                    "advisory: no PolicyDecisionPoint bean for @Authorize %s.%s — proceeding (enforce=false)",
-                    ctx.method.declaringClass.simpleName,
-                    ctx.method.name,
-                )
-                return ctx.proceed()
-            }
-            // Fail closed — an authorization point that cannot reach a decision
-            // must not silently allow. 503 (not 403) flags a wiring/outage, not a
-            // policy denial, so it reads distinctly in the audit trail.
-            log.errorf(
-                "no PolicyDecisionPoint bean for @Authorize method %s.%s — failing closed",
-                ctx.method.declaringClass.simpleName,
-                ctx.method.name,
-            )
-            throw ServiceUnavailableException("policy decision point not configured")
+            return onMissingPdp(ctx, annotation)
         }
         val decisionPoint = pdp.get()
 
@@ -170,6 +169,7 @@ class AuthorizeInterceptor {
         val decision: AuthzDecision = runBlocking {
             runCatching { decisionPoint.allow(query) }
                 .getOrElse { ex ->
+                    record(annotation.action, "pdp_unavailable", query.principal.type)
                     if (!enforce) {
                         log.warnf(
                             "advisory: PDP unavailable for action=%s: %s — proceeding (enforce=false)",
@@ -187,6 +187,9 @@ class AuthorizeInterceptor {
         } ?: return ctx.proceed() // advisory + PDP unavailable: observe, do not block
 
         if (!decision.allow) {
+            // The rollout signal: outcome=deny + enforced=false is the "would DENY" population that
+            // a service's advisory window has to show empty before AUTHZ_ENFORCE can flip.
+            record(annotation.action, "deny", query.principal.type)
             if (!enforce) {
                 log.warnf(
                     "advisory: would DENY action=%s resource=%s principal=%s reason=%s — proceeding (enforce=false)",
@@ -206,8 +209,45 @@ class AuthorizeInterceptor {
             )
             throw ForbiddenException(decision.reason ?: "policy denied")
         }
+        record(annotation.action, "allow", query.principal.type)
         return requireFourEyesOrProceed(ctx, annotation, query, decision)
     }
+
+    /**
+     * An `@Authorize` method exists but the service wired no [PolicyDecisionPoint]. Advisory
+     * proceeds; enforce fails CLOSED with 503 (not 403) — an authorization point that cannot reach
+     * a decision must not silently allow, and an outage must not read as a flurry of policy denials
+     * in the audit trail.
+     */
+    private fun onMissingPdp(ctx: InvocationContext, annotation: Authorize): Any? {
+        // No query was built yet, so the principal type is not yet known — hence the "unknown" tag.
+        record(annotation.action, "pdp_unconfigured", "unknown")
+        if (!enforce) {
+            log.warnf(
+                "advisory: no PolicyDecisionPoint bean for @Authorize %s.%s — proceeding (enforce=false)",
+                ctx.method.declaringClass.simpleName,
+                ctx.method.name,
+            )
+            return ctx.proceed()
+        }
+        log.errorf(
+            "no PolicyDecisionPoint bean for @Authorize method %s.%s — failing closed",
+            ctx.method.declaringClass.simpleName,
+            ctx.method.name,
+        )
+        throw ServiceUnavailableException("policy decision point not configured")
+    }
+
+    /**
+     * `null` when no [DomainMetrics] bean resolves, so every call site is a safe-call no-op.
+     * [DomainMetrics] in turn no-ops without a [io.micrometer.core.instrument.MeterRegistry], so a
+     * service with no micrometer extension records nothing and pays nothing.
+     */
+    private val meters: DomainMetrics?
+        get() = if (metrics.isResolvable) metrics.get() else null
+
+    private fun record(action: String, outcome: String, principalType: String) =
+        meters?.authzDecision(action, outcome, enforce, principalType)
 
     /**
      * ADR-0155: gate an otherwise-allowed money-path action behind a second
@@ -222,10 +262,19 @@ class AuthorizeInterceptor {
         decision: AuthzDecision,
     ): Any? {
         val fourEyesRequired = decision.attributes["four_eyes_required"] == true
-        if (!fourEyesRequired || !fourEyesEnforce) {
+        if (!fourEyesRequired) {
+            return ctx.proceed()
+        }
+        if (!fourEyesEnforce) {
+            // OPA asked for a second approver and we are about to proceed without one. Nothing
+            // recorded this before, which made it indistinguishable from "four-eyes not required" —
+            // so a fleet where authz.four-eyes.enforce is false everywhere (the current default,
+            // and never overridden in gitops) looked exactly like a fleet with no flagged actions.
+            meters?.authzFourEyes(annotation.action, "required_not_enforced")
             return ctx.proceed()
         }
         if (!approvalStore.isResolvable) {
+            meters?.authzFourEyes(annotation.action, "no_approval_store")
             // Code review finding: this used to fall into the same silent-proceed branch as
             // "four-eyes not required" / "not enforced", with no log at all — indistinguishable
             // from a service correctly not opting in. Mirrors the log.errorf the PDP-missing
@@ -249,6 +298,7 @@ class AuthorizeInterceptor {
             val approval = runBlocking { store.find(approvalId) }
             if (approval.satisfies(annotation.action, resourceId, maker)) {
                 runBlocking { store.markExecuted(approvalId) }
+                meters?.authzFourEyes(annotation.action, "approval_satisfied")
                 return ctx.proceed()
             }
             log.warnf(
@@ -261,6 +311,7 @@ class AuthorizeInterceptor {
         }
 
         val pending = runBlocking { store.create(annotation.action, resourceId, maker) }
+        meters?.authzFourEyes(annotation.action, "pending_approval")
         log.infof(
             "four-eyes: action=%s resource=%s maker=%s requires a second approver — approvalId=%s",
             annotation.action,

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/observability/DomainMetrics.kt
@@ -252,6 +252,52 @@ class DomainMetrics {
         counter("openbank.aml.hits", "severity", severity)
     }
 
+    // ── Authorization (ADR-0034 D5) ───────────────────────────────────────────
+
+    /**
+     * Increment on every `@Authorize` decision, whatever the outcome.
+     *
+     * This exists because advisory mode (`authz.enforce=false`) previously left **no signal but a
+     * WARN log line**. Every service's gitops manifest states the rollout precondition as "flip to
+     * true only after an observation window with a clean advisory report" — but with no metric,
+     * that report was not obtainable for any service, so the precondition could not be evaluated at
+     * all. The `enforced` tag is the point: `outcome=deny, enforced=false` is exactly the
+     * "would DENY" population a rollout needs to be empty before flipping.
+     *
+     * @param action        the `@Authorize(action = ...)` value, e.g. `card.block` — a bounded set
+     * @param outcome       `allow` | `deny` | `pdp_unavailable` | `pdp_unconfigured`
+     * @param enforced      the `authz.enforce` value in effect for this call. `false` means the
+     *                      call PROCEEDED regardless of `outcome`
+     * @param principalType `HUMAN` | `AI_AGENT` | `ANONYMOUS` | `unknown` (unknown only when the
+     *                      decision failed before a query could be built)
+     */
+    fun authzDecision(action: String, outcome: String, enforced: Boolean, principalType: String) {
+        counter(
+            "openbank.authz.decisions",
+            "action", action,
+            "outcome", outcome,
+            "enforced", enforced.toString(),
+            "principal_type", principalType,
+        )
+    }
+
+    /**
+     * Increment when OPA flags an allowed action `four_eyes_required` (ADR-0155).
+     *
+     * `required_not_enforced` is the one that matters: the policy asked for a second approver and
+     * the interceptor proceeded anyway because `authz.four-eyes.enforce` is false. That is the
+     * fleet's current default and it was previously invisible — the policy computes the flag, the
+     * interceptor drops it silently, and nothing distinguishes that from "four-eyes not required".
+     * A non-zero `required_not_enforced` is a live maker-checker gap, not a curiosity.
+     *
+     * @param action   the `@Authorize(action = ...)` value
+     * @param outcome  `required_not_enforced` | `no_approval_store` | `pending_approval` |
+     *                 `approval_satisfied`
+     */
+    fun authzFourEyes(action: String, outcome: String) {
+        counter("openbank.authz.four_eyes", "action", action, "outcome", outcome)
+    }
+
     // ── Outbox ────────────────────────────────────────────────────────────────
 
     /**

--- a/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
+++ b/openbank-libs-runtime/src/test/kotlin/com/openbank/libs/authz/AuthorizeInterceptorTest.kt
@@ -9,6 +9,8 @@ import com.openbank.libs.approval.ApprovalStore
 import com.openbank.libs.approval.InvalidApprovalStateException
 import com.openbank.libs.approval.PendingApproval
 import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import com.openbank.libs.observability.DomainMetrics
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.quarkus.security.identity.SecurityIdentity
@@ -41,12 +43,30 @@ class AuthorizeInterceptorTest {
     private lateinit var interceptor: AuthorizeInterceptor
     private lateinit var sc: SecurityContext
     private lateinit var identity: SecurityIdentity
+    private lateinit var registry: SimpleMeterRegistry
+
+    /** Counter value for the given name+tags, or 0.0 when the meter was never created. */
+    private fun counter(name: String, vararg tags: String): Double =
+        registry.find(name).tags(*tags).counter()?.count() ?: 0.0
 
     @BeforeEach
     fun setUp() {
         sc = mockk()
         identity = mockk()
+        // A real registry (not a mock) so the tests assert the metric a scrape would actually see,
+        // tags included — a mock would only prove the interceptor called a method.
+        registry = SimpleMeterRegistry()
+        val domainMetrics = DomainMetrics().apply {
+            registryInstance = mockk {
+                every { isResolvable } returns true
+                every { get() } returns this@AuthorizeInterceptorTest.registry
+            }
+        }
         interceptor = AuthorizeInterceptor().apply {
+            metrics = mockk {
+                every { isResolvable } returns true
+                every { get() } returns domainMetrics
+            }
             // securityContext / identity are now Instance<> (lazy) so libs doesn't force a
             // SecurityIdentity bean on non-security services — mirror the pdp wrapping.
             securityContext = mockk { every { get() } returns sc }
@@ -135,6 +155,116 @@ class AuthorizeInterceptorTest {
         val ctx = makeCtx(annotatedMethod)
         val result = interceptor.authorize(ctx)
         assertThat(result).isEqualTo("ok")
+    }
+
+    // ── openbank.authz.decisions (ADR-0034 D5 rollout signal) ────────────────
+    //
+    // Each of these fails on the pre-metric interceptor, where the only advisory signal was a WARN
+    // line on stdout. That absence is what made every service's stated rollout precondition ("flip
+    // to true only after an observation window with a clean advisory report") unevaluable.
+
+    private fun denyingPdp() = object : PolicyDecisionPoint {
+        override suspend fun allow(query: AuthzQuery): AuthzDecision =
+            AuthzDecision(allow = false, reason = "insufficient role", policyVersion = "v1")
+    }
+
+    private fun allowingPdp(attributes: Map<String, Any> = emptyMap()) = object : PolicyDecisionPoint {
+        override suspend fun allow(query: AuthzQuery): AuthzDecision =
+            AuthzDecision(allow = true, reason = "ok", policyVersion = "v1", attributes = attributes)
+    }
+
+    private fun wirePdp(pdp: PolicyDecisionPoint) {
+        interceptor.pdp = mockk {
+            every { isResolvable } returns true
+            every { get() } returns pdp
+        }
+    }
+
+    @Test
+    fun `advisory deny is counted as would-DENY, tagged enforced=false`() {
+        interceptor.enforce = false
+        every { identity.roles } returns emptySet()
+        wirePdp(denyingPdp())
+
+        assertThat(interceptor.authorize(makeCtx(annotatedMethod))).isEqualTo("ok")
+
+        // This exact series is the "advisory report" a rollout needs empty before flipping.
+        assertThat(
+            counter(
+                "openbank.authz.decisions",
+                "action", "party.read", "outcome", "deny",
+                "enforced", "false", "principal_type", "HUMAN",
+            ),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `enforced deny is counted separately from an advisory deny`() {
+        every { identity.roles } returns emptySet()
+        wirePdp(denyingPdp())
+
+        assertThatThrownBy { interceptor.authorize(makeCtx(annotatedMethod)) }
+            .isInstanceOf(ForbiddenException::class.java)
+
+        assertThat(counter("openbank.authz.decisions", "outcome", "deny", "enforced", "true"))
+            .isEqualTo(1.0)
+        // The enforced=false series must stay untouched, or the two populations are conflated and
+        // the whole rollout signal is worthless.
+        assertThat(counter("openbank.authz.decisions", "outcome", "deny", "enforced", "false"))
+            .isZero()
+    }
+
+    @Test
+    fun `allow is counted`() {
+        every { identity.roles } returns setOf("ROLE_OPERATOR")
+        wirePdp(allowingPdp())
+
+        interceptor.authorize(makeCtx(annotatedMethod))
+
+        assertThat(counter("openbank.authz.decisions", "outcome", "allow", "enforced", "true"))
+            .isEqualTo(1.0)
+    }
+
+    @Test
+    fun `missing PDP bean is counted as pdp_unconfigured`() {
+        every { identity.roles } returns emptySet()
+        interceptor.pdp = mockk { every { isResolvable } returns false }
+
+        assertThatThrownBy { interceptor.authorize(makeCtx(annotatedMethod)) }
+            .isInstanceOf(ServiceUnavailableException::class.java)
+
+        assertThat(counter("openbank.authz.decisions", "outcome", "pdp_unconfigured"))
+            .isEqualTo(1.0)
+    }
+
+    @Test
+    fun `four_eyes_required with enforcement off is counted, not silently dropped`() {
+        // The fleet's current state: every service that declares the key sets
+        // ${AUTHZ_FOUR_EYES_ENFORCE:false} and gitops never overrides it. OPA computes the flag and
+        // the interceptor proceeds anyway — previously with no signal whatsoever, so a real
+        // maker-checker gap looked identical to "no action is flagged".
+        interceptor.fourEyesEnforce = false
+        every { identity.roles } returns setOf("ROLE_OPERATOR")
+        wirePdp(allowingPdp(mapOf("four_eyes_required" to true)))
+
+        assertThat(interceptor.authorize(makeCtx(annotatedMethod))).isEqualTo("ok")
+
+        assertThat(
+            counter("openbank.authz.four_eyes", "action", "party.read", "outcome", "required_not_enforced"),
+        ).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `an allow with no four-eyes flag records no four_eyes series`() {
+        // Guards the counter's meaning: if it fired on every allow, a non-zero
+        // required_not_enforced would say nothing about a real gap.
+        interceptor.fourEyesEnforce = false
+        every { identity.roles } returns setOf("ROLE_OPERATOR")
+        wirePdp(allowingPdp())
+
+        interceptor.authorize(makeCtx(annotatedMethod))
+
+        assertThat(registry.find("openbank.authz.four_eyes").counters()).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
## Why

Every service's gitops manifest states the same `AUTHZ_ENFORCE` rollout precondition:

> Flip to true only after an observation window with a clean advisory report.

**That report did not exist.** In advisory mode `AuthorizeInterceptor` only called `log.warnf("advisory: would DENY ...")` — no metric. There is not a single `openbank_authz_*` series in the cluster's Prometheus, so the precondition could not be evaluated for any of the 25 services, whether already flipped or not.

This surfaced while working the last four `AUTHZ_ENFORCE=false` services (#266). The evidence I had assembled for flipping them did not survive verification, and the root cause was the same in each case — there was nothing to measure:

| claim | what verification found |
|---|---|
| "sanctions-service: 20,503 calls/7d" | not reproducible — `http_server_requests_seconds_count` exists only as Pyrra `:burnrate*` recording rules, and there is no `app` label to group by |
| "zero shadow denials" | no such metric exists; the live OPA sidecar had served only `/health` |
| "four-eyes bounds the M2M `sanctions.clear`" | **false** — the policy sets `four_eyes_required`, the interceptor drops it, because `authz.four-eyes.enforce` defaults to `false`, every service that declares it sets `${AUTHZ_FOUR_EYES_ENFORCE:false}`, and gitops never sets that variable |

Flipping enforcement against an unmeasured precondition is exactly how the SBOM Audit→Enforce rollout took down five workloads. So: metric first, flip second, on real data.

## What

Two counters on the existing `DomainMetrics` facade (no-op without a `MeterRegistry`, so services with no micrometer extension are unaffected):

**`openbank.authz.decisions{action,outcome,enforced,principal_type}`**
`outcome` = `allow` | `deny` | `pdp_unavailable` | `pdp_unconfigured`.
`outcome=deny, enforced=false` **is** the advisory report — the calls that would have been blocked. A rollout wants that series empty before flipping. The `enforced` tag keeps the two populations from being conflated, which is the whole point.

**`openbank.authz.four_eyes{action,outcome}`**
`outcome` = `required_not_enforced` | `no_approval_store` | `pending_approval` | `approval_satisfied`.
`required_not_enforced` makes a live maker-checker gap visible. Previously OPA computed the flag, the interceptor dropped it silently, and that was indistinguishable from "no action is flagged".

**Cardinality:** all tags bounded (~7 actions/service × 4 outcomes × 2 enforced × 3 principal types). No principal id, resource id, or deny reason — per the `DomainMetrics` cardinality contract.

**Injection:** `Instance<DomainMetrics>`, matching `pdp`/`securityContext`/`approvalStore`. This interceptor is validated by ArC in **every** service, so a hard `@Inject` is a fleet-wide build hazard — that is what the existing comments on those fields are about.

## Verification

`detekt` + `ktlintCheck` + `test` + `koverVerify` green on `openbank-libs-runtime`. 23 tests, 0 failures, 6 new.

Tests use a real `SimpleMeterRegistry`, not a mock, so they assert the series a scrape would actually see — tags included. A mock would only prove the interceptor called a method.

**The assertions were verified to catch the defect.** With the `record()` calls neutered but the field kept (so it still compiles), **5 of the 6 new tests fail**:

```
advisory deny is counted as would-DENY, tagged enforced=false   FAILED
enforced deny is counted separately from an advisory deny       FAILED
allow is counted                                                FAILED
missing PDP bean is counted as pdp_unconfigured                 FAILED
four_eyes_required with enforcement off is counted              FAILED
```

The 6th (`an allow with no four-eyes flag records no four_eyes series`) still passes there — by design: it guards against *over*-recording, so it is trivially true when nothing records. Noting it rather than claiming 6/6.

## Not in this PR

No `AUTHZ_ENFORCE` value changes. The four remaining `false` services (anacredit, interest, card-issuance, sanctions) stay advisory until this metric has actually observed a window. `card.block` on card-issuance is separately blocked on #1323.

## Linked issues

Refs #266
