### PR TITLE
fix(ledger): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/outbox/LedgerOutboxDispatcher.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/outbox/LedgerOutboxDispatcher.kt
@@ -24,10 +24,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout
  * Resilience annotations live here on the concrete CDI bean — CDI interceptors only fire when
  * the call enters through the proxy that wraps this bean (ADR-0013).
  *
- * **N4 — single writer.** `concurrentExecution = SKIP` prevents in-JVM overlap, and the ledger
- * deployment is pinned to `replicas: 1`; together they guarantee exactly one dispatcher claims a
- * row. A `FOR UPDATE SKIP LOCKED` claim is the tracked refinement for any future multi-writer
- * topology.
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously for
+ * the whole rollout duration, and both dispatch on their own tick. `LedgerOutboxRepositoryImpl`
+ * therefore implements [OutboxRepository.claimProcessable] as an atomic `FOR UPDATE SKIP LOCKED`
+ * claim, not the unclaimed-peek default, so two concurrently running pods can never both select
+ * and publish the same row.
  */
 @ApplicationScoped
 class LedgerOutboxDispatcher(

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/LedgerOutboxEntity.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/entity/LedgerOutboxEntity.kt
@@ -4,9 +4,23 @@
 package com.openbank.ledger.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is ledger-only — added straight on this entity, not on the shared
+ * [PanacheOutboxEntity], because that base class is mapped by every outbox-bearing service and
+ * adding a column there would break every other service's table until it also migrated (#1201
+ * fleet rollout is deliberately follow-up, not this change). Stamped by
+ * `LedgerOutboxRepositoryImpl.claimProcessable`'s atomic claim query when a row moves to
+ * [com.openbank.libs.persistence.outbox.OutboxStatus.DISPATCHING]; read back by the same query
+ * to decide whether a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "ledger_outbox")
-class LedgerOutboxEntity : PanacheOutboxEntity()
+class LedgerOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/LedgerOutboxRepositoryImpl.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/persistence/repository/LedgerOutboxRepositoryImpl.kt
@@ -16,6 +16,7 @@ import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
@@ -58,6 +59,37 @@ class LedgerOutboxRepositoryImpl(private val clock: Clock) :
     override suspend fun listProcessable(limit: Int): List<OutboxEntry> = listProcessableUni(limit).awaitSuspending()
 
     override suspend fun countProcessable(): Long = countProcessableUni().awaitSuspending()
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer
+     * `UPDATE` flips exactly those rows to DISPATCHING and returns them — so two dispatcher
+     * instances racing this at the same instant can never both claim the same row. Also reclaims
+     * rows still DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was
+     * evicted before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it does not need to (and must not) span the
+     * network publish call that follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, LedgerOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun markSent(eventId: UUID, sentAt: Instant) {
         Panache.withTransaction {
@@ -125,5 +157,20 @@ class LedgerOutboxRepositoryImpl(private val clock: Clock) :
         const val MAX_ATTEMPTS: Int = OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS
 
         fun statusAfterFailure(attemptCount: Int): OutboxStatus = OutboxFailurePolicy.statusAfterFailure(attemptCount)
+
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE ledger_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM ledger_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }

--- a/openbank-ledger-service/src/main/resources/db/migration/V18__ledger_outbox_claimed_at.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V18__ledger_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE ledger_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerOutboxClaimIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/LedgerOutboxClaimIT.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.ledger.integration
+
+import com.openbank.ledger.infrastructure.persistence.repository.LedgerOutboxRepositoryImpl
+import com.openbank.ledger.it.PostgresTestResource
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing [LedgerOutboxRepositoryImpl]'s
+ * `claimProcessable` at the same instant (an Argo Rollouts canary window running old + new pod)
+ * must never both claim the same row, and a claim that never reaches `markSent`/`markFailed`
+ * (the claiming pod crashed or was evicted) must not strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class LedgerOutboxClaimIT {
+
+    @Inject
+    lateinit var repository: LedgerOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    // The @QuarkusTest Postgres is shared across test classes (same convention as
+    // LedgerOutboxDispatchFailureIT.clearOutbox) — without this, backlog rows other IT classes
+    // left behind get scooped up by this test's claimProcessable calls too.
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    private fun seedPending(count: Int): List<OutboxMessage> {
+        val messages = (1..count).map {
+            OutboxMessage(
+                aggregateId = Ids.newId(),
+                eventType = "test.event.claim",
+                payload = """{"seq":$it}""",
+                createdAt = Instant.now(),
+            )
+        }
+        messages.forEach { msg ->
+            onEventLoop { Panache.withTransaction { repository.persistInTransaction(msg) }.awaitSuspending() }
+        }
+        return messages
+    }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seeded = seedPending(50)
+        val seededIds = seeded.map { it.eventId }.toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seeded = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seeded.eventId)
+
+        // Simulate the claiming pod crashing before markSent/markFailed: back-date claimed_at
+        // far enough that any staleAfter window has already elapsed.
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seeded.eventId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seeded.eventId)
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxDispatch.kt
@@ -15,6 +15,12 @@ import org.jboss.logging.Logger
  *
  * Keeping the @Scheduled and @CircuitBreaker annotations service-side preserves CDI proxying
  * (interceptors only fire on direct CDI injection, not on a libs-side base class).
+ *
+ * Rows are obtained via [OutboxRepository.claimProcessable], not `listProcessable` directly —
+ * on a repository with a real atomic claim implementation this prevents two concurrently
+ * running dispatcher instances (e.g. both pods live during an Argo Rollouts canary window)
+ * from selecting and publishing the same rows (#1201). On a repository still using the
+ * `claimProcessable` default, this is behaviourally identical to the old unclaimed peek.
  */
 object OutboxDispatch {
     private val log: Logger = Logger.getLogger(OutboxDispatch::class.java)
@@ -26,8 +32,8 @@ object OutboxDispatch {
         batchSize: Int = DEFAULT_BATCH_SIZE,
         publish: suspend (entry: OutboxEntry) -> Unit,
     ) {
-        runCatching { repository.listProcessable(batchSize) }
-            .onFailure { ex -> log.warnf(ex, "outbox.listProcessable failed") }
+        runCatching { repository.claimProcessable(batchSize) }
+            .onFailure { ex -> log.warnf(ex, "outbox.claimProcessable failed") }
             .getOrNull()
             ?.forEach { entry ->
                 try {

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxPorts.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxPorts.kt
@@ -4,12 +4,35 @@
 
 package com.openbank.libs.persistence.outbox
 
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
 interface OutboxRepository {
     /** PENDING + FAILED rows, oldest first. DEAD (N5) and SENT rows are excluded. */
     suspend fun listProcessable(limit: Int): List<OutboxEntry>
+
+    /**
+     * Atomically claim up to [limit] processable rows for **this** dispatcher instance,
+     * transitioning them to [OutboxStatus.DISPATCHING] so a concurrently running instance
+     * cannot select the same rows (#1201). This matters whenever more than one pod can run the
+     * dispatch loop at once — including under a steady-state `replicas: 1` deployment, since an
+     * Argo Rollouts canary window runs the old and new pod simultaneously for the duration of the
+     * rollout, and **both** run every `@Scheduled` bean regardless of traffic-weight split.
+     *
+     * Also reclaims rows still [OutboxStatus.DISPATCHING] after [staleAfter] — the claiming pod
+     * crashed or was evicted between claiming the row and calling `markSent`/`markFailed` — so a
+     * claim can never strand a row forever.
+     *
+     * The default delegates to [listProcessable]: an **unclaimed peek**, safe only when the
+     * caller can guarantee a single dispatcher instance is ever running (no concurrent-claim
+     * protection). Override with an atomic `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP
+     * LOCKED)` claim wherever that guarantee doesn't hold — see
+     * `LedgerOutboxRepositoryImpl.claimProcessable` for the reference implementation. Rolling
+     * this out to the rest of the outbox-bearing fleet is tracked as follow-up scope on #1201.
+     */
+    suspend fun claimProcessable(limit: Int, staleAfter: Duration = Duration.ofMinutes(2)): List<OutboxEntry> =
+        listProcessable(limit)
 
     /**
      * Count of processable (PENDING + FAILED) rows — the outbox **backlog**, the single most

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxStatus.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/outbox/OutboxStatus.kt
@@ -11,13 +11,19 @@ import java.util.UUID
  * Lifecycle of an outbox row (ADR-0050).
  *
  * - [PENDING] — written in the same transaction as the state change, not yet relayed.
+ * - [DISPATCHING] — claimed by one dispatcher instance ([OutboxRepository.claimProcessable],
+ *   #1201) and in flight to the broker. Not a durable end state: a repository that implements
+ *   claim semantics reclaims rows stuck here past its stale-claim window (the claiming pod
+ *   crashed or was evicted between claim and `markSent`/`markFailed`) instead of leaving them
+ *   stranded. Repositories still on the [OutboxRepository.claimProcessable] default never
+ *   produce this status.
  * - [SENT] — successfully relayed to the broker.
  * - [FAILED] — a relay attempt failed; the row stays eligible for re-dispatch.
  * - [DEAD] — terminal. The row exhausted [OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS]
  *   publish attempts and is parked so a poison row can neither be retried forever nor
  *   starve the batch (ADR-0050 N5). Excluded from `listProcessable`.
  */
-enum class OutboxStatus { PENDING, SENT, FAILED, DEAD }
+enum class OutboxStatus { PENDING, DISPATCHING, SENT, FAILED, DEAD }
 
 data class OutboxMessage(
     val eventId: UUID = UUID.randomUUID(),


### PR DESCRIPTION
## Why

`LedgerOutboxDispatcher`'s own docstring claimed "N4 — single writer" on the grounds that `replicas: 1` plus `concurrentExecution = SKIP` guarantees exactly one dispatcher claims a row. That's false: an Argo Rollouts canary window runs the old and new pod simultaneously for the whole rollout duration, and **both** run every `@Scheduled` bean regardless of traffic-weight split — the same live behaviour `TieOutScheduler`'s catch-up fix (#1378) was built to tolerate. Two pods could both call `listProcessable`, both select the same PENDING/FAILED rows, and both publish them.

## Fix

`OutboxRepository` gains `claimProcessable(limit, staleAfter)`, an atomic claim that transitions rows to a new `DISPATCHING` status so a concurrently running instance can't select them, and reclaims rows still `DISPATCHING` past `staleAfter` (the claiming pod crashed or was evicted before `markSent`/`markFailed`) so a claim can never strand a row forever. `OutboxDispatch.dispatchOnce` now calls `claimProcessable` instead of `listProcessable`. **The default implementation delegates straight to `listProcessable`** — identical to today's behaviour — so every other outbox-bearing service compiles and runs unchanged.

`LedgerOutboxRepositoryImpl` is the one reference implementation: a single native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement. Plain native SQL rather than a Panache lock hint, since `FOR UPDATE SKIP LOCKED` has no `jakarta.persistence.LockModeType` equivalent, and the lock only needs to live for this one statement — it must not span the network publish call that follows. `claimed_at` is added straight on `LedgerOutboxEntity` (V18 migration), not on the shared `PanacheOutboxEntity` every service maps, so no other service's table needs to change for this to compile or run.

## Not in scope here

Rolling the same claim to the rest of the outbox-bearing fleet (sdd, psd2, billing, account, ...) is tracked as follow-up scope on #1201, along with an advisory-lock lease helper for the once-per-cluster schedulers (tie-out, FX reval, freshness watchdogs, partition maintenance) and outboxing `FxRevaluedEvent`.

## Verified

- `LedgerOutboxClaimIT` (new): two concurrent `claimProcessable` calls never return an overlapping row; a stale `DISPATCHING` row is reclaimed. Mutation-tested — reverted the atomic claim to a plain `listProcessable` passthrough and confirmed both tests fail (not vacuous), then restored it.
- Full non-cached `:openbank-ledger-service:test` (all IT + unit tests, including the existing `OutboxDispatchConformanceIT` suite which now runs through `claimProcessable`) + `ktlintCheck` + `detekt` green.
- `openbank-sdd-service`, `openbank-psd2-service`, `openbank-billing-service`, `openbank-account-service` (other outbox-bearing services) still compile unchanged against the new port method.
- Diff scope: exactly the 8 files this touches, no ktlintFormat collateral.

Refs #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)