### PR TITLE
[DO NOT MERGE] test: prove the Gradle dependency-review gate fails a vulnerable dep

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,10 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest  # public repo => hosted runners free+unlimited (FinOps: hosted-first)
-    timeout-minutes: 10
+    # 25 > the retry window below, which must in turn outlast dependency-submission.yml
+    # (measured ~11 min for the full-fleet resolve) or this job would give up before the
+    # graph it is waiting for exists.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -23,6 +26,22 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
+          # This action only ever diffs SUBMITTED dependency graphs. Gradle — the fleet's
+          # primary language — is not natively parsed by GitHub, so until
+          # dependency-submission.yml also ran on pull_request (#1419) the Gradle half of
+          # every PR was invisible here and vulnerable deps landed unreviewed, to surface
+          # later as Dependabot alerts on main.
+          #
+          # On a dependency-touching PR that submission job runs concurrently with this
+          # one, so the head-SHA snapshot may not exist yet when this starts: retry until
+          # it does. gradle/actions documents 600 s, but the fleet's resolve was MEASURED
+          # at ~670 s, so 600 would time out before the snapshot ever landed — 1200 leaves
+          # room for the resolve plus queue time.
+          #
+          # On a PR that touches no dependency manifest, no submission runs and there is no
+          # snapshot warning to retry on, so this returns at its usual few seconds.
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 1200
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
           # starlette (pulled in transitively via schemathesis==3.39.16's own
           # starlette<1,>=0.13 pin — .github/workflows/requirements/schemathesis.txt)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,6 +21,42 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Whether to wait for a Gradle snapshot depends on whether one is coming: the retry
+      # below must be armed ONLY when dependency-submission.yml is also running for this PR,
+      # i.e. when the same paths it filters on changed. Measured the hard way — with the
+      # retry armed unconditionally this job sat >11 min on a PR that touched no manifest
+      # at all, because GitHub reports a snapshot warning for the head SHA regardless (the
+      # Gradle graph is inherited from main, never submitted for this SHA). That would have
+      # taxed the ~93% of PRs this feature has nothing to say about.
+      #
+      # Same merge-base resolution as ci.yml's shared diff-base step, and for the same
+      # reason: pull_request.base.sha is frozen at PR creation and misclassifies once a
+      # competing PR merges first.
+      - name: Detect dependency-manifest changes
+        id: deps
+        env:
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          base="${EVENT_BASE_SHA}"
+          git fetch --depth=2 origin "${GITHUB_SHA}" 2>/dev/null || true
+          if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
+            base="$(git rev-parse 'HEAD^1')"
+          else
+            git fetch --depth=1 origin "${base}" 2>/dev/null || true
+          fi
+          # Keep this list in sync with dependency-submission.yml's path filters.
+          # Here-string, not a pipe: `set -o pipefail` + `grep -q` exiting early SIGPIPEs
+          # the producer and fails the step (a known footgun in this repo's workflows).
+          files="$(git diff --name-only "${base}" "${GITHUB_SHA}")"
+          if grep -qE '(^|/)build\.gradle\.kts$|^openbank-libs/gradle/libs\.versions\.toml$|^settings\.gradle\.kts$|^gradle/wrapper/' <<< "${files}"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Dependency manifests changed — will wait for the Gradle snapshot from dependency-submission.yml."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No dependency manifest touched — no Gradle submission runs for this PR, so nothing to wait for."
+          fi
+
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
@@ -32,15 +68,13 @@ jobs:
           # every PR was invisible here and vulnerable deps landed unreviewed, to surface
           # later as Dependabot alerts on main.
           #
-          # On a dependency-touching PR that submission job runs concurrently with this
-          # one, so the head-SHA snapshot may not exist yet when this starts: retry until
-          # it does. gradle/actions documents 600 s, but the fleet's resolve was MEASURED
-          # at ~670 s, so 600 would time out before the snapshot ever landed — 1200 leaves
-          # room for the resolve plus queue time.
-          #
-          # On a PR that touches no dependency manifest, no submission runs and there is no
-          # snapshot warning to retry on, so this returns at its usual few seconds.
-          retry-on-snapshot-warnings: true
+          # Armed only on dependency-touching PRs (see the detect step above): there the
+          # submission job runs concurrently with this one, so the head-SHA snapshot may
+          # not exist yet when this starts and we must wait for it. gradle/actions
+          # documents a 600 s timeout, but this fleet's resolve was MEASURED at ~670 s —
+          # 600 would give up before the snapshot could ever land. 1200 covers the resolve
+          # plus queue time, and the job's own timeout-minutes is set above it.
+          retry-on-snapshot-warnings: ${{ steps.deps.outputs.changed == 'true' }}
           retry-on-snapshot-warnings-timeout: 1200
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
           # starlette (pulled in transitively via schemathesis==3.39.16's own

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -27,6 +27,20 @@ on:
       - "openbank-libs/gradle/libs.versions.toml"
       - "settings.gradle.kts"
       - "gradle/wrapper/**"
+  # PRs too, so dependency-review.yml has a head-SHA graph to diff against main's
+  # (issue #1419): without a per-PR submission the Gradle graph is main-only, and
+  # dependency-review — which only ever compares submitted graphs — silently had
+  # nothing to say about the fleet's primary language. This is the integration
+  # documented by gradle/actions (docs/dependency-submission.md). Same path filter
+  # as the push trigger: only a PR that can change resolution pays the ~11 min, which
+  # is 3 of the last 40 PRs.
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/build.gradle.kts"
+      - "openbank-libs/gradle/libs.versions.toml"
+      - "settings.gradle.kts"
+      - "gradle/wrapper/**"
   schedule:
     # Weekly belt-and-braces resubmission — dependency resolution can drift even without a
     # manifest change (a transitive version moving inside a declared range).
@@ -44,6 +58,16 @@ jobs:
   submit:
     name: Submit fleet dependency graph
     runs-on: ubuntu-latest # public repo => hosted runners free+unlimited (FinOps: hosted-first)
+    # Skip on fork PRs: GitHub hands them a read-only token no matter what the block
+    # below asks for, so the submission API call would fail — a guaranteed red check
+    # on every external contribution. Consequence: a fork PR gets dependency review
+    # for the natively-parsed ecosystems (npm/pip/actions/docker) but NOT for Gradle.
+    # Accepted deliberately: closing it needs the generate-and-upload + workflow_run
+    # download-and-submit split, and a `workflow_run` job holding `contents: write`
+    # while consuming a fork-authored artifact is the first such pattern in this repo —
+    # not worth introducing for a repo whose changes all land from same-repo branches.
+    # Revisit if external contributions become routine (tracked in #1419).
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     timeout-minutes: 30
     permissions:
       contents: write # required by the dependency-submission API

--- a/openbank-libs-domain/build.gradle.kts
+++ b/openbank-libs-domain/build.gradle.kts
@@ -22,6 +22,11 @@ repositories {
 }
 
 dependencies {
+    // DO NOT MERGE — throwaway proof that the PR-time Gradle dependency gate (#1419)
+    // actually fails a vulnerable dependency. commons-text 1.9 is Text4Shell
+    // (CVE-2022-42889 / GHSA-599f-7c49-w659, critical). This branch is closed, never merged.
+    implementation("org.apache.commons:commons-text:1.9")
+
     api(libs.kotlin.stdlib)
     api(libs.kotlin.reflect)
     api(libs.kotlinx.coroutines.core)


### PR DESCRIPTION
## Summary

**Throwaway. Do not merge. Will be closed once the gate's verdict is recorded.**

Stacked on `security/gradle-dependency-review-on-prs` (#1421) and deliberately adds `org.apache.commons:commons-text:1.9` — **Text4Shell**, CVE-2022-42889 / GHSA-599f-7c49-w659, critical — to `openbank-libs-domain`.

## What this proves

#1421 claims a PR that introduces a vulnerable Gradle dependency will now be **blocked**. That claim is worthless unless the gate is seen failing on a real one. So:

- **Expected:** `Dependency submission` runs (this PR touches `build.gradle.kts`, matching the path filter), then `Dependency review` **FAILS** on a high/critical Gradle advisory.
- **Before #1421** the same PR would have passed dependency review untouched — Gradle had no head-SHA graph to diff, so the gate never saw it.

## Linked issues

Refs #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)