### PR TITLE
feat(admin-ui): compose and approve operator-initiated messages (ADR-0176)

### DIFF
--- a/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
+++ b/openbank-admin-ui/src/app/api/svc/[service]/[...path]/route.ts
@@ -99,6 +99,10 @@ async function serviceBaseUrl(svcKey: string): Promise<ResolvedService | null> {
 const FORWARD_HEADERS = [
   'content-type', 'accept', 'authorization',
   'idempotency-key', 'x-request-id', 'x-correlation-id',
+  // ADR-0155/ADR-0176: the maker's four-eyes retry carries this header once a checker has
+  // approved (AuthorizeInterceptor). Without forwarding it, every retry looks identical to the
+  // original request and gets 202'd again forever.
+  'x-approval-id',
 ]
 
 export const dynamic = 'force-dynamic'

--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -5,10 +5,13 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { Bell, RefreshCw, Mail, AlertTriangle, CheckCircle2, Info } from 'lucide-react'
+import { Bell, RefreshCw, Mail, AlertTriangle, CheckCircle2, Info, Clock, Check, X } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { useAuth } from '@/lib/auth/useAuth'
+import { hasPermission } from '@/lib/auth/roles'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { opsMessageApi, type OperatorMessage } from '@/lib/api'
 
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
@@ -27,6 +30,8 @@ const STATUS_COLOR: Record<string, string> = {
 
 export default function NotificationsPage() {
   const { t, language } = useLanguage()
+  const { roles } = useAuth()
+  const canApprove = hasPermission(roles, 'opsmessage:approve')
   const [items, setItems]     = useState<Notification[]>([])
   const [loading, setLoading] = useState(true)
   // Typed unavailable reason → renders the calm <DataUnavailable> panel instead
@@ -94,6 +99,8 @@ export default function NotificationsPage() {
         ))}
       </div>
 
+      {canApprove && <PendingOperatorMessages />}
+
       {unavailable && (
         <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
           <DataUnavailable
@@ -155,6 +162,122 @@ export default function NotificationsPage() {
           </tbody>
         </table>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Operator-initiated customer messages awaiting a second approver (ADR-0176 D5). Backed by
+ * OperatorMessageResource.listPending — reuses the opsmessage.approve grant, since
+ * ApprovalStore itself has no query to list pending approvals (see that endpoint's KDoc).
+ *
+ * A DIFFERENT operator than the one who composed the message must decide it —
+ * SelfApprovalNotAllowedException refuses it server-side if the same operator tries. This
+ * component doesn't try to hide the "compose" button from the maker (there's no reliable
+ * client-side way to know in advance who composed which row before deciding), it just
+ * surfaces the server's rejection as a plain error if it happens.
+ */
+function PendingOperatorMessages() {
+  const { t } = useLanguage()
+  const [rows, setRows] = useState<OperatorMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [rowError, setRowError] = useState<Record<string, string>>({})
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const { items } = await opsMessageApi.listPending()
+      setRows(items)
+    } catch {
+      setRows([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const decide = async (row: OperatorMessage, approve: boolean) => {
+    setBusyId(row.id)
+    setRowError(prev => { const next = { ...prev }; delete next[row.id]; return next })
+    try {
+      if (approve) await opsMessageApi.approve(row.id)
+      else await opsMessageApi.reject(row.id)
+      await load()
+    } catch {
+      // Most often SelfApprovalNotAllowedException (the maker tried to decide their own
+      // message) — never surface the raw backend message for a user-initiated write.
+      setRowError(prev => ({
+        ...prev,
+        [row.id]: t(
+          'Rozhodnutí se nezdařilo. Jiný operátor už možná rozhodl, nebo jste zprávu sami vytvořili.',
+          'The decision failed. Another operator may have already decided it, or you composed this message yourself.',
+        ),
+      }))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  if (!loading && rows.length === 0) return null
+
+  return (
+    <div className="card" style={{ overflow: 'hidden', marginBottom: '16px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '16px 20px', borderBottom: '1px solid var(--border)' }}>
+        <Clock size={15} style={{ color: 'var(--yellow)' }} />
+        <span style={{ fontWeight: 600, fontSize: '13px' }}>
+          {t('Zprávy čekající na schválení', 'Messages awaiting approval')}
+        </span>
+        {!loading && <span className="tag" style={{ marginLeft: 'auto' }}>{rows.length}</span>}
+      </div>
+      <table className="data-table">
+        <thead>
+          <tr>
+            <th>{t('Šablona', 'Template')}</th>
+            <th>{t('Reference', 'Reference')}</th>
+            <th>{t('Účel', 'Purpose')}</th>
+            <th>{t('Akce', 'Actions')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading && Array.from({ length: 2 }).map((_, i) => (
+            <tr key={i}>{Array.from({ length: 4 }).map((_, j) => (
+              <td key={j}><div className="skeleton" style={{ height: '14px', width: '80px' }} /></td>
+            ))}</tr>
+          ))}
+          {!loading && rows.map(row => (
+            <tr key={row.id}>
+              <td><span className="tag">{row.template}</span></td>
+              <td style={{ fontSize: '12px', fontFamily: 'var(--font-mono)' }}>{row.referenceId}</td>
+              <td><span className="tag">{row.purpose}</span></td>
+              <td>
+                <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                  <button
+                    className="btn btn-secondary"
+                    style={{ color: 'var(--green)' }}
+                    onClick={() => decide(row, true)}
+                    disabled={busyId === row.id}
+                  >
+                    <Check size={13} /> {t('Schválit', 'Approve')}
+                  </button>
+                  <button
+                    className="btn btn-secondary"
+                    style={{ color: 'var(--red)' }}
+                    onClick={() => decide(row, false)}
+                    disabled={busyId === row.id}
+                  >
+                    <X size={13} /> {t('Zamítnout', 'Reject')}
+                  </button>
+                  {rowError[row.id] && (
+                    <span style={{ fontSize: '11px', color: 'var(--red)' }}>{rowError[row.id]}</span>
+                  )}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -7,13 +7,14 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { Users, ArrowLeft, ShieldCheck, FileText, RefreshCw, Bell, ChevronDown } from 'lucide-react'
+import { Users, ArrowLeft, ShieldCheck, FileText, RefreshCw, Bell, ChevronDown, Send, Clock } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
 import { useAuth } from '@/lib/auth/useAuth'
 import { hasPermission } from '@/lib/auth/roles'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { opsMessageApi } from '@/lib/api'
 
 const PAGE_SIZE = 25
 
@@ -231,7 +232,7 @@ function PartyDetailPage() {
         </div>
       )}
 
-      {tab === 'messages' && <MessagesTab partyId={party.id} />}
+      {tab === 'messages' && <MessagesTab partyId={party.id} roles={roles} />}
     </div>
   )
 }
@@ -247,7 +248,7 @@ function PartyDetailPage() {
  * `notifications:view` permission gating this tab is UX only — it decides what we render,
  * not what an operator can fetch. Showing bodies here needs the policy fix first.
  */
-function MessagesTab({ partyId }: { partyId: string }) {
+function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
   // A helper component outside the page needs its own language context (all admin-ui pages
   // are 'use client') — never reference the page's `t` out of scope (CLAUDE.md rule #4).
   const { t, language } = useLanguage()
@@ -257,6 +258,16 @@ function MessagesTab({ partyId }: { partyId: string }) {
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+
+  const canCompose = hasPermission(roles, 'opsmessage:compose')
+  const [sending, setSending] = useState(false)
+  const [composeError, setComposeError] = useState<string | null>(null)
+  // Set once the maker's first submit call returns 202 — nothing here polls automatically
+  // (ADR-0176 introduces the fleet's first 202/X-Approval-Id UI flow; a real approval
+  // notification channel is a separate, larger piece of work). The maker clicks "Retry send"
+  // themselves once a colleague has approved it.
+  const [pendingSubmit, setPendingSubmit] = useState<{ id: string; approvalId?: string } | null>(null)
+  const [retrying, setRetrying] = useState(false)
 
   const load = useCallback(async (nextPage: number) => {
     if (nextPage === 0) setLoading(true); else setLoadingMore(true)
@@ -291,8 +302,86 @@ function MessagesTab({ partyId }: { partyId: string }) {
   // The endpoint is offset-paged (page/size/total), not cursor-paged like party search.
   const hasNextPage = (page + 1) * PAGE_SIZE < total
 
+  const REFERENCE_ID_PATTERN = /^[A-Za-z0-9-]{1,40}$/
+
+  // ADR-0176 D2: OPERATOR_ACCOUNT_NOTICE is the only composable template today, so the operator
+  // supplies just a reference code — never free text. Two calls, mirroring
+  // OperatorMessageResource's own KDoc: draft persists the content, submit is the four-eyes
+  // -gated one and pauses (202) until a different operator approves it.
+  async function sendMessage() {
+    const referenceId = window.prompt(
+      t('Referenční kód (např. TICKET-123):', 'Reference (e.g. TICKET-123):'),
+    )
+    if (referenceId === null) return
+    if (!REFERENCE_ID_PATTERN.test(referenceId)) {
+      setComposeError(t(
+        'Referenční kód musí obsahovat 1–40 alfanumerických znaků nebo pomlček.',
+        'Reference must be 1-40 alphanumeric characters or hyphens.',
+      ))
+      return
+    }
+    setSending(true); setComposeError(null)
+    try {
+      const drafted = await opsMessageApi.draft({ partyId, template: 'OPERATOR_ACCOUNT_NOTICE', referenceId, purpose: 'SERVICE' })
+      const result = await opsMessageApi.submit(drafted.id)
+      if (result.status === 'PENDING_APPROVAL') {
+        setPendingSubmit({ id: drafted.id, approvalId: result.approvalId })
+      } else {
+        // Only reached if four-eyes enforcement is off in this environment — still a real
+        // send, so refresh the history to show it.
+        load(0)
+      }
+    } catch {
+      // Never surface a raw backend message for a user-initiated write (CLAUDE.md rule).
+      setComposeError(t(
+        'Zprávu se nepodařilo odeslat. Zkuste to prosím znovu.',
+        'The message could not be sent. Please try again.',
+      ))
+    } finally { setSending(false) }
+  }
+
+  async function retrySubmit() {
+    if (!pendingSubmit) return
+    setRetrying(true)
+    try {
+      const result = await opsMessageApi.submit(pendingSubmit.id, pendingSubmit.approvalId)
+      if (result.status !== 'PENDING_APPROVAL') {
+        setPendingSubmit(null)
+        load(0)
+      }
+      // Still PENDING_APPROVAL: nobody has decided it yet — leave the banner up.
+    } catch {
+      // A 409 (already resolved) or 403 (rejected/self-approval) most often means someone
+      // already decided it — leave the banner up rather than guessing; the Pending approvals
+      // queue on the Notifications page has the authoritative status.
+    } finally { setRetrying(false) }
+  }
+
   return (
-    <div className="card" style={{ overflow: 'hidden' }}>
+    <>
+      {canCompose && (
+        <div className="card" style={{ padding: '14px 20px', marginBottom: '16px' }}>
+          {pendingSubmit ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <Clock size={15} style={{ color: 'var(--yellow)' }} />
+              <span style={{ fontSize: '13px' }}>
+                {t('Zpráva čeká na schválení druhým operátorem.', 'Message is awaiting a second operator’s approval.')}
+              </span>
+              <button className="btn btn-secondary" style={{ marginLeft: 'auto' }} onClick={retrySubmit} disabled={retrying}>
+                <RefreshCw size={13} /> {retrying ? t('Zkouším…', 'Retrying…') : t('Zkusit znovu odeslat', 'Retry send')}
+              </button>
+            </div>
+          ) : (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <button className="btn btn-secondary" onClick={sendMessage} disabled={sending}>
+                <Send size={13} /> {sending ? t('Odesílám…', 'Sending…') : t('Poslat zprávu', 'Send message')}
+              </button>
+              {composeError && <span style={{ fontSize: '12px', color: 'var(--red)' }}>{composeError}</span>}
+            </div>
+          )}
+        </div>
+      )}
+      <div className="card" style={{ overflow: 'hidden' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '16px 20px', borderBottom: '1px solid var(--border)' }}>
         <Bell size={15} style={{ color: 'var(--accent)' }} />
         <span style={{ fontWeight: 600, fontSize: '13px' }}>{t('Historie zpráv', 'Message history')}</span>
@@ -366,7 +455,8 @@ function MessagesTab({ partyId }: { partyId: string }) {
           {t('Načítám…', 'Loading…')}
         </div>
       )}
-    </div>
+      </div>
+    </>
   )
 }
 

--- a/openbank-admin-ui/src/lib/api.ts
+++ b/openbank-admin-ui/src/lib/api.ts
@@ -7,6 +7,7 @@ import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 
 const ACCOUNT_SERVICE = '/api/svc/account-service'
 const TRANSACTION_SERVICE = '/api/svc/transaction-service'
+const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
 export const SERVICES: { name: string; port: number }[] = [
   { name: 'account-service',        port: 8100 },
@@ -96,6 +97,49 @@ export const accountApi = {
     apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/freeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
   unfreeze: (id: string, reason: string) =>
     apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/unfreeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
+}
+
+// Operator-initiated customer messaging (ADR-0176). draft/submit is a two-call maker
+// step — see openbank-notification-service's OperatorMessageResource KDoc for why a single
+// annotated endpoint cannot both create the row and be the four-eyes-gated one.
+export interface OperatorMessage {
+  id: string; partyId: string; template: string; referenceId: string; purpose: string; status: string
+}
+// The 202-pending shape AuthorizeInterceptor returns on submit's first (un-approved) call.
+// Shares `status` with OperatorMessage so callers can branch on one field regardless of which
+// shape actually came back.
+export interface OpsMessageSubmitResult {
+  status: string; approvalId?: string; id?: string
+}
+
+export const opsMessageApi = {
+  draft: (data: { partyId: string; template: string; referenceId: string; purpose: string }) =>
+    apiFetchSimple<OperatorMessage>(`${NOTIFICATION_SERVICE}/api/v1/opsmessages`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  // No approvalId yet -> first call, expect back {status:"PENDING_APPROVAL", approvalId}.
+  // With approvalId (the maker's retry, once a different operator has approved) -> expect back
+  // the sent OperatorMessage, status "SENT".
+  submit: (id: string, approvalId?: string) =>
+    apiFetchSimple<OpsMessageSubmitResult>(`${NOTIFICATION_SERVICE}/api/v1/opsmessages/${id}/submit`, {
+      method: 'POST',
+      headers: approvalId ? { 'X-Approval-Id': approvalId } : undefined,
+    }),
+  listPending: (page = 0, size = 20) =>
+    apiFetchSimple<{ items: OperatorMessage[]; total: number }>(
+      `${NOTIFICATION_SERVICE}/api/v1/opsmessages?page=${page}&size=${size}`,
+    ),
+  approve: (id: string) =>
+    apiFetchSimple<{ id: string; status: string }>(
+      `${NOTIFICATION_SERVICE}/api/v1/opsmessages/approvals/${id}/approve`,
+      { method: 'POST' },
+    ),
+  reject: (id: string) =>
+    apiFetchSimple<{ id: string; status: string }>(
+      `${NOTIFICATION_SERVICE}/api/v1/opsmessages/approvals/${id}/reject`,
+      { method: 'POST' },
+    ),
 }
 
 const LEDGER_SERVICE = '/api/svc/ledger-service'

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -71,6 +71,14 @@ export const PERMISSIONS = {
   // call the endpoint directly. This decides what we *render*, not what they can *fetch*.
   // Real metadata/body separation needs a policy change — issue #1326.
   "notifications:view":       [ROLES.ADMIN, ROLES.OPERATOR],
+  // Operator-initiated customer messaging (ADR-0176 D4/D5). Matches the backend's actual rego
+  // grants exactly (opsmessage-compose / opsmessage-approve in rest.rego) — any
+  // ROLE_OPERATOR/ROLE_ADMIN may compose or decide, with self-approval refused server-side by
+  // SelfApprovalNotAllowedException, not by a narrower UI-side role split. Unlike
+  // notifications:view above, this one DOES mirror a real backend check (opsmessage.compose is
+  // also four-eyes gated, which no UI permission could substitute for either way).
+  "opsmessage:compose":       [ROLES.ADMIN, ROLES.OPERATOR],
+  "opsmessage:approve":       [ROLES.ADMIN, ROLES.OPERATOR],
   // System
   "system:view":              [ROLES.ADMIN, ROLES.OPERATOR],
   "system:config":            [ROLES.ADMIN],


### PR DESCRIPTION
## What

Third of three PRs implementing **ADR-0176** end to end. Depends on [#1369](https://github.com/JiRaska/open-bank-oss/pull/1369) (notification-service backend) for the endpoints this wires against.

**The read side (party Messages tab, `notifications:view` permission) already exists on `main`** from separate work I found already in place while starting this PR — I did not rebuild it. This PR adds only the write side: composing a message and deciding a pending one.

## `lib/api.ts` — `opsMessageApi`

`draft` / `submit` / `listPending` / `approve` / `reject`. `submit`'s response is a union of two shapes depending on whether the call paused or actually sent: `{status, approvalId}` on the 202 pause, the full `OperatorMessage` on success. Both carry `status`, so the caller branches on that one field without caring which shape came back. Worth calling out: `apiFetch` already treats any 2xx (including 202) as success without throwing — this only works because the caller explicitly checks `response.status === 'PENDING_APPROVAL'` rather than relying on a thrown error to distinguish the cases.

## `lib/auth/roles.ts`

`opsmessage:compose` / `opsmessage:approve`, mirroring the backend's actual rego grants exactly (any `ROLE_OPERATOR`/`ROLE_ADMIN` — self-approval is refused server-side by `SelfApprovalNotAllowedException`, not by a narrower UI-side role split that would just be theater).

## `route.ts`

Added `x-approval-id` to `FORWARD_HEADERS` — confirmed missing before this change. Without it, the maker's four-eyes retry header would be silently dropped by the BFF proxy and every retry would look identical to the original request.

## `parties/[id]/page.tsx`

A "Send message" action on the existing Messages tab, gated `opsmessage:compose`. Mirrors `accounts/[id]`'s `window.prompt()` pattern for the one input (`referenceId`) rather than inventing new form UI — this codebase's established convention for "one text field gates a write action" already existed and fit. Two calls (draft, then submit), per `OperatorMessageResource`'s own design (see PR 2). A 202 shows an "awaiting a second approver" banner with a retry button — nothing here auto-polls. This is the fleet's first 202/`X-Approval-Id` UI flow; a real approval-notification channel (so the maker doesn't have to remember to come back and click retry) is separate, larger work I'm not taking on here.

## `notifications/page.tsx`

A "Messages awaiting approval" section, gated `opsmessage:approve`, listing every `PENDING_APPROVAL` operator message **fleet-wide** — deliberately not embedded in the party page. The backend's `listPending` endpoint has no `partyId` filter, and a review queue is inherently cross-party (a checker should see everything awaiting decision, not just one customer's), unlike the compose action which is naturally party-scoped. (There's a separate, pre-existing `/approvals` page — that one is the AI-agent proposal queue, ADR-0031 D4, an unrelated backend and domain; I did not touch or conflate it with this.)

Approve/reject call straight through to the backend. A `SelfApprovalNotAllowedException` (the maker trying to decide their own message) surfaces as a plain, translated per-row error rather than a raw HTTP message, matching this codebase's error-handling convention.

## Test plan

- [x] `npm run type-check` — clean.
- [x] `npm run lint` — 0 errors. Two new `useEffect(() => { load() }, [load])` warnings, but this exact pattern is already the established (if imperfect) convention throughout this codebase, including in the very files I edited — not a new class of warning introduced here.
- [x] Full `vitest run` — 593/593 passing, including the i18n guard test and the service-registry guard test.
- [ ] Manual browser verification (compose → 202 → approve as a different operator → retry → SENT) — noted separately, since it needs PR 2 actually deployed to exercise the real endpoints.

Refs `docs/adr/0176-operator-initiated-customer-messaging.md`
