### PR TITLE
fix(ledger): give TieOutScheduler catch-up so a deploy-window miss self-heals

### DIFF
--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -17,6 +17,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.runBlocking
+import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
@@ -36,6 +37,17 @@ import java.time.ZoneId
  * [TieOutFreshnessWatchdog] can escalate a MISSING run (the #855 failure mode: a control
  * that silently stops running is invisible in metrics that only fire on breaks).
  * The scheduler never crashes — failures are caught, logged and recorded as ERROR.
+ *
+ * **Catch-up (issue #1378).** A single JVM instance owns this `@Scheduled` trigger with no
+ * cross-pod coordination (ADR-0039 Phase B pre-dates that work); a deploy — canary rollout or
+ * plain restart — that straddles the exact 06:00 fire time skips the tick with nothing to
+ * retry it. That happened for real on 2026-07-17: PR #1316's rollout landed on the trigger
+ * minute and the day was never checked (confirmed clean only by a manual query against
+ * [LedgerUseCase.getControlAccountTieOut] after the fact). So every run first asks
+ * [TieOutRunRepository.findLatest] for the last `as_of` it has a row for and walks forward from
+ * there to yesterday, oldest day first — the same healing shape as `CloseCalendar`'s
+ * oldest-first catch-up in statement-service, for the same reason: capping to the *newest* N
+ * days would strand the oldest gap forever, since the cursor here only ever moves forward too.
  */
 @ApplicationScoped
 class TieOutScheduler(
@@ -43,6 +55,8 @@ class TieOutScheduler(
     private val glAccountRepository: GlAccountRepository,
     private val runRepository: TieOutRunRepository,
     private val clock: Clock,
+    @ConfigProperty(name = "openbank.ledger.tieout.max-catchup-days", defaultValue = "7")
+    private val maxCatchUpDays: Int,
     registry: MeterRegistry,
 ) {
     private val log: Logger = Logger.getLogger(TieOutScheduler::class.java)
@@ -58,7 +72,50 @@ class TieOutScheduler(
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     fun runTieOut(): Unit = runBlocking {
-        val asOf = LocalDate.now(zone).minusDays(1)
+        // clock.withZone(zone), NOT LocalDate.now(zone): the latter is `Clock.system(zone)` —
+        // it silently ignores the injected `clock` and reads the JVM's real wall clock. Harmless
+        // in production (the CDI clock is `Clock.systemUTC()`, so both give the same instant and
+        // therefore the same Prague date), but it makes this method untestable with a fixed clock
+        // — exactly the class of clock-injection violation flagged fleet-wide in the closing audit
+        // (docs/audits/2026-07-16-closing-audit.md, systemic root cause 1).
+        val through = LocalDate.now(clock.withZone(zone)).minusDays(1)
+        val dates = catchUpDates(through)
+        if (dates.isEmpty()) {
+            log.infof("Sub-ledger tie-out: already checked through %s — nothing to do", through)
+        }
+        dates.forEach { asOf -> runTieOutFor(asOf) }
+    }
+
+    /**
+     * The dates this run must (re-)check, oldest first: everything after the latest recorded
+     * `as_of` up to and including [through]. No prior run at all means this is the very first
+     * tick ever — there is no history to anchor a backlog from, so only [through] is checked,
+     * exactly the pre-catch-up behaviour.
+     *
+     * Bounded to [maxCatchUpDays] so a long-dormant scheduler can't enqueue an unbounded backlog
+     * in one run; the *oldest* days are kept (not the newest — see the class KDoc) so later runs
+     * keep making forward progress on the gap instead of re-checking the same recent window
+     * forever.
+     */
+    private suspend fun catchUpDates(through: LocalDate): List<LocalDate> {
+        val latestAsOf = runRepository.findLatest()?.asOf ?: return listOf(through)
+        val from = latestAsOf.plusDays(1)
+        if (from > through) return emptyList()
+        val gap = generateSequence(from) { it.plusDays(1) }.takeWhile { it <= through }.toList()
+        if (gap.size > maxCatchUpDays) {
+            log.warnf(
+                "Sub-ledger tie-out: %d-day gap since %s exceeds the %d-day catch-up cap — " +
+                    "healing oldest-first; %d day(s) will remain after this run",
+                gap.size,
+                latestAsOf,
+                maxCatchUpDays,
+                gap.size - maxCatchUpDays,
+            )
+        }
+        return gap.take(maxCatchUpDays)
+    }
+
+    private suspend fun runTieOutFor(asOf: LocalDate) {
         log.infof("Sub-ledger tie-out check for %s", asOf)
         // Aggregate per-account outcomes rather than mutating counters inside the loop lambda:
         // the accumulation is the same, but it reads as one expression and CodeQL can actually

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
@@ -35,7 +35,17 @@ class TieOutSchedulerTest {
     private val registry = SimpleMeterRegistry()
     private val clock = Clock.fixed(Instant.parse("2026-07-16T04:00:00Z"), ZoneOffset.UTC)
 
-    private val scheduler = TieOutScheduler(ledger, glAccounts, runs, clock, registry)
+    private val scheduler = TieOutScheduler(ledger, glAccounts, runs, clock, maxCatchUpDays = 7, registry)
+
+    private fun runRecord(asOf: LocalDate) = TieOutRunRecord(
+        id = UUID.randomUUID(),
+        asOf = asOf,
+        runAt = Instant.parse("2026-07-16T04:00:00Z"),
+        status = TieOutRunStatus.OK,
+        accountsChecked = 1,
+        breaks = 0,
+        errors = 0,
+    )
 
     private fun control(code: String) = GlAccount(
         id = UUID.randomUUID(),
@@ -63,6 +73,7 @@ class TieOutSchedulerTest {
     fun `persists OK run when every control ties out`() {
         val account = control("2100")
         coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { runs.findLatest() } returns null // no prior run -> single-day (yesterday) check
         coEvery { glAccounts.findByCode("2100") } returns account
         coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal.ZERO))
         val saved = slot<TieOutRunRecord>()
@@ -81,6 +92,7 @@ class TieOutSchedulerTest {
     fun `persists BREAK run and increments counter on delta`() {
         val account = control("2100")
         coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { runs.findLatest() } returns null // no prior run -> single-day (yesterday) check
         coEvery { glAccounts.findByCode("2100") } returns account
         coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal("200")))
         val saved = slot<TieOutRunRecord>()
@@ -97,6 +109,7 @@ class TieOutSchedulerTest {
     fun `persists ERROR run when a control check throws`() {
         val account = control("2100")
         coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { runs.findLatest() } returns null // no prior run -> single-day (yesterday) check
         coEvery { glAccounts.findByCode("2100") } returns account
         coEvery { ledger.getControlAccountTieOut(any()) } throws IllegalStateException("db down")
         val saved = slot<TieOutRunRecord>()
@@ -114,6 +127,7 @@ class TieOutSchedulerTest {
         val broken = control("2100")
         val failing = control("2101")
         coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { runs.findLatest() } returns null // no prior run -> single-day (yesterday) check
         coEvery { glAccounts.findByCode("2100") } returns broken
         coEvery { glAccounts.findByCode("2101") } returns failing
         coEvery { ledger.getControlAccountTieOut(match { it.controlAccountId == broken.id }) } returns
@@ -134,6 +148,7 @@ class TieOutSchedulerTest {
     fun `scheduler survives a run-record persist failure`() {
         val account = control("2100")
         coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { runs.findLatest() } returns null // no prior run -> single-day (yesterday) check
         coEvery { glAccounts.findByCode("2100") } returns account
         coEvery { ledger.getControlAccountTieOut(any()) } returns listOf(tieOut(account.id, BigDecimal.ZERO))
         coEvery { runs.save(any()) } throws IllegalStateException("insert failed")
@@ -141,5 +156,65 @@ class TieOutSchedulerTest {
         scheduler.runTieOut() // must not throw
 
         coVerify(exactly = 1) { runs.save(any()) }
+    }
+
+    // --- Catch-up (issue #1378) -----------------------------------------------------------
+
+    @Test
+    fun `catches up a gap since the latest recorded run, oldest day first`() {
+        // clock -> "yesterday" (through) = 2026-07-15; latest recorded run is 2026-07-12,
+        // so the gap is 13th, 14th, 15th.
+        val account = control("2100")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns account
+        coEvery { runs.findLatest() } returns runRecord(LocalDate.of(2026, 7, 12))
+        coEvery { ledger.getControlAccountTieOut(any()) } returns emptyList() // no activity, trivially OK
+        val savedDates = mutableListOf<LocalDate>()
+        coEvery { runs.save(capture(slot<TieOutRunRecord>())) } answers {
+            val record = firstArg<TieOutRunRecord>()
+            savedDates.add(record.asOf)
+            record
+        }
+
+        scheduler.runTieOut()
+
+        assertThat(savedDates).containsExactly(
+            LocalDate.of(2026, 7, 13),
+            LocalDate.of(2026, 7, 14),
+            LocalDate.of(2026, 7, 15),
+        )
+    }
+
+    @Test
+    fun `caps a large gap at maxCatchUpDays, keeping the OLDEST days so later runs still progress`() {
+        // A 5-day gap (11th..15th) capped to 2: takeLast would strand the 11th/12th forever,
+        // since the cursor only ever moves forward from the latest saved as_of (the #1201-class
+        // bug CloseCalendar had). take() keeps 11th, 12th and leaves 13th-15th for the next run.
+        val capped = TieOutScheduler(ledger, glAccounts, runs, clock, maxCatchUpDays = 2, registry)
+        val account = control("2100")
+        coEvery { glAccounts.findByCode(any()) } returns null
+        coEvery { glAccounts.findByCode("2100") } returns account
+        coEvery { runs.findLatest() } returns runRecord(LocalDate.of(2026, 7, 10))
+        coEvery { ledger.getControlAccountTieOut(any()) } returns emptyList()
+        val savedDates = mutableListOf<LocalDate>()
+        coEvery { runs.save(capture(slot<TieOutRunRecord>())) } answers {
+            val record = firstArg<TieOutRunRecord>()
+            savedDates.add(record.asOf)
+            record
+        }
+
+        capped.runTieOut()
+
+        assertThat(savedDates).containsExactly(LocalDate.of(2026, 7, 11), LocalDate.of(2026, 7, 12))
+    }
+
+    @Test
+    fun `does nothing when already caught up through yesterday`() {
+        coEvery { runs.findLatest() } returns runRecord(LocalDate.of(2026, 7, 15)) // == through
+
+        scheduler.runTieOut()
+
+        coVerify(exactly = 0) { runs.save(any()) }
+        coVerify(exactly = 0) { glAccounts.findByCode(any()) }
     }
 }


### PR DESCRIPTION
Fixes #1378: gives `TieOutScheduler` catch-up so a deploy-window miss self-heals instead of silently skipping the day forever.

## What happened, live, this morning

```
2026-07-16T13:59:19Z  old ledger pod starts, runs continuously overnight
2026-07-17T03:48:30Z  PR #1316 merged -> auto-deploy kicks off
2026-07-17T04:00:00Z  TieOutScheduler's daily trigger (06:00 Prague) is due
2026-07-17T04:01:55Z  new pod created for the #1316 rollout
2026-07-17T04:40:00Z  TieOutFreshnessWatchdog: "NO tie-out run has ever been recorded"
```

`ledger_tieout_runs` had zero rows. `TieOutScheduler` always computed `asOf = yesterday` from wall-clock time — once the 06:00 tick landed in the deploy window and was missed, the day was never checked again. `TieOutFreshnessWatchdog` escalated correctly (it worked exactly as designed — that's not this bug), but escalating a gap isn't closing it. The only way to close it was a human manually re-deriving the answer via the read-only tie-out endpoint (which I did — CZK tied out clean, `delta: 0.000000`, confirming this was a control-execution gap, not a data-integrity one).

## The fix

Every run now asks `TieOutRunRepository.findLatest()` for the last `as_of` it has a row for and walks forward from there through yesterday, **oldest day first**, instead of always checking a single fixed day. No prior run at all (the very first tick ever) still checks only yesterday — there's no history to anchor a backlog from.

Bounded to a configurable `maxCatchUpDays` (default 7) so a long-dormant scheduler can't enqueue an unbounded backlog in one run. **The cap keeps the oldest days, not the newest** — the cursor only ever moves forward from the latest recorded `as_of`, so capping to the newest N days would strand the oldest gap forever. Same shape as `CloseCalendar`'s `takeLast` bug in statement-service from earlier this cycle; same fix (`take`, not `takeLast`).

## A second, smaller thing this uncovered

Writing a deterministic test for the catch-up window required controlling "what day is it", and `LocalDate.now(zone)` wouldn't cooperate: that overload is `Clock.system(zone)` — the JVM's **real wall clock** zoned to Prague, silently ignoring the class's own CDI-injected `clock` (which this class otherwise uses correctly, e.g. `Instant.now(clock)` in `recordRun`). **Harmless in production** — the CDI clock is `Clock.systemUTC()`, so both give the same instant and therefore the same Prague date — but it made the method untestable with a fixed clock. Now `LocalDate.now(clock.withZone(zone))`: identical production behaviour, and the class of clock-injection violation named fleet-wide in the closing audit (`docs/audits/2026-07-16-closing-audit.md`, systemic root cause 1 — "no owner of the business date") is one instance smaller.

## Verified

- Mutation-tested: reverted to the old single-tick behaviour and confirmed all three new catch-up tests fail (`catches up a gap...`, `caps a large gap...`, `does nothing when already caught up...`) — they're not vacuous.
- All five pre-existing tests still pass unmodified in behaviour (just stubbed `findLatest()` returning null, matching the "first tick ever" branch they were already implicitly exercising).
- `:openbank-ledger-service:test :openbank-ledger-service:ktlintCheck :openbank-ledger-service:detekt` green, non-cached (`--rerun-tasks`).
- Diff scope: exactly the two files this touches, no formatting collateral.

## Not in scope here

A manual re-trigger endpoint (issue #1378's second proposed fix) — this PR covers the common case (a deploy-window miss self-heals on the very next tick, as it will tomorrow at 06:00 for anything this doesn't already catch). An operator-facing trigger for the rarer "catch-up itself needs a nudge" case is a separate, smaller follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
