### PR TITLE
feat(notification): operator-initiated customer messaging, four-eyes gated

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "92074cfb9e487f57"
+    openbank.tech/policy-checksum: "8e3c4c9a57f575bd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1871,6 +1914,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "92074cfb9e487f57"
+        openbank.tech/policy-checksum: "8e3c4c9a57f575bd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "1374ce79526a2a85"
+    openbank.tech/policy-checksum: "6f48b1fac731e8a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1814,6 +1857,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1374ce79526a2a85"
+        openbank.tech/policy-checksum: "6f48b1fac731e8a9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "5fd283ed0bfd22a9"
+    openbank.tech/policy-checksum: "4bd762fe44b9e0b8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1915,6 +1958,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5fd283ed0bfd22a9"
+        openbank.tech/policy-checksum: "4bd762fe44b9e0b8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "91c821d61f67cd72"
+    openbank.tech/policy-checksum: "0652c76e74063727"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1820,6 +1863,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "91c821d61f67cd72"
+        openbank.tech/policy-checksum: "0652c76e74063727"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "bdb3174420815353"
+    openbank.tech/policy-checksum: "738734254108648b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1852,6 +1895,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bdb3174420815353"
+        openbank.tech/policy-checksum: "738734254108648b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "9becfeb96c18c264"
+    openbank.tech/policy-checksum: "55539db40d126e33"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1903,6 +1946,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9becfeb96c18c264"
+        openbank.tech/policy-checksum: "55539db40d126e33"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "d3f2d00b953e0133"
+    openbank.tech/policy-checksum: "f13c9dc267e9e541"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -150,6 +150,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -292,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1088,6 +1131,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d3f2d00b953e0133"
+        openbank.tech/policy-checksum: "f13c9dc267e9e541"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "d3f2d00b953e0133"
+    openbank.tech/policy-checksum: "f13c9dc267e9e541"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -150,6 +150,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -292,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1088,6 +1131,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d3f2d00b953e0133"
+        openbank.tech/policy-checksum: "f13c9dc267e9e541"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "7609de8301d92f1e"
+    openbank.tech/policy-checksum: "a18151fd1f8a0bad"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1831,6 +1874,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7609de8301d92f1e"
+        openbank.tech/policy-checksum: "a18151fd1f8a0bad"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "7c2f0b1f13bf42eb"
+    openbank.tech/policy-checksum: "dc9935d7ba7998db"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1882,6 +1925,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7c2f0b1f13bf42eb"
+        openbank.tech/policy-checksum: "dc9935d7ba7998db"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "c97c8e5bdffc95bf"
+    openbank.tech/policy-checksum: "6d48314631667c12"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1816,6 +1859,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c97c8e5bdffc95bf"
+        openbank.tech/policy-checksum: "6d48314631667c12"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "b3ff51c56f3967f3"
+    openbank.tech/policy-checksum: "5bb2b0327ce984f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1929,6 +1972,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b3ff51c56f3967f3"
+        openbank.tech/policy-checksum: "5bb2b0327ce984f1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "f6e721b6270a31de"
+    openbank.tech/policy-checksum: "75d9264ae072bd96"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1884,6 +1927,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f6e721b6270a31de"
+        openbank.tech/policy-checksum: "75d9264ae072bd96"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/network-policies.yaml
+++ b/openbank-infra/gitops/components/notifications/network-policies.yaml
@@ -64,3 +64,21 @@ spec:
       ports:
         - protocol: TCP
           port: 8085
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-ingress-allow-list
+  namespace: notifications
+  labels:
+    app.kubernetes.io/part-of: notifications
+    openbank.io/derived: gen-network-policies
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "d3f2d00b953e0133"
+    openbank.tech/policy-checksum: "f13c9dc267e9e541"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -150,6 +150,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -292,6 +324,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1088,6 +1131,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "d3f2d00b953e0133"
+        openbank.tech/policy-checksum: "f13c9dc267e9e541"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/notifications/redis.yaml
+++ b/openbank-infra/gitops/components/notifications/redis.yaml
@@ -1,0 +1,84 @@
+# Redis for the four-eyes ApprovalStore (ADR-0155, wired here for ADR-0176 D5's
+# opsmessage.compose) — notification-service has no other Redis usage. Ephemeral on
+# purpose — persistence is disabled (--save "" --appendonly no), so a restart just
+# clears in-flight pending approvals, which is acceptable for the sandbox. Prod should
+# use an operator-managed HA Redis. Pinned to the alpine image's redis uid 999/gid 1000
+# to satisfy PSS restricted; /data is a writable emptyDir so the root fs can stay
+# read-only. Mirrors balances/redis.yaml exactly — see issue #1354 for what happens
+# when a service ships the ApprovalStore bean without this.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: notifications
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: notifications
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: docker.io/valkey/valkey:8-alpine
+          args: ["--save", "", "--appendonly", "no"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 192Mi
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: notifications
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3fb46e611ca95d73"
+    openbank.tech/policy-checksum: "bd1d1e47c4b851e5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1837,6 +1880,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "19a9ac806bfb0d40"
+    openbank.tech/policy-checksum: "32bf2b5e5cb6c914"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1874,6 +1917,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c77cc841a36be35b"
+    openbank.tech/policy-checksum: "27f927edc01ae80d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1859,6 +1902,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "56668ec48b4de096" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "9a52b0897270c124" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0848c6796656516a"
+        openbank.tech/policy-checksum: "de0b65484f7becaa"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "c77cc841a36be35b" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "27f927edc01ae80d" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bf5c211cfcf5518d"
+        openbank.tech/policy-checksum: "430fd0d1fe92f4ab"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "19a9ac806bfb0d40" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "32bf2b5e5cb6c914" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3fb46e611ca95d73"
+        openbank.tech/policy-checksum: "bd1d1e47c4b851e5"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "3133cd43f8eb6ac0" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "5fe8a87b5beaa86d" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "3f8546b73585d8b6"
+        openbank.tech/policy-checksum: "b4e8ee8885d24848"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7d504a1fe73829ba"
+        openbank.tech/policy-checksum: "1f8977ee9c49a269"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bf5c211cfcf5518d"
+    openbank.tech/policy-checksum: "430fd0d1fe92f4ab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1832,6 +1875,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "0848c6796656516a"
+    openbank.tech/policy-checksum: "de0b65484f7becaa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1853,6 +1896,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3133cd43f8eb6ac0"
+    openbank.tech/policy-checksum: "5fe8a87b5beaa86d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1833,6 +1876,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "3f8546b73585d8b6"
+    openbank.tech/policy-checksum: "b4e8ee8885d24848"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1836,6 +1879,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "56668ec48b4de096"
+    openbank.tech/policy-checksum: "9a52b0897270c124"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1889,6 +1932,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7d504a1fe73829ba"
+    openbank.tech/policy-checksum: "1f8977ee9c49a269"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1840,6 +1883,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "cfcb970183d86e67"
+    openbank.tech/policy-checksum: "6c9a4805a12dfab4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1842,6 +1885,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cfcb970183d86e67"
+        openbank.tech/policy-checksum: "6c9a4805a12dfab4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "f876cea669403a20"
+    openbank.tech/policy-checksum: "b6cc5ebbf0df7c80"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1820,6 +1863,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f876cea669403a20"
+        openbank.tech/policy-checksum: "b6cc5ebbf0df7c80"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "594b284c8d00fe52"
+    openbank.tech/policy-checksum: "f6b084a95bd2d150"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -149,6 +149,38 @@ data:
     	role in input.principal.roles
     	some verb in {"list", "read"}
     	endswith(input.action, sprintf(".%v", [verb]))
+    }
+
+    # ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+    # (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+    # grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+    # and opsmessage.compose must never be reachable that way. A namespace split alone is not
+    # sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+    # client_credentials tokens never produce principal.type == SERVICE — see
+    # authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+    # the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+    # HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+    # `service-account-` exclusion below is what actually keeps it out — same idiom as
+    # m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+    # not excluding it).
+    allowed_reasons contains "operator-compose-message" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.compose"
+    }
+
+    # Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+    # an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+    # HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+    # service otherwise has no equivalent of.
+    allowed_reasons contains "operator-decide-message-approval" if {
+    	input.principal.type == "HUMAN"
+    	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+    	role in input.principal.roles
+    	not startswith(input.principal.id, "service-account-")
+    	input.action == "opsmessage.approval.decide"
     }
 
     # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
@@ -291,6 +323,17 @@ data:
     four_eyes_required if {
     	input.action == "featureflag.flip"
     	input.attributes.flag in data.rules.feature_flags.money_path_flags
+    }
+
+    # Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+    # featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+    # a one-off inline check — for an action whose service will never appear in
+    # money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+    # since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+    # for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+    # collection simply does not fire.
+    four_eyes_required if {
+    	input.action in data.rules.four_eyes.actions
     }
 
     # ---------------------------------------------------------------------------------------
@@ -1856,6 +1899,28 @@ data:
         # caller found but the rego already reserves the grant), the risky path needs its own distinct
         # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
         # gated safely — do not reuse the shared customer/M2M-facing action.
+      #
+      # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+      # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+      # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+      # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+      # blocks down (an exact action name, independent of money-path scope, already shipped with
+      # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+      # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+      # both computing the same answer twice.
+      #
+      # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+      # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+      # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+      # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+      # reason (ADR-0176 D4).
+      actions:
+        - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                             # Confirmed no M2M caller — the only allow rule for this
+                                             # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                             # explicitly excludes any service-account-* principal id
+                                             # (rest.rego operator-compose-message), the same exclusion
+                                             # m2m-sanctions-screening uses for the opposite carve-out.
 
     # ---------------------------------------------------------------------------------------
     # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "594b284c8d00fe52"
+        openbank.tech/policy-checksum: "f6b084a95bd2d150"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -137,6 +137,38 @@ allowed_reasons contains "operator-read-any" if {
 	endswith(input.action, sprintf(".%v", [verb]))
 }
 
+# ADR-0176 D4: operator-initiated customer messaging is its own action namespace
+# (opsmessage.*), deliberately NOT notification.* — the edge-service-notification rule below
+# grants every notification.* action to customer-edge's M2M identity via a plain prefix match,
+# and opsmessage.compose must never be reachable that way. A namespace split alone is not
+# sufficient, though: service-account-openbank-edge is classified HUMAN (Keycloak
+# client_credentials tokens never produce principal.type == SERVICE — see
+# authz_policy.principal_type_service_unreachable in rules.yaml) and carries ROLE_OPERATOR in
+# the realm (openbank-infra/gitops/components/keycloak/realm-template.json), so a rule gated on
+# HUMAN + ROLE_OPERATOR alone would silently re-admit that exact M2M identity. The explicit
+# `service-account-` exclusion below is what actually keeps it out — same idiom as
+# m2m-sanctions-screening further down, used there for the opposite purpose (identifying M2M,
+# not excluding it).
+allowed_reasons contains "operator-compose-message" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	not startswith(input.principal.id, "service-account-")
+	input.action == "opsmessage.compose"
+}
+
+# Checker side of the same four-eyes flow (ADR-0155 mechanism, ADR-0176 D5 trigger). Deciding
+# an approval is exactly as sensitive as issuing the request it gates, so it gets the identical
+# HUMAN + operator-role + non-service-account shape, not the broader operator-write-any this
+# service otherwise has no equivalent of.
+allowed_reasons contains "operator-decide-message-approval" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	not startswith(input.principal.id, "service-account-")
+	input.action == "opsmessage.approval.decide"
+}
+
 # Authenticated customers may perform any `customer.*` action (initiate payments, enroll
 # devices, register, etc.). The JWT `sub` equals the partyId in the customer realm
 # (ADR-0065/0066). Per-handler IDOR guards (e.g. debtorAccountId ownership in
@@ -277,6 +309,17 @@ four_eyes_required if {
 four_eyes_required if {
 	input.action == "featureflag.flip"
 	input.attributes.flag in data.rules.feature_flags.money_path_flags
+}
+
+# Exact-action four-eyes, independent of money-path scope (ADR-0176 D5). Generalises the
+# featureflag.flip clause above into a reusable list (data.rules.four_eyes.actions) rather than
+# a one-off inline check — for an action whose service will never appear in
+# money_path_services (opsmessage.compose today), the verb-based clause above can never match,
+# since it requires deriving a scope FROM money_path_services first. Undefined, not an error,
+# for any bundle whose rules.yaml predates this key — Rego membership over an undefined
+# collection simply does not fire.
+four_eyes_required if {
+	input.action in data.rules.four_eyes.actions
 }
 
 # ---------------------------------------------------------------------------------------

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -52,11 +52,14 @@ rules_real := {
 		"clearing": ["clearingBatch"],
 		"sca": ["device", "scaChallenge"],
 	},
-	"four_eyes": {"verbs": [
-		"transfer", "post", "reverse", "freeze", "release", "flip",
-		"transitionStatus", "recall", "settle", "disburse", "send", "credit", "debit",
-		"collateralRegister",
-	]},
+	"four_eyes": {
+		"verbs": [
+			"transfer", "post", "reverse", "freeze", "release", "flip",
+			"transitionStatus", "recall", "settle", "disburse", "send", "credit", "debit",
+			"collateralRegister",
+		],
+		"actions": ["opsmessage.compose"],
+	},
 	"feature_flags": {
 		"prohibited_flag_combinations": [
 			"sca-enforcement-disabled",
@@ -765,4 +768,117 @@ test_deny_human_operator_sanctions_create_via_m2m_rule if {
 		"action": "sanctions.create",
 		"resource": "",
 	}
+}
+
+# ---------------------------------------------------------------------------------------
+# opsmessage.compose (ADR-0176 D4/D5): operator-initiated customer messaging. Its own action
+# namespace, deliberately not notification.*, and its own four-eyes trigger, independent of
+# money_path_scopes.
+# ---------------------------------------------------------------------------------------
+test_allow_operator_compose_message if {
+	decision := rest.allow with input as {
+		"principal": {"id": "operator-1", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.compose",
+		"resource": "",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "operator-compose-message"
+}
+
+test_allow_admin_compose_message if {
+	rest.allow with input as {
+		"principal": {"id": "admin-1", "type": "HUMAN", "roles": ["ROLE_ADMIN"]},
+		"action": "opsmessage.compose",
+		"resource": "",
+	}
+		with data.openbank.bundle as bundle
+}
+
+# The finding that made D4's namespace split necessary rather than merely tidy:
+# service-account-openbank-edge carries ROLE_OPERATOR in the realm and is classified HUMAN
+# (Keycloak client_credentials tokens never produce principal.type == SERVICE), so a rule
+# gated on HUMAN + ROLE_OPERATOR alone would re-admit it. This is the regression test for
+# that specific identity, not just the class of service-account ids.
+test_deny_edge_service_account_compose_message if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.compose",
+		"resource": "",
+	}
+}
+
+# Any service-account caller is excluded, not only the edge identity — the rule gates on the
+# id prefix, not a specific client.
+test_deny_any_service_account_compose_message if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-kyc", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.compose",
+		"resource": "",
+	}
+}
+
+# A role that is neither operator nor admin does not gain this action.
+test_deny_viewer_compose_message if {
+	not rest.allow with input as {
+		"principal": {"id": "viewer-1", "type": "HUMAN", "roles": ["ROLE_VIEWER"]},
+		"action": "opsmessage.compose",
+		"resource": "",
+	}
+}
+
+# edge-service-notification's plain notification.*/device.* prefix match does NOT extend to
+# opsmessage.* — this is the namespace split (ADR-0176 D4) actually holding, not just asserted
+# in a comment.
+test_deny_edge_service_notification_does_not_cover_opsmessage if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": []},
+		"action": "opsmessage.compose",
+		"resource": "",
+	}
+}
+
+# The checker-side decide action gets the identical shape.
+test_allow_operator_decide_message_approval if {
+	decision := rest.allow with input as {
+		"principal": {"id": "operator-2", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.approval.decide",
+		"resource": "approval-1",
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "operator-decide-message-approval"
+}
+
+test_deny_edge_service_account_decide_message_approval if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "opsmessage.approval.decide",
+		"resource": "approval-1",
+	}
+}
+
+# four_eyes_required fires for opsmessage.compose via the NEW data.rules.four_eyes.actions
+# list, not via money_path_scopes — notification-service is not and will never be in
+# money_path_services, so this proves the exact-action clause is what is actually firing.
+test_four_eyes_required_for_opsmessage_compose if {
+	rest.four_eyes_required with input as {"action": "opsmessage.compose"}
+		with data.rules as rules_real
+}
+
+# Confirms the exact-action clause is scoped, not a wildcard: an arbitrary action outside
+# both four_eyes.verbs and four_eyes.actions is not flagged.
+test_four_eyes_not_required_for_unrelated_action if {
+	not rest.four_eyes_required with input as {"action": "notification.list"}
+		with data.rules as rules_real
+}
+
+# The exact-action clause never fires against a bundle with no rules.yaml override (the
+# undefined-collection case the rest.rego comment documents) — proves this is a genuinely
+# additive change: a service whose bundle predates four_eyes.actions sees no behaviour change.
+test_four_eyes_not_required_when_actions_key_absent if {
+	not rest.four_eyes_required with input as {"action": "opsmessage.compose"}
+		with data.rules as {"four_eyes": {"verbs": []}}
 }

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -601,6 +601,28 @@ four_eyes:
     # caller found but the rego already reserves the grant), the risky path needs its own distinct
     # action (e.g. a dedicated operator-only "enrollOnBehalf" endpoint) before it can be four-eyes
     # gated safely — do not reuse the shared customer/M2M-facing action.
+  #
+  # actions: exact action names, gated independently of money_path_scopes (ADR-0176 D5).
+  # `verbs` above only ever fires for an action whose SCOPE derives from money_path_services —
+  # notification-service is not, and never will be, on that list (D5's own reasoning), so no verb
+  # addition could reach opsmessage.compose. This generalises the featureflag.flip precedent two
+  # blocks down (an exact action name, independent of money-path scope, already shipped with
+  # ADR-0067) into a reusable list instead of a one-off inline clause. Read disjunctively with
+  # `verbs` in rest.rego's four_eyes_required — a service can be gated by either mechanism, never
+  # both computing the same answer twice.
+  #
+  # The GUARDRAIL above applies here too, unchanged: opsmessage.compose is its own action
+  # namespace specifically so this list-membership can never accidentally cover an M2M-reachable
+  # action — rest.rego's edge-service-notification rule grants notification.* to customer-edge's
+  # M2M identity via a prefix match, and opsmessage.* was kept out of that family for exactly this
+  # reason (ADR-0176 D4).
+  actions:
+    - opsmessage.compose                # ADR-0176 D5: operator-initiated customer messaging.
+                                         # Confirmed no M2M caller — the only allow rule for this
+                                         # action requires HUMAN + (ROLE_OPERATOR or ROLE_ADMIN) and
+                                         # explicitly excludes any service-account-* principal id
+                                         # (rest.rego operator-compose-message), the same exclusion
+                                         # m2m-sanctions-screening uses for the opposite carve-out.
 
 # ---------------------------------------------------------------------------------------
 # Feature-flag flip governance (ADR-0067 follow-up, issue #419). The OPA PEP (rest.rego)

--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.oidc)
     implementation(libs.quarkus.mailer)
+    implementation(libs.quarkus.redis.client) // four-eyes ApprovalStore (ADR-0155, ADR-0176 D5)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.quarkus.smallrye.fault.tolerance)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.notification.application
 
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.notification.domain.model.OperatorMessageTemplate
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
@@ -58,7 +59,10 @@ class OperatorMessageService {
         }
 
         val (subject, body) = render(request.template, request.variables)
-        val notificationId = UUID.randomUUID()
+        // notificationId is the entity's durable, indexed identifier (ADR-0106) — Ids.newId()
+        // (UUIDv7), not a bare UUID.randomUUID(). Matches NotificationConsumer's existing rows,
+        // which predate this guard.
+        val notificationId = Ids.newId()
         val entity = NotificationEntity().also {
             it.notificationId = notificationId
             it.partyId = request.partyId

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -11,9 +11,11 @@ import com.openbank.notification.infrastructure.persistence.repository.Notificat
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.mailer.Mail
 import io.quarkus.mailer.reactive.ReactiveMailer
+import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
+import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
@@ -39,6 +41,8 @@ class OperatorMessageRejected(message: String) : RuntimeException(message)
  */
 @ApplicationScoped
 class OperatorMessageService {
+
+    private val log = Logger.getLogger(OperatorMessageService::class.java)
 
     @Inject
     lateinit var notificationRepo: NotificationRepository
@@ -76,7 +80,23 @@ class OperatorMessageService {
         }
         Panache.withTransaction { notificationRepo.persist(entity) }.awaitSuspending()
 
+        // Two `.onFailure()` handlers, deliberately at two different points in the chain — not
+        // one after both stages (code-review finding, PR #1368). A single trailing handler
+        // cannot tell "the mail never went out" from "the mail went out, but recording SENT
+        // failed" — Mutiny's Uni#chain composes onto ONE failure channel, so it would catch
+        // both, and the original code did: a transient Postgres error AFTER a successful send
+        // silently overwrote the row with status=FAILED, while the customer had actually
+        // received the message. That is a worse outcome than leaving the row PENDING.
         mailer.send(Mail.withHtml(request.recipient, subject, body))
+            .onFailure().invoke { e ->
+                log.warnf(e, "opsmessage.compose: mail send failed notificationId=%s", notificationId)
+            }
+            .onFailure().recoverWithUni { _ ->
+                Panache.withTransaction {
+                    notificationRepo.find("notificationId", notificationId).firstResult()
+                        .map { e -> e?.also { it.status = "FAILED" } }
+                }.replaceWithVoid()
+            }
             .chain { _ ->
                 Panache.withTransaction {
                     notificationRepo.find("notificationId", notificationId).firstResult()
@@ -86,14 +106,23 @@ class OperatorMessageService {
                                 it.sentAt = Instant.now(clock)
                             }
                         }
-                }
+                }.replaceWithVoid()
             }
-            .onFailure().recoverWithUni { _ ->
-                Panache.withTransaction {
-                    notificationRepo.find("notificationId", notificationId).firstResult()
-                        .map { e -> e?.also { it.status = "FAILED" } }
-                }
+            // Only reachable if the mail genuinely went out (the FAILED path above already
+            // recovered any send failure into a completed Uni). Never marks the row FAILED —
+            // that would be a lie about a message that was actually delivered — logs loudly
+            // instead, and swallows so the endpoint still returns 201: the customer already has
+            // the message, this is a bookkeeping problem for an operator to notice via the log,
+            // not a reason to fail the request.
+            .onFailure().invoke { e ->
+                log.warnf(
+                    e,
+                    "opsmessage.compose: mail sent but recording SENT status failed notificationId=%s " +
+                        "— row left as-is, NOT marked FAILED (the email was actually delivered)",
+                    notificationId,
+                )
             }
+            .onFailure().recoverWithUni { _ -> Uni.createFrom().voidItem() }
             .awaitSuspending()
 
         return notificationId

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -59,9 +59,9 @@ class OperatorMessageService {
         }
 
         val (subject, body) = render(request.template, request.variables)
-        // notificationId is the entity's durable, indexed identifier (ADR-0106) — Ids.newId()
-        // (UUIDv7), not a bare UUID.randomUUID(). Matches NotificationConsumer's existing rows,
-        // which predate this guard.
+        // notificationId is the entity's durable, indexed identifier (ADR-0106) — minted via
+        // Ids, a UUIDv7 generator, not a plain random UUID. Matches NotificationConsumer's
+        // existing rows, which predate this guard.
         val notificationId = Ids.newId()
         val entity = NotificationEntity().also {
             it.notificationId = notificationId

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.application
+
+import com.openbank.notification.domain.model.OperatorMessageTemplate
+import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
+import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.mailer.Mail
+import io.quarkus.mailer.reactive.ReactiveMailer
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+/** Thrown for a request `opsmessage.compose` cannot fulfil; the resource maps this to 400. */
+class OperatorMessageRejected(message: String) : RuntimeException(message)
+
+/**
+ * The `opsmessage.compose` write path (ADR-0176 D2/D5) — separate from [NotificationConsumer],
+ * which owns system-triggered delivery from `openbank.notification.requests`. Kept apart
+ * deliberately: [NotificationConsumer.dispatch] is typed to the system [com.openbank.notification
+ * .domain.model.NotificationTemplate] enum and built for at-least-once Kafka redelivery, neither of
+ * which fits a synchronous, four-eyes-gated operator action. Sharing storage (`NotificationEntity`
+ * / `NotificationRepository`) is enough to give operator messages the same read path (the admin-ui
+ * history tab, `GET /api/v1/notifications`) without sharing the dispatch machinery.
+ *
+ * EMAIL only, for now. PUSH is refused: `sendPush` puts rendered content in the APNs/FCM payload,
+ * which ADR-0135 §3 forbids (issue #1182, unresolved, blocked on the customer app's fetch-on-tap
+ * handling in another repository) — adding a second producer onto that broken path would make it
+ * worse, not better. IN_APP is refused because it is a stub that never leaves `PENDING` (no real
+ * delivery exists yet). SMS was never implemented for any template. Real multi-channel delivery is
+ * the remaining ADR-0176 D2/D3 work.
+ */
+@ApplicationScoped
+class OperatorMessageService {
+
+    @Inject
+    lateinit var notificationRepo: NotificationRepository
+
+    @Inject
+    lateinit var mailer: ReactiveMailer
+
+    @Inject
+    lateinit var clock: Clock
+
+    suspend fun compose(request: OperatorMessageRequest): UUID {
+        val unknown = request.template.unknownVariables(request.variables)
+        if (unknown.isNotEmpty()) {
+            throw OperatorMessageRejected(
+                "template ${request.template.name} declares ${request.template.variables.sorted()} " +
+                    "but request carried undeclared ${unknown.sorted()}",
+            )
+        }
+
+        val (subject, body) = render(request.template, request.variables)
+        val notificationId = UUID.randomUUID()
+        val entity = NotificationEntity().also {
+            it.notificationId = notificationId
+            it.partyId = request.partyId
+            it.channel = "EMAIL"
+            it.template = request.template.name
+            it.recipient = request.recipient
+            it.subject = subject
+            it.body = body
+            it.status = "PENDING"
+            it.createdAt = Instant.now(clock)
+        }
+        Panache.withTransaction { notificationRepo.persist(entity) }.awaitSuspending()
+
+        mailer.send(Mail.withHtml(request.recipient, subject, body))
+            .chain { _ ->
+                Panache.withTransaction {
+                    notificationRepo.find("notificationId", notificationId).firstResult()
+                        .map { e ->
+                            e?.also {
+                                it.status = "SENT"
+                                it.sentAt = Instant.now(clock)
+                            }
+                        }
+                }
+            }
+            .onFailure().recoverWithUni { _ ->
+                Panache.withTransaction {
+                    notificationRepo.find("notificationId", notificationId).firstResult()
+                        .map { e -> e?.also { it.status = "FAILED" } }
+                }
+            }
+            .awaitSuspending()
+
+        return notificationId
+    }
+
+    /** Exhaustive, no `else` — a new [OperatorMessageTemplate] constant fails to compile here. */
+    private fun render(template: OperatorMessageTemplate, vars: Map<String, String>): Pair<String, String> =
+        when (template) {
+            OperatorMessageTemplate.GENERIC_NOTICE ->
+                (vars.v("subject").ifBlank { "A message from OpenBank" }) to
+                    "<p>${vars.v("note")}</p>"
+            OperatorMessageTemplate.SUPPORT_FOLLOWUP ->
+                "Following up on your support request" to
+                    "<p>We are following up on your support request " +
+                    "(reference <b>${vars.v("ticketReference")}</b>). " +
+                    "Please reply to this message if you have further questions.</p>"
+        }
+}
+
+private fun Map<String, String>.v(key: String): String = this[key] ?: ""
+
+data class OperatorMessageRequest(
+    val partyId: UUID,
+    val template: OperatorMessageTemplate,
+    val recipient: String,
+    val variables: Map<String, String>,
+)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplate.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplate.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+/**
+ * The closed set of messages an operator may send via `POST /api/v1/notifications/messages`
+ * (ADR-0176 D2, `opsmessage.compose`).
+ *
+ * **Deliberately not [NotificationTemplate].** That enum is system-triggered lifecycle content,
+ * tightly bound to a real domain event, and some of it is wired into the ADR-0059 oversight
+ * webhook: `ACCOUNT_FROZEN`, `KYC_REJECTED`, `TRANSACTION_FAILED` and `CONSENT_REVOKED` fire a
+ * Slack alert on send (`OversightWebhook.OVERSIGHT_TEMPLATES`). If `opsmessage.compose` reused
+ * that enum, an operator manually sending `ACCOUNT_FROZEN` — to test the feature, or by mistake —
+ * would raise a false "account frozen" alert for an account that is not frozen, and every other
+ * lifecycle template has the same problem in miniature: its very existence in the notification
+ * history implies a domain event that did not happen. This enum holds only generic,
+ * pre-reviewed, operator-appropriate copy that makes no domain claim.
+ *
+ * Same closed-schema shape as [NotificationTemplate] (issue #1325, ADR-0176 D1): variables are a
+ * constructor argument, so a new entry cannot be added without declaring what it accepts, and
+ * `OperatorMessageConsumer.render` is exhaustive with no `else` — a new constant is a compile
+ * error until its copy is written.
+ *
+ * Intentionally minimal. `ADR-0176 D2`'s versioned, reviewed catalogue — ideally backed by
+ * `openbank-document-service`'s `TemplateRepositoryPort` per the ADR's corrected Neutral
+ * consequence — is future work (tracked as the remaining slice of the ADR-0176 rollout). This
+ * is the smallest closed set that proves the four-eyes write path end-to-end without shipping
+ * unreviewed free text.
+ */
+enum class OperatorMessageTemplate(val variables: Set<String>) {
+    GENERIC_NOTICE(setOf("subject", "note")),
+    SUPPORT_FOLLOWUP(setOf("ticketReference")),
+    ;
+
+    /** Keys in [vars] that this template does not accept. Empty = the request is well-formed. */
+    fun unknownVariables(vars: Map<String, String>): Set<String> = vars.keys - variables
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/approval/ApprovalConfig.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/approval/ApprovalConfig.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.approval
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+/**
+ * Per-service producer for [ApprovalStore] (ADR-0155, wired for ADR-0176 D5's
+ * `opsmessage.compose`). Mirrors `com.openbank.lending.infrastructure.approval.ApprovalConfig`.
+ *
+ * Producing this bean makes `AuthorizeInterceptor.approvalStore.isResolvable` true, which
+ * matters beyond this service: `isResolvable` checks CDI bean presence, not whether
+ * [ReactiveRedisDataSource] can actually reach a Redis instance. `gitops/components/notifications/
+ * redis.yaml` and the `QUARKUS_REDIS_HOSTS` override on the Deployment are what make that
+ * true here — without them this bean would exist but every call would fail on Redis
+ * connection, not fail open with the interceptor's documented log line (see issue #1354,
+ * found live in lending-service's identical wiring with no Redis behind it).
+ */
+@ApplicationScoped
+class ApprovalConfig {
+    @Produces
+    @ApplicationScoped
+    fun approvalStore(redis: ReactiveRedisDataSource, clock: Clock): ApprovalStore = RedisApprovalStore(redis, clock)
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResource.kt
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.authz.Authorize
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.PATCH
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+
+/**
+ * Checker-facing endpoint for the four-eyes gate on operator-initiated messaging
+ * (ADR-0176 D5). A maker's `POST /api/v1/notifications/messages` call on a
+ * `four_eyes_required` action (`opsmessage.compose`) is paused by
+ * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a `PendingApproval` id;
+ * a DIFFERENT operator decides it here, then the maker retries the original call with an
+ * `X-Approval-Id` header.
+ *
+ * One decide action with an `approve` boolean (mirrors `lending-service`'s
+ * `ApprovalResource`), not the separate `opsmessage.approve` / `opsmessage.reject`
+ * actions ADR-0176 D4 sketched — that split was schema-level shorthand in the decision
+ * record, not a wire-format commitment, and the proven pattern is one endpoint.
+ */
+@Path("/api/v1/notifications/approvals")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Notification Approvals", description = "Four-eyes decisions for opsmessage.compose")
+class ApprovalResource(private val approvalStore: ApprovalStore) {
+
+    @Inject
+    lateinit var identity: SecurityIdentity
+
+    @PATCH
+    @Path("/{id}")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.approval.decide", resource = "#id")
+    @Operation(summary = "Approve or reject a pending four-eyes approval for an operator message")
+    suspend fun decide(@PathParam("id") id: String, request: DecideApprovalRequest): Response {
+        val decided = approvalStore.decide(id, checkerId(), request.approve)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        return Response.ok(decided.toResponse()).build()
+    }
+
+    // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id
+    // (sc.userPrincipal?.name), or approval.makerId and this checker's id would be
+    // formatted differently for the same real person, and ApprovalStore.decide's
+    // self-approval guard could silently fail to catch a maker approving their own request.
+    private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+}
+
+data class DecideApprovalRequest(val approve: Boolean)
+
+data class ApprovalResponse(
+    val id: String,
+    val action: String,
+    val resourceId: String?,
+    val status: String,
+    val decidedBy: String?,
+)
+
+fun PendingApproval.toResponse() = ApprovalResponse(
+    id = id,
+    action = action,
+    resourceId = resourceId,
+    status = status.name,
+    decidedBy = decidedBy,
+)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ExceptionMappers.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.approval.InvalidApprovalStateException
+import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.ext.ExceptionMapper
+import jakarta.ws.rs.ext.Provider
+
+// ADR-0155/ADR-0176 D5: a checker can never decide their own PendingApproval — ApprovalStore.decide
+// enforces this itself (defense-in-depth), surfaced here as a plain 403. Entity shape matches this
+// service's existing convention (NotificationResource/DeviceResource: {"code", "message"}), not the
+// shared ApiError DTO other services use — kept local rather than mixing two error shapes in one API.
+@Provider
+class SelfApprovalNotAllowedMapper : ExceptionMapper<SelfApprovalNotAllowedException> {
+    override fun toResponse(exception: SelfApprovalNotAllowedException): Response =
+        Response.status(Response.Status.FORBIDDEN)
+            .entity(mapOf("code" to "FORBIDDEN", "message" to (exception.message ?: "Forbidden")))
+            .build()
+}
+
+// decide()/markExecuted() reject re-deciding or re-consuming an approval that isn't in the
+// expected status (e.g. an EXECUTED approval flipped back to APPROVED and replayed).
+@Provider
+class InvalidApprovalStateMapper : ExceptionMapper<InvalidApprovalStateException> {
+    override fun toResponse(exception: InvalidApprovalStateException): Response =
+        Response.status(Response.Status.CONFLICT)
+            .entity(mapOf("code" to "CONFLICT", "message" to (exception.message ?: "Conflict")))
+            .build()
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResource.kt
@@ -32,6 +32,21 @@ import java.util.UUID
  * deliberate, separate operational decision, not shipped with this endpoint), a maker's call is
  * paused by `AuthorizeInterceptor` with HTTP 202 and a `PendingApproval` id; the operator retries
  * with `X-Approval-Id` once a different operator decides it via `ApprovalResource`.
+ *
+ * `resource = "#request"` matters more here than on a typical gated action. Every other
+ * four-eyes-gated action in the fleet (e.g. `lending.disburse`) binds `resource` to an
+ * ALREADY-EXISTING entity id, so a `PendingApproval` can only ever satisfy a retry against that
+ * same entity. `opsmessage.compose` is create-with-rich-body — there is no pre-existing entity to
+ * bind to — so without a resource binding, `AuthorizeInterceptor.satisfies()` would compare only
+ * (action, resourceId=null, maker), making every pending approval for one maker interchangeable:
+ * a checker approving message A would silently also authorize a later retry carrying a
+ * completely different message B, never reviewed by anyone (code-review finding, PR #1368).
+ * `#request` resolves via reflection (`extractResource`) to `request.toString()` — `data class
+ * ComposeMessageRequest`'s generated `toString()` is a deterministic, content-derived
+ * fingerprint of partyId+template+recipient+variables. Two calls with the same content produce
+ * the same resourceId (the retry the maker is meant to make); any change to the content produces
+ * a different one (a NEW pending approval, requiring a fresh checker decision) — server-computed,
+ * so the maker cannot forge a match by claiming an id, only by resending byte-identical content.
  */
 @Path("/api/v1/notifications/messages")
 @Produces(MediaType.APPLICATION_JSON)
@@ -44,7 +59,7 @@ class OperatorMessageResource {
 
     @POST
     @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
-    @Authorize(action = "opsmessage.compose")
+    @Authorize(action = "opsmessage.compose", resource = "#request")
     @Operation(summary = "Send a customer a message from a reviewed, closed catalogue of templates")
     suspend fun compose(request: ComposeMessageRequest): Response {
         val notificationId = try {

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResource.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.authz.Authorize
+import com.openbank.notification.application.OperatorMessageRejected
+import com.openbank.notification.application.OperatorMessageRequest
+import com.openbank.notification.application.OperatorMessageService
+import com.openbank.notification.domain.model.OperatorMessageTemplate
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.util.UUID
+
+/**
+ * Operator-initiated customer messaging (ADR-0176). `opsmessage.compose` is a distinct action
+ * namespace, not `notification.*` (ADR-0176 D4): `rest.rego`'s `edge-service-notification` rule
+ * grants every `notification.*` action to the customer-edge M2M identity via a `startswith`
+ * match, and this write path must never be reachable that way.
+ *
+ * `four_eyes.actions` in `rules.yaml` flags this action; when `AUTHZ_FOUR_EYES_ENFORCE=true`
+ * (`false` by default here, matching every other four-eyes-wired service — flipping it is a
+ * deliberate, separate operational decision, not shipped with this endpoint), a maker's call is
+ * paused by `AuthorizeInterceptor` with HTTP 202 and a `PendingApproval` id; the operator retries
+ * with `X-Approval-Id` once a different operator decides it via `ApprovalResource`.
+ */
+@Path("/api/v1/notifications/messages")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Operator Messages", description = "Operator-initiated customer messaging (ADR-0176)")
+class OperatorMessageResource {
+
+    @Inject
+    lateinit var service: OperatorMessageService
+
+    @POST
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.compose")
+    @Operation(summary = "Send a customer a message from a reviewed, closed catalogue of templates")
+    suspend fun compose(request: ComposeMessageRequest): Response {
+        val notificationId = try {
+            service.compose(
+                OperatorMessageRequest(
+                    partyId = request.partyId,
+                    template = request.template,
+                    recipient = request.recipient,
+                    variables = request.variables,
+                ),
+            )
+        } catch (e: OperatorMessageRejected) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(mapOf("code" to "BAD_REQUEST", "message" to e.message))
+                .build()
+        }
+        return Response.status(Response.Status.CREATED)
+            .entity(mapOf("id" to notificationId))
+            .build()
+    }
+}
+
+data class ComposeMessageRequest(
+    val partyId: UUID,
+    val template: OperatorMessageTemplate,
+    val recipient: String,
+    val variables: Map<String, String> = emptyMap(),
+)

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -55,6 +55,8 @@ quarkus:
     start-tls: DISABLED
     auth-methods: DISABLED
     from: noreply@openbank.cz
+  redis:
+    hosts: redis://localhost:6379
   shutdown:
     timeout: 30S
   log:
@@ -112,6 +114,17 @@ mp:
         # set via the gitops ConfigMap instead (issue #686).
         topic: openbank.party.events
         value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+# ADR-0155 four-eyes, opted into by opsmessage.compose (ADR-0176 D5). Default false, matching
+# every other four-eyes-wired service (lending, balance, sepa-payment, sepa-instant, account) —
+# the mechanism is wired here (ApprovalConfig producing a Redis-backed ApprovalStore) so it CAN
+# be enforced, but flipping it is a deliberate, separate operational decision, not shipped
+# enabled by this PR. Unlike lending-service's identical wiring, this one has a real Redis
+# behind it in gitops (redis.yaml + QUARKUS_REDIS_HOSTS) — see issue #1354 for what happens when
+# a service ships the ApprovalStore bean without that.
+authz:
+  four-eyes:
+    enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"
 "%dev":
   quarkus:
     log:

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplateTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplateTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Same closed-schema shape as [NotificationTemplate] (issue #1325) — see
+ * [TemplateVariableSchemaTest] for the equivalent coverage on that enum. The property worth
+ * re-proving here is disjointness from [NotificationTemplate]: no [OperatorMessageTemplate]
+ * name collides with a system-lifecycle constant such as `ACCOUNT_FROZEN`, several of which
+ * feed the oversight webhook (`OversightWebhook.OVERSIGHT_TEMPLATES`) — the reason this enum
+ * exists separately at all, not just a naming nicety.
+ */
+class OperatorMessageTemplateTest {
+
+    @Test
+    fun `an undeclared variable is rejected`() {
+        val unknown = OperatorMessageTemplate.GENERIC_NOTICE.unknownVariables(
+            mapOf("subject" to "Hello", "note" to "Following up", "code" to "483920"),
+        )
+        assertThat(unknown).containsExactly("code")
+    }
+
+    @Test
+    fun `a well-formed request has no unknown variables`() {
+        assertThat(
+            OperatorMessageTemplate.SUPPORT_FOLLOWUP.unknownVariables(mapOf("ticketReference" to "TCK-123")),
+        ).isEmpty()
+    }
+
+    @Test
+    fun `no name collides with a system-lifecycle NotificationTemplate constant`() {
+        val systemNames = NotificationTemplate.entries.map { it.name }.toSet()
+        val operatorNames = OperatorMessageTemplate.entries.map { it.name }.toSet()
+        assertThat(operatorNames intersect systemNames).isEmpty()
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResourceTest.kt
@@ -48,7 +48,7 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `decide passes the authenticated principal name as checker, never a body field`() = runBlocking {
+    fun `decide passes the authenticated principal name as checker, never a body field`(): Unit = runBlocking {
         val store = mockk<ApprovalStore> {
             coEvery { decide("approval-1", "checker-1", true) } returns approval()
         }
@@ -63,7 +63,7 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `a missing or already-consumed approval id is a 404, not a 200 with a null body`() = runBlocking {
+    fun `a missing or already-consumed approval id is a 404, not a 200 with a null body`(): Unit = runBlocking {
         val store = mockk<ApprovalStore> {
             coEvery { decide("does-not-exist", any(), any()) } returns null
         }
@@ -75,7 +75,7 @@ class ApprovalResourceTest {
     }
 
     @Test
-    fun `an unauthenticated identity resolves to a literal anonymous id, not null or a crash`() = runBlocking {
+    fun `an unauthenticated identity resolves to a literal anonymous id, not null or a crash`(): Unit = runBlocking {
         val store = mockk<ApprovalStore> {
             coEvery { decide("approval-1", "anonymous", true) } returns approval(decidedBy = "anonymous")
         }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/ApprovalResourceTest.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStatus
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.ws.rs.NotFoundException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.security.Principal
+import java.time.OffsetDateTime
+
+/**
+ * [ApprovalResource] delegates the actual self-approval / not-found / state-machine rules to
+ * [ApprovalStore] (unit-tested in openbank-libs-domain) — what THIS test covers is the
+ * resource's own two responsibilities: resolving the checker's identity from
+ * [SecurityIdentity] rather than the request body (same anti-spoofing property
+ * [DispatchControlResourceTest] guards for the maker side), and translating a `null` decide
+ * result into 404.
+ */
+class ApprovalResourceTest {
+
+    private fun approval(status: ApprovalStatus = ApprovalStatus.APPROVED, decidedBy: String? = "checker-1") =
+        PendingApproval(
+            id = "approval-1",
+            action = "opsmessage.compose",
+            resourceId = null,
+            makerId = "operator-1",
+            status = status,
+            createdAt = OffsetDateTime.now(),
+            decidedBy = decidedBy,
+        )
+
+    private fun resourceWith(store: ApprovalStore, principalName: String?): ApprovalResource {
+        val identity = mockk<SecurityIdentity>()
+        every { identity.principal } returns principalName?.let { name -> Principal { name } }
+        val resource = ApprovalResource(store)
+        resource.identity = identity
+        return resource
+    }
+
+    @Test
+    fun `decide passes the authenticated principal name as checker, never a body field`() = runBlocking {
+        val store = mockk<ApprovalStore> {
+            coEvery { decide("approval-1", "checker-1", true) } returns approval()
+        }
+        val resource = resourceWith(store, "checker-1")
+
+        val response = resource.decide("approval-1", DecideApprovalRequest(approve = true))
+
+        assertThat(response.status).isEqualTo(200)
+        val body = response.entity as ApprovalResponse
+        assertThat(body.status).isEqualTo("APPROVED")
+        assertThat(body.decidedBy).isEqualTo("checker-1")
+    }
+
+    @Test
+    fun `a missing or already-consumed approval id is a 404, not a 200 with a null body`() = runBlocking {
+        val store = mockk<ApprovalStore> {
+            coEvery { decide("does-not-exist", any(), any()) } returns null
+        }
+        val resource = resourceWith(store, "checker-1")
+
+        assertThatThrownBy {
+            runBlocking { resource.decide("does-not-exist", DecideApprovalRequest(approve = false)) }
+        }.isInstanceOf(NotFoundException::class.java)
+    }
+
+    @Test
+    fun `an unauthenticated identity resolves to a literal anonymous id, not null or a crash`() = runBlocking {
+        val store = mockk<ApprovalStore> {
+            coEvery { decide("approval-1", "anonymous", true) } returns approval(decidedBy = "anonymous")
+        }
+        val resource = resourceWith(store, principalName = null)
+
+        val response = resource.decide("approval-1", DecideApprovalRequest(approve = true))
+
+        assertThat(response.status).isEqualTo(200)
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/NotificationSecurityTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/NotificationSecurityTest.kt
@@ -64,6 +64,28 @@ class NotificationSecurityTest {
             .containsExactlyInAnyOrder("ROLE_OPERATOR", "ROLE_ADMIN")
     }
 
+    /**
+     * Code-review finding (PR #1368): `compose()` originally shipped `@Authorize` with no
+     * `resource` binding, so `AuthorizeInterceptor.satisfies()` compared only (action,
+     * resourceId=null, maker) on retry — a checker's approval of one message would silently
+     * also unlock a retry carrying completely different content, never reviewed by anyone.
+     * `resource = "#request"` fixes this by binding the approval to `request.toString()` (the
+     * data class's generated, content-derived fingerprint). This pins the annotation carries
+     * that binding; `ComposeMessageRequest toString() is a content-sensitive fingerprint` below
+     * proves the fingerprint itself actually varies with content, which is what the fix depends on.
+     */
+    @Test
+    fun `opsmessage compose binds its four-eyes approval to the request content, not to nothing`() {
+        val compose = methodNamed(OperatorMessageResource::class.java, "compose")
+        assertThat(compose.getAnnotation(Authorize::class.java)?.resource)
+            .describedAs(
+                "compose() must bind a resource — see PR #1368: without it, a checker's " +
+                    "approval of one message content silently authorizes ANY later retry from the " +
+                    "same maker, regardless of content",
+            )
+            .isEqualTo("#request")
+    }
+
     @Test
     fun `neither opsmessage endpoint is @PermitAll`() {
         val methods = listOf(

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/NotificationSecurityTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/NotificationSecurityTest.kt
@@ -4,7 +4,9 @@
 
 package com.openbank.notification.infrastructure.rest
 
+import com.openbank.libs.authz.Authorize
 import jakarta.annotation.security.PermitAll
+import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.PATCH
@@ -29,6 +31,45 @@ class NotificationSecurityTest {
                 m.getAnnotation(PATCH::class.java) != null
         }
         assertThat(methods).isNotEmpty()
+        methods.forEach { m ->
+            assertThat(m.getAnnotation(PermitAll::class.java))
+                .describedAs("${m.name} must not be @PermitAll — use @RolesAllowed")
+                .isNull()
+        }
+    }
+
+    // `suspend fun` compiles to a JVM method with a trailing synthetic Continuation parameter,
+    // so getDeclaredMethod(name, <declared param types>) never matches — find by name instead,
+    // same as the `no NotificationResource endpoint is @PermitAll` test above does by annotation.
+    private fun methodNamed(type: Class<*>, name: String) = type.declaredMethods.single { it.name == name }
+
+    /**
+     * `@Authorize`'s `action` string is the ONE thing tying `OperatorMessageResource` /
+     * `ApprovalResource` to the rego rules that gate them (`operator-compose-message`,
+     * `operator-decide-message-approval`) and to `four_eyes.actions` in `rules.yaml`. None of
+     * that is typechecked — a typo here compiles fine and fails closed only in a live OPA
+     * decision (403, or 202-forever if it silently stops matching `four_eyes.actions`). This
+     * pins the exact strings so a rename shows up as a test diff, not a production surprise.
+     */
+    @Test
+    fun `opsmessage endpoints carry the exact @Authorize action strings the rego rules match on`() {
+        val compose = methodNamed(OperatorMessageResource::class.java, "compose")
+        assertThat(compose.getAnnotation(Authorize::class.java)?.action).isEqualTo("opsmessage.compose")
+        assertThat(compose.getAnnotation(RolesAllowed::class.java)?.value)
+            .containsExactlyInAnyOrder("ROLE_OPERATOR", "ROLE_ADMIN")
+
+        val decide = methodNamed(ApprovalResource::class.java, "decide")
+        assertThat(decide.getAnnotation(Authorize::class.java)?.action).isEqualTo("opsmessage.approval.decide")
+        assertThat(decide.getAnnotation(RolesAllowed::class.java)?.value)
+            .containsExactlyInAnyOrder("ROLE_OPERATOR", "ROLE_ADMIN")
+    }
+
+    @Test
+    fun `neither opsmessage endpoint is @PermitAll`() {
+        val methods = listOf(
+            methodNamed(OperatorMessageResource::class.java, "compose"),
+            methodNamed(ApprovalResource::class.java, "decide"),
+        )
         methods.forEach { m ->
             assertThat(m.getAnnotation(PermitAll::class.java))
                 .describedAs("${m.name} must not be @PermitAll — use @RolesAllowed")

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
@@ -64,4 +64,48 @@ class OperatorMessageResourceTest {
         assertThat(response.status).isEqualTo(400)
         assertThat((response.entity as Map<*, *>)["code"]).isEqualTo("BAD_REQUEST")
     }
+
+    /**
+     * `compose()`'s `@Authorize(resource = "#request")` (PR #1368 code-review fix) leans entirely
+     * on `ComposeMessageRequest`'s generated `toString()` being a deterministic, content-derived
+     * fingerprint: `AuthorizeInterceptor.extractResource` just calls `.toString()` on the
+     * parameter, and `satisfies()` string-compares it on retry. If two DIFFERENT requests ever
+     * produced the SAME string, a checker's approval of one would silently also unlock the other
+     * — the exact bug this fix closes. This test proves the property the fix actually depends on,
+     * not just that the annotation string is present (NotificationSecurityTest covers that).
+     */
+    @Test
+    fun `ComposeMessageRequest toString() is a content-sensitive fingerprint`() {
+        val partyId = UUID.randomUUID()
+        val base = ComposeMessageRequest(
+            partyId = partyId,
+            template = OperatorMessageTemplate.SUPPORT_FOLLOWUP,
+            recipient = "customer@example.com",
+            variables = mapOf("ticketReference" to "TCK-1"),
+        )
+
+        // Identical content -> identical fingerprint: this is what makes the maker's real retry
+        // (same request, replayed with X-Approval-Id) satisfy AuthorizeInterceptor at all.
+        val repeat = base.copy()
+        assertThat(repeat.toString()).isEqualTo(base.toString())
+
+        // Any single field changing -> a different fingerprint: this is what stops a DIFFERENT
+        // request from consuming an approval that was only ever reviewed against `base`.
+        assertThat(base.copy(recipient = "someone-else@example.com").toString())
+            .isNotEqualTo(base.toString())
+        assertThat(
+            base.copy(
+                template = OperatorMessageTemplate.GENERIC_NOTICE,
+                variables = mapOf(
+                    "subject" to "x",
+                    "note" to "y",
+                ),
+            ).toString(),
+        )
+            .isNotEqualTo(base.toString())
+        assertThat(base.copy(variables = mapOf("ticketReference" to "TCK-2")).toString())
+            .isNotEqualTo(base.toString())
+        assertThat(base.copy(partyId = UUID.randomUUID()).toString())
+            .isNotEqualTo(base.toString())
+    }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class OperatorMessageResourceTest {
 
     @Test
-    fun `a successful compose returns 201 with the new notification id`() = runBlocking {
+    fun `a successful compose returns 201 with the new notification id`(): Unit = runBlocking {
         val id = UUID.randomUUID()
         val service = mockk<OperatorMessageService> {
             coEvery { compose(any()) } returns id
@@ -43,7 +43,7 @@ class OperatorMessageResourceTest {
     }
 
     @Test
-    fun `an undeclared variable is rejected as 400, not an unmapped 500`() = runBlocking {
+    fun `an undeclared variable is rejected as 400, not an unmapped 500`(): Unit = runBlocking {
         val service = mockk<OperatorMessageService> {
             coEvery { compose(any()) } throws
                 OperatorMessageRejected(

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.notification.application.OperatorMessageRejected
+import com.openbank.notification.application.OperatorMessageService
+import com.openbank.notification.domain.model.OperatorMessageTemplate
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * [OperatorMessageResource] has exactly one job beyond delegation: map
+ * [OperatorMessageRejected] (a caller-shaped error — an undeclared variable) to 400, not let it
+ * escape as an unmapped 500. Everything else (the closed schema, rendering, delivery) is
+ * [OperatorMessageService]'s concern and is tested there.
+ */
+class OperatorMessageResourceTest {
+
+    @Test
+    fun `a successful compose returns 201 with the new notification id`() = runBlocking {
+        val id = UUID.randomUUID()
+        val service = mockk<OperatorMessageService> {
+            coEvery { compose(any()) } returns id
+        }
+        val resource = OperatorMessageResource().apply { this.service = service }
+
+        val response = resource.compose(
+            ComposeMessageRequest(
+                partyId = UUID.randomUUID(),
+                template = OperatorMessageTemplate.SUPPORT_FOLLOWUP,
+                recipient = "customer@example.com",
+                variables = mapOf("ticketReference" to "TCK-123"),
+            ),
+        )
+
+        assertThat(response.status).isEqualTo(201)
+        assertThat((response.entity as Map<*, *>)["id"]).isEqualTo(id)
+    }
+
+    @Test
+    fun `an undeclared variable is rejected as 400, not an unmapped 500`() = runBlocking {
+        val service = mockk<OperatorMessageService> {
+            coEvery { compose(any()) } throws
+                OperatorMessageRejected(
+                    "template SUPPORT_FOLLOWUP declares [ticketReference] but request carried undeclared [note]",
+                )
+        }
+        val resource = OperatorMessageResource().apply { this.service = service }
+
+        val response = resource.compose(
+            ComposeMessageRequest(
+                partyId = UUID.randomUUID(),
+                template = OperatorMessageTemplate.SUPPORT_FOLLOWUP,
+                recipient = "customer@example.com",
+                variables = mapOf("note" to "smuggled"),
+            ),
+        )
+
+        assertThat(response.status).isEqualTo(400)
+        assertThat((response.entity as Map<*, *>)["code"]).isEqualTo("BAD_REQUEST")
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/ApprovalStoreWiringIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/ApprovalStoreWiringIT.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.integration
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.notification.it.RedisTestResource
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.Uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.future
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * The regression test for issue #1354: `ApprovalConfig.approvalStore` being a resolvable CDI
+ * bean is NOT proof that four-eyes actually works — `AuthorizeInterceptor` only checks
+ * `Instance<ApprovalStore>.isResolvable` (bean presence), never whether the
+ * `ReactiveRedisDataSource` behind it can reach anything. `lending-service` ships the identical
+ * `ApprovalConfig` with no Redis deployed in gitops at all; this test is what that service is
+ * missing — a real round-trip against a real Redis, so a broken `QUARKUS_REDIS_HOSTS` fails
+ * this IT instead of failing silently the first time `AUTHZ_FOUR_EYES_ENFORCE` is flipped true
+ * in production.
+ */
+@QuarkusTest
+@QuarkusTestResource(RedisTestResource::class)
+class ApprovalStoreWiringIT {
+
+    @Inject
+    lateinit var approvalStore: ApprovalStore
+
+    // RedisApprovalStore's ReactiveRedisDataSource calls need a Vert.x duplicated context, same
+    // constraint as reactive Panache — see OperatorMessageServiceIT.onVertxContext for the why
+    // and the bridge shape (Dispatchers.Unconfined + future{} -> Uni.createFrom().completionStage).
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        Uni.createFrom().completionStage(CoroutineScope(Dispatchers.Unconfined).future { block() })
+    }
+
+    @Test
+    fun `the produced ApprovalStore bean round-trips a real approval through real Redis`() {
+        val pending = onVertxContext {
+            approvalStore.create(action = "opsmessage.compose", resourceId = null, makerId = "operator-1")
+        }
+        assertThat(pending.action).isEqualTo("opsmessage.compose")
+        assertThat(pending.makerId).isEqualTo("operator-1")
+
+        val found = onVertxContext { approvalStore.find(pending.id) }
+        assertThat(found).isNotNull
+        assertThat(found?.id).isEqualTo(pending.id)
+
+        val decided = onVertxContext { approvalStore.decide(pending.id, decidedBy = "operator-2", approve = true) }
+        assertThat(decided?.decidedBy).isEqualTo("operator-2")
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/OperatorMessageServiceIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/OperatorMessageServiceIT.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.integration
+
+import com.openbank.notification.application.OperatorMessageRejected
+import com.openbank.notification.application.OperatorMessageRequest
+import com.openbank.notification.application.OperatorMessageService
+import com.openbank.notification.domain.model.OperatorMessageTemplate
+import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
+import com.openbank.notification.it.PostgresTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.mailer.MockMailbox
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.future.future
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * [OperatorMessageService] end to end against a real Postgres — the closed schema rejects
+ * before anything is written, and an accepted request is persisted and actually mailed. No
+ * Redis/ApprovalStore involvement: `compose()` never touches four-eyes, only the
+ * `@Authorize`-annotated resource method does — see [ApprovalStoreWiringIT] for that half.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class OperatorMessageServiceIT {
+
+    @Inject
+    lateinit var service: OperatorMessageService
+
+    @Inject
+    lateinit var mailbox: MockMailbox
+
+    @Inject
+    lateinit var repository: NotificationRepository
+
+    // service.compose is `suspend` and internally uses Panache.withTransaction, which needs a
+    // Vert.x DUPLICATED context — a plain runBlocking on the JUnit thread does not have one
+    // (see NotificationConsumer.consume's KDoc for the long version of why). subscribeAndAwait's
+    // supplier runs ON that context; Dispatchers.Unconfined runs the coroutine body immediately
+    // on the calling thread up to its first suspension point rather than hopping to a different
+    // dispatcher's thread pool (GlobalScope.future's default Dispatchers.Default loses the
+    // context that way — confirmed by making this test fail first). Panache's very first call
+    // (SessionOperations.vertxContext()) reads Vertx.currentContext() synchronously before any
+    // suspension, so Unconfined is what keeps it on the right thread.
+    private fun <T> onVertxContext(block: suspend () -> T): T = VertxContextSupport.subscribeAndAwait {
+        Uni.createFrom().completionStage(CoroutineScope(Dispatchers.Unconfined).future { block() })
+    }
+
+    private fun bodyFor(partyId: UUID): String? = onVertxContext {
+        Panache.withSession { repository.find("partyId", partyId).firstResult() }.awaitSuspending()
+    }?.body
+
+    @Test
+    fun `an accepted request is persisted and actually delivered`() {
+        val partyId = UUID.randomUUID()
+        mailbox.clear()
+
+        val notificationId = onVertxContext {
+            service.compose(
+                OperatorMessageRequest(
+                    partyId = partyId,
+                    template = OperatorMessageTemplate.SUPPORT_FOLLOWUP,
+                    recipient = "followup@example.com",
+                    variables = mapOf("ticketReference" to "TCK-42"),
+                ),
+            )
+        }
+
+        assertThat(notificationId).isNotNull()
+
+        val sent = mailbox.getMailMessagesSentTo("followup@example.com")
+        assertThat(sent).hasSize(1)
+        assertThat(sent.first().html).contains("TCK-42")
+
+        assertThat(bodyFor(partyId)).contains("TCK-42")
+    }
+
+    @Test
+    fun `an undeclared variable is rejected before anything is persisted or sent`() {
+        val partyId = UUID.randomUUID()
+        mailbox.clear()
+
+        assertThatThrownBy {
+            onVertxContext {
+                service.compose(
+                    OperatorMessageRequest(
+                        partyId = partyId,
+                        template = OperatorMessageTemplate.SUPPORT_FOLLOWUP,
+                        recipient = "rejected@example.com",
+                        variables = mapOf("ticketReference" to "TCK-1", "internalNote" to "smuggled"),
+                    ),
+                )
+            }
+        }.isInstanceOf(OperatorMessageRejected::class.java)
+
+        assertThat(mailbox.getMailMessagesSentTo("rejected@example.com")).isEmpty()
+        assertThat(bodyFor(partyId)).isNull()
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Isolated Valkey (Redis) per test JVM, for the four-eyes `ApprovalStore` (ADR-0155,
+ * ADR-0176 D5). Separate from [PostgresTestResource] — most tests need only Postgres, and
+ * `@QuarkusTestResource` composes cleanly, so a Redis-touching test adds this alongside it
+ * rather than folding both into one resource. Mirrors
+ * `openbank-lending-service/.../it/PostgresRedisTestResource.kt`'s Redis half.
+ */
+class RedisTestResource : QuarkusTestResourceLifecycleManager {
+
+    private var redis: GenericContainer<*>? = null
+
+    override fun start(): Map<String, String> {
+        val rd = GenericContainer(DockerImageName.parse("valkey/valkey:8-alpine")).withExposedPorts(6379)
+        rd.start()
+        redis = rd
+        return mapOf(
+            "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
+        )
+    }
+
+    override fun stop() {
+        redis?.stop()
+    }
+}


### PR DESCRIPTION
Refs #1179, #1325, #1354 · **based on #1350** (needs its closed variable schema — this PR's diff is empty until #1350 merges and this retargets to `main`)

Second of three PRs implementing ADR-0176 (operator-initiated customer messaging). `opsmessage.compose`: an operator sends a customer a message from a small, closed, pre-reviewed catalogue, gated by a real maker-checker flow.

## Why not the existing `NotificationTemplate` enum

Found while designing the catalogue, before writing any code: some of its 13 constants (`ACCOUNT_FROZEN`, `KYC_REJECTED`, `TRANSACTION_FAILED`, `CONSENT_REVOKED`) feed the ADR-0059 oversight webhook. An operator manually sending `ACCOUNT_FROZEN` — to test the feature, or by mistake — would raise a **false "account frozen" Slack alert** for an account that isn't frozen. Every other lifecycle template has the same problem in miniature: its existence in the notification history implies a domain event that didn't happen.

`OperatorMessageTemplate` is a new, disjoint, closed enum (`GENERIC_NOTICE`, `SUPPORT_FOLLOWUP` — deliberately minimal; the real catalogue, reusing `document-service`'s `TemplateRepositoryPort` per ADR-0176's corrected Neutral consequence, is B3). Same closed-schema shape #1350 gave `NotificationTemplate`: variables are a constructor argument, `render()` is exhaustive with no `else`, a new constant fails to *compile* until its copy is written.

## Channel: EMAIL only

- **PUSH refused.** `sendPush` already puts rendered content in the APNs/FCM payload — an ADR-0135 §3 violation (#1182, unresolved, blocked on the customer app's fetch-on-tap handling in another repo). A second producer onto that broken path makes it worse, not better.
- **IN_APP refused.** Still a stub that never leaves `PENDING`.
- Real multi-channel delivery is remaining ADR-0176 D2/D3 work.

## Authz: a namespace split that had to survive its own edge case

`opsmessage.compose` / `opsmessage.approval.decide` are their own rego action namespace, not `notification.*` — `edge-service-notification` grants every `notification.*` action to customer-edge's M2M identity via a prefix match.

The namespace split **alone isn't sufficient**, and this is the finding that made D4 more than tidiness: `service-account-openbank-edge` carries `ROLE_OPERATOR` in the realm and is classified `HUMAN` (Keycloak `client_credentials` tokens never produce `principal.type == SERVICE`) — so a rule gated on `HUMAN + ROLE_OPERATOR` alone would silently re-admit that exact M2M identity. Both new allow rules explicitly exclude any `service-account-*` principal id (same idiom `m2m-sanctions-screening` uses for the opposite purpose).

**Regression-tested by removing the exclusion**: exactly the two service-account tests fail, nothing else (135/135 restored after). Not asserted — demonstrated.

## Four-eyes: generalizes an existing precedent, doesn't invent one

`four_eyes.actions` is a new `rules.yaml` list — exact action names, evaluated by `rest.rego` independently of `money_path_scopes`, since notification-service is not and will never be money-path. This is smaller than it sounds: `four_eyes_required` already had a `featureflag.flip` clause matching an exact action name independent of money-path scope, shipped with ADR-0067. This is a third clause in the same shape, not a new mechanism.

**Fleet-wide ripple, expected and required**: `rules.yaml` is embedded in ~25 of 27 OPA bundle generators, so this PR regenerates all 27 — every service's `policy-checksum` annotation moves, rolling those pods on deploy. `opa test`: 135/135 (11 new). `build-bundle.sh` (`opa check --strict` + decision assertions against the real `agents.yaml`): all green.

## Redis: real, unlike the same wiring in lending-service

`ApprovalConfig` / `ApprovalResource` / `ExceptionMappers` mirror `lending-service`'s ADR-0155 wiring closely — with one deliberate deviation: **one decide action with an `approve` boolean**, not ADR-0176 D4's sketched separate `opsmessage.approve`/`opsmessage.reject` — that split was schema-level shorthand in the decision record, not a wire-format commitment, and the proven pattern is one endpoint.

Checking the precedent closely surfaced something outside this PR's scope but too important to sit on: **lending ships that exact wiring with `redis.hosts: localhost:6379` and no Redis deployed anywhere in its gitops.** `ApprovalStore.isResolvable` would be `true` (the bean exists) while every real call fails on connection-refused — not the interceptor's documented "proceeds without the gate, logs an error" fallback, which only fires when the *bean* is absent, not when it's present but unreachable. Filed as #1354, not fixed here (it's lending's money-path threat model, not this PR's call).

notification-service gets it right: a real `redis.yaml` (mirrors `balances/redis.yaml`, the one other service that already does this correctly) + `QUARKUS_REDIS_HOSTS`. `ApprovalStoreWiringIT` proves the whole chain with a real create/find/decide round-trip through Testcontainers Redis — and I verified it's a real guard, not decoration: pointing `quarkus.redis.hosts` at a closed port fails the test.

`AUTHZ_FOUR_EYES_ENFORCE` defaults `false`, matching every other four-eyes-wired service (lending, balance, sepa-payment, sepa-instant, account). The mechanism is wired so it *can* be enforced; flipping it is a deliberate, separate operational decision, not shipped enabled by this PR.

## Verification, split by what actually needs a live OPA sidecar

| Layer | How |
|---|---|
| rego allow/deny matrix + service-account exclusion | `opa test`, 135/135 |
| Closed schema, exhaustive render, persist+deliver | `OperatorMessageServiceIT` — real Postgres + `MockMailbox` |
| Redis/`ApprovalStore` wiring | `ApprovalStoreWiringIT` — real Testcontainers Redis |
| `@Authorize` action string ↔ rego action string | Reflection pin in `NotificationSecurityTest` — the one thing tying Kotlin to rego, and it's untypechecked; a typo compiles fine and fails closed only in a live OPA decision |

**Not covered, and said plainly rather than left implicit**: a live authenticated HTTP round trip through a real OPA sidecar (maker → 202 → checker approves via HTTP → maker retries with `X-Approval-Id` → succeeds). That needs a WireMock OPA stub or a live sidecar in CI — net-new test infrastructure this repo doesn't have yet anywhere, and standing it up for one PR felt like scope creep past "prove B2's own wiring is sound." The *generic* maker/checker mechanism (202/retry/self-approval) is already covered by `AuthorizeInterceptorTest` in `openbank-libs-runtime`; what's genuinely untested here is the full HTTP path specifically for these two new endpoints.

`detekt`, `ktlintCheck`, `test` (92 tests, 0 failures), `quarkusBuild` all green.

## Small, while already touching the file

Fixed a stale comment on `notification-service.yaml`'s Deployment (claimed OIDC is disabled for the pilot; it's been on since customer-edge started proxying authenticated reads) — adjacent to the Redis env var I was already adding there.
