### PR TITLE
ci(dependency-submission): raise fleet dependency-graph resolution heap to 6g

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -50,7 +50,14 @@ jobs:
     env:
       # Same OOM guard as fleet-lint.yml / security.yml CodeQL job: a full-fleet dependency
       # resolution (~30 modules + the quarkus-bom) needs more than Gradle's 3 GiB default heap.
-      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
+      # 4g stopped being enough as the fleet grew: every run since 2026-07-14 failed with
+      # "Java heap space" (`assemble testClasses` OOMs before the graph is written), so the
+      # dependency graph GitHub uses for Dependabot alerts/SBOM has been silently stale since
+      # then — no graph file to submit, but the job still exits without visibly failing that
+      # step (issue #909's residual-alert investigation traced back here). security.yml's
+      # CodeQL java-kotlin leg resolves the same whole-fleet graph on the same ubuntu-latest
+      # runner at -Xmx6g without OOMing — match that proven headroom here.
+      GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8 -Dsun.jnu.encoding=UTF-8"
       LANG: C.UTF-8
       LC_ALL: C.UTF-8
     steps:


### PR DESCRIPTION
## Summary
- Investigating issue #909's residual Netty/Jackson Dependabot alerts, I found the `Dependency submission` workflow has failed on **7 of its last 10 runs** (every run since 2026-07-14), all with `Java heap space` during `./gradlew assemble testClasses --continue --no-daemon` at `-Xmx4g`.
- When that step OOMs, `gradle/actions/setup-gradle`'s dependency-graph extractor never writes a graph file, so the post-build step logs "No dependency graph files found to submit." and the job exits without failing loudly — GitHub's dependency graph / SBOM / Dependabot alerts have therefore been resolving against a **stale snapshot from before 2026-07-14**, silently.
- `security.yml`'s CodeQL `java-kotlin` leg already resolves the same whole-fleet dependency graph (~30 modules + the Quarkus BOM) on the same `ubuntu-latest` runner at `-Xmx6g` without OOMing — this bumps `dependency-submission.yml` to match that proven headroom (plus `-XX:MaxMetaspaceSize=1g`, also copied from the same job).
- Verified locally with `dependencyInsight` against `origin/main` that the fleet's actual resolved runtime/test classpaths (e.g. `openbank-transaction-service`, `openbank-account-service`) already correctly force `jackson-databind:2.22.1` and `netty-handler:4.1.135.Final` via `openbank.dependency-vulnerability-pins` — the stale-graph theory is consistent with what a fresh submission should show once this job can actually complete.

## Test plan
- [ ] CI: workflow YAML change only, validated with `python3 -c "import yaml; yaml.safe_load(...)"` locally (passed).
- [ ] After merge, watch the next `Dependency submission` run on `main` (or trigger via `workflow_dispatch`) to confirm it completes with `BUILD SUCCESSFUL` and actually submits a graph.
- [ ] Once a fresh graph lands, re-check `gh api repos/JiRaska/open-bank-oss/dependency-graph/sbom` for whether the residual `jackson-databind:2.14.2` / `netty-handler:4.2.1.Final` entries clear — if they persist even against a fresh graph, that confirms issue #909's original build-time/test-time-only theory (Pact provider's own netty pin, Temporal SDK's own jackson-bom request) rather than staleness.

## Linked issues
Refs #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)