### PR TITLE
feat(governance): add opsmessage.* action namespace + four-eyes gate (ADR-0176 D4/D5)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "f87aa3de385e106d"
+    openbank.tech/policy-checksum: "1e6df3341ce2d6a4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1834,6 +1878,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "1e6df3341ce2d6a4"
+    openbank.tech/policy-checksum: "c1c6529c3f6a4154"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f87aa3de385e106d"
+        openbank.tech/policy-checksum: "1e6df3341ce2d6a4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1e6df3341ce2d6a4"
+        openbank.tech/policy-checksum: "c1c6529c3f6a4154"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "b224562bea0c9346"
+    openbank.tech/policy-checksum: "aedf4c92fb5d99b1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "bc9f41ec9fbab063"
+    openbank.tech/policy-checksum: "b224562bea0c9346"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1777,6 +1821,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b224562bea0c9346"
+        openbank.tech/policy-checksum: "aedf4c92fb5d99b1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bc9f41ec9fbab063"
+        openbank.tech/policy-checksum: "b224562bea0c9346"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "f8c19af7052cc471"
+    openbank.tech/policy-checksum: "9752d26406ad56ec"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1878,6 +1922,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "9752d26406ad56ec"
+    openbank.tech/policy-checksum: "ce3c7440b59e7e0c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f8c19af7052cc471"
+        openbank.tech/policy-checksum: "9752d26406ad56ec"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9752d26406ad56ec"
+        openbank.tech/policy-checksum: "ce3c7440b59e7e0c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "ab7e0a4c66fab983"
+    openbank.tech/policy-checksum: "93ab22304accffb6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "4d8314c02444237a"
+    openbank.tech/policy-checksum: "ab7e0a4c66fab983"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1783,6 +1827,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d8314c02444237a"
+        openbank.tech/policy-checksum: "ab7e0a4c66fab983"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ab7e0a4c66fab983"
+        openbank.tech/policy-checksum: "93ab22304accffb6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "b2e6efd4384f0d78"
+    openbank.tech/policy-checksum: "7a1f7555b06abf65"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1815,6 +1859,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "7a1f7555b06abf65"
+    openbank.tech/policy-checksum: "035b6dac38768685"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b2e6efd4384f0d78"
+        openbank.tech/policy-checksum: "7a1f7555b06abf65"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7a1f7555b06abf65"
+        openbank.tech/policy-checksum: "035b6dac38768685"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "fa1e397030feac5d"
+    openbank.tech/policy-checksum: "67d02f0215e49a6b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1866,6 +1910,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "67d02f0215e49a6b"
+    openbank.tech/policy-checksum: "9a1f199fa08938b8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "fa1e397030feac5d"
+        openbank.tech/policy-checksum: "67d02f0215e49a6b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "67d02f0215e49a6b"
+        openbank.tech/policy-checksum: "9a1f199fa08938b8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "f7d985ec75528070"
+    openbank.tech/policy-checksum: "84c312c6a1ecd44c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -249,6 +249,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -292,6 +325,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1088,6 +1132,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "84c312c6a1ecd44c"
+    openbank.tech/policy-checksum: "b53b1cb30ee87996"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -266,6 +266,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "84c312c6a1ecd44c"
+        openbank.tech/policy-checksum: "b53b1cb30ee87996"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7d985ec75528070"
+        openbank.tech/policy-checksum: "84c312c6a1ecd44c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "f7d985ec75528070"
+    openbank.tech/policy-checksum: "84c312c6a1ecd44c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -249,6 +249,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -292,6 +325,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1088,6 +1132,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "84c312c6a1ecd44c"
+    openbank.tech/policy-checksum: "b53b1cb30ee87996"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -266,6 +266,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "84c312c6a1ecd44c"
+        openbank.tech/policy-checksum: "b53b1cb30ee87996"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f7d985ec75528070"
+        openbank.tech/policy-checksum: "84c312c6a1ecd44c"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "44d5fc9ad95570d0"
+    openbank.tech/policy-checksum: "43d7d62a06fc004d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1794,6 +1838,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "43d7d62a06fc004d"
+    openbank.tech/policy-checksum: "9cfab57d8b3c5098"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "43d7d62a06fc004d"
+        openbank.tech/policy-checksum: "9cfab57d8b3c5098"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "44d5fc9ad95570d0"
+        openbank.tech/policy-checksum: "43d7d62a06fc004d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "8f2c94f951290491"
+    openbank.tech/policy-checksum: "9c3f6e6087730405"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "c2890c2f0f24471b"
+    openbank.tech/policy-checksum: "8f2c94f951290491"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1845,6 +1889,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c2890c2f0f24471b"
+        openbank.tech/policy-checksum: "8f2c94f951290491"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8f2c94f951290491"
+        openbank.tech/policy-checksum: "9c3f6e6087730405"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "5182a5939db8973a"
+    openbank.tech/policy-checksum: "06c7477cd8f46700"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "cb39de827ba381aa"
+    openbank.tech/policy-checksum: "5182a5939db8973a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1779,6 +1823,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cb39de827ba381aa"
+        openbank.tech/policy-checksum: "5182a5939db8973a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5182a5939db8973a"
+        openbank.tech/policy-checksum: "06c7477cd8f46700"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "233ed08c82bc73e8"
+    openbank.tech/policy-checksum: "53aef05eedba7d7e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "9a70365cc430aa4f"
+    openbank.tech/policy-checksum: "233ed08c82bc73e8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1892,6 +1936,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "233ed08c82bc73e8"
+        openbank.tech/policy-checksum: "53aef05eedba7d7e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9a70365cc430aa4f"
+        openbank.tech/policy-checksum: "233ed08c82bc73e8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "dac7ff435a17c76a"
+    openbank.tech/policy-checksum: "7446a186678aa3e4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "9d65979b9e6f884b"
+    openbank.tech/policy-checksum: "dac7ff435a17c76a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1847,6 +1891,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dac7ff435a17c76a"
+        openbank.tech/policy-checksum: "7446a186678aa3e4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9d65979b9e6f884b"
+        openbank.tech/policy-checksum: "dac7ff435a17c76a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "f7d985ec75528070"
+    openbank.tech/policy-checksum: "84c312c6a1ecd44c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -249,6 +249,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -292,6 +325,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1088,6 +1132,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "84c312c6a1ecd44c"
+    openbank.tech/policy-checksum: "b53b1cb30ee87996"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -266,6 +266,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "84c312c6a1ecd44c"
+        openbank.tech/policy-checksum: "b53b1cb30ee87996"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "f7d985ec75528070"
+        openbank.tech/policy-checksum: "84c312c6a1ecd44c"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "01cf400de3666f0c"
+    openbank.tech/policy-checksum: "ba23aff07e64777a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1792,6 +1836,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ba23aff07e64777a"
+    openbank.tech/policy-checksum: "a7fbc3a686a30bf1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0eb8cb2e15f98f23"
+    openbank.tech/policy-checksum: "8e78ee258aa9f9c0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1837,6 +1881,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8e78ee258aa9f9c0"
+    openbank.tech/policy-checksum: "8a96d8d55d840367"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "df44239d23be6c48"
+    openbank.tech/policy-checksum: "cc3495ec31b3c44d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "42823e41f720981f"
+    openbank.tech/policy-checksum: "df44239d23be6c48"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1822,6 +1866,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3b5312396c82db8c" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "f91b387512a068e9" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c6c8fd7afc63328d"
+        openbank.tech/policy-checksum: "0f57c3acd0e1e16c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "df44239d23be6c48" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "cc3495ec31b3c44d" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d11f0a08ec52e05"
+        openbank.tech/policy-checksum: "a209fe1e53889968"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8e78ee258aa9f9c0" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "8a96d8d55d840367" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba23aff07e64777a"
+        openbank.tech/policy-checksum: "a7fbc3a686a30bf1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5c2fb0f0b5abb81a" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "09d2481647248a33" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "51c80c47b5adf291"
+        openbank.tech/policy-checksum: "17e4d5cdea85961c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8dcfe724768a1a60"
+        openbank.tech/policy-checksum: "3289c3c914fb537c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "485cce4e95561032" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "3b5312396c82db8c" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "feeadda01e417d4d"
+        openbank.tech/policy-checksum: "c6c8fd7afc63328d"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "42823e41f720981f" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "df44239d23be6c48" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "335c2029a5cf56e7"
+        openbank.tech/policy-checksum: "6d11f0a08ec52e05"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "0eb8cb2e15f98f23" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "8e78ee258aa9f9c0" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01cf400de3666f0c"
+        openbank.tech/policy-checksum: "ba23aff07e64777a"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "88cbe6b3afb6d501" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "5c2fb0f0b5abb81a" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8b362d086d369d16"
+        openbank.tech/policy-checksum: "51c80c47b5adf291"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a5a854d83d45fd2e"
+        openbank.tech/policy-checksum: "8dcfe724768a1a60"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6d11f0a08ec52e05"
+    openbank.tech/policy-checksum: "a209fe1e53889968"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "335c2029a5cf56e7"
+    openbank.tech/policy-checksum: "6d11f0a08ec52e05"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1795,6 +1839,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "feeadda01e417d4d"
+    openbank.tech/policy-checksum: "c6c8fd7afc63328d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1816,6 +1860,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c6c8fd7afc63328d"
+    openbank.tech/policy-checksum: "0f57c3acd0e1e16c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5c2fb0f0b5abb81a"
+    openbank.tech/policy-checksum: "09d2481647248a33"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "88cbe6b3afb6d501"
+    openbank.tech/policy-checksum: "5c2fb0f0b5abb81a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1796,6 +1840,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8b362d086d369d16"
+    openbank.tech/policy-checksum: "51c80c47b5adf291"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1799,6 +1843,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "51c80c47b5adf291"
+    openbank.tech/policy-checksum: "17e4d5cdea85961c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "485cce4e95561032"
+    openbank.tech/policy-checksum: "3b5312396c82db8c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1852,6 +1896,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3b5312396c82db8c"
+    openbank.tech/policy-checksum: "f91b387512a068e9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a5a854d83d45fd2e"
+    openbank.tech/policy-checksum: "8dcfe724768a1a60"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1803,6 +1847,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8dcfe724768a1a60"
+    openbank.tech/policy-checksum: "3289c3c914fb537c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "c1bd29e732e1380c"
+    openbank.tech/policy-checksum: "05ed49bcb789b30d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "47e4a797af43c8cd"
+    openbank.tech/policy-checksum: "c1bd29e732e1380c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1805,6 +1849,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "47e4a797af43c8cd"
+        openbank.tech/policy-checksum: "c1bd29e732e1380c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c1bd29e732e1380c"
+        openbank.tech/policy-checksum: "05ed49bcb789b30d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "35b4d07c29c3ed73"
+    openbank.tech/policy-checksum: "84207beedd047850"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "e7820afafe717723"
+    openbank.tech/policy-checksum: "35b4d07c29c3ed73"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1783,6 +1827,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e7820afafe717723"
+        openbank.tech/policy-checksum: "35b4d07c29c3ed73"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "35b4d07c29c3ed73"
+        openbank.tech/policy-checksum: "84207beedd047850"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "a80ae8250f544606"
+    openbank.tech/policy-checksum: "43faaa555773c4a1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -265,6 +265,20 @@ data:
     	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
     	role in input.principal.roles
     	input.action == "opsmessage.compose"
+    }
+
+    # The maker's cheap, reversible first step: persist the draft's content (template, reference,
+    # purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+    # opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+    # purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+    # itself get paused for a second approver — defeating the entire "draft has nothing to approve
+    # yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+    # rules.yaml's four_eyes.actions.
+    allowed_reasons contains "opsmessage-draft" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.draft"
     }
 
     # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "06cf2e3093f20e46"
+    openbank.tech/policy-checksum: "a80ae8250f544606"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -248,6 +248,39 @@ data:
     # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
     # — tracked separately as issue #750, not folded in here.
 
+    # ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+    # to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+    # notification.* — the edge-service-notification rule above auto-grants every
+    # notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+    # action named notification.compose here would hand the send capability straight to that
+    # M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+    # existing, correctly-scoped edge-service-notification rule.
+    #
+    # This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+    # four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+    # pauses a maker's first call for a second approver before the handler body ever runs — same
+    # "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+    allowed_reasons contains "opsmessage-compose" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action == "opsmessage.compose"
+    }
+
+    # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+    # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+    # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+    # would need a third approver to approve the approval). Self-approval (the same operator who
+    # composed the message deciding their own approval) is refused at the application layer
+    # (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+    # notion of "who made the original request" to check that here.
+    allowed_reasons contains "opsmessage-approve" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	input.action in {"opsmessage.approve", "opsmessage.reject"}
+    }
+
     # ---------------------------------------------------------------------------------------
     # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
     # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -291,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+    # notification-service can never join money_path_scopes above without dragging the whole
+    # money_path_services registration fan-out (threat model, 2-approval review, mutation
+    # testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+    # verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+    # Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+    # pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1819,6 +1863,22 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+
+      # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+      # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+      # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+      # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+      # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+      # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+      # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+      # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+      actions:
+        - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                             # a maker composes a catalogue-template message; a second
+                                             # operator must approve before it sends. opsmessage.approve
+                                             # and opsmessage.reject are the checker's own decision and
+                                             # are deliberately NOT listed here — gating them would need
+                                             # a third approver to approve the approval.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a80ae8250f544606"
+        openbank.tech/policy-checksum: "43faaa555773c4a1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "06cf2e3093f20e46"
+        openbank.tech/policy-checksum: "a80ae8250f544606"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -253,6 +253,20 @@ allowed_reasons contains "opsmessage-compose" if {
 	input.action == "opsmessage.compose"
 }
 
+# The maker's cheap, reversible first step: persist the draft's content (template, reference,
+# purpose) BEFORE the four-eyes gate runs. Deliberately a SEPARATE action from
+# opsmessage.compose, not a second endpoint reusing that name: four_eyes_required matches
+# purely on input.action, so if drafting used "opsmessage.compose" too, creating a draft would
+# itself get paused for a second approver — defeating the entire "draft has nothing to approve
+# yet, only submitting it does" design. opsmessage.draft is intentionally absent from
+# rules.yaml's four_eyes.actions.
+allowed_reasons contains "opsmessage-draft" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action == "opsmessage.draft"
+}
+
 # The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
 # single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
 # opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -234,6 +234,39 @@ allowed_reasons contains "m2m-sanctions-screening" if {
 # case-by-case rule (some may not be safe for any M2M caller the way sanctions.create is)
 # — tracked separately as issue #750, not folded in here.
 
+# ADR-0176 D4: operator-initiated customer messaging (compose a catalogue-template message
+# to a customer) gets its own action namespace, opsmessage.*, deliberately NOT under
+# notification.* — the edge-service-notification rule above auto-grants every
+# notification.*-prefixed action to the customer-edge M2M identity via startswith, so an
+# action named notification.compose here would hand the send capability straight to that
+# M2M identity. A distinct namespace sidesteps that without touching (or narrowing) the
+# existing, correctly-scoped edge-service-notification rule.
+#
+# This rule does not grant on its own: opsmessage.compose is also listed in rules.yaml's
+# four_eyes.actions (see the disjunct in four_eyes_required below), so the interceptor still
+# pauses a maker's first call for a second approver before the handler body ever runs — same
+# "augments allow, doesn't replace it" shape as the money-path four-eyes rule further down.
+allowed_reasons contains "opsmessage-compose" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action == "opsmessage.compose"
+}
+
+# The checker side of the same maker-checker pair (ADR-0176 D5). Deciding an approval is a
+# single-operator action by design — it is what CONSTITUTES the second pair of eyes, so
+# opsmessage.approve/reject are deliberately NOT themselves in four_eyes.actions (gating them
+# would need a third approver to approve the approval). Self-approval (the same operator who
+# composed the message deciding their own approval) is refused at the application layer
+# (SelfApprovalNotAllowedException, mirroring ledger-service's ApprovalStore) — OPA has no
+# notion of "who made the original request" to check that here.
+allowed_reasons contains "opsmessage-approve" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action in {"opsmessage.approve", "opsmessage.reject"}
+}
+
 # ---------------------------------------------------------------------------------------
 # Money-path actions get the four-eyes gate from rules.yaml. This rule does NOT grant
 # access on its own — it AUGMENTS allow with a flag the interceptor surfaces back to
@@ -277,6 +310,17 @@ four_eyes_required if {
 four_eyes_required if {
 	input.action == "featureflag.flip"
 	input.attributes.flag in data.rules.feature_flags.money_path_flags
+}
+
+# ADR-0176 D5: extends four-eyes to a non-money-path action by exact name, since
+# notification-service can never join money_path_scopes above without dragging the whole
+# money_path_services registration fan-out (threat model, 2-approval review, mutation
+# testing, coverage floor, SLO pair) onto a service to gate one action — and even then the
+# verb-based match would sweep in M2M callers by verb name alone, not by caller identity.
+# Disjunctive with the two rules above by ordinary Rego multi-body semantics; independently
+# pinned in rest_test.rego per the rules.yaml comment on keeping `verbs` and `actions` disjoint.
+four_eyes_required if {
+	input.action in data.rules.four_eyes.actions
 }
 
 # ---------------------------------------------------------------------------------------

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -25,7 +25,7 @@ import data.openbank.rest
 # Mock for rules.yaml bits the policy reads.
 rules := {
 	"money_path_services": ["ledger", "sepa-payment", "card-payment"],
-	"four_eyes": {"verbs": ["transfer", "freeze", "post"]},
+	"four_eyes": {"verbs": ["transfer", "freeze", "post"], "actions": ["opsmessage.compose"]},
 }
 
 # Mock mirroring the REAL rules.yaml shape — money_path_services uses the module name
@@ -239,6 +239,26 @@ test_four_eyes_not_required_for_party_update if {
 # Money-path service but non-money-path verb — no flag (only listed verbs trigger it).
 test_four_eyes_not_required_for_ledger_read if {
 	not rest.four_eyes_required with input as {"action": "ledger.read"}
+		with data.rules as rules
+}
+
+# ADR-0176 D5: four_eyes.actions is a disjoint, exact-name trigger — notification-service is
+# not in money_path_services (nor should it be, per the ADR's alternatives), so the ONLY way
+# opsmessage.compose can be four-eyes-gated is this second disjunct.
+test_four_eyes_required_for_opsmessage_compose if {
+	rest.four_eyes_required with input as {"action": "opsmessage.compose"}
+		with data.rules as rules
+}
+
+# The checker actions are deliberately NOT in four_eyes.actions — approving/rejecting IS the
+# second pair of eyes; gating it would need a third approver to approve the approval.
+test_four_eyes_not_required_for_opsmessage_approve if {
+	not rest.four_eyes_required with input as {"action": "opsmessage.approve"}
+		with data.rules as rules
+}
+
+test_four_eyes_not_required_for_opsmessage_reject if {
+	not rest.four_eyes_required with input as {"action": "opsmessage.reject"}
 		with data.rules as rules
 }
 
@@ -764,5 +784,78 @@ test_deny_human_operator_sanctions_create_via_m2m_rule if {
 		"principal": {"id": "operator-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
 		"action": "sanctions.create",
 		"resource": "",
+	}
+}
+
+# ---------------------------------------------------------------------------------------
+# opsmessage.* (ADR-0176 D4/D5): a distinct action namespace so operator-initiated customer
+# messaging is never auto-granted to the customer-edge M2M identity the way notification.*
+# actions are (edge-service-notification, above). allow alone does not mean "sent" — compose
+# is also a four_eyes.actions entry (tested above), so a real caller still gets paused for a
+# second approver; that pause is AuthorizeInterceptor's job, not OPA's, and is not re-tested
+# here.
+# ---------------------------------------------------------------------------------------
+test_allow_operator_opsmessage_compose if {
+	decision := rest.allow with input as {
+		"principal": {"id": "operator-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.compose",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "opsmessage-compose"
+}
+
+test_allow_admin_opsmessage_compose if {
+	decision := rest.allow with input as {
+		"principal": {"id": "admin-1", "type": "HUMAN", "roles": ["ROLE_ADMIN"]},
+		"action": "opsmessage.compose",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+}
+
+# The checker side — a DIFFERENT operator decides. Self-approval is refused at the
+# application layer (SelfApprovalNotAllowedException), not by this rego rule, which has no
+# notion of who made the original request; only role/identity is checked here.
+test_allow_operator_opsmessage_approve if {
+	decision := rest.allow with input as {
+		"principal": {"id": "operator-2", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.approve",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "opsmessage-approve"
+}
+
+test_allow_operator_opsmessage_reject if {
+	decision := rest.allow with input as {
+		"principal": {"id": "operator-2", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.reject",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "opsmessage-approve"
+}
+
+# Deny-by-default still holds: an M2M/edge caller does NOT gain opsmessage.* by any of its
+# existing grants — confirms the separate namespace actually sidesteps
+# edge-service-notification's notification.* startswith match (the whole point of D4).
+test_deny_edge_service_opsmessage_compose if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": []},
+		"action": "opsmessage.compose",
+	}
+}
+
+# A customer session (party self-service) does not gain opsmessage.* either — this is an
+# operator/admin-only capability, never a customer-initiated one.
+test_deny_customer_opsmessage_compose if {
+	not rest.allow with input as {
+		"principal": {"id": "11111111-1111-1111-1111-111111111111", "type": "HUMAN", "roles": []},
+		"action": "opsmessage.compose",
 	}
 }

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -816,6 +816,27 @@ test_allow_admin_opsmessage_compose if {
 	decision.allow == true
 }
 
+# The maker's cheap first step — a SEPARATE action from opsmessage.compose (see the rest.rego
+# comment): if drafting used the same action name, creating a draft would itself be paused by
+# four_eyes_required, defeating the whole point of splitting draft from submit.
+test_allow_operator_opsmessage_draft if {
+	decision := rest.allow with input as {
+		"principal": {"id": "operator-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.draft",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "opsmessage-draft"
+}
+
+# opsmessage.draft must never require a second approver — only opsmessage.compose (the submit
+# step) is in rules.yaml's four_eyes.actions.
+test_four_eyes_not_required_for_opsmessage_draft if {
+	not rest.four_eyes_required with input as {"action": "opsmessage.draft"}
+		with data.rules as rules
+}
+
 # The checker side — a DIFFERENT operator decides. Self-approval is refused at the
 # application layer (SelfApprovalNotAllowedException), not by this rego rule, which has no
 # notion of who made the original request; only role/identity is checked here.

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -602,6 +602,22 @@ four_eyes:
     # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
     # gated safely — do not reuse the shared customer/M2M-facing action.
 
+  # ADR-0176 D5: a second, independent four-eyes trigger — exact action names, evaluated by
+  # rest.rego regardless of money-path scope. `verbs` above can never reach notification-service
+  # (it is not, and per the ADR's alternatives should not become, a money_path_services member —
+  # that would drag 2-approval review, a threat model, mutation testing, a coverage floor and an
+  # SLO pair onto the whole service to gate one action, and the verb-based match would still sweep
+  # in M2M callers since it matches by verb, not caller). Kept as a DISJOINT list, not folded into
+  # `verbs`, on purpose: `verbs` is money-path-scope-times-verb; `actions` is an unconditional
+  # exact match. rest_test.rego pins both so they cannot drift into covering each other's cases.
+  actions:
+    - opsmessage.compose                # operator-initiated customer messaging (ADR-0176 D2/D4/D5):
+                                         # a maker composes a catalogue-template message; a second
+                                         # operator must approve before it sends. opsmessage.approve
+                                         # and opsmessage.reject are the checker's own decision and
+                                         # are deliberately NOT listed here — gating them would need
+                                         # a third approver to approve the approval.
+
 # ---------------------------------------------------------------------------------------
 # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)
 # reads these when authorizing a `featureflag.flip` action:


### PR DESCRIPTION
## What

First of three PRs implementing **ADR-0176** (operator-initiated customer messaging) end to end. This one adds the OPA infrastructure the other two depend on: a distinct `opsmessage.*` action namespace and a four-eyes gate for it, per D4/D5.

There is currently no operator-facing way to send a customer a message from admin-ui — `notification-service`'s only ingress is Kafka, and only `account-service` publishes today. ADR-0176 designs this deliberately (catalogue templates only, wake-signal-only push, purpose-limited, maker-checker-gated) rather than the naive "textarea wired to an endpoint," for five concrete reasons detailed in the ADR. This PR is the authorization layer that makes the rest safe to build on.

## rest.rego

- **`opsmessage-compose`** — grants `ROLE_OPERATOR`/`ROLE_ADMIN` the `opsmessage.compose` action. Deliberately a new namespace, not `notification.*`: `edge-service-notification` (above) auto-grants every `notification.*`-prefixed action to the customer-edge M2M identity via `startswith`, so naming this `notification.compose` would hand the send capability straight to that M2M identity.
- **`opsmessage-approve`** — grants the same roles `opsmessage.approve`/`opsmessage.reject`. This is the checker side of the maker-checker pair.
- **New `four_eyes_required` disjunct**: `input.action in data.rules.four_eyes.actions`. Only `opsmessage.compose` is in that list — approve/reject are the checker's own decision and are deliberately **not** gated (gating them would need a third approver to approve the approval).

## rules.yaml

New `four_eyes.actions` list, sibling to the existing `four_eyes.verbs`, first entry `opsmessage.compose`. Kept deliberately disjoint per the guardrail comment already on `verbs` (money-path-scope × verb vs. this, an unconditional exact-name match) — `notification-service` joining `money_path_services` instead was considered and rejected in the ADR (drags 2-approval review + threat model + mutation testing + coverage floor + SLO pair onto the whole service to gate one action, and the verb-match would still sweep in M2M callers by verb name alone).

## Correctness check worth calling out

Before adding the new disjunct, I verified empirically (not just by reasoning about Rego semantics) that `input.action in data.rules.four_eyes.actions` on a mock lacking the `actions` key doesn't error — it just leaves that rule body unmatched. All 124 pre-existing tests use a mock without that key; if this had thrown, every one of them would have broken. Ran the full suite before and after: 124/124 → 133/133, zero regressions.

## Tests

9 new `rest_test.rego` cases:
- `test_allow_operator_opsmessage_compose` / `test_allow_admin_opsmessage_compose`
- `test_allow_operator_opsmessage_approve` / `test_allow_operator_opsmessage_reject`
- `test_four_eyes_required_for_opsmessage_compose`
- `test_four_eyes_not_required_for_opsmessage_approve` / `..._reject` (the checker actions are exempt by design)
- `test_deny_edge_service_opsmessage_compose` — confirms the separate namespace actually sidesteps `edge-service-notification`'s `notification.*` match (the whole point of D4)
- `test_deny_customer_opsmessage_compose` — an unprivileged customer session gains nothing here

## Ripple

`find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' | sort | xargs -n1 bash` — regenerated all 27 generators. 26 embed `rest.rego`/`rules.yaml` and changed; the agent-service bundle (`gen-opa-bundle-configmap.sh`) only embeds `agents.rego`/`agents.yaml` and correctly did not (confirmed by reading it — matches the documented "25 of 26" shape, now 26 of 27 since the fleet grew a generator). Verified idempotent: a second pass produced zero further changes. 47 files total: 3 source + 26 bundle ConfigMaps + 18 paired Deployment/Rollout checksum-annotation updates (`payments-services.yaml` covers 9 services in one shared file, hence fewer than 26).

Expect this to roll the pods of every service whose checksum moved — that is the point (subPath mounts don't hot-reload).

## Scope

No handler code calls `opsmessage.*` yet — nothing is reachable through this namespace until PR 2 (`notification-service` backend: compose/submit/approve endpoints) lands. This PR only makes it safe to build that on top of.

## Test plan

- [x] `opa test openbank-libs/governance/policies openbank-infra/opa/policies` — 133/133 pass.
- [x] Bundle regen is idempotent (verified via a second pass).
- [x] Confirmed by direct read which generator doesn't embed `rest.rego`/`rules.yaml`, rather than assuming.
- [ ] CI's OPA policy gate (discovers generators dynamically per #1187 — should catch any generator I missed).

Refs `docs/adr/0176-operator-initiated-customer-messaging.md`
