### PR TITLE
feat(notification-service): add operator-initiated customer messaging (ADR-0176)

### DIFF
--- a/openbank-notification-service/build.gradle.kts
+++ b/openbank-notification-service/build.gradle.kts
@@ -17,6 +17,11 @@ dependencies {
     implementation(libs.quarkus.flyway)
     implementation(libs.quarkus.jdbc.postgresql)
     implementation(libs.quarkus.smallrye.kafka)
+    // Redis-backed ApprovalStore for the ADR-0155 four-eyes mechanism, extended to
+    // opsmessage.compose by ADR-0176 D5. notification-service has no other Redis surface today
+    // — this is the first Redis dependency in this service (same shape as ledger-service's own
+    // first-Redis-dependency comment on its ApprovalConfig).
+    implementation(libs.quarkus.redis.client)
     implementation(libs.quarkus.smallrye.health)
     implementation(libs.quarkus.scheduler)
     implementation(libs.quarkus.micrometer.registry.prometheus)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -15,6 +15,7 @@ import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationStatus
 import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.PushContentPolicy
 import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
@@ -107,7 +108,11 @@ class NotificationConsumer {
             }
     }
 
-    private fun dispatch(req: NotificationRequest): Uni<Void> {
+    // internal, not private: OperatorMessageResource (ADR-0176) calls this directly, in-process,
+    // once four-eyes clears an operator-composed message — reusing render/persist/deliver/
+    // oversight unchanged rather than round-tripping through Kafka for a caller that is already
+    // inside this service.
+    internal fun dispatch(req: NotificationRequest): Uni<Void> {
         val (subject, body) = renderTemplate(req.template, req.variables)
         val entity = NotificationEntity().also {
             it.notificationId = UUID.randomUUID()
@@ -256,7 +261,17 @@ class NotificationConsumer {
         body: String,
         entity: NotificationEntity,
     ): Uni<Void> {
-        val pushText = htmlToPlain(body)
+        // ADR-0176 D3: WAKE_SIGNAL_ONLY carries no body text and a generic title — only
+        // notificationId in `data`, so the app fetches detail on tap via an authenticated
+        // GET /api/v1/notifications/{id}. FULL preserves today's existing behaviour for every
+        // system-triggered template unchanged (the ADR-0135 §3 violation this sidesteps for the
+        // new path only; retrofitting existing templates is separate, deferred work).
+        val (pushTitle, pushText, pushData) = when (req.pushContentPolicy) {
+            PushContentPolicy.FULL ->
+                Triple(subject, htmlToPlain(body), mapOf("template" to req.template.name))
+            PushContentPolicy.WAKE_SIGNAL_ONLY ->
+                Triple("You have a new message", "", mapOf("notificationId" to entity.notificationId.toString()))
+        }
         return Panache.withTransaction { deviceTokenRepo.findActiveByParty(req.partyId) }
             .chain { tokens ->
                 if (tokens.isEmpty()) {
@@ -268,7 +283,7 @@ class NotificationConsumer {
                 val targets = tokens.map { Triple(it.deviceId, PushPlatform.valueOf(it.platform), it.token) }
                 val sends = targets.map { (deviceId, platform, token) ->
                     pushSender.send(
-                        PushMessage(platform, token, subject, pushText, mapOf("template" to req.template.name)),
+                        PushMessage(platform, token, pushTitle, pushText, pushData),
                     ).map { result -> deviceId to result }
                 }
                 Uni.join().all(sends).andCollectFailures()
@@ -332,6 +347,15 @@ class NotificationConsumer {
             NotificationTemplate.WELCOME ->
                 "Welcome to OpenBank" to
                     "<h2>Welcome!</h2><p>Thank you for joining OpenBank, ${vars["name"] ?: ""}.</p>"
+            // ADR-0176 D2: the ONLY variable is `referenceId`, already validated by
+            // OperatorMessageResource against `^[A-Za-z0-9-]{1,40}$` before the draft is ever
+            // persisted — never operator-supplied prose. Fixed skeleton, same shape as every
+            // other explicit case above; this template must never fall into the `else` branch
+            // below, which does unescaped, unvalidated interpolation of the whole variables map.
+            NotificationTemplate.OPERATOR_ACCOUNT_NOTICE ->
+                "There's an update on your account" to
+                    "<p>Please open the OpenBank app or contact support for details about your " +
+                    "account. Reference: <b>${vars["referenceId"] ?: ""}</b>.</p>"
             else -> template.name.replace("_", " ").lowercase().replaceFirstChar { it.uppercase() } to
                 "<p>${vars.entries.joinToString("<br>") { "${it.key}: ${it.value}" }}</p>"
         }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -23,7 +23,30 @@ enum class NotificationTemplate {
     OTP_CODE,
     PASSWORD_RESET,
     WELCOME,
+
+    /**
+     * ADR-0176 D2: the first operator-composable catalogue template. Deliberately has its
+     * OWN [com.openbank.notification.application.NotificationConsumer.renderTemplate] case
+     * (fixed HTML skeleton, one server-validated variable) rather than falling through to
+     * the generic `else` branch, which does verbatim, unescaped interpolation of the caller
+     * -supplied `variables` map — building the operator-compose path on that branch would
+     * smuggle back exactly the free-text injection D2 exists to prevent (tracked
+     * separately as issue #1325, not fixed by this template's addition).
+     */
+    OPERATOR_ACCOUNT_NOTICE,
 }
+
+/**
+ * ADR-0176 D3: governs what [com.openbank.notification.application.NotificationConsumer.sendPush]
+ * puts in the push payload. `FULL` is today's existing behaviour for every system-triggered
+ * template (unchanged, so no existing caller needs to opt in). `WAKE_SIGNAL_ONLY` — used
+ * exclusively by the operator-message compose path — carries no body text, only a generic
+ * title and the notification id, so the customer app fetches detail on tap via an
+ * authenticated `GET /api/v1/notifications/{id}` (ADR-0135 §3, violated today by the `FULL`
+ * path for `TRANSACTION_COMPLETED`; retrofitting existing templates onto this shape is a
+ * separate, deferred piece of work — this enum only closes the gap for the NEW path).
+ */
+enum class PushContentPolicy { FULL, WAKE_SIGNAL_ONLY }
 
 data class Notification(
     val id: UUID,
@@ -45,4 +68,5 @@ data class NotificationRequest(
     val template: NotificationTemplate,
     val recipient: String,
     val variables: Map<String, String>,
+    val pushContentPolicy: PushContentPolicy = PushContentPolicy.FULL,
 )

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/OperatorMessage.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/OperatorMessage.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+import java.time.Instant
+import java.util.UUID
+
+/** ADR-0176 D6: fixes the lawful basis. MARKETING is refused at the compose endpoint, always. */
+enum class OperatorMessagePurpose { SERVICE, LEGAL, MARKETING }
+
+/**
+ * No DRAFT state: [com.openbank.libs.authz.AuthorizeInterceptor] short-circuits before the
+ * submit handler's method body ever runs on an un-approved first call, so a row is born
+ * PENDING_APPROVAL and stays that way until the checker's decision or the maker's approved
+ * retry resolves it to REJECTED or SENT.
+ */
+enum class OperatorMessageStatus { PENDING_APPROVAL, SENT, REJECTED }
+
+/**
+ * A draft operator-initiated customer message (ADR-0176), persisted BEFORE the four-eyes gate
+ * runs. [ApprovalStore][com.openbank.libs.approval.ApprovalStore] only tracks
+ * (action, resourceId, makerId, status) — this row is where the actual content lives, keyed by
+ * [id] as the approval's `resourceId`.
+ */
+data class OperatorMessage(
+    val id: UUID,
+    val partyId: UUID,
+    val template: NotificationTemplate,
+    val referenceId: String,
+    val purpose: OperatorMessagePurpose,
+    val status: OperatorMessageStatus,
+    val makerId: String,
+    val createdAt: Instant,
+)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/approval/ApprovalConfig.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/approval/ApprovalConfig.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.approval
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.impl.RedisApprovalStore
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import java.time.Clock
+
+/**
+ * Per-service producer for [ApprovalStore] (ADR-0155, extended to `opsmessage.compose` by
+ * ADR-0176 D5). Mirrors the standard per-service producer pattern used by every other ADR-0155
+ * rollout (ledger-service et al.) — see [RedisApprovalStore]'s KDoc for why this is a per-service
+ * `@Produces` rather than a libs-side bean.
+ */
+@ApplicationScoped
+class ApprovalConfig {
+    @Produces
+    @ApplicationScoped
+    fun approvalStore(redis: ReactiveRedisDataSource, clock: Clock): ApprovalStore = RedisApprovalStore(redis, clock)
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/entity/OperatorMessageEntity.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/entity/OperatorMessageEntity.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "operator_messages")
+class OperatorMessageEntity : PanacheEntity() {
+    @Column(name = "message_id", nullable = false, unique = true)
+    lateinit var messageId: UUID
+
+    @Column(name = "party_id", nullable = false)
+    lateinit var partyId: UUID
+
+    @Column(nullable = false)
+    lateinit var template: String
+
+    @Column(name = "reference_id", nullable = false)
+    lateinit var referenceId: String
+
+    @Column(nullable = false)
+    lateinit var purpose: String
+
+    @Column(nullable = false)
+    lateinit var status: String
+
+    @Column(name = "maker_id", nullable = false)
+    lateinit var makerId: String
+
+    @Column(name = "created_at", nullable = false)
+    lateinit var createdAt: Instant
+
+    @Column(name = "updated_at", nullable = false)
+    lateinit var updatedAt: Instant
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/OperatorMessageRepository.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/OperatorMessageRepository.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.persistence.repository
+
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.OperatorMessagePurpose
+import com.openbank.notification.infrastructure.persistence.entity.OperatorMessageEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import java.time.Instant
+import java.util.UUID
+
+@ApplicationScoped
+class OperatorMessageRepository : PanacheRepository<OperatorMessageEntity> {
+
+    /** Born PENDING_APPROVAL (see V10 migration comment on why there is no separate DRAFT state). */
+    suspend fun create(
+        id: UUID,
+        partyId: UUID,
+        template: NotificationTemplate,
+        referenceId: String,
+        purpose: OperatorMessagePurpose,
+        makerId: String,
+    ): OperatorMessageEntity {
+        val now = Instant.now()
+        val entity = OperatorMessageEntity().also {
+            it.messageId = id
+            it.partyId = partyId
+            it.template = template.name
+            it.referenceId = referenceId
+            it.purpose = purpose.name
+            it.status = "PENDING_APPROVAL"
+            it.makerId = makerId
+            it.createdAt = now
+            it.updatedAt = now
+        }
+        return Panache.withTransaction { persist(entity) }.awaitSuspending()
+    }
+
+    suspend fun findByMessageId(id: UUID): OperatorMessageEntity? =
+        Panache.withSession { find("messageId", id).firstResult() }.awaitSuspending()
+
+    /** Second operator's discovery surface — ApprovalStore itself cannot be listed. */
+    suspend fun pageByStatus(status: String, page: Int, size: Int): Pair<List<OperatorMessageEntity>, Long> =
+        Panache.withSession {
+            val query = find("status", status)
+            query.count().flatMap { total -> query.page(page, size).list().map { items -> items to total } }
+        }.awaitSuspending()
+
+    /**
+     * PENDING_APPROVAL -> SENT, after dispatch() has already succeeded. Scoped to rows still
+     * PENDING_APPROVAL so a duplicate retry (e.g. a maker double-submitting once already
+     * approved) cannot flip an already-SENT or already-REJECTED row back.
+     */
+    suspend fun markSent(id: UUID) {
+        Panache.withTransaction {
+            update(
+                "status = ?1, updatedAt = ?2 where messageId = ?3 and status = 'PENDING_APPROVAL'",
+                "SENT",
+                Instant.now(),
+                id,
+            )
+        }.awaitSuspending()
+    }
+
+    /**
+     * PENDING_APPROVAL -> REJECTED. Called from the checker's reject decision, NOT from the
+     * maker's retry — ApprovalStore refuses a retry against a non-APPROVED decision, so the
+     * maker's own submit body never runs to record a rejection; this is the only place that does.
+     */
+    suspend fun markRejected(id: UUID) {
+        Panache.withTransaction {
+            update(
+                "status = ?1, updatedAt = ?2 where messageId = ?3 and status = 'PENDING_APPROVAL'",
+                "REJECTED",
+                Instant.now(),
+                id,
+            )
+        }.awaitSuspending()
+    }
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/ExceptionMappers.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.approval.InvalidApprovalStateException
+import com.openbank.libs.approval.SelfApprovalNotAllowedException
+import com.openbank.libs.domain.identifiers.Ids
+import jakarta.ws.rs.core.Response
+import jakarta.ws.rs.ext.ExceptionMapper
+import jakarta.ws.rs.ext.Provider
+
+// Generic IllegalArgument/IllegalState/Exception mappers are provided by openbank-libs
+// (com.openbank.libs.api.error.CommonExceptionMappers) with log-correlated traceIds.
+// Declaring them here too is a non-deterministic JAX-RS @Provider collision (ADR-0048/0049 D4).
+
+// ADR-0155 (extended to opsmessage.compose by ADR-0176 D5): a checker can never decide their own
+// PendingApproval — ApprovalStore.decide enforces this itself (defense-in-depth), surfaced here
+// as a plain 403. Mirrors account-service's SelfApprovalNotAllowedMapper exactly.
+@Provider
+class SelfApprovalNotAllowedMapper : ExceptionMapper<SelfApprovalNotAllowedException> {
+    override fun toResponse(exception: SelfApprovalNotAllowedException): Response =
+        Response.status(Response.Status.FORBIDDEN)
+            .entity(
+                ApiError(
+                    // ADR-0106: a per-response correlation id, not a durable/indexed identifier — Ids.randomId().
+                    traceId = Ids.randomId().toString(),
+                    status = 403,
+                    code = "FORBIDDEN",
+                    message = exception.message ?: "Forbidden",
+                ),
+            )
+            .build()
+}
+
+// Rejects re-deciding or re-consuming an approval that isn't in the expected status (e.g. an
+// EXECUTED approval flipped back to APPROVED and replayed). Surfaced as a 409, matching
+// account-service's InvalidApprovalStateMapper convention for state-machine violations.
+@Provider
+class InvalidApprovalStateMapper : ExceptionMapper<InvalidApprovalStateException> {
+    override fun toResponse(exception: InvalidApprovalStateException): Response =
+        Response.status(Response.Status.CONFLICT)
+            .entity(
+                ApiError(
+                    traceId = Ids.randomId().toString(),
+                    status = 409,
+                    code = "CONFLICT",
+                    message = exception.message ?: "Conflict",
+                ),
+            )
+            .build()
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageApprovalResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageApprovalResource.kt
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.approval.ApprovalStore
+import com.openbank.libs.approval.PendingApproval
+import com.openbank.libs.authz.Authorize
+import com.openbank.notification.infrastructure.persistence.repository.OperatorMessageRepository
+import io.quarkus.security.identity.SecurityIdentity
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.util.UUID
+
+/**
+ * Checker-facing endpoints for the opsmessage.compose four-eyes gate (ADR-0155/ADR-0176 D5). A
+ * maker's `POST /opsmessages/{id}/submit` call is paused by
+ * [com.openbank.libs.authz.AuthorizeInterceptor] with HTTP 202 and a `PendingApproval` id; a
+ * DIFFERENT operator decides it here, then the maker retries the original call with an
+ * `X-Approval-Id` header. Mirrors ledger-service's ApprovalResource, split into two named
+ * endpoints (not one PATCH + an `approve: Boolean` body) because ADR-0176 D4 names
+ * `opsmessage.approve` and `opsmessage.reject` as two distinct actions, each with its own rego
+ * allow rule.
+ */
+@Path("/api/v1/opsmessages/approvals")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Operator Message Approvals", description = "Four-eyes decisions for opsmessage.compose")
+class OperatorMessageApprovalResource(
+    private val approvalStore: ApprovalStore,
+    private val operatorMessageRepo: OperatorMessageRepository,
+) {
+
+    @Inject
+    lateinit var identity: SecurityIdentity
+
+    @POST
+    @Path("/{id}/approve")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.approve", resource = "#id")
+    @Operation(summary = "Approve a pending operator message — lets the maker's retry send it")
+    suspend fun approve(@PathParam("id") id: String): Response {
+        val decided = approvalStore.decide(id, checkerId(), approve = true)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        // The row itself is NOT flipped here — it stays PENDING_APPROVAL until the maker's own
+        // retry actually dispatches the message and marks it SENT. Approving only clears the
+        // gate; it does not send anything by itself.
+        return Response.ok(decided.toResponse()).build()
+    }
+
+    @POST
+    @Path("/{id}/reject")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.reject", resource = "#id")
+    @Operation(summary = "Reject a pending operator message — it will never be sent")
+    suspend fun reject(@PathParam("id") id: String): Response {
+        val decided = approvalStore.decide(id, checkerId(), approve = false)
+            ?: throw NotFoundException("no pending approval with id=$id")
+        // Explicitly recorded here, not left for the maker's retry: ApprovalStore refuses a
+        // retry against a non-APPROVED decision, so the submit handler's method body — the only
+        // other place that ever updates this row — never runs for a rejected message. Without
+        // this call the row would stay PENDING_APPROVAL forever.
+        operatorMessageRepo.markRejected(UUID.fromString(id))
+        return Response.ok(decided.toResponse()).build()
+    }
+
+    // .principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id, or approval.makerId and
+    // this checker's id would be formatted differently for the same real person and the
+    // self-approval guard in ApprovalStore.decide could silently fail to catch a maker approving
+    // their own request. Same trap ledger-service's ApprovalResource comments on.
+    private fun checkerId(): String = identity.principal?.name ?: "anonymous"
+}
+
+data class ApprovalResponse(
+    val id: String,
+    val action: String,
+    val resourceId: String?,
+    val status: String,
+    val decidedBy: String?,
+)
+
+fun PendingApproval.toResponse() = ApprovalResponse(
+    id = id,
+    action = action,
+    resourceId = resourceId,
+    status = status.name,
+    decidedBy = decidedBy,
+)

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResource.kt
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.api.error.ApiError
+import com.openbank.libs.authz.Authorize
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.notification.application.NotificationConsumer
+import com.openbank.notification.domain.model.NotificationChannel
+import com.openbank.notification.domain.model.NotificationRequest
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.OperatorMessagePurpose
+import com.openbank.notification.domain.model.PushContentPolicy
+import com.openbank.notification.infrastructure.persistence.entity.OperatorMessageEntity
+import com.openbank.notification.infrastructure.persistence.repository.OperatorMessageRepository
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.NotFoundException
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.util.UUID
+
+/**
+ * Operator-initiated customer messaging (ADR-0176). Two steps, not one, because
+ * [com.openbank.libs.approval.ApprovalStore] cannot hold the actual message content and
+ * [com.openbank.libs.authz.AuthorizeInterceptor] never runs this class's method bodies at all
+ * on an un-approved first call — it short-circuits with its own 202 response before `ctx.proceed()`.
+ * So there is nothing for a single annotated method to persist content INTO at the moment a
+ * pending approval is created; the content has to already exist, keyed by an id the interceptor
+ * can carry as `resource`:
+ *
+ * 1. [draft] — plain `@RolesAllowed`, its own `opsmessage.draft` action (NOT four-eyes gated).
+ *    Validates and persists the message, returns its id.
+ * 2. [submit] — `opsmessage.compose`, the sole `four_eyes.actions` entry. First call (no
+ *    `X-Approval-Id`) pauses for a second approver; the maker's retry (once approved) actually
+ *    sends, by calling [NotificationConsumer.dispatch] directly — reusing render/persist/deliver
+ *    /oversight unchanged rather than round-tripping through Kafka for a caller already inside
+ *    this service.
+ */
+@Path("/api/v1/opsmessages")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Operator Messages", description = "ADR-0176 operator-initiated customer messaging")
+class OperatorMessageResource {
+
+    @Inject lateinit var repo: OperatorMessageRepository
+
+    @Inject lateinit var consumer: NotificationConsumer
+
+    @Inject lateinit var identity: SecurityIdentity
+
+    @POST
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.draft", resource = "")
+    @Operation(summary = "Draft an operator-initiated customer message")
+    suspend fun draft(request: DraftOperatorMessageRequest): Response {
+        if (request.template != NotificationTemplate.OPERATOR_ACCOUNT_NOTICE) {
+            return errorResponse(422, "UNSUPPORTED_TEMPLATE", "Only OPERATOR_ACCOUNT_NOTICE is composable today.")
+        }
+        // ADR-0176 D2: the whole point of the catalogue design is that this is the ONLY place
+        // an operator-supplied value reaches a customer message, and it is validated BEFORE the
+        // row is ever written — never free text, never reaching four-eyes or renderTemplate
+        // unchecked.
+        if (!REFERENCE_ID_PATTERN.matches(request.referenceId)) {
+            return errorResponse(
+                422,
+                "INVALID_REFERENCE_ID",
+                "referenceId must match ${REFERENCE_ID_PATTERN.pattern}.",
+            )
+        }
+        // ADR-0176 D6: refused at the API, not merely hidden in the UI, until a real consent
+        // gate exists (marketing scope in consent-service, marketing_consent mapped in
+        // party-service, a check here — none of which exist yet).
+        if (request.purpose == OperatorMessagePurpose.MARKETING) {
+            return errorResponse(
+                422,
+                "MARKETING_NOT_SUPPORTED",
+                "Marketing messages are refused until a consent gate exists.",
+            )
+        }
+        val id = Ids.randomId()
+        val entity = repo.create(
+            id = id,
+            partyId = request.partyId,
+            template = request.template,
+            referenceId = request.referenceId,
+            purpose = request.purpose,
+            makerId = makerId(),
+        )
+        return Response.status(201).entity(entity.toResponse()).build()
+    }
+
+    @POST
+    @Path("/{id}/submit")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.compose", resource = "#id")
+    @Operation(summary = "Submit a drafted message for sending (four-eyes gated)")
+    suspend fun submit(@PathParam("id") id: UUID): Response {
+        // This body only ever runs once a second operator has approved (see class KDoc) — a
+        // fresh draft, an already-sent, or an already-rejected id are all just "not currently
+        // sendable", surfaced the same way rather than distinguished, since none of them is
+        // reachable from the maker's own retry loop without an approval already existing.
+        val entity = repo.findByMessageId(id) ?: throw NotFoundException("no operator message with id=$id")
+        if (entity.status != "PENDING_APPROVAL") {
+            return errorResponse(409, "ALREADY_RESOLVED", "This message is already ${entity.status}.")
+        }
+        val notificationRequest = NotificationRequest(
+            partyId = entity.partyId,
+            channel = NotificationChannel.PUSH,
+            template = NotificationTemplate.valueOf(entity.template),
+            recipient = entity.partyId.toString(),
+            variables = mapOf("referenceId" to entity.referenceId),
+            pushContentPolicy = PushContentPolicy.WAKE_SIGNAL_ONLY,
+        )
+        consumer.dispatch(notificationRequest).awaitSuspending()
+        repo.markSent(id)
+        return Response.ok(entity.toResponse().copy(status = "SENT")).build()
+    }
+
+    // Reuses opsmessage.approve rather than inventing a fourth action name: ADR-0176 D4 names
+    // exactly three actions (compose/approve/reject), and browsing "what needs my decision" is
+    // conceptually part of the checker's role, not a distinct capability worth its own rego rule.
+    @GET
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "opsmessage.approve", resource = "")
+    @Operation(summary = "List operator messages awaiting a second approver")
+    suspend fun listPending(
+        @QueryParam("page") @DefaultValue("0") page: Int,
+        @QueryParam("size") @DefaultValue("20") size: Int,
+    ): Response {
+        val (items, total) = repo.pageByStatus("PENDING_APPROVAL", page, size.coerceIn(1, 100))
+        return Response.ok(mapOf("items" to items.map { it.toResponse() }, "total" to total)).build()
+    }
+
+    // identity.principal.name (preferred_username), NOT .subject (UUID) — MUST match how
+    // AuthorizeInterceptor.buildQuery resolves the maker's Principal.id for ApprovalStore, or
+    // the self-approval guard could silently fail to catch a maker approving their own request
+    // (same trap ledger-service's ApprovalResource comments on).
+    private fun makerId(): String = identity.principal?.name ?: "anonymous"
+
+    private fun errorResponse(status: Int, code: String, message: String): Response = Response.status(status)
+        .entity(ApiError(traceId = Ids.randomId().toString(), status = status, code = code, message = message))
+        .build()
+
+    companion object {
+        private val REFERENCE_ID_PATTERN = Regex("^[A-Za-z0-9-]{1,40}$")
+    }
+}
+
+data class DraftOperatorMessageRequest(
+    val partyId: UUID,
+    val template: NotificationTemplate,
+    val referenceId: String,
+    val purpose: OperatorMessagePurpose,
+)
+
+data class OperatorMessageResponse(
+    val id: UUID,
+    val partyId: UUID,
+    val template: String,
+    val referenceId: String,
+    val purpose: String,
+    val status: String,
+)
+
+fun OperatorMessageEntity.toResponse() = OperatorMessageResponse(
+    id = messageId,
+    partyId = partyId,
+    template = template,
+    referenceId = referenceId,
+    purpose = purpose,
+    status = status,
+)

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -176,6 +176,16 @@ mp:
     # an unrelated background dispatch against its assertions.
     scheduler:
       enabled: false
+authz:
+  # ADR-0176 D5: four-eyes ENFORCEMENT for opsmessage.compose, independent of the base
+  # allow/deny enforce toggle (which has no YAML override here and so runs on its code
+  # default, authz.enforce=true — this service is NOT advisory-mode today). Stays false
+  # here; flipping it to true is authored to happen day one in sandbox via this service's
+  # own gitops Deployment env (AUTHZ_FOUR_EYES_ENFORCE), not gated on any fleet-wide rollout —
+  # same key every other four-eyes service uses (e.g. ledger-service's application.yaml).
+  four-eyes:
+    enforce: "${AUTHZ_FOUR_EYES_ENFORCE:false}"
+
 openbank:
   rate-limit:
     enabled: true

--- a/openbank-notification-service/src/main/resources/db/migration/V10__create_operator_messages.sql
+++ b/openbank-notification-service/src/main/resources/db/migration/V10__create_operator_messages.sql
@@ -1,0 +1,66 @@
+-- Operator-initiated customer messaging drafts and their approval lifecycle (ADR-0176).
+--
+-- ApprovalStore (the shared ADR-0155 four-eyes mechanism, RedisApprovalStore) only tracks
+-- (action, resourceId, makerId, status) — it has no field for the actual message content, and
+-- no query to list every pending approval. This table IS the persisted draft, keyed by its own
+-- id as the ApprovalStore resourceId once the maker calls submit.
+--
+-- No separate DRAFT status: AuthorizeInterceptor short-circuits BEFORE the submit handler's
+-- method body ever runs on a first (un-approved) call — it throws its own 202 response and
+-- never reaches application code — so there is no hook inside the resource method to flip a
+-- row from an earlier DRAFT state at the moment an approval becomes pending. A row is therefore
+-- born PENDING_APPROVAL at creation and stays that way until it resolves. The checker's REJECT
+-- decision explicitly flips it to REJECTED (the maker's own retry would never otherwise run to
+-- record that, since ApprovalStore refuses a retry against a non-APPROVED decision); the maker's
+-- successful retry (once approved) flips it to SENT after dispatch succeeds.
+--
+-- This table is also what backs the admin-ui "pending approvals" list
+-- (WHERE status = 'PENDING_APPROVAL') — there is no other way to discover what needs a second
+-- operator's attention, since ApprovalStore itself cannot be listed.
+CREATE TABLE operator_messages (
+    id             BIGSERIAL PRIMARY KEY,
+    message_id     UUID NOT NULL UNIQUE,
+    party_id       UUID NOT NULL,
+    template       VARCHAR(64) NOT NULL,
+    -- ADR-0176 D2: the only parameter the sole MVP template (OPERATOR_ACCOUNT_NOTICE) takes,
+    -- validated server-side (^[A-Za-z0-9-]{1,40}$) before this row is ever written — never
+    -- operator-supplied prose. A generic variables map is deliberately NOT used here: the whole
+    -- point of the catalogue design is that each template's parameters are named and typed, not
+    -- an arbitrary bag of strings. A second template needing more than one parameter is a new
+    -- nullable column (or, if the shape genuinely varies per template, a JSONB migration at that
+    -- point) — not a reason to generalise ahead of the second real use case.
+    reference_id   VARCHAR(40) NOT NULL,
+    -- SERVICE | LEGAL | MARKETING (ADR-0176 D6). MARKETING is rejected at the compose endpoint
+    -- before a row is ever written — this column exists so the lawful basis is still explicit
+    -- and auditable for the two purposes that ARE allowed, not because MARKETING rows occur.
+    purpose        VARCHAR(16) NOT NULL,
+    -- PENDING_APPROVAL (from creation) -> SENT, or PENDING_APPROVAL -> REJECTED.
+    status         VARCHAR(20) NOT NULL DEFAULT 'PENDING_APPROVAL',
+    -- The maker's identity.principal.name (preferred_username) — MUST match the format
+    -- AuthorizeInterceptor.buildQuery uses for ApprovalStore's makerId, or the self-approval
+    -- guard (SelfApprovalNotAllowedException) could silently fail to catch a maker approving
+    -- their own request (same trap ledger-service's ApprovalResource comments on).
+    maker_id       VARCHAR(255) NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Discovery path for the second operator: "what needs my approval right now".
+CREATE INDEX idx_operator_messages_status ON operator_messages(status);
+-- Party message history (admin-ui party detail tab reads notifications, not this table
+-- directly, but a party-scoped lookup here is the natural audit/debug path).
+CREATE INDEX idx_operator_messages_party ON operator_messages(party_id);
+
+-- Hibernate Reactive + Kotlin PanacheEntity allocates the id from a sequence named
+-- "<table>_seq" (default allocationSize 50); BIGSERIAL alone only yields
+-- "operator_messages_id_seq". Without this every INSERT fails with: relation
+-- "operator_messages_seq" does not exist. Same convention as V5__notification_sequences.sql /
+-- V6__create_device_tokens.sql; enforced by HibernateSequenceGuardTest.
+-- Rollback: DROP TABLE operator_messages; DROP SEQUENCE operator_messages_seq.
+-- No data-loss note beyond the ordinary one: every row here is either an unsent draft or a
+-- record of a message that was ALSO persisted to `notifications` on send, so nothing here is
+-- the only copy of anything that reached a customer.
+CREATE SEQUENCE IF NOT EXISTS operator_messages_seq INCREMENT BY 50;
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO openbank;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO openbank;

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/infrastructure/rest/OperatorMessageResourceTest.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.notification.application.NotificationConsumer
+import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.OperatorMessagePurpose
+import com.openbank.notification.infrastructure.persistence.entity.OperatorMessageEntity
+import com.openbank.notification.infrastructure.persistence.repository.OperatorMessageRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.quarkus.security.identity.SecurityIdentity
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.core.Response
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.security.Principal
+import java.time.Instant
+import java.util.UUID
+
+class OperatorMessageResourceTest {
+
+    private val repo = mockk<OperatorMessageRepository>()
+    private val consumer = mockk<NotificationConsumer>()
+    private val identity = mockk<SecurityIdentity> {
+        every { principal } returns Principal { "operator-1" }
+    }
+    private val resource = OperatorMessageResource().also {
+        it.repo = repo
+        it.consumer = consumer
+        it.identity = identity
+    }
+
+    private fun draftRequest(
+        referenceId: String = "TICKET-123",
+        purpose: OperatorMessagePurpose = OperatorMessagePurpose.SERVICE,
+        template: NotificationTemplate = NotificationTemplate.OPERATOR_ACCOUNT_NOTICE,
+    ) = DraftOperatorMessageRequest(
+        partyId = UUID.randomUUID(),
+        template = template,
+        referenceId = referenceId,
+        purpose = purpose,
+    )
+
+    // ADR-0176 D2: the whole point of the catalogue design is that referenceId is validated
+    // BEFORE a row is ever written — never operator-supplied prose reaching four-eyes unchecked.
+    @Test
+    fun `draft rejects a referenceId that does not match the allow-listed pattern`(): Unit = runBlocking {
+        val response = resource.draft(draftRequest(referenceId = "not valid! <script>"))
+
+        assertEquals(422, response.status)
+        coVerify(exactly = 0) { repo.create(any(), any(), any(), any(), any(), any()) }
+    }
+
+    // ADR-0176 D6: refused at the API, not merely hidden in the UI.
+    @Test
+    fun `draft refuses MARKETING purpose at the API`(): Unit = runBlocking {
+        val response = resource.draft(draftRequest(purpose = OperatorMessagePurpose.MARKETING))
+
+        assertEquals(422, response.status)
+        coVerify(exactly = 0) { repo.create(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `draft rejects any template other than the one supported today`(): Unit = runBlocking {
+        val response = resource.draft(draftRequest(template = NotificationTemplate.WELCOME))
+
+        assertEquals(422, response.status)
+        coVerify(exactly = 0) { repo.create(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `draft persists a valid request and returns 201`(): Unit = runBlocking {
+        val request = draftRequest()
+        val entity = operatorMessageEntity(partyId = request.partyId, referenceId = request.referenceId)
+        coEvery {
+            repo.create(any(), request.partyId, request.template, request.referenceId, request.purpose, "operator-1")
+        } returns entity
+
+        val response = resource.draft(request)
+
+        assertEquals(201, response.status)
+        coVerify(exactly = 1) {
+            repo.create(any(), request.partyId, request.template, request.referenceId, request.purpose, "operator-1")
+        }
+    }
+
+    @Test
+    fun `submit refuses an already-resolved message`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.findByMessageId(id) } returns operatorMessageEntity(id = id, status = "SENT")
+
+        val response = resource.submit(id)
+
+        assertEquals(409, response.status)
+        coVerify(exactly = 0) { repo.markSent(any()) }
+    }
+
+    @Test
+    fun `submit dispatches and marks the message SENT`(): Unit = runBlocking {
+        val id = UUID.randomUUID()
+        coEvery { repo.findByMessageId(id) } returns operatorMessageEntity(id = id, status = "PENDING_APPROVAL")
+        every { consumer.dispatch(any()) } returns Uni.createFrom().voidItem()
+        coEvery { repo.markSent(id) } returns Unit
+
+        val response = resource.submit(id)
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+        coVerify(exactly = 1) { repo.markSent(id) }
+    }
+
+    private fun operatorMessageEntity(
+        id: UUID = UUID.randomUUID(),
+        partyId: UUID = UUID.randomUUID(),
+        referenceId: String = "TICKET-123",
+        status: String = "PENDING_APPROVAL",
+    ) = OperatorMessageEntity().also {
+        it.messageId = id
+        it.partyId = partyId
+        it.template = NotificationTemplate.OPERATOR_ACCOUNT_NOTICE.name
+        it.referenceId = referenceId
+        it.purpose = OperatorMessagePurpose.SERVICE.name
+        it.status = status
+        it.makerId = "operator-1"
+        it.createdAt = Instant.now()
+        it.updatedAt = Instant.now()
+    }
+}


### PR DESCRIPTION
## What

Second of three PRs implementing **ADR-0176** (operator-initiated customer messaging) end to end. Wires the actual compose/submit/approve endpoints in `openbank-notification-service` against the `opsmessage.*` namespace [#1358](https://github.com/JiRaska/open-bank-oss/pull/1358) added.

## Domain

- **`NotificationTemplate.OPERATOR_ACCOUNT_NOTICE`** — the first operator-composable catalogue template, with its own explicit `renderTemplate` case (fixed HTML skeleton, one variable: `referenceId`). Deliberately **not** built on an existing template that falls into the `else` branch: that branch does verbatim, unescaped interpolation of the caller-supplied `variables` map, and building compose on top of it would smuggle back exactly the free-text injection ADR-0176 D2 exists to prevent. (This is issue #1325's territory — a real, separate, pre-existing gap. Not fixed here.)
- **`PushContentPolicy`** (`FULL`/`WAKE_SIGNAL_ONLY`) on `NotificationRequest`, defaulting to `FULL` — every existing call site is unchanged (only `account-service` publishes today, and never sets it). `sendPush` branches on it: `WAKE_SIGNAL_ONLY` carries no body text, only `notificationId` in the data payload, matching ADR-0135 §3 for this new path without touching the pre-existing `TRANSACTION_COMPLETED` violation (retrofitting existing templates is separate, deferred work per the ADR).
- **`OperatorMessage`/`OperatorMessageEntity`** + `V10__create_operator_messages.sql`. `ApprovalStore` only tracks `(action, resourceId, makerId, status)` — no field for the actual message content, and no query to list pending approvals (confirmed: ledger-service's `ApprovalResource` has only `PATCH /{id}`, no list, anywhere in the fleet). This table **is** the persisted draft, and what backs the admin-ui pending-approvals list in PR 3.

## A real design correction along the way

`AuthorizeInterceptor` never runs a four-eyes-gated method's body at all on an un-approved first call — it short-circuits with its own 202 response *before* `ctx.proceed()`. That means there's no hook inside an annotated method to persist content at the exact moment a pending approval gets created; the content has to already exist, keyed by an id the interceptor can carry as `resource`. Two consequences that shaped this PR:

1. **Two REST steps, not one.** `OperatorMessageResource.draft` (own action, `opsmessage.draft`, **not** four-eyes gated — validates and persists) and `.submit` (`opsmessage.compose`, the gated one — the maker's approved retry actually sends). Filed a [follow-up commit on PR 1](https://github.com/JiRaska/open-bank-oss/pull/1358#issuecomment-4996508216) adding `opsmessage.draft` once I hit this — reusing `opsmessage.compose` for both would have paused *drafting itself*.
2. **No separate `DRAFT` row status.** A row is born `PENDING_APPROVAL` and stays that way until it resolves — there's no code path that would ever transition it out of an earlier `DRAFT` state, so modeling one would just be a state nothing exits. `OperatorMessageApprovalResource.reject` explicitly marks the row `REJECTED`, rather than leaving that to the maker's retry: `ApprovalStore` refuses a retry against a non-`APPROVED` decision, so the submit handler's body — the only other place that ever updates this row — never runs for a rejected message.

## REST layer

- **`OperatorMessageResource`**: `POST /api/v1/opsmessages` (draft), `POST /api/v1/opsmessages/{id}/submit` (four-eyes gated — calls `NotificationConsumer.dispatch` directly, now `internal` instead of `private`, reusing render/persist/deliver/oversight unchanged rather than round-tripping through Kafka for a caller already inside this service), `GET /api/v1/opsmessages?status=PENDING_APPROVAL` (reuses the `opsmessage.approve` grant rather than inventing a fourth action name ADR-0176 doesn't name).
- **`OperatorMessageApprovalResource`**: mirrors ledger-service's `ApprovalResource` almost exactly, but split into `.../approve` and `.../reject` (not one `PATCH` + an `approve: Boolean` body) since ADR-0176 D4 names two distinct actions, each with its own rego rule.

## Wiring (mirrors ledger-service's ApprovalStore setup exactly)

`quarkus-redis-client` (first Redis dependency in this service — same as ledger's own first-Redis comment), `ApprovalConfig` producer, `SelfApprovalNotAllowedMapper`/`InvalidApprovalStateMapper` (copied from account-service's exception mappers), `authz.four-eyes.enforce` (defaults `false`; per the ADR, flips `true` only in this service's own sandbox gitops env, gating nothing fleet-wide).

## Test plan

- [x] `:openbank-notification-service:compileTestKotlin` + `ktlintCheck` pass.
- [x] `:openbank-notification-service:quarkusBuild` passes — this is the one that actually validates ArC/CDI wiring (the constructor-injected `ApprovalStore`/`OperatorMessageRepository` in `OperatorMessageApprovalResource`, the new `@Produces` bean); the other two don't catch that class of failure.
- [x] 6 new unit tests on `OperatorMessageResource` (`referenceId` pattern rejection, `MARKETING` rejection, unsupported-template rejection, the happy path, and the submit status guard) — all passing.
- [ ] Full IT-level verification of the actual four-eyes pause/resume (202 → approve → retry → `SENT`) against a live Postgres + Redis is left to CI; not exercised locally in this PR.

## Scope

No admin-ui changes here — PR 3 wires the compose form and pending-approvals panel against these endpoints.

Refs `docs/adr/0176-operator-initiated-customer-messaging.md`
