### PR TITLE
security(ci): harden pipeline supply chain — verify tool downloads, narrow auto-merge, fix audit-cancelling concurrency

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -64,9 +64,15 @@ permissions:
 
 concurrency:
   # One admin-ui deploy at a time — a second push while a deploy PR is open would
-  # produce conflicting image tags. Cancel the in-flight run; the newer commit wins.
+  # produce conflicting image tags. cancel-in-progress must stay FALSE: the
+  # build-push job pushes to ECR and only then signs + attests (build-push-admin-ui.sh
+  # → cosign_sign_and_attest), so cancelling mid-job can strand a pushed-but-unattested
+  # image that Kyverno's verify-images policy denies on the next reschedule — days
+  # later, far from the cause (same hazard auto-deploy.yml documents). Queueing is
+  # safe: GitHub keeps only the newest pending run per group, so the latest commit
+  # still wins — it just waits for the in-flight deploy to finish signing.
   group: admin-ui-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-push:

--- a/.github/workflows/backfill-release-evidence.yml
+++ b/.github/workflows/backfill-release-evidence.yml
@@ -106,7 +106,20 @@ jobs:
           bin="$(command -v cosign || true)"
           if ! { [ -n "$bin" ] && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; }; then
             bin="${RUNNER_TEMP}/cosign2"
-            curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
+            # sha256 pins from the release's cosign_checksums.txt — bump together with
+            # COSIGN_VERSION (same block as release-please.yml).
+            case "${os}-${arch}" in
+              linux-amd64)  COSIGN_SHA256="caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708" ;;
+              linux-arm64)  COSIGN_SHA256="bd0f9763bca54de88699c3656ade2f39c9a1c7a2916ff35601caf23a79be0629" ;;
+              darwin-amd64) COSIGN_SHA256="98a3bfd691f42c6a5b721880116f89210d8fdff61cc0224cd3ef2f8e55a466fb" ;;
+              darwin-arm64) COSIGN_SHA256="edfc761b27ced77f0f9ca288ff4fac7caa898e1e9db38f4dfdf72160cdf8e638" ;;
+              *) echo "::error::no pinned cosign checksum for ${os}-${arch}"; exit 1 ;;
+            esac
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+              -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
+            SHATOOL="sha256sum"; command -v sha256sum >/dev/null 2>&1 || SHATOOL="shasum -a 256"
+            echo "${COSIGN_SHA256}  ${bin}" | ${SHATOOL} -c - \
+              || { echo "::error::cosign ${COSIGN_VERSION} download failed checksum verification"; exit 1; }
             chmod +x "$bin"
           fi
           sign() { COSIGN_YES=true "$bin" sign-blob --key "$COSIGN_KEY" --output-signature "${1}.sig" "$1"; }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,12 +1,22 @@
 # Dependabot auto-merge (OSS-readiness D4, ADR-0119 §D4).
 #
-# Policy: auto-merge patch and minor Dependabot PRs once CI is green.
-# Major updates stay open for human review — they can introduce breaking changes.
-#
-# Allowlist: gradle, npm, github-actions, docker ecosystems (all configured in
-# .github/dependabot.yml). Excluded from auto-merge:
-#   - Major version bumps (any ecosystem)
+# Policy: auto-merge PATCH Dependabot PRs (gradle, npm) once CI is green.
+# Everything else stays open for human review:
+#   - Minor + major bumps (any ecosystem) — minors regularly carry new transitive
+#     dependencies; the Gradle graph has no PR-time vuln gate (dependency-review
+#     doesn't parse Gradle and there is no gradle.lockfile for Trivy fs), so an
+#     auto-merged minor is an uninspected supply-chain entry point.
+#   - github-actions bumps (any size) — a version bump swaps the pinned commit SHA
+#     for NEW action code that then runs in CI with contents:write/id-token:write.
+#     A human must eyeball the diff of what will execute with those permissions.
+#   - docker bumps (any size) — base-image changes alter the runtime attack surface
+#     of every service built on them; same eyeball rule.
 #   - PRs that are not authored by dependabot[bot]
+#
+# Note: dependabot-verification-metadata.yml auto-recomputes gradle checksums from
+# whatever Maven Central serves at PR time, so verification-metadata.xml is NOT a
+# defense against a poisoned upstream release riding an auto-merge — human review
+# of minors is.
 #
 # Token: GITHUB_TOKEN with `contents: write` is enough for auto-merge on a repo
 # without environment protection (GitHub Free / public repos). The workflow
@@ -42,22 +52,30 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      # Auto-merge patch or minor updates. Major stays for human review.
-      - name: Enable auto-merge (patch / minor only)
+      # Auto-merge patch updates only, and never for github-actions / docker
+      # (see the policy header). Ecosystem ids are fetch-metadata's: github_actions
+      # uses an underscore.
+      - name: Enable auto-merge (patch only, gradle/npm)
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          steps.metadata.outputs.package-ecosystem != 'github_actions' &&
+          steps.metadata.outputs.package-ecosystem != 'docker'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Skip — major update (requires human review)
-        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+      - name: Skip — requires human review
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-patch' ||
+          steps.metadata.outputs.package-ecosystem == 'github_actions' ||
+          steps.metadata.outputs.package-ecosystem == 'docker'
         # PR_TITLE via env, not `${{ }}` interpolated straight into the script: the title is
         # attacker-influenceable and direct interpolation is a script-injection vector
         # (Scorecard Dangerous-Workflow). Env-var passing is not subject to shell expansion.
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
         run: |
-          echo "::notice title=Major update::${PR_TITLE} is a major bump — skipping auto-merge, human review required."
+          echo "::notice title=Human review required::${PR_TITLE} (${ECOSYSTEM}, ${UPDATE_TYPE}) is outside the auto-merge policy (patch-only, gradle/npm) — skipping auto-merge."

--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -104,15 +104,23 @@ jobs:
           mkdir -p "$HOME/bin"
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')   # darwin | linux
           ARCH=$(uname -m)                               # x86_64 | arm64 | aarch64
+          # Verify the download against the per-platform sha256 published alongside the
+          # release (opa_<suffix>.sha256): this binary is CI's policy authority — an
+          # unverified download could rubber-stamp any bundle. Bump the checksums together
+          # with the version (same standard as the oasdiff + pyyaml pins in ci.yml).
           case "${OS}_${ARCH}" in
-            darwin_arm64)   SUFFIX="darwin_arm64_static" ;;
-            darwin_x86_64)  SUFFIX="darwin_amd64" ;;
-            linux_aarch64)  SUFFIX="linux_arm64_static" ;;
-            linux_arm64)    SUFFIX="linux_arm64_static" ;;
-            *)              SUFFIX="linux_amd64" ;;
+            darwin_arm64)   SUFFIX="darwin_arm64_static"; OPA_SHA256="7d7debaf10bba97d32b7e67b7f8ce128c92e911b82e3c6cec24b95c34f8a5003" ;;
+            darwin_x86_64)  SUFFIX="darwin_amd64";        OPA_SHA256="088f6c9d8c7b0e2ee0bee450cba7599953e3167649f3623019bada67a26229a4" ;;
+            linux_aarch64)  SUFFIX="linux_arm64_static";  OPA_SHA256="9d8d4d18e4240e61d6259381066080420441a498f559bcb3a24f7561f76e25eb" ;;
+            linux_arm64)    SUFFIX="linux_arm64_static";  OPA_SHA256="9d8d4d18e4240e61d6259381066080420441a498f559bcb3a24f7561f76e25eb" ;;
+            *)              SUFFIX="linux_amd64";         OPA_SHA256="5485f9c32548af84bc0bfa06a7f40a98ecc742477a7f9f24ea3556d221dc295f" ;;
           esac
-          curl -fsSL -o "$HOME/bin/opa" \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 -o "$HOME/bin/opa" \
             "https://openpolicyagent.org/downloads/v1.17.0/opa_${SUFFIX}"
+          # sha256sum on Linux; macOS (self-hosted) ships shasum instead.
+          SHATOOL="sha256sum"; command -v sha256sum >/dev/null 2>&1 || SHATOOL="shasum -a 256"
+          echo "${OPA_SHA256}  $HOME/bin/opa" | ${SHATOOL} -c - \
+            || { echo "::error::OPA v1.17.0 download failed checksum verification"; exit 1; }
           chmod +x "$HOME/bin/opa"
           echo "$HOME/bin" >> "$GITHUB_PATH"
           "$HOME/bin/opa" version

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -453,7 +453,20 @@ jobs:
           bin="$(command -v cosign || true)"
           if ! { [ -n "$bin" ] && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; }; then
             bin="${RUNNER_TEMP}/cosign2"
-            curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
+            # sha256 pins from the release's cosign_checksums.txt — bump together with
+            # COSIGN_VERSION. Unverified: a MITM'd cosign binary could fake every signature.
+            case "${os}-${arch}" in
+              linux-amd64)  COSIGN_SHA256="caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708" ;;
+              linux-arm64)  COSIGN_SHA256="bd0f9763bca54de88699c3656ade2f39c9a1c7a2916ff35601caf23a79be0629" ;;
+              darwin-amd64) COSIGN_SHA256="98a3bfd691f42c6a5b721880116f89210d8fdff61cc0224cd3ef2f8e55a466fb" ;;
+              darwin-arm64) COSIGN_SHA256="edfc761b27ced77f0f9ca288ff4fac7caa898e1e9db38f4dfdf72160cdf8e638" ;;
+              *) echo "::error::no pinned cosign checksum for ${os}-${arch}"; exit 1 ;;
+            esac
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+              -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
+            SHATOOL="sha256sum"; command -v sha256sum >/dev/null 2>&1 || SHATOOL="shasum -a 256"
+            echo "${COSIGN_SHA256}  ${bin}" | ${SHATOOL} -c - \
+              || { echo "::error::cosign ${COSIGN_VERSION} download failed checksum verification"; exit 1; }
             chmod +x "$bin"
           fi
           sign() { COSIGN_YES=true "$bin" sign-blob --key "$COSIGN_KEY" --output-signature "${1}.sig" "$1"; }

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,8 +10,11 @@ on:
 permissions:
   contents: read
 
+# event_name is part of the key: schedule and push:[main] both resolve to
+# refs/heads/main, so without it a routine main push cancels the weekly
+# scheduled history scan (same fix as security.yml).
 concurrency:
-  group: secret-scan-${{ github.ref }}
+  group: secret-scan-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,8 +13,11 @@ permissions:
 
 # Cancel superseded runs on the same ref so Dependabot/PR pushes don't stack up
 # expensive CodeQL/Trivy/SBOM runs and drain the Free-tier minute budget.
+# event_name is part of the key: schedule and push:[main] both resolve to
+# refs/heads/main, so without it a routine Monday-morning push CANCELS the
+# weekly scheduled audit — the audit posture silently never runs that week.
 concurrency:
-  group: security-${{ github.ref }}
+  group: security-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/verify-release-evidence.yml
+++ b/.github/workflows/verify-release-evidence.yml
@@ -61,7 +61,20 @@ jobs:
           bin="$(command -v cosign || true)"
           if ! { [ -n "$bin" ] && cosign version 2>/dev/null | grep -Eq 'GitVersion:[[:space:]]*v2\.'; }; then
             bin="${RUNNER_TEMP}/cosign2"
-            curl -fsSL -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
+            # sha256 pins from the release's cosign_checksums.txt — bump together with
+            # COSIGN_VERSION (same block as release-please.yml).
+            case "${os}-${arch}" in
+              linux-amd64)  COSIGN_SHA256="caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708" ;;
+              linux-arm64)  COSIGN_SHA256="bd0f9763bca54de88699c3656ade2f39c9a1c7a2916ff35601caf23a79be0629" ;;
+              darwin-amd64) COSIGN_SHA256="98a3bfd691f42c6a5b721880116f89210d8fdff61cc0224cd3ef2f8e55a466fb" ;;
+              darwin-arm64) COSIGN_SHA256="edfc761b27ced77f0f9ca288ff4fac7caa898e1e9db38f4dfdf72160cdf8e638" ;;
+              *) echo "::error::no pinned cosign checksum for ${os}-${arch}"; exit 1 ;;
+            esac
+            curl -fsSL --retry 5 --retry-all-errors --retry-delay 3 \
+              -o "$bin" "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-${os}-${arch}"
+            SHATOOL="sha256sum"; command -v sha256sum >/dev/null 2>&1 || SHATOOL="shasum -a 256"
+            echo "${COSIGN_SHA256}  ${bin}" | ${SHATOOL} -c - \
+              || { echo "::error::cosign ${COSIGN_VERSION} download failed checksum verification"; exit 1; }
             chmod +x "$bin"
           fi
           cd ev


### PR DESCRIPTION
## Summary

Wave 1 (security) of the 2026-07-17 audit of all 44 workflows: checksum-verify every trust-critical tool download, narrow Dependabot auto-merge to patch-only gradle/npm, stop routine pushes from cancelling the weekly scheduled audits, and stop admin-ui deploy cancellation from stranding a pushed-but-unattested image.

## Type of change

- [x] security (private until disclosed)
- [ ] feat / fix / refactor / perf / docs / chore / breaking change

## Linked issues

Closes #1397

## Changes

- `opa-policy.yml`: pin the OPA v1.17.0 download by per-platform sha256 (values from the release's `opa_<suffix>.sha256` files) + `curl --retry`. Portable check (`sha256sum`, `shasum -a 256` fallback for the darwin self-hosted case).
- `release-please.yml`, `backfill-release-evidence.yml`, `verify-release-evidence.yml`: pin the cosign v2.4.3 fallback download by sha256 from `cosign_checksums.txt` + `--retry` — same pattern `runner-image.yml` already uses (the linux-arm64 value cross-checks against runner-image's existing pin).
- `dependabot-auto-merge.yml`: auto-merge only `version-update:semver-patch`, and never for `github_actions` / `docker` ecosystems (ecosystem ids verified against this repo's real Dependabot branch names). Policy rationale documented in the header, incl. why `verification-metadata.xml` is not a defense (it self-recomputes checksums from whatever Maven Central serves).
- `security.yml`, `secret-scan.yml`: concurrency key now includes `github.event_name` — `push:[main]` and `schedule` previously shared `…-refs/heads/main`, so a routine Monday push cancelled the weekly audit.
- `admin-ui-deploy.yml`: `cancel-in-progress: false`. The build-push job pushes to ECR and only then runs `cosign_sign_and_attest`; a cancel in that window strands an unattested image that Kyverno denies on the next reschedule (the #1284-class failure). Newest queued run still wins.

## Definition of Done

- [x] Hexagonal layering preserved (no service code touched — workflows only).
- [ ] Unit tests added/updated — N/A (CI YAML).
- [ ] Integration/contract tests — N/A.
- [x] No new lint warnings: `actionlint` finding set identical to `origin/main` (one pre-existing SC2015 shifted by inserted lines); `yamllint` clean at the level CI enforces.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — policy rationale lives in the workflow headers.

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs (checksums + public release URLs only).
- [x] No new suppressions.
- [x] No new third-party dependency (pins existing downloads by hash).
- [ ] Auth / crypto / payment code — workflows only; no service auth path touched.

## Compliance impact

- [x] DORA — strengthens ICT supply-chain controls on the CI tooling path (checksum-verified policy/signing binaries, human review of action/base-image bumps). No compensating controls needed.

## Rollout / Rollback

- Deployment strategy: N/A (CI-only; takes effect on merge)
- Rollback plan: revert the commit; no state or data involved
- Data migration reversible: N/A

## Reviewer notes

- Behavior change to be aware of: **minor** Dependabot bumps (incl. the grouped `*-minor` PRs) and **all** github-actions/docker bumps now wait for a human merge — expect a few more open Dependabot PRs per week.
- `admin-ui-deploy` runs now queue instead of cancelling; GitHub keeps only the newest pending run per group, so the latest commit still deploys.
- Checksum sources: cosign values fetched from the official `cosign_checksums.txt` (linux-arm64 matches the pin already in `runner-image.yml`); OPA values from the per-platform `.sha256` files on `openpolicyagent.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)