### PR TITLE
chore(ci): add missing job timeouts, correct lying pin comments, drop dead suppressions

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -24,6 +24,14 @@ on:
         description: "Service directory, e.g. openbank-ledger-service"
         required: true
         type: string
+    secrets:
+      PACT_BROKER_PASSWORD:
+        # Must be declared here for the caller to pass it explicitly: an undeclared
+        # secret in the caller's `secrets:` map is a workflow-file error. Optional so
+        # the workflow still loads where the secret is unset (forks) — the pact steps
+        # already gate on pactbroker.url / an empty password.
+        description: "Pact Broker password (ADR-0092) — publishing pacts + verification results."
+        required: false
 
 permissions:
   contents: read
@@ -195,7 +203,7 @@ jobs:
         id: ecr_auth
         if: ${{ runner.environment == 'self-hosted' }}
         continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: eu-north-1

--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -127,7 +127,7 @@ jobs:
         # Sets AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN in env.
         # The role has ECR push + KMS sign permissions.
         # See "Stub AWS profile" step below for why a stub ~/.aws/config entry is also needed.
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: eu-north-1

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -84,6 +84,7 @@ jobs:
       github.actor != 'github-actions[bot]' &&
       !startsWith(github.head_ref, 'chore/admin-ui-deploy-')
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # measured max 14s, but the Claude fallback is an agentic gh loop that can hang
     # secrets context isn't available in a step-level `if:` — expose it as a
     # job-level boolean env so the Claude fallback can gate on its presence.
     env:

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -280,7 +280,7 @@ jobs:
       # token.actions.githubusercontent.com for repo:JiRaska/open-bank-oss:*) — no per-pod webhook
       # dependency, deterministic. configure-aws-credentials exports the creds to the job env.
       - name: Configure AWS credentials (GitHub OIDC)
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: eu-north-1

--- a/.github/workflows/backfill-release-evidence.yml
+++ b/.github/workflows/backfill-release-evidence.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: eu-north-1   # KMS cosign key lives in eu-north-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,12 @@ jobs:
           rules:
             line-length: disable
             document-start: disable
-            # The fleet manifests use single-spaced flow style — `{ a: b }`,
-            # `[ x, y ]` — pervasively (ArgoCD Applications, component resources).
-            # Allow one inner space rather than fight it file-by-file (it kept
-            # re-reddening main as new services landed).
+            # Allow ONE space inside flow collections (`{ a: b }`, `[ x, y ]`) as well
+            # as zero. The fleet manifests use that style pervasively (ArgoCD
+            # Applications, component resources, the single-owner service manifests);
+            # both styles are equivalent YAML and harmless. Defaulting to 0-only kept
+            # re-breaking this required check every time a new service was onboarded
+            # (#648, #657, ...).
             braces:
               max-spaces-inside: 1
             brackets:
@@ -216,15 +218,6 @@ jobs:
               min-spaces-from-content: 1
             truthy:
               check-keys: false
-            # Allow ONE space inside flow collections (`{ a: b }`, `[ x, y ]`) as
-            # well as zero. The gitops single-owner service manifests are authored
-            # in compact flow style with inner spaces; both styles are equivalent
-            # YAML and harmless. Defaulting to 0-only kept re-breaking the required
-            # check every time a new service was onboarded (#648, #657, ...).
-            braces:
-              max-spaces-inside: 1
-            brackets:
-              max-spaces-inside: 1
             # Allow either sequence-indentation style (block sequences indented
             # under their key, or flush with it). The Kyverno mutation policies
             # (ecr-pull-through-rewrite.yaml) and several ArgoCD/gitops manifests

--- a/.github/workflows/dast-zap-baseline.yml
+++ b/.github/workflows/dast-zap-baseline.yml
@@ -33,6 +33,7 @@ jobs:
   zap-baseline:
     name: ZAP baseline / ledger-service
     runs-on: ubuntu-latest
+    timeout-minutes: 20  # measured max 327s; boots a compose stack
     permissions:
       contents: read
       issues: none

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -40,6 +40,7 @@ jobs:
   auto-merge:
     name: Auto-merge patch/minor Dependabot PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # API calls only
     if: github.actor == 'dependabot[bot]'
     permissions:
       contents: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,20 +24,11 @@ jobs:
           fail-on-severity: high
           comment-summary-in-pr: always
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
-          # starlette (pulled in transitively via schemathesis==3.39.16's own
-          # starlette<1,>=0.13 pin — .github/workflows/requirements/schemathesis.txt)
-          # is stuck below the versions that fix these two advisories (patched at
-          # 1.1.0 / 1.3.1). schemathesis 4.x drops that pin but renames the v3 CLI
-          # flags api-fuzz.yml depends on, so it isn't a drop-in bump. Both flagged
-          # code paths (StaticFiles Windows-UNC SSRF, request.form() limits) belong
-          # to starlette's ASGI-server surface; schemathesis only uses starlette as
-          # an in-process test client in an ephemeral CI job — it never serves
-          # traffic or accepts untrusted uploads here.
-          allow-ghsas: GHSA-wqp7-x3pw-xc5r, GHSA-82w8-qh3p-5jfq
-          # rfc3987 (GPL-3.0-or-later) is pulled in by schemathesis's own
-          # jsonschema[format] extra (the IRI/iri-reference format validator;
-          # jsonschema's non-GPL alternative extra is format-nongpl, which
-          # schemathesis does not use). It is a CI-only fuzzing-tool dependency,
-          # never redistributed or linked into anything we ship, so GPL's
-          # copyleft/distribution obligations don't apply here.
-          allow-dependencies-licenses: pkg:pypi/rfc3987@1.3.8
+          # No allow-ghsas / allow-dependencies-licenses entries: both suppressions
+          # here existed solely for schemathesis 3.39.16's transitive pins, and the
+          # migration to schemathesis 4.22.3 retired the reasons for both —
+          # starlette now resolves to 1.3.1 (the version that FIXES GHSA-wqp7-x3pw-xc5r
+          # and GHSA-82w8-qh3p-5jfq), and rfc3987 (GPL-3.0-or-later) is no longer in
+          # the resolved set at all. Keeping them would silently re-suppress the same
+          # advisories/licence if a future dependency reintroduced them.
+          # Re-add only with a fresh justification and a tracking issue.

--- a/.github/workflows/fleet-attestation.yml
+++ b/.github/workflows/fleet-attestation.yml
@@ -42,6 +42,7 @@ jobs:
   lint:
     name: Lint gate script
     runs-on: ubuntu-latest
+    timeout-minutes: 5  # measured max 8s
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # ci.yml's shellcheck only globs openbank-infra/scripts — this script lives under
@@ -52,6 +53,7 @@ jobs:
   verify:
     name: Verify fleet attestations
     runs-on: ubuntu-latest
+    timeout-minutes: 20  # measured max 198s
     # Needs the AWS OIDC role to read ECR. Fork PRs cannot assume it, so skip rather than
     # fail red on a contribution that could never have run this.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -65,7 +67,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: ${{ env.AWS_REGION }}
@@ -116,6 +118,7 @@ jobs:
     needs: verify
     if: ${{ failure() && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5  # API calls only
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -32,6 +32,7 @@ jobs:
     name: issue-hygiene
     # actions/github-script only — no self-hosted-pool dependency.
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # measured max 6s
     steps:
       - name: Lint PR "Linked issues"
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -24,6 +24,7 @@ jobs:
   pitest:
     name: pitest / ${{ matrix.service }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # measured max 414s (ledger); mutation runs are the likeliest to hang
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -388,7 +388,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: eu-north-1   # KMS cosign key + ECR live in eu-north-1 (matches auto-deploy)

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -241,7 +241,10 @@ jobs:
       service: ${{ matrix.service }}
     # Pass the Pact Broker password (secret) through to the reusable workflow
     # (ADR-0092); vars.PACT_BROKER_URL/_USERNAME are available to it automatically.
-    secrets: inherit
+    # Named explicitly rather than `secrets: inherit` — inherit hands the called
+    # workflow EVERY repo secret, and this is the only one it reads.
+    secrets:
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
 
   # Single required status check that aggregates the matrix, so branch protection
   # can require "Services CI / all-green" without enumerating every service.

--- a/.github/workflows/verify-release-evidence.yml
+++ b/.github/workflows/verify-release-evidence.yml
@@ -31,7 +31,7 @@ jobs:
       TAG: ${{ inputs.tag }}
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v5.0.0
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
           role-to-assume: arn:aws:iam::265175468565:role/openbank-arc-build-runner
           aws-region: eu-north-1   # KMS cosign key + ECR live in eu-north-1 (matches auto-deploy)


### PR DESCRIPTION
## Summary

Wave 3 (hygiene) of the workflow audit: job timeouts sized from measured maxima, action-pin comments that contradicted the SHA they pin, two suppressions whose reason no longer exists, `secrets: inherit` narrowed to the one secret actually read, and a duplicate-key block in the job that enforces a duplicate-key gate. Every item was verified against live data first — several other audit findings were **dropped** because measurement disproved them (see Reviewer notes).

## Type of change

- [x] chore (build / tooling)
- [ ] feat / fix / refactor / perf / docs / security / breaking change

## Linked issues

Refs #1412

## Changes

- **Timeouts** on the six workflows that had none (a hung job otherwise holds a runner for the 6 h default). Sized from measured maxima across the last 10 runs, not guessed:
  - `pitest` → 30 m (max observed 414 s, ledger; mutation runs are the likeliest to hang)
  - `fleet-attestation` → lint 5 m (max 8 s), verify 20 m (max 198 s), raise-issue 5 m (API-only)
  - `dast-zap-baseline` → 20 m (max 327 s; boots a compose stack)
  - `agent-review` → 15 m (max 14 s, but the Claude fallback is an agentic `gh` loop that can hang)
  - `issue-hygiene` → 10 m (max 6 s), `dependabot-auto-merge` → 10 m (API-only)
- **Action pin comments**: 7 workflows pinned `configure-aws-credentials` to SHA `517a711d…` while commenting `# v5.0.0`. That SHA **is v6.2.2** — verified via the GitHub API (`v5.0.0` = `a03048d8…`); `platform-tofu.yml` / `substrate-tofu.yml` already labelled it correctly. No SHA changed; only the comments now tell the truth.
- **`dependency-review.yml`**: removed `allow-ghsas` + `allow-dependencies-licenses`. Both existed for `schemathesis==3.39.16`'s transitive pins; the tree now pins `schemathesis==4.22.3` → `starlette==1.3.1`, the version that **fixes** GHSA-wqp7-x3pw-xc5r and GHSA-82w8-qh3p-5jfq, and `rfc3987` is gone from the resolved set.
- **`services-ci.yml`**: `secrets: inherit` → an explicit `PACT_BROKER_PASSWORD` map. This required declaring the secret under `workflow_call.secrets` in `_service-ci.yml` — an undeclared secret in the caller's map is a workflow-file error, which would have broken every service build. Declared `required: false` so the workflow still loads where the secret is unset (forks).
- **`ci.yml`**: collapsed the duplicated `braces:`/`brackets:` keys in the inline yamllint config, merging the surviving comment so the `#648 / #657` context isn't lost.

## Definition of Done

- [x] Hexagonal layering preserved (workflow-only change).
- [ ] Unit/integration/contract tests — N/A (CI YAML).
- [x] No new lint warnings: per-file `actionlint` finding set is **identical** to `origin/main` (1 `runner-label`, 9 `shellcheck`, all pre-existing); `yamllint` clean on all 15 changed files. The linters were validated against a known-positive first — an earlier "clean" result in this session was a broken probe.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — rationale lives in the workflow comments.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions — this PR **removes** two.
- [x] No new third-party dependency; no action SHA changed.
- [x] Least-privilege improved (`secrets: inherit` narrowed to one named secret).

## Compliance impact

- [x] DORA — small ICT-pipeline hygiene improvements (runner-exhaustion bound, honest supply-chain pin metadata, no stale vulnerability suppressions). No compensating controls needed.

## Rollout / Rollback

- Deployment strategy: N/A (CI-only)
- Rollback plan: revert the commit
- Data migration reversible: N/A

## Reviewer notes

- **Riskiest change is the `secrets:` one** — it touches the required `all-green` path. The caller/callee pair must agree or every service build fails at parse time; the `workflow_call.secrets` declaration in `_service-ci.yml` is what makes it legal. Worth a close look.
- **`ci.yml` yamllint config**: proved semantically identical — parsed both main's and this branch's heredoc and compared the rule dicts (`old == new` → `True`); main had 2 `braces:` keys, this has 1, same effective config.
- **Audit findings deliberately NOT acted on, because verification contradicted them:**
  - *"pact standalone download has no `--retry`"* — current main already has `curl -fsSL --retry 2 --retry-delay 3` inside a 3-attempt loop.
  - *"the macOS-keychain steps are dead, remove them"* — they are `if: runner.os == 'macOS'` on `ubuntu-24.04-arm`, so they cost nothing, and they encode a real documented ECR/Keychain fix. Deleting insurance that costs zero to re-learn a bug is a bad trade.
  - *"the AWS-CLI-install block in the tofu workflows is dead code"* — `command -v aws` short-circuits, so it costs ~0; only its comment is stale.
  - *"spread the Monday 06:00 crons"* — GitHub jitters scheduled crons and hosted minutes are free on a public repo; the audit itself conceded this is latency, not cost.
  - *"`fleet-lint`'s CodeArtifact step is a dead no-op because `aws` is absent"* — the opposite: `ubuntu-latest` **ships** the aws CLI, so the early-exit never fires; it proceeds and fails at the token fetch, warning on **every** run (verified in run 29561114250's logs). That one is real but is a design question — route fleet-lint to ARC, or drop the steps — so it's filed in #1412 rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)