### PR TITLE
build(finrep): add fast-jar Dockerfile for finrep-service

### DIFF
--- a/openbank-finrep-service/Dockerfile
+++ b/openbank-finrep-service/Dockerfile
@@ -1,0 +1,34 @@
+FROM eclipse-temurin:25-jdk-alpine@sha256:5ecfde8e5ecde5954ea3721155b345ef56c1d579b940c761318ad4c05959a151 AS build
+WORKDIR /build
+
+# Build from the FULL repo root context, NOT a selective per-module COPY. The root
+# settings.gradle.kts unconditionally `include`s all 30+ modules with an explicit
+# projectDir each, so Gradle configuration fails ("Configuring project ':openbank-
+# ledger-service' without an existing directory") unless every module dir is present.
+# Building from inside the module with its own gradlew instead trips a
+# quarkusGenerateCode -> jar -> classes circular dependency. Mirrors the canonical
+# openbank-infra/docker/services/standalone-service.Dockerfile. .dockerignore strips
+# build/, .gradle/, node_modules/ so the context stays lean.
+COPY . /build
+
+# Kotlin 2.3 + Quarkus 3.33 compile is heap-hungry; size the JVM up front.
+ENV GRADLE_OPTS="-Xmx2g -Xms256m -XX:MaxMetaspaceSize=512m"
+RUN chmod +x gradlew && \
+    ./gradlew :openbank-finrep-service:quarkusBuild \
+      -Dorg.gradle.java.installations.auto-detect=false \
+      --no-daemon \
+      --console=plain
+
+FROM eclipse-temurin:25-jre-alpine@sha256:28db6fdf60e38945e43d840c0333aeaec66c15943070104f7586fd3c9d1665b0
+WORKDIR /app
+
+RUN addgroup -S openbank && adduser -S openbank -G openbank
+USER openbank
+
+COPY --from=build /build/openbank-finrep-service/build/quarkus-app/lib/ /app/lib/
+COPY --from=build /build/openbank-finrep-service/build/quarkus-app/*.jar /app/
+COPY --from=build /build/openbank-finrep-service/build/quarkus-app/app/ /app/app/
+COPY --from=build /build/openbank-finrep-service/build/quarkus-app/quarkus/ /app/quarkus/
+
+EXPOSE 8140
+ENTRYPOINT ["java", "-XX:+UseZGC", "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", "-jar", "/app/quarkus-run.jar"]


### PR DESCRIPTION
## Summary

finrep-service is a released component (`version.txt`, added to `ALL_SERVICES` by #1227) but has never had a `Dockerfile` — its ArgoCD Deployment sits at `0/1` `ErrImagePull` against the ADR-0097 placeholder tag.

Adds `openbank-finrep-service/Dockerfile`, modeled on `openbank-anacredit-service/Dockerfile`: fast-jar build from the repo root context (never uber-jar, per `CLAUDE.md`), `EXPOSE 8140` matching `application.yaml`'s `quarkus.http.port` and the gitops manifest's `containerPort`.

## What this does NOT fix

Per #1205 and PR #1227 (which explicitly baselined finrep-service as known debt rather than a list-edit fix): **the `openbank-finrep-service` ECR repository does not exist yet**, and `build-push-service.sh` has no `create-repository` step. A `docker push` will fail with `RepositoryNotFoundException` until the repo is provisioned — that is infra/ops work outside this PR's scope (no ECR-repo Terraform module exists for per-service repos in `openbank-infra`; sibling repos appear to be provisioned out-of-band). Once the ECR repo exists, `build-push-service.sh finrep --bump` (or the CI auto-deploy pipeline) will build+push a real image and rewrite the gitops manifest's placeholder tag.

The CI guard from #1227 ("close the class") and the `clearing-simulator` fix are already merged — this PR only adds the missing Dockerfile piece of #1205's Part 1.

## Verification

- [x] `./gradlew :openbank-finrep-service:quarkusBuild` — succeeds locally, `build/quarkus-app/{app,lib,quarkus,quarkus-run.jar}` layout confirmed to match the Dockerfile's `COPY --from=build` paths.
- [ ] `docker build` not run locally (no local Docker daemon in this sandbox) — the Dockerfile is a straight per-service rename of the already-proven `openbank-anacredit-service/Dockerfile` pattern, no new logic.
- Not money-path; no `openapi.yaml`/`version.txt` change (no API/release surface touched).

Closes part of #1205 (Part 1, Dockerfile only — ECR repo creation and the CI guard/clearing-simulator items are already covered by #1227 or remain separate infra work).