### PR TITLE
feat(customer-edge): mint the session from the passkey enrolment ceremony

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResource.kt
@@ -171,7 +171,18 @@ class WebAuthnResource(
                 signCount = authenticatorData.signCount,
             ),
         )
-        return Response.noContent().build()
+
+        // Mint the session straight from the registration ceremony (ADR-0066 F2). This used to
+        // return 204, forcing the app to run a SECOND ceremony against /auth/begin+complete just
+        // to get a token — a second Face ID prompt during onboarding for no security gain: the
+        // registration verified above is a user-verified (Face ID), user-present ceremony over a
+        // server challenge bound to this origin/rpId, i.e. exactly the factors /auth/complete
+        // checks before calling the same impersonate(). The enrollment ticket already authorised
+        // this party binding.
+        //
+        // The response is additive: a client that only checked the status code keeps working.
+        val (accessToken, refreshToken) = keycloakClient.impersonate(keycloakUserId)
+        return Response.ok(TokenPairDto(accessToken, refreshToken)).build()
     }
 
     // ── Authentication (returning-user login, no browser) ───────────────────────────────────

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResourceTest.kt
@@ -157,6 +157,24 @@ class WebAuthnResourceTest {
         verify(exactly = 0) { keycloakClient.ensureUser(any(), any(), any()) }
     }
 
+    // A registration ceremony is user-verified (Face ID) + user-present over a server challenge —
+    // the same factors /auth/complete checks before minting. Returning 204 here forced the app to
+    // run a SECOND ceremony purely to get a token, i.e. a second Face ID prompt in onboarding for
+    // no security gain (ADR-0066 F2). The mint must never fire before the credential is stored.
+    @Test
+    fun `register complete never mints a session when the ceremony is rejected`() {
+        every { ticketService.verify("good-ticket") } returns "party-123"
+        // Malformed clientDataJSON -> the ceremony fails before any credential is stored.
+        val resp = resource.registerComplete(
+            authorization = "Bearer good-ticket",
+            request = RegistrationCompleteRequestDto("id", "attestation", "bm90LWpzb24"),
+        )
+
+        assertThat(resp.status).isNotEqualTo(200)
+        verify(exactly = 0) { keycloakClient.impersonate(any()) }
+        verify(exactly = 0) { credentialStore.save(any()) }
+    }
+
     // ---- auth/begin + auth/complete: fully public, challenge-store gate --------------------
 
     @Test


### PR DESCRIPTION
## Proč

Nativní passkey onboarding (ADR-0066 F2) žádal Face ID **dvakrát**: nejdřív na **zápis** passkey (`/webauthn/register/complete` → 204), pak hned znovu na celou **druhou** ceremonii proti `/auth/begin+complete` jen kvůli tokenu. Dva biometrické prompty za sebou, bez bezpečnostního přínosu.

## Co

Registrační ceremonie ověřená o pár řádků výš je **user-verified (Face ID) + user-present** nad serverovou challenge vázanou na origin/rpId — přesně faktory, které `/auth/complete` kontroluje před tím, než zavolá **stejný** `impersonate()`. Enrollment ticket už autorizoval binding party. Takže `register/complete` teď TokenPair rovnou vydá, hned po uložení credentialu.

**Aditivní:** tělo přibylo jen na 200, které volající už bral jako úspěch — klient ignorující tělo funguje dál (starší edge vracející 204 → app fallbackne na assertion).

## Testy

Nový test pinuje, že se session **nikdy nevydá při odmítnuté ceremonii** (mint musí následovat až po uloženém credentialu). Existující WebAuthnResourceTest prošly beze změny.

App strana (openbank-app) navazuje: jeden Face ID místo dvou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)