### PR TITLE
fix(notification): reject opsmessage.compose requests missing required template variables

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -54,11 +54,18 @@ class OperatorMessageService {
     lateinit var clock: Clock
 
     suspend fun compose(request: OperatorMessageRequest): UUID {
+        // Symmetrical check (issue #1381): unknownVariables() only ever caught EXTRA keys, so a
+        // request missing a required key sailed through and render()'s old fallback-to-"" quietly
+        // substituted a blank — a real customer got a message with an empty body/subject, and the
+        // row was persisted and mailed as an ordinary SENT row with no error anywhere in the chain.
         val unknown = request.template.unknownVariables(request.variables)
-        if (unknown.isNotEmpty()) {
+        val missing = request.template.variables - request.variables.keys
+        if (unknown.isNotEmpty() || missing.isNotEmpty()) {
             throw OperatorMessageRejected(
                 "template ${request.template.name} declares ${request.template.variables.sorted()} " +
-                    "but request carried undeclared ${unknown.sorted()}",
+                    "but request carried ${request.variables.keys.sorted()}" +
+                    (if (unknown.isNotEmpty()) " (undeclared: ${unknown.sorted()})" else "") +
+                    (if (missing.isNotEmpty()) " (missing: ${missing.sorted()})" else ""),
             )
         }
 
@@ -128,21 +135,24 @@ class OperatorMessageService {
         return notificationId
     }
 
-    /** Exhaustive, no `else` — a new [OperatorMessageTemplate] constant fails to compile here. */
+    /**
+     * Exhaustive, no `else` — a new [OperatorMessageTemplate] constant fails to compile here.
+     * `vars.getValue(key)` is safe: [compose] already rejected any request whose `variables`
+     * don't exactly match `template.variables` (extra AND missing), so every declared key is
+     * guaranteed present by the time render() runs — no fallback-to-"" indirection needed.
+     */
     private fun render(template: OperatorMessageTemplate, vars: Map<String, String>): Pair<String, String> =
         when (template) {
             OperatorMessageTemplate.GENERIC_NOTICE ->
-                (vars.v("subject").ifBlank { "A message from OpenBank" }) to
-                    "<p>${vars.v("note")}</p>"
+                (vars.getValue("subject").ifBlank { "A message from OpenBank" }) to
+                    "<p>${vars.getValue("note")}</p>"
             OperatorMessageTemplate.SUPPORT_FOLLOWUP ->
                 "Following up on your support request" to
                     "<p>We are following up on your support request " +
-                    "(reference <b>${vars.v("ticketReference")}</b>). " +
+                    "(reference <b>${vars.getValue("ticketReference")}</b>). " +
                     "Please reply to this message if you have further questions.</p>"
         }
 }
-
-private fun Map<String, String>.v(key: String): String = this[key] ?: ""
 
 data class OperatorMessageRequest(
     val partyId: UUID,

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/OperatorMessageServiceIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/OperatorMessageServiceIT.kt
@@ -107,4 +107,31 @@ class OperatorMessageServiceIT {
         assertThat(mailbox.getMailMessagesSentTo("rejected@example.com")).isEmpty()
         assertThat(bodyFor(partyId)).isNull()
     }
+
+    /**
+     * Issue #1381: `unknownVariables()` only ever caught EXTRA keys. A request missing a
+     * required key used to sail through and render() silently substituted an empty string —
+     * a real customer got a blank-body email, persisted and mailed as an ordinary SENT row.
+     */
+    @Test
+    fun `a request missing a required variable is rejected before anything is persisted or sent`() {
+        val partyId = UUID.randomUUID()
+        mailbox.clear()
+
+        assertThatThrownBy {
+            onVertxContext {
+                service.compose(
+                    OperatorMessageRequest(
+                        partyId = partyId,
+                        template = OperatorMessageTemplate.SUPPORT_FOLLOWUP,
+                        recipient = "missing-var@example.com",
+                        variables = emptyMap(),
+                    ),
+                )
+            }
+        }.isInstanceOf(OperatorMessageRejected::class.java)
+
+        assertThat(mailbox.getMailMessagesSentTo("missing-var@example.com")).isEmpty()
+        assertThat(bodyFor(partyId)).isNull()
+    }
 }


### PR DESCRIPTION
## Summary
- `OperatorMessageTemplate.unknownVariables()` only ever rejected EXTRA keys; a request missing a required key (e.g. `variables={}`) passed the closed-schema check and `render()`'s `.v()` fallback silently substituted an empty string, so a blank-body email could be sent to a real customer and persisted as an ordinary `SENT` row.
- `compose()` now checks both directions: `unknownVariables` (extra) and `template.variables - request.variables.keys` (missing), rejecting either with `OperatorMessageRejected` (400).
- `render()` now indexes the map directly with `getValue()` since a validated `variables` map is guaranteed to carry every declared key by the time it runs; the `.v()` fallback-to-"" extension is removed.

## Test plan
- [x] Added `OperatorMessageServiceIT`: "a request missing a required variable is rejected before anything is persisted or sent" — asserts no mail sent and no row persisted for `SUPPORT_FOLLOWUP` with `variables=emptyMap()`.
- [x] `./gradlew :openbank-notification-service:detekt :openbank-notification-service:ktlintCheck :openbank-notification-service:compileKotlin :openbank-notification-service:compileTestKotlin` — green.
- [x] `./gradlew :openbank-notification-service:test --tests OperatorMessageResourceTest` — green (existing resource-layer tests unaffected).
- Note: the new IT requires Testcontainers/Docker (`PostgresTestResource`), same as the sibling tests in that file; not re-run standalone here beyond compile, matching the existing suite's infra requirements.

Closes #1381