### PR TITLE
docs(interest): stop claiming an operator can fix a mixed-currency accrual wedge

### DIFF
--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -103,14 +103,22 @@ class InterestService(
      * numerics are not commensurable (summing 100 CZK and 5 EUR into "105" is nonsense), and
      * [WithholdingTaxPolicy] assesses per currency (§E — only CZK is withheld in v1), so folding
      * them would also withhold against the wrong base. There is no safe guess, so refuse loudly and
-     * leave every accrual `ACCRUING`: an operator must split the product's accruals per currency.
+     * leave every accrual `ACCRUING`.
+     *
+     * NOTE (issue #1265): this refusal is permanent as shipped. Nothing binds a currency to a
+     * product ([InterestRateConfig] has no currency field, and [AccrualStatus.REVERSED] /
+     * [AccrualStatus.SUSPENDED] have zero writers anywhere), so there is currently no operator
+     * or API path that can split, reverse, or otherwise unwedge the pending set once this fires.
+     * Do not tell a caller to "split the accruals" or "investigate" as if that were actionable —
+     * see #1265 for the options (currency on the product config, currency in the accrual unique
+     * key, or a guarded reversal endpoint) and get a decision before promising a way out here.
      */
     private fun mixedCurrencyFailure(accountId: UUID, productId: String, currencies: List<String>) =
         IllegalStateException(
             "Refusing to capitalize a mixed-currency accrual set for account=$accountId product=$productId: " +
                 "pending accruals are denominated in ${currencies.sorted()}. Interest must be capitalized per " +
-                "(product, currency) — the accruals stay ACCRUING; investigate why one product accrued in " +
-                "several currencies.",
+                "(product, currency), but there is currently no operator or API path to split, reverse, or " +
+                "otherwise resolve this set — see issue #1265. Manual intervention is required.",
         )
 
     /** Capitalizes one single-currency pending set (ADR-0033 §B/§D). See [capitalize] for the guards. */


### PR DESCRIPTION
## Summary

Small, zero-risk correction flagged while triaging #1265. `InterestService.capitalize()`'s KDoc and its `mixedCurrencyFailure()` exception message (added by #1246) tell the reader an operator can "split the accruals per currency" or should "investigate why one product accrued in several currencies." Neither is actionable as shipped:

- No endpoint exists to split, reverse, or otherwise mutate a pending accrual.
- `AccrualStatus.REVERSED` / `AccrualStatus.SUSPENDED` have zero writers anywhere in `src/main` (verified fleet-wide).
- `InterestRateConfig` has no currency field to "split" a product's accruals against.

This does **not** change behavior — the guard still refuses loudly and leaves every accrual `ACCRUING`. It only fixes what the message promises, since a misleading "here's the fix" is worse than an honest "there is no fix yet" for whoever is paged at 03:00.

The actual architecture decision (currency on `InterestRateConfig`, currency in the accrual unique key, or a guarded reversal endpoint using the already-unused `REVERSED` status) is intentionally **not** made here — that's #1265, still open, needs an owner decision given the differing blast radii of the three options.

## Type of change

- [x] docs
- [ ] fix / feat / perf / refactor / test / chore / build / ci / security / breaking

## Linked issues

Refs #1265 (does not close it)

## Test plan

- [x] `./gradlew :openbank-interest-service:ktlintCheck :openbank-interest-service:compileKotlin` — passes
- [x] Grepped `src/` for any test asserting on the old exact message text — none found, no test changes needed
- Behavior-preserving (string/comment only), so no new test coverage needed