### PR TITLE
fix(infra): move 9 non-money-path CNPG clusters off ghcr.io to ECR pull-through

### DIFF
--- a/openbank-infra/gitops/components/apicurio/postgres.yaml
+++ b/openbank-infra/gitops/components/apicurio/postgres.yaml
@@ -18,7 +18,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 1Gi

--- a/openbank-infra/gitops/components/authz-policy-auditor/postgres.yaml
+++ b/openbank-infra/gitops/components/authz-policy-auditor/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/control-liveness-sentinel/postgres.yaml
+++ b/openbank-infra/gitops/components/control-liveness-sentinel/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/devops-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/devops-agent/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/docs-truth-agent/postgres.yaml
+++ b/openbank-infra/gitops/components/docs-truth-agent/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/flaky-test-hunter/postgres.yaml
+++ b/openbank-infra/gitops/components/flaky-test-hunter/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/governance-auditor/postgres.yaml
+++ b/openbank-infra/gitops/components/governance-auditor/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/release-steward/postgres.yaml
+++ b/openbank-infra/gitops/components/release-steward/postgres.yaml
@@ -14,7 +14,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi

--- a/openbank-infra/gitops/components/security-scanner/postgres.yaml
+++ b/openbank-infra/gitops/components/security-scanner/postgres.yaml
@@ -17,7 +17,15 @@ spec:
   monitoring:
     enablePodMonitor: true
   instances: 1
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # ECR pull-through instead of ghcr.io (issue #1290, fleet rollout after the #1304 pilot on
+  # pact-broker-db). CNPG instance pods are (correctly) excluded from the Kyverno
+  # ecr-pull-through-rewrite policy: the operator reconciles the running pod's image against
+  # spec.imageName, so a mutating webhook would make the pod permanently drift and get
+  # recreated every ~10s. Setting the ref HERE avoids that — no mutation, nothing to drift
+  # from. Same tag (18.1) as before, only the registry changes; verified this ref resolves
+  # via the pull-through cache before this PR (previously only 16.14 had ever been pulled
+  # through). Non-money-path, single-instance, low-traffic DB — safe rollout candidate.
+  imageName: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1
   storage:
     storageClass: gp3
     size: 2Gi


### PR DESCRIPTION
## Summary

Extends the #1304 pilot (`pact-broker-db`) to the next wave of the fleet rollout `#1290` asks for: 9 low-risk, single-instance CNPG clusters backing internal agent/tooling services — `apicurio`, `docs-truth-agent`, `flaky-test-hunter`, `governance-auditor`, `authz-policy-auditor`, `devops-agent`, `control-liveness-sentinel`, `release-steward`, `security-scanner`.

Each `spec.imageName` moves from `ghcr.io/cloudnative-pg/postgresql:18.1` to the ECR pull-through ref at the same tag — no version change, registry only. CNPG instance pods stay (correctly) excluded from the Kyverno `ecr-pull-through-rewrite` policy; setting the ref directly in `spec.imageName` is the mechanism the policy's own comment asks for ("CNPG must own its image ref end-to-end"), with nothing for a mutating webhook to drift from.

**Money-path DBs are intentionally NOT touched** in this PR, per the issue's own suggested order ("money-path DBs last"). Also not touched: the `bootstrap-controller` initContainer (follows the operator's own image, a separate axis per the issue).

## Verification (live sandbox, before writing this PR)

- All 9 ArgoCD Applications: `Synced` / `Healthy` (no `pact-broker-db`-style broken sync to worry about).
- All 9 clusters' live `postgres` container currently runs exactly `ghcr.io/cloudnative-pg/postgresql:18.1` — matches the declared spec, so this is a pure registry swap, not a hidden version bump.
- All 9 PVCs already report the same capacity as the declared `storage.size` — no risk of the CNPG shrink-webhook rejection that broke `pact-broker-db`'s sync for 16 days.
- The ECR pull-through cache path (`ghcr/cloudnative-pg/postgresql`) had **only ever cached `16.14`** (from the pilot) — `18.1` had never been pulled through. Logged into ECR and pulled `265175468565.dkr.ecr.eu-north-1.amazonaws.com/ghcr/cloudnative-pg/postgresql:18.1` directly to prove the pull-through resolves for this tag before relying on it in gitops.
- `kubectl apply --server-side --dry-run=server` against the live cluster accepts all 9 edited manifests (one, `security-scanner`, only conflicts on field ownership with `argocd-controller` under my own ad-hoc field-manager — expected, since ArgoCD is the real owner; `--force-conflicts --dry-run=server` confirms the schema itself is accepted).

## Type of change

- [x] fix (bug fix / infra correction)
- [ ] feat / perf / refactor / docs / chore / build / ci / security / breaking

## Linked issues

Refs #1290 (fleet rollout, step 3 of 4 — pact-broker-db pilot already merged in #1304; remaining: the rest of the non-money-path fleet, then money-path DBs last, then the CNPG operator's own image for `bootstrap-controller`).

## Test plan

- [x] Server-side dry-run against the live sandbox cluster for all 9 manifests (see above)
- [x] Confirmed ECR pull-through resolves `postgresql:18.1` before relying on it
- [ ] Post-merge: ArgoCD will sync these automatically; confirm each Application stays `Synced`/`Healthy` after the image pull (no local build/test applicable — pure gitops YAML change, no Kotlin/Gradle touched)