### PR TITLE
fix(fraud-service): restore @PactBroker on provider verification (unblocks sepa-payment auto-deploy)

### DIFF
--- a/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactProviderVerificationTest.kt
+++ b/openbank-fraud-service/src/test/kotlin/com/openbank/fraud/contract/FraudPactProviderVerificationTest.kt
@@ -10,13 +10,14 @@ import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvide
 import au.com.dius.pact.provider.junitsupport.IgnoreNoPactsToVerify
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
-import au.com.dius.pact.provider.junitsupport.loader.PactFolder
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.security.TestSecurity
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
 
 /**
@@ -26,8 +27,21 @@ import org.junit.jupiter.api.extension.ExtendWith
  * verification lives in FraudPactProviderVerificationTest") but never existed (issue #468) —
  * the consumer contract was committed and generated, but nothing on the provider side replayed it.
  *
- * git-pact (`@PactFolder`), mirroring `LedgerPactProviderVerificationTest` /
- * `AccountEventPactProviderVerificationTest`: always runs, no broker/CI secret required.
+ * `@PactBroker` (not `@PactFolder`) — the same fix #1166/#1333 applied to party-service and
+ * account-service. `_service-ci.yml` publishes every consumer's pacts to the broker on a main
+ * push, but reading the pact from a git-committed file (`@PactFolder`) instead of pulling it back
+ * OUT of the broker means Pact-JVM has no broker-side interaction to attach a verification result
+ * to — so this class verified the contract correctly but never published a result for ANY
+ * fraud-service version, real or otherwise. `can-i-deploy` reads the broker and nothing else, so
+ * it permanently saw "no verified pact" for sepa-payment (a money-path consumer) and hard-blocked
+ * its deploy — confirmed live: `sepa-payment` #844 (a real bug fix) has sat undeployed since
+ * 2026-07-12 with "There is no verified pact between openbank-sepa-payment and openbank-fraud-service"
+ * (issue #1348). Rewriting the broker's stale/phantom deployed-version record (a separate bug,
+ * also #1348) would NOT have unblocked this — there would still be no verification for whatever
+ * the correct version is, until this class actually publishes one.
+ *
+ * `@EnabledIfSystemProperty` keeps it a no-op locally and on the PR lane, where no broker is
+ * configured, matching every other broker-based provider test in the fleet.
  *
  * IMPORTANT: if `SepaPaymentFraudServicePactConsumerTest` changes the contract, regenerate
  * (`./gradlew :openbank-sepa-payment:test --tests "*SepaPaymentFraudServicePactConsumerTest*"`)
@@ -37,8 +51,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 @QuarkusTestResource(com.openbank.fraud.it.PostgresRedisTestResource::class)
 @TestSecurity(user = "pact-verifier", roles = ["ROLE_SERVICE", "ROLE_OPERATOR"])
 @Provider("openbank-fraud-service")
-@PactFolder("../pacts")
+@PactBroker(enablePendingPacts = "true")
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")
+@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")
 class FraudPactProviderVerificationTest {
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "8081")


### PR DESCRIPTION
## What

`sepa-payment` #844 (a real bug fix: send `valueDate` in the format `transaction-service` actually parses) has sat undeployed since 2026-07-12 — 5 days — because `can-i-deploy` permanently sees:

```
There is no verified pact between the latest version of openbank-sepa-payment
with tag main (9b29570e5…) and the version of openbank-fraud-service currently
in sandbox (dae215b5…)
```

## Root cause

`FraudPactProviderVerificationTest` reads the consumer pact from a git-committed file (`@PactFolder`), not from the broker. Pact-JVM verifies the interaction correctly against that file, but has no broker-side interaction to attach a result to — so it **never publishes a verification for any fraud-service version, real or otherwise.** `can-i-deploy` reads only the broker, so it has permanently blocked every consumer of fraud-service since this test was introduced (issue #468).

This is the exact same shape as #1166 (party-service, merged) and #1333 (account-service, open) — in fact this class's own docstring already namechecked `AccountEventPactProviderVerificationTest` as a sibling pattern, which is what tipped me off.

## Why this isn't a broker-data fix (issue #1348)

I initially diagnosed this as "the broker holds a phantom `deployed` record (`dae215b5`) that never actually deployed" (#1348, addressed for new occurrences by #1351). That diagnosis is real — `dae215b5` genuinely never left CI, confirmed against the cluster (`fraud-service` actually runs `sandbox-31e6692a`). **But rewriting that phantom record to the correct SHA would not have unblocked `sepa-payment`:** there would still be no verification for `31e6692a` either, because this test has never published one for *any* version. The two bugs compound; only this one is the actual blocker.

## The fix

Mirrors #1166/#1333 exactly: `@PactFolder("../pacts")` → `@PactBroker(enablePendingPacts = "true")` + `@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")`. Unlike account-service's message-only fix, `fraud-service`'s single interaction (`POST /api/v1/fraud/score`) is HTTP-only, so no `MessageTestTarget` branching is needed — the existing `HttpTestTarget`-only `@BeforeEach` is unchanged.

## Review note

`fraud-service` is money-path (`rules.yaml: money_path_services`) — needs **2 approvals**, same as #1166/#1333. Test-only change: no `src/main` code, no API, no schema. `docs/threat-models/openbank-fraud-service.md` is unaffected.

## Verification

- `:openbank-fraud-service:compileTestKotlin` + `ktlintCheck` pass.
- Confirmed the class is a **local no-op**, exactly like the merged party-service/account-service fixes: `--tests "*FraudPactProviderVerificationTest*"` reports `No tests found for given includes` (real verification only runs in CI against a configured broker).
- Confirmed the test filter itself isn't lying: `--tests "*FraudRuleEngineTest*"` against the same tree reports `BUILD SUCCESSFUL`.

## What merging this does — and doesn't — do

Per #1333's precedent, merging publishes a verification for the **new** fraud-service SHA on the next main-push, not for `dae215b5` or `31e6692a` retroactively. The full chain: merge → fraud-service CI publishes a verification on its next main push → fraud-service auto-deploys → sandbox carries a version with a verification → `sepa-payment`'s gate passes.

Refs #1348
