### PR TITLE
docs(adr): qualify cross-repo issue refs so they resolve to the right number space

### DIFF
--- a/docs/adr/0031-ai-agent-governance-and-operations.md
+++ b/docs/adr/0031-ai-agent-governance-and-operations.md
@@ -10,7 +10,7 @@ Author(s): jiri.raska
 - **D2 (policy-gated MCP)** — Partial: `OpaPolicyDecisionPoint` + `agents.rego` deny-by-default logic shipped; sidecar enforcement pending (PR #638, D9 phase 1 advisory).
 - **D4 (human-in-the-loop)** — ✅ Shipped: proposal queue + admin-UI approvals (#657); read-only MCP oversight tools across 7 domains (#639).
 - **D5 (AI-attributed audit)** — ⬜ Skeleton present; model-id + prompt-hash enforcement pending.
-- **D8 (AGPL agent-runtime public repo)** — ⬜ Planned (issue #224).
+- **D8 (AGPL agent-runtime public repo)** — ⬜ Planned (issue JiRaska/open-bank#224).
 
 > **Ratification (2026-06-10).** The load-bearing controls are in place and deployed, so the
 > decision is ratified and the phasing (D9) becomes the execution plan:
@@ -25,7 +25,7 @@ Author(s): jiri.raska
 > Ratification does **not** widen blast radius: agents stay `advisory` + proposal-only until the D9
 > gates flip. Acceptance unblocks the remaining tail — enforcement (D2 sidecar), the oversight
 > trigger (D9 phase 2), AI-attributed tool-execution audit (D5), and the AGPL agent-runtime repo
-> (D8, issue #224) — without re-litigating the decision each time.
+> (D8, issue JiRaska/open-bank#224) — without re-litigating the decision each time.
 
 ## Context
 

--- a/docs/adr/0047-governed-runtime-operational-control-plane.md
+++ b/docs/adr/0047-governed-runtime-operational-control-plane.md
@@ -141,7 +141,7 @@ relaxing sanctions/AML screening, raising an SCA limit, bypassing four-eyes — 
 OPA prohibitions; disabling sanctions screening is *prohibited outright*, not merely
 gated). Conversely, engineer-owned feature rollout never enters the `PolicyStore`.
 For the grey zone: money-path flag flips on the ADR-0067 side still require four-eyes
-(`libs/foureyes`, tracked in issue #419) — but if a "flag" would change a
+(`libs/foureyes`, tracked in issue JiRaska/open-bank#419) — but if a "flag" would change a
 risk/compliance-owned parameter or its threshold, it is a Tier-B parameter here, not a flag.
 
 ## Alternatives considered

--- a/docs/adr/0060-ci-applies-platform-tofu.md
+++ b/docs/adr/0060-ci-applies-platform-tofu.md
@@ -139,4 +139,4 @@ keys). Safety rests on the *trust scope*, not on a trimmed permission list:
   merge surfaced this gap).
 - `openbank-infra/aws/envs/sandbox-platform/ci-tofu-apply.tf` — roles, OIDC, access entries.
 - `.github/workflows/platform-tofu.yml` — the plan/apply pipeline.
-- Issue #274 — the follow-up this realizes; #282 — the Environment/plan upgrade tail.
+- Issue JiRaska/open-bank#274 — the follow-up this realizes; JiRaska/open-bank#282 — the Environment/plan upgrade tail.

--- a/docs/adr/0060-ci-applies-platform-tofu.md
+++ b/docs/adr/0060-ci-applies-platform-tofu.md
@@ -121,7 +121,7 @@ keys). Safety rests on the *trust scope*, not on a trimmed permission list:
   workflow file; actions pinned by SHA.
 - PCI/GDPR/PSD2: unchanged (no CDE/personal data; sandbox account).
 
-## Follow-ups (tracked, issue #282)
+## Follow-ups (tracked, issue JiRaska/open-bank#282)
 
 1. **Reviewer-gated Environment** for apply once the repo is on GitHub Pro/Team
    (move the apply trust to `environment:platform-apply`, switch apply back to

--- a/docs/adr/0067-feature-flags-and-experimentation.md
+++ b/docs/adr/0067-feature-flags-and-experimentation.md
@@ -5,14 +5,14 @@ Status: Accepted (2026-06-14 — decision implemented: `openbank-libs/.../flags`
 ships the OpenFeature-aligned surface (`FeatureClient`, `FlagdProvider`,
 `@FeatureFlag` + interceptor, `FlagDefinition`/`FlagExposure`) merged to `main`.
 Remaining tail is tracked as a follow-up issue, not a blocker: four-eyes
-enforcement on money-path flag flips — issue #419.)
+enforcement on money-path flag flips — issue JiRaska/open-bank#419.)
 Delivery-Status: Shipped
 
 **Delivery note (updated 2026-06-30):**
 Core feature-flag infrastructure shipped: `FeatureClient`, `FlagdProvider`, `@FeatureFlag`
 interceptor, `FlagDefinition`/`FlagExposure` in `openbank-libs/flags`; flagd OFREP sidecar
 integration; fast-path Kafka kill-switch (`feature-control` topic); flag definitions as code
-in Git + ConfigMap. Four-eyes enforcement on money-path flag flips (issue #419) is a
+in Git + ConfigMap. Four-eyes enforcement on money-path flag flips (issue JiRaska/open-bank#419) is a
 tracked follow-up governed by ADR-0034 MakerChecker — not a blocker for non-money-path use.
 Author(s): Jiří Raška
 
@@ -85,7 +85,7 @@ same asymmetry ADR-0047 uses for break-glass.
 **5. Governance classification.** Every flag declares a `classification`:
 `COSMETIC` | `FEATURE` | `MONEY_PATH`. This ADR's skeleton carries the
 classification and `fourEyes` metadata (`FlagDefinition`); the runtime
-**enforcement** is a tracked follow-up (issue #419). When wired, a `MONEY_PATH`
+**enforcement** is a tracked follow-up (issue JiRaska/open-bank#419). When wired, a `MONEY_PATH`
 flip **will be** gated through the four-eyes primitive (`libs/foureyes` +
 `governance.Proposal`, ADR-0023/0034) and **will** emit an `AuditEvent`
 (`operation = "featureflag.flip"`); OPA (`libs/authz`) **will** decide *who* may
@@ -136,7 +136,7 @@ feature flag**. It belongs to ADR-0047 governance (four-eyes, effective-dating,
 OPA prohibitions — disabling sanctions screening is prohibited outright). A flag
 whose flip would do a compliance officer's job is misclassified by definition; CI
 must reject it. Within this ADR's own scope, **money-path flag flips require
-four-eyes** (`libs/foureyes`, enforcement tracked in issue #419).
+four-eyes** (`libs/foureyes`, enforcement tracked in issue JiRaska/open-bank#419).
 
 ## Alternatives considered
 

--- a/docs/adr/0077-observability-three-pillar-strategy.md
+++ b/docs/adr/0077-observability-three-pillar-strategy.md
@@ -11,7 +11,7 @@
 > - **Tier C domain metrics** (business counters/gauges): fleet sweep shipped in 26 PRs (#789–#815)
 >   + #788 via `DomainMetrics` per-service pattern (ADR-0079). The 7 money-path services (ledger,
 >   balance, transaction, sepa-payment, domestic-payment, sepa-instant, fx) await the 2-approval
->   gate per ADR-0030 — tracked in issue #787.
+>   gate per ADR-0030 — tracked in issue JiRaska/open-bank#787.
 > - **Pillar 2 traces**: OTel SDK enabled fleet-wide (QUARKUS_OTEL_SDK_DISABLED removed); native-image
 >   auto-instrumentation pilot on product-catalog (ADR-0083, PR #1021).
 > - **Alertmanager** wired (GoAlert/ntfy last-mile): ADR-0088 D1.
@@ -28,7 +28,7 @@
 >   services with a custom format (`account`, `psd2`, `sca`, `agent`) keep their own value.
 >   Dev-profile override (plain text) also centralised in the same file.
 > - **Remaining:** Phase 4 alerting (Alertmanager already wired per ADR-0088 D1); money-path
->   domain metrics (issue #787, 2-approval gate).
+>   domain metrics (issue JiRaska/open-bank#787, 2-approval gate).
 
 ---
 

--- a/docs/adr/0078-accounting-close-model.md
+++ b/docs/adr/0078-accounting-close-model.md
@@ -217,5 +217,5 @@ and tracked as its own future ADR. This ADR's job is to stop the gap from being 
 - ADR-0039 — ledger as golden source; control-account ⇄ sub-ledger reconciliation (the integrity gate).
 - ADR-0046 — ČNB FX fixing ingestion + daily revaluation posting.
 - ADR-0030 (threat models); ADR-0029 (governance-as-code).
-- Actionable tail: statement-close hardening (D3) — issue #470; entity-level statutory close (D5) —
-  issue #471 (future ADR when prioritised).
+- Actionable tail: statement-close hardening (D3) — issue JiRaska/open-bank#470; entity-level statutory close (D5) —
+  issue JiRaska/open-bank#471 (future ADR when prioritised).

--- a/docs/adr/0096-entity-level-statutory-accounting-close.md
+++ b/docs/adr/0096-entity-level-statutory-accounting-close.md
@@ -7,7 +7,7 @@ Author(s): @JiRaska
 
 Relates to: ADR-0039 (ledger golden source, balance projection), ADR-0078 (per-customer
 statement close), ADR-0035 (statement periods), ADR-0026 (EoD reconciliation),
-ADR-0037 (AnaCredit render-only reporting). Closes the gap tracked in issue #471.
+ADR-0037 (AnaCredit render-only reporting). Closes the gap tracked in issue JiRaska/open-bank#471.
 Prerequisite for: ADR-0097 (supervisory / prudential returns — FINREP/COREP).
 
 ## Context

--- a/docs/adr/0100-deterministic-simulation-testing.md
+++ b/docs/adr/0100-deterministic-simulation-testing.md
@@ -212,4 +212,4 @@ case).
 - Antithesis deterministic hypervisor: https://antithesis.com/
 - ADR-0029 (governance as code, test ratchet)
 - ADR-0101 (Temporal durable execution — companion ADR)
-- Test coverage programme (issue #1122 et seq.)
+- Test coverage programme (issue JiRaska/open-bank#1122 et seq.)

--- a/docs/adr/0167-authz-policy-auditor-ai-agent.md
+++ b/docs/adr/0167-authz-policy-auditor-ai-agent.md
@@ -83,7 +83,7 @@ control-liveness-sentinel, governance-auditor, release-steward, and docs-truth-a
   4. **REST bypassing `agents.allow`.** Flags any `charter_allowed` reference found outside
      `agents.rego`/`agents_test.rego` — the only place that predicate is meant to be defined and
      consumed; a REST/MCP bridge rule must delegate to `agents.allow` instead.
-  - **Check 5 (charter-vs-deployed-runtime-grant drift, issue #743)** — a charter's declared
+  - **Check 5 (charter-vs-deployed-runtime-grant drift, issue JiRaska/open-bank#743)** — a charter's declared
     `tools.allow` in `agents.yaml` not matching what a service's `application.yaml` actually
     grants at runtime — is a deliberate bootstrap-phase stub. It needs a live-cluster or
     fleet-wide-repo-scan correlation this agent's v1 does not perform, the same "genuinely


### PR DESCRIPTION
Refs #1301

## Problem

`docs/adr/*.md` cites bare `issue #N` in ~65 places across ~36 distinct numbers. Because GitHub shares one number space between issues and PRs, and both `JiRaska/open-bank-oss` (public) and `JiRaska/open-bank` (private) are numbered densely, every stale reference resolves to *something* in whichever repo the reader is viewing — no 404, just a confidently wrong artifact. #1301 documents the case that surfaced it: ADR-0078's `issue #470`/`#471` resolve in this repo to two unrelated merged PRs, while the real targets (statement-close hardening / entity-level statutory close) are private-repo issues.

## What this does

Checked every distinct `issue #N` cited in `docs/adr/` against both repos' actual issue/PR title + type (`gh api repos/<owner>/<repo>/issues/<n>`), then compared against the referencing ADR's own context to judge which repo the reference actually means.

**9 confirmed mismatches fixed** (bare number resolved to an unrelated oss PR/issue while a near-exact title match exists in the private repo) — now qualified as `issue JiRaska/open-bank#N`:

| # | ADR(s) | Topic |
|---|---|---|
| #224 | ADR-0031 (×2) | D8 AGPL agent-runtime repo |
| #419 | ADR-0047, ADR-0067 (×4) | money-path flag four-eyes |
| #787 | ADR-0077 (×2) | money-path domain metrics 2-approval gate |
| #282 | ADR-0060 | platform-apply control chain |
| #743 | ADR-0167 | charter-vs-deployed-runtime-grant drift (Check 5) |
| #1122 | ADR-0100 | test coverage programme |
| #470, #471 | ADR-0078, ADR-0096 | statement-close hardening / entity-level statutory close — the exact pair #1301 flags |

The remaining ~27 distinct numbers already point at the correct oss issue/PR (title matches the ADR's context closely, e.g. #266→ADR-0034 Phase 5, #855→balance reconciliation, #413→ADR-0155 rollout) and are left unchanged — no ambiguity to resolve there.

**3 refs left as open questions**, not confidently relabeled either way: `issue #26` (ADR-0074), `issue #667`/`#668` (ADR-0028), `issue #667` (ADR-0084) — neither repo's title is a close enough match to justify a guess.

## Not in this PR

#1301's proposal item 2 (a CI lint rejecting bare `issue #N` in favour of an explicit form) is real follow-up work, not done here — it needs a decision on the exact enforced format (this repo's existing correct refs use bare `issue #N`, so a lint would need an allowlist or a wider rewrite of every already-correct instance). Left for a separate PR per the issue's own item ordering.

## Verification

`bash .github/scripts/check-adr-registry.sh` → `OK — 169 ADRs, unique numbers, headings match filenames, index fresh.` (unaffected by this change; it doesn't check issue-ref cross-repo resolution).

Docs-only change, no build/CDI surface.