### PR TITLE
fix(document-service): heal documents signed before the SIGNED transition existed

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
@@ -79,6 +79,18 @@ class SignatureCeremonyService(
     ): SignatureCeremony {
         val ceremony = ceremonyRepo.findById(ceremonyId) ?: error("Ceremony not found: $ceremonyId")
         val now = Instant.now(clock)
+        // At-least-once safety. The caller retries a decision whose HTTP response was lost, and
+        // SignatureCeremony.recordDecision rejects any decision on a ceremony that already reached
+        // a terminal status — so without this, one dropped response leaves the client tapping
+        // "sign" against a ceremony that IS already signed, failing forever with no way forward.
+        // Replaying a decision this signer already recorded converges on the recorded outcome
+        // instead: returning here re-signs nothing and re-seals nothing, which is the point — the
+        // signature act itself is not idempotent (single-use SCA evidence, a fresh one-time client
+        // certificate per act), so a replay must be absorbed, never re-executed.
+        val recorded = ceremony.signers.find { it.partyRef == partyRef }
+        if (recorded != null && recorded.status == decision) {
+            return ceremony
+        }
         // Validate the decision in the domain FIRST — signer order, not-already-decided, ceremony
         // status — before any object-store mutation. A rejected decision (wrong signer order, a
         // replayed duplicate, an already-terminal ceremony) must never leave a phantom client

--- a/openbank-document-service/src/main/resources/db/migration/V7__heal_signed_documents.sql
+++ b/openbank-document-service/src/main/resources/db/migration/V7__heal_signed_documents.sql
@@ -1,0 +1,39 @@
+-- Heal documents that were signed for real but never recorded as SIGNED.
+--
+-- Until the fix that shipped alongside this migration, SignatureCeremonyService.sealDocument()
+-- applied the institutional seal to the stored PDF but never persisted the document's own
+-- GENERATED/PENDING_SIGNATURE -> SIGNED transition. Document.markSigned() existed and was unit
+-- tested, but had no call site. So a completed ceremony left behind a contradiction that no code
+-- path could ever resolve:
+--
+--   signature_ceremonies.status = 'COMPLETED'  (the client really did sign, SCA-verified)
+--   documents.status            = 'GENERATED'  (…but the bank never wrote it down)
+--
+-- That contradiction is a deadlock, not a cosmetic drift. OnboardingDocumentService
+-- .ensureOnboardingAgreement returns early ONLY on documents.status = 'SIGNED', so an affected
+-- client was handed the same unsigned agreement on every login — and could not sign their way out
+-- of it, because SignatureCeremony.recordDecision() rejects any decision on a ceremony that is
+-- already COMPLETED. Sign screen forever; an active client locked out of their own bank.
+--
+-- Healing here is a status correction, not a signature: sealDocument() stored the sealed bytes
+-- BEFORE the missing transition, so the PDF on these rows is already sealed and the ceremony
+-- already holds the SCA-verified per-signer evidence (signers_json.signedAt). The only thing this
+-- statement writes is the fact the bank failed to record.
+--
+-- Scope is deliberately narrow:
+--   - COMPLETED ceremonies only — never DECLINED/EXPIRED/PENDING/PARTIALLY_SIGNED, where no
+--     signature act finished and 'SIGNED' would be a fabrication.
+--   - GENERATED/PENDING_SIGNATURE documents only — the exact two states the missing transition
+--     could strand a document in. ARCHIVED rows are left untouched: they were superseded before
+--     signing (a language switch, ADR-0169 D3), are already excluded from the agreement lookup,
+--     and resurrecting one to SIGNED would assert a contract the client never signed.
+--
+-- Rollback: none. This does not create or destroy legal state — it records state that already
+-- exists in signature_ceremonies. Reverting it would re-strand the same clients.
+
+UPDATE documents d
+SET status = 'SIGNED'
+FROM signature_ceremonies c
+WHERE c.document_id = d.id
+  AND c.status = 'COMPLETED'
+  AND d.status IN ('GENERATED', 'PENDING_SIGNATURE');

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
@@ -217,6 +217,28 @@ class SignatureCeremonyServiceTest {
         coVerify(exactly = 0) { signerVerificationPort.verify(any(), any(), any(), any()) }
     }
 
+    @Test
+    fun `replaying a decision this signer already recorded absorbs it instead of failing`(): Unit = runBlocking {
+        // The deadlock this guards, seen live: the caller retries a decision whose HTTP response
+        // was lost, the ceremony behind it is already COMPLETED, and the domain rejects every
+        // decision on a terminal ceremony -- so the retry failed forever and the client sat on the
+        // signing screen unable to sign a contract they had ALREADY signed. Absorbing the replay
+        // must not re-execute the signature act: the SCA evidence is single-use and each signing
+        // act mints a fresh one-time certificate, so re-running it is not a no-op.
+        val signed = Signer(partyRef = "party-1", order = 1, status = SignerStatus.SIGNED, signedAt = FIXED_NOW)
+        val completed = ceremony(listOf(signed)).copy(status = CeremonyStatus.COMPLETED)
+        coEvery { ceremonyRepo.findById(completed.id) } returns completed
+
+        val result = service.recordDecision(completed.id, "party-1", SignerStatus.SIGNED, "evidence-1")
+
+        assertThat(result.status).isEqualTo(CeremonyStatus.COMPLETED)
+        coVerify(exactly = 0) { signerVerificationPort.verify(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { sealPort.sealPades(any(), any()) }
+        coVerify(exactly = 0) { ceremonyRepo.save(any()) }
+        coVerify(exactly = 0) { ceremonyRepo.saveWithOutbox(any(), any()) }
+    }
+
     private fun signer(partyRef: String, order: Int = 1) =
         Signer(partyRef = partyRef, order = order, status = SignerStatus.PENDING, signedAt = null)
 


### PR DESCRIPTION
fix(document-service): heal documents signed before the SIGNED transition existed

The previous fix wired Document.markSigned() into sealDocument(), but only helps
ceremonies completed after it deployed. It left behind — and could not repair — a
contradiction that is a hard deadlock for the client:

  signature_ceremonies.status = 'COMPLETED'   the client really did sign, SCA-verified
  documents.status            = 'GENERATED'   ...but the bank never wrote it down

ensureOnboardingAgreement() returns early only on documents.status = 'SIGNED', so an
affected client is handed the same unsigned agreement forever. They cannot sign their
way out: recordDecision() rejects every decision on an already-COMPLETED ceremony. An
active client, locked out of their own bank, with no path forward from inside the app.

Found live, not hypothesised: party 24977cca signed at 06:15:07Z (signer SIGNED,
ceremony COMPLETED), the fix deployed 06:43:37Z — 28 minutes late — and their document
sat at GENERATED. The four sign attempts at 07:12–07:13 are them trying to escape it.

Three defects, three fixes:

1. V7__heal_signed_documents.sql — record the SIGNED status these documents already
   earned. A status correction, not a signature: sealDocument() stored the sealed bytes
   before the missing transition, so the PDF is already sealed and the ceremony already
   holds the per-signer SCA evidence. Scoped to COMPLETED ceremonies with
   GENERATED/PENDING_SIGNATURE documents only; ARCHIVED rows are left alone (superseded
   before signing — resurrecting one would assert a contract nobody signed).

2. recordDecision() absorbs a replay of a decision the signer already recorded, instead
   of failing on the terminal-status guard. One lost HTTP response was enough to brick a
   client the same way, during onboarding, where the sign screen is a real gate. The
   replay returns without re-executing the signature act — single-use SCA evidence and a
   fresh one-time certificate per act mean re-running it is not a no-op.

3. (openbank-app) the login path no longer re-gates on the signing screen at all.

Signed-off-by: Jiri Raska <jiri@iraska.cz>

## Linked issues

Closes #1417
