### PR TITLE
security(notification): close the variable schema; render every template

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -98,6 +98,24 @@ class NotificationConsumer {
             log.errorf(e, "Failed to parse notification payload: %s", payload)
             return Uni.createFrom().voidItem()
         }
+        // Closed variable schema (ADR-0176 D1, issue #1325). A key the template does not declare
+        // is rejected here, before it can be rendered into a body and persisted — this is what
+        // stops a secret-shaped variable riding an ordinary template into storage, which
+        // TemplateSensitivity cannot catch because it classifies templates, not variables.
+        //
+        // Logs the offending KEYS only, never the values: a rejected payload is exactly the case
+        // where a value is most likely to be a secret, and writing it to a log would recreate the
+        // leak this rejection exists to close.
+        val unknown = req.template.unknownVariables(req.variables)
+        if (unknown.isNotEmpty()) {
+            log.errorf(
+                "Rejected notification: template=%s declares %s but request carried undeclared %s",
+                req.template.name,
+                req.template.variables.sorted(),
+                unknown.sorted(),
+            )
+            return Uni.createFrom().voidItem()
+        }
         return dispatch(req)
             .onFailure().recoverWithUni { e ->
                 // Processing failure (e.g. transient DB error): log and ack. Preserves the prior
@@ -312,27 +330,85 @@ class NotificationConsumer {
     private fun htmlToPlain(html: String): String =
         html.replace(Regex("<[^>]+>"), " ").replace(Regex("\\s+"), " ").trim()
 
+    /**
+     * Renders [template] into a (subject, body) pair.
+     *
+     * Exhaustive by design — there is deliberately **no `else` branch**. The `else` this replaces
+     * dumped every caller-supplied variable into the body (`"$key: $value"`), which is how a
+     * secret could ride an ordinary template into storage (issue #1325), and it silently absorbed
+     * the seven constants nobody had written a render for: they reached real customers as raw
+     * variable dumps. Without the `else`, adding a constant to [NotificationTemplate] is a
+     * COMPILE error here until someone writes its copy — a guard that cannot be forgotten, unlike
+     * the review the classification allow-list depends on (ADR-0176 D1).
+     *
+     * Every `vars[...]` key read here must be declared in that constant's [NotificationTemplate.variables];
+     * anything else is rejected upstream and can never arrive.
+     */
     private fun renderTemplate(template: NotificationTemplate, vars: Map<String, String>): Pair<String, String> =
         when (template) {
             NotificationTemplate.ACCOUNT_OPENED ->
                 "Your OpenBank account is ready" to
-                    "<h2>Welcome to OpenBank!</h2><p>Your account <b>${vars["accountNumber"] ?: ""}</b> has been opened.</p>"
+                    "<h2>Welcome to OpenBank!</h2><p>Your account <b>${vars.v(
+                        "accountNumber",
+                    )}</b> has been opened.</p>"
+            NotificationTemplate.ACCOUNT_CLOSED ->
+                "Your OpenBank account has been closed" to
+                    "<h2>Account Closed</h2><p>Your account <b>${vars.v("accountNumber")}</b> has been closed. " +
+                    "Statements and transaction history remain available on request.</p>"
+            NotificationTemplate.ACCOUNT_FROZEN ->
+                "Your OpenBank account has been frozen" to
+                    "<h2>Account Frozen</h2><p>Access to your account <b>${vars.v("accountNumber")}</b> has been " +
+                    "temporarily suspended. Reason: ${vars.v("reason")}. Please contact support.</p>"
             NotificationTemplate.TRANSACTION_COMPLETED ->
                 "Transaction completed" to
-                    "<p>Transaction of <b>${vars["amount"] ?: ""} ${vars["currency"] ?: ""}</b> completed successfully.</p>"
+                    "<p>Transaction of <b>${vars.v("amount")} ${vars.v("currency")}</b> completed successfully.</p>"
+            NotificationTemplate.TRANSACTION_FAILED ->
+                "Transaction failed" to
+                    "<h2>Transaction Failed</h2><p>Your transaction of <b>${vars.v("amount")} " +
+                    "${vars.v("currency")}</b> could not be completed. Reason: ${vars.v("reason")}. " +
+                    "No funds have left your account.</p>"
             NotificationTemplate.KYC_APPROVED ->
                 "Identity verification approved" to
                     "<h2>KYC Approved</h2><p>Your identity has been verified. You can now use all OpenBank services.</p>"
             NotificationTemplate.KYC_REJECTED ->
                 "Identity verification failed" to
-                    "<h2>KYC Rejected</h2><p>We could not verify your identity. Reason: ${vars["reason"] ?: ""}. Please contact support.</p>"
+                    "<h2>KYC Rejected</h2><p>We could not verify your identity. Reason: ${vars.v(
+                        "reason",
+                    )}. Please contact support.</p>"
+            NotificationTemplate.KYC_DOCUMENT_REQUIRED ->
+                "We need a document from you" to
+                    "<h2>Document Required</h2><p>To finish verifying your identity we need your " +
+                    "<b>${vars.v("documentType")}</b>. You can upload it in the OpenBank app.</p>"
+            NotificationTemplate.CONSENT_GRANTED ->
+                "Access to your account data was granted" to
+                    "<h2>Consent Granted</h2><p>You granted access to your account data " +
+                    "(<b>${vars.v("scope")}</b>). You can withdraw this at any time in the OpenBank app.</p>"
+            NotificationTemplate.CONSENT_REVOKED ->
+                "Access to your account data was withdrawn" to
+                    "<h2>Consent Withdrawn</h2><p>Access to your account data " +
+                    "(<b>${vars.v("scope")}</b>) has been withdrawn. No further data will be shared under it.</p>"
             NotificationTemplate.OTP_CODE ->
                 "Your OpenBank verification code" to
-                    "<h2>Verification Code</h2><p>Your code is: <b>${vars["code"] ?: ""}</b>. Valid for 5 minutes.</p>"
+                    "<h2>Verification Code</h2><p>Your code is: <b>${vars.v("code")}</b>. Valid for 5 minutes.</p>"
+            NotificationTemplate.PASSWORD_RESET ->
+                "Reset your OpenBank password" to
+                    "<h2>Password Reset</h2><p>Use the link below to set a new password. It expires in 15 minutes " +
+                    "and can be used once. If you did not ask for this, ignore this message and your password stays " +
+                    "unchanged.</p><p><a href=\"${vars.v("resetLink")}\">Reset your password</a></p>"
             NotificationTemplate.WELCOME ->
                 "Welcome to OpenBank" to
-                    "<h2>Welcome!</h2><p>Thank you for joining OpenBank, ${vars["name"] ?: ""}.</p>"
-            else -> template.name.replace("_", " ").lowercase().replaceFirstChar { it.uppercase() } to
-                "<p>${vars.entries.joinToString("<br>") { "${it.key}: ${it.value}" }}</p>"
+                    "<h2>Welcome!</h2><p>Thank you for joining OpenBank, ${vars.v("name")}.</p>"
         }
 }
+
+/**
+ * Reads a declared template variable, or "" when the caller omitted it.
+ *
+ * The schema is closed against **undeclared** keys, not against missing ones (see
+ * [NotificationTemplate.variables]): rejecting a partial request would silently drop a real
+ * message, since poison payloads are acked. An omitted variable renders empty, as it always has.
+ *
+ * Top-level rather than a member so `renderTemplate` reads as copy instead of null-handling — the
+ * 16 inline `?: ""` reads it replaces were most of that function's cyclomatic complexity.
+ */
+private fun Map<String, String>.v(key: String): String = this[key] ?: ""

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -9,20 +9,42 @@ import java.util.UUID
 
 enum class NotificationChannel { EMAIL, SMS, PUSH, IN_APP }
 enum class NotificationStatus { PENDING, SENT, FAILED, BOUNCED }
-enum class NotificationTemplate {
-    ACCOUNT_OPENED,
-    ACCOUNT_CLOSED,
-    ACCOUNT_FROZEN,
-    TRANSACTION_COMPLETED,
-    TRANSACTION_FAILED,
-    KYC_APPROVED,
-    KYC_REJECTED,
-    KYC_DOCUMENT_REQUIRED,
-    CONSENT_GRANTED,
-    CONSENT_REVOKED,
-    OTP_CODE,
-    PASSWORD_RESET,
-    WELCOME,
+
+/**
+ * A message template and — inseparably — the complete set of variables it accepts.
+ *
+ * The schema is a constructor argument rather than a lookup table beside the enum, and that is
+ * the whole point: a new constant cannot be added without declaring its variables, because the
+ * compiler demands the argument. A side table can silently gain a constant it has no entry for;
+ * this cannot (ADR-0176 D1).
+ *
+ * [variables] is a CLOSED set. `NotificationConsumer` rejects a request carrying any key not
+ * listed here, which is what stops a secret-shaped variable riding an ordinary template into
+ * storage — `ACCOUNT_FROZEN` with a `code` variable used to render and persist that code in
+ * cleartext (issue #1325). Secrecy is a property of the variables, not of the template, so the
+ * defence has to live here and not only in [TemplateSensitivity].
+ *
+ * Keep this in step with `NotificationConsumer.renderTemplate`: a variable declared but never
+ * rendered is dead, and a variable rendered but not declared cannot arrive.
+ */
+enum class NotificationTemplate(val variables: Set<String>) {
+    ACCOUNT_OPENED(setOf("accountNumber")),
+    ACCOUNT_CLOSED(setOf("accountNumber")),
+    ACCOUNT_FROZEN(setOf("accountNumber", "reason")),
+    TRANSACTION_COMPLETED(setOf("amount", "currency")),
+    TRANSACTION_FAILED(setOf("amount", "currency", "reason")),
+    KYC_APPROVED(emptySet()),
+    KYC_REJECTED(setOf("reason")),
+    KYC_DOCUMENT_REQUIRED(setOf("documentType")),
+    CONSENT_GRANTED(setOf("scope")),
+    CONSENT_REVOKED(setOf("scope")),
+    OTP_CODE(setOf("code")),
+    PASSWORD_RESET(setOf("resetLink")),
+    WELCOME(setOf("name")),
+    ;
+
+    /** Keys in [vars] that this template does not accept. Empty = the request is well-formed. */
+    fun unknownVariables(vars: Map<String, String>): Set<String> = vars.keys - variables
 }
 
 data class Notification(

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateVariableSchemaTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/TemplateVariableSchemaTest.kt
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Executable form of the closed-variable-schema guarantee (ADR-0176 D1, issue #1325): a template
+ * accepts exactly the variables it declares, so a secret-shaped value cannot ride an ordinary
+ * template into a stored body.
+ *
+ * The strongest guard for this rule is NOT here — it is the compiler. `renderTemplate`'s `when`
+ * has no `else`, so a new constant fails to build until someone writes its copy, and the schema
+ * is a constructor argument, so it cannot be added without declaring variables. These tests cover
+ * what the type system cannot: that the closed set actually rejects, and that every declared
+ * variable is one a real render reads.
+ */
+class TemplateVariableSchemaTest {
+
+    @Test
+    fun `every template declares its schema — an undeclared key is unknown`() {
+        // The exact hole #1325 describes: an OPERATIONAL template carrying a secret-shaped key.
+        val unknown = NotificationTemplate.ACCOUNT_FROZEN.unknownVariables(
+            mapOf("accountNumber" to "CZ65...", "reason" to "AML review", "code" to "483920"),
+        )
+        assertThat(unknown).containsExactly("code")
+    }
+
+    @Test
+    fun `a well-formed request has no unknown variables`() {
+        assertThat(
+            NotificationTemplate.TRANSACTION_COMPLETED.unknownVariables(
+                mapOf("amount" to "250.00", "currency" to "CZK"),
+            ),
+        ).isEmpty()
+    }
+
+    @Test
+    fun `missing variables are not rejected — only undeclared ones are`() {
+        // Deliberate: the schema is closed against ADDITION, lenient about omission. Rejecting a
+        // partial request would silently drop a real message (poison payloads are acked), turning
+        // a degraded message into no message at all. Undeclared keys are the security property;
+        // missing keys are a caller bug that renders an empty placeholder, as it always has.
+        assertThat(NotificationTemplate.OTP_CODE.unknownVariables(emptyMap())).isEmpty()
+    }
+
+    @Test
+    fun `the accepted set is closed — an empty-schema template accepts nothing`() {
+        assertThat(NotificationTemplate.KYC_APPROVED.variables).isEmpty()
+        assertThat(NotificationTemplate.KYC_APPROVED.unknownVariables(mapOf("code" to "483920")))
+            .containsExactly("code")
+    }
+
+    @Test
+    fun `secret templates declare exactly the variable that carries the secret`() {
+        assertThat(NotificationTemplate.OTP_CODE.variables).containsExactly("code")
+        assertThat(NotificationTemplate.PASSWORD_RESET.variables).containsExactly("resetLink")
+        // Both are also classified SECRET, so their rendered body is delivered but never stored.
+        // Two independent controls: the schema stops the secret arriving on the WRONG template,
+        // TemplateSensitivity stops it being stored on the RIGHT one.
+        assertThat(TemplateSensitivity.SECRET_TEMPLATES).contains(
+            NotificationTemplate.OTP_CODE,
+            NotificationTemplate.PASSWORD_RESET,
+        )
+    }
+
+    @Test
+    fun `no template declares a variable whose name suggests a secret unless it is classified SECRET`() {
+        // A cheap, honest heuristic — not a proof. If a future template declares a `code`/`token`/
+        // `password`/`secret`/`otp` variable, it is almost certainly secret-bearing and belongs in
+        // SECRET_TEMPLATES. Failing here is a prompt to think, not necessarily a bug.
+        val secretish = setOf("code", "token", "password", "secret", "otp", "pin", "resetLink")
+        for (template in NotificationTemplate.entries) {
+            val carriesSecretish = template.variables.any { it in secretish }
+            if (carriesSecretish) {
+                assertThat(TemplateSensitivity.isSecret(template))
+                    .describedAs(
+                        "%s declares a secret-shaped variable %s but is not in SECRET_TEMPLATES — " +
+                            "its rendered body would be stored in cleartext",
+                        template.name,
+                        template.variables.filter { it in secretish },
+                    )
+                    .isTrue()
+            }
+        }
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -175,6 +175,54 @@ class NotificationConsumerIT {
         assertThat(bodyFor(partyId)).doesNotContain(code)
     }
 
+    /**
+     * The #1325 hole, end to end: a secret-shaped variable on an ordinary, non-SECRET template.
+     *
+     * Before the closed schema this rendered through the `else` branch as `code: 483920` and was
+     * persisted in cleartext — `TemplateSensitivity` could not help, because it classifies
+     * templates and the template here is legitimately not secret. Now the request never reaches
+     * `dispatch`, so no row exists at all.
+     */
+    @Test
+    fun `undeclared variable is rejected before anything is stored (issue 1325)`() {
+        val partyId = UUID.randomUUID()
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.EMAIL,
+                template = NotificationTemplate.ACCOUNT_FROZEN,
+                recipient = "frozen@example.com",
+                variables = mapOf(
+                    "accountNumber" to "CZ6508000000192000145399",
+                    "reason" to "AML review",
+                    "code" to "483920",
+                ),
+            ),
+        )
+
+        // Rejected, not stored-then-redacted: the row was never written.
+        assertThat(countFor(partyId)).isEqualTo(0L)
+    }
+
+    /** The same template without the smuggled key goes through untouched. */
+    @Test
+    fun `declared variables on the same template are accepted and stored`() {
+        val partyId = UUID.randomUUID()
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.EMAIL,
+                template = NotificationTemplate.ACCOUNT_FROZEN,
+                recipient = "frozen-ok@example.com",
+                variables = mapOf("accountNumber" to "CZ6508000000192000145399", "reason" to "AML review"),
+            ),
+        )
+
+        assertThat(countFor(partyId)).isEqualTo(1L)
+        assertThat(bodyFor(partyId)).contains("AML review")
+        assertThat(bodyFor(partyId)).doesNotContain("483920")
+    }
+
     /** An ordinary template is untouched — redaction is an allow-list, not a blanket. */
     @Test
     fun `non-secret template still stores its rendered body`() {


### PR DESCRIPTION
Closes #1325 · first of three PRs behind operator-initiated messaging (ADR-0176), and a standalone security fix.

## The hole

`renderTemplate` mapped **6 of 13** templates. The other 7 fell to an `else` branch that dumped every caller-supplied variable into the body as `key: value`. Two live consequences:

- **Secret smuggling.** Secrecy is a property of the *variables*, not the *template* — so `TemplateSensitivity` (which classifies templates, #1180) could not catch it. `ACCOUNT_FROZEN`, legitimately not SECRET, carrying `{"code": "483920"}` rendered and **stored that code in cleartext**, readable by any `ROLE_OPERATOR`.
- **7 templates reached customers as raw variable dumps** — literally `token: abc123` — including `PASSWORD_RESET`. A correctness bug hiding behind the same `else`.

## Fix (ADR-0176 D1)

**The variable schema is a constructor argument on the enum**, not a side table:

```kotlin
enum class NotificationTemplate(val variables: Set<String>) {
    ACCOUNT_FROZEN(setOf("accountNumber", "reason")),
    OTP_CODE(setOf("code")),
    ...
}
```

A new constant *cannot* be added without declaring its variables — the compiler demands the argument. A side table can silently gain a constant it has no entry for; this cannot.

**The consumer rejects any undeclared key** before rendering or persisting, so a secret-shaped variable on an ordinary template never arrives. Rejection logs the offending **keys only, never values** — a rejected payload is exactly where a value is most likely a secret.

**`renderTemplate` is now exhaustive with no `else`**, and copy is written for all 13 templates. A new constant is a **compile error** until someone writes its render — a guard that cannot be forgotten, unlike the review the sensitivity allow-list relies on.

## Two design choices worth review

- **Closed against addition, lenient about omission.** An undeclared key is rejected; a *missing* declared key renders empty, as it always has. Rejecting a partial request would silently drop a real message (poison payloads are acked), turning a degraded message into no message — a worse failure than an empty field. The security property is undeclared keys; missing keys are a caller bug, not an attack.
- **`TemplateSensitivity` is untouched.** It stays as the second, independent control: the schema stops a secret arriving on the *wrong* template, `TemplateSensitivity` stops it being stored on the *right* one (`OTP_CODE`). Two controls, two different failure modes.

## Verification

`detekt`, `ktlintCheck`, `test`, `quarkusBuild` all green.

**The compile-error guard is proven, not asserted:** adding a 14th constant fails the build with `'when' expression must be exhaustive. Add the 'PROBE_TEMPLATE' branch or an 'else' branch.` (probe removed before commit).

**The rejection is proven end to end and proven to be a real guard.** The IT sends `ACCOUNT_FROZEN` with an undeclared `code` → **zero rows stored**; the same template without it → stored, body contains `reason`, never the smuggled value. Disabling the rejection turns exactly that test red (`tests="5" failures="1"`) and nothing else — it is not a tautology.

**No API contract change** — the Kafka inbound shape is unchanged and `openapi.yaml` is untouched, so no `info.version` bump.

## What this unblocks, and what it does not

This is B1 of the three PRs the ADR-0176 review split PR-B into. It is a prerequisite for the catalogue (D2) — the catalogue cannot be safe while templates accept arbitrary variables. Still ahead: **B2** (`ApprovalStore` + Redis, because `AUTHZ_FOUR_EYES_ENFORCE=true` fails *open* today with no store wired) and **B3** (the `POST` endpoint, the `opsmessage.*` rego rule, `four_eyes.actions`, real `IN_APP` delivery, the compose UI).
