### PR TITLE
docs(notification): document opsmessage.compose / opsmessage.approval.decide in openapi.yaml

### DIFF
--- a/openbank-notification-service/src/main/resources/openapi.yaml
+++ b/openbank-notification-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Notification Service API
-  version: 1.5.0
+  version: 1.6.0
   description: Notification delivery management — query sent/pending notifications, manage push device tokens.
   license:
     name: Apache-2.0
@@ -15,6 +15,8 @@ tags:
   - name: Notifications
   - name: Devices
   - name: Ops — Dispatch Control
+  - name: Operator Messages
+  - name: Notification Approvals
 
 paths:
   /api/v1/devices:
@@ -191,6 +193,82 @@ paths:
       responses:
         '200':
           description: Count of notifications flipped to read
+
+  /api/v1/notifications/messages:
+    post:
+      tags: [Operator Messages]
+      summary: Send a customer a message from a reviewed, closed catalogue of templates
+      description: |
+        `opsmessage.compose` (ADR-0176 D2). ROLE_OPERATOR/ROLE_ADMIN only. EMAIL only. Gated by
+        `four_eyes.actions` in rules.yaml: when `AUTHZ_FOUR_EYES_ENFORCE=true`, a maker's call is
+        paused with `202` and a pending-approval id; the maker retries with `X-Approval-Id` once a
+        different operator decides it via `PATCH /api/v1/notifications/approvals/{id}`.
+        `AUTHZ_FOUR_EYES_ENFORCE` defaults `false`, so a `201` is the common response today.
+      operationId: composeOperatorMessage
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComposeMessageRequest'
+      responses:
+        '201':
+          description: Message persisted and sent (or, once four-eyes enforcement is on, approved and sent)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeMessageResponse'
+        '202':
+          description: Four-eyes enforcement is on — paused pending a different operator's approval
+        '400':
+          description: Unknown/missing template variables, or a malformed recipient
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /api/v1/notifications/approvals/{id}:
+    patch:
+      tags: [Notification Approvals]
+      summary: Approve or reject a pending four-eyes approval for an operator message
+      description: |
+        `opsmessage.approval.decide` (ADR-0176 D5). ROLE_OPERATOR/ROLE_ADMIN only; the checker
+        must be a different operator than the maker who called `POST /api/v1/notifications/messages`.
+      operationId: decideOperatorMessageApproval
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The pending-approval id returned by the paused compose call
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecideApprovalRequest'
+      responses:
+        '200':
+          description: Decided approval
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalResponse'
+        '403':
+          description: The checker is the same operator who made the original request (self-approval)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+        '404':
+          description: No pending approval with that id
+        '409':
+          description: The approval is not in a decidable state (already decided or executed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
 
   /api/v1/ops/dispatch:
     get:
@@ -545,3 +623,64 @@ components:
         state:
           type: string
           enum: [PROPOSED, APPROVED, REJECTED, WITHDRAWN, EXECUTED]
+
+    OperatorMessageTemplate:
+      type: string
+      description: |
+        The closed set of messages an operator may send (ADR-0176 D2). Deliberately not
+        NotificationTemplate — see OperatorMessageTemplate's own KDoc for why: some
+        NotificationTemplate constants feed the ADR-0059 oversight webhook, and reusing that
+        enum here would let an operator raise a false lifecycle alert.
+      enum: [GENERIC_NOTICE, SUPPORT_FOLLOWUP]
+
+    ComposeMessageRequest:
+      type: object
+      required: [partyId, template, recipient]
+      properties:
+        partyId:
+          type: string
+          format: uuid
+        template:
+          $ref: '#/components/schemas/OperatorMessageTemplate'
+        recipient:
+          type: string
+          description: Email address. Must be well-formed; rejected with 400 otherwise.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Must exactly match the chosen template's declared variable set — GENERIC_NOTICE
+            needs {subject, note}, SUPPORT_FOLLOWUP needs {ticketReference}. Extra or missing
+            keys are both rejected with 400.
+
+    ComposeMessageResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The new notification's id.
+
+    DecideApprovalRequest:
+      type: object
+      required: [approve]
+      properties:
+        approve:
+          type: boolean
+
+    ApprovalResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        action:
+          type: string
+        resourceId:
+          type: string
+          nullable: true
+        status:
+          type: string
+        decidedBy:
+          type: string
+          nullable: true

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/contract/OperatorMessageContractTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/contract/OperatorMessageContractTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.notification.contract
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Guards the published contract for the `opsmessage.compose` / `opsmessage.approval.decide`
+ * endpoints (ADR-0176 D2/D5, PR #1368) without booting the app: they shipped with zero
+ * `openapi.yaml` update (issue #1387), invisible to `check-api-contract.py` because that gate
+ * only classifies a diff for a changed spec — nothing to compare when the spec never moves at
+ * all. This test fails if either path (or the version bump that documenting them requires)
+ * regresses.
+ */
+class OperatorMessageContractTest {
+
+    private val openapi = File("src/main/resources/openapi.yaml").readText()
+
+    @Test
+    fun `info version documents a semver contract version at or above the additive bump`() {
+        // ADR-0048: additive change (new paths, same /v1) => MINOR (or MAJOR) bump within the
+        // same URL major. This test only pins that the declared version parses and is at least
+        // 1.6.0, the version this documentation shipped under -- it does not re-derive the
+        // classification itself, that is check-api-contract.py's job.
+        val version = Regex("""(?m)^\s+version:\s*"?([^"\s]+)"?\s*$""").find(openapi)?.groupValues?.get(1)
+        assertThat(version).isNotNull()
+        val (major, minor) = version!!.split(".").take(2).map { it.toInt() }
+        assertThat(major).isEqualTo(1)
+        assertThat(minor).isGreaterThanOrEqualTo(6)
+    }
+
+    @Test
+    fun `opsmessage compose is documented`() {
+        assertThat(openapi)
+            .contains("/api/v1/notifications/messages:")
+            .contains("composeOperatorMessage")
+            .contains("ComposeMessageRequest")
+    }
+
+    @Test
+    fun `opsmessage approval decide is documented`() {
+        assertThat(openapi)
+            .contains("/api/v1/notifications/approvals/{id}:")
+            .contains("decideOperatorMessageApproval")
+            .contains("DecideApprovalRequest")
+    }
+}


### PR DESCRIPTION
## Summary
- PR #1368 shipped `POST /api/v1/notifications/messages` (`opsmessage.compose`) and `PATCH /api/v1/notifications/approvals/{id}` (`opsmessage.approval.decide`) with zero `openapi.yaml` update. `check-api-contract.py` stayed green because it only classifies a diff for a spec that actually changed — nothing to compare when the spec never moves.
- Second time this service has shipped this exact gap (PR #1303 fixed the same class of drift earlier).
- Adds both paths + `ComposeMessageRequest`/`ComposeMessageResponse`/`DecideApprovalRequest`/`ApprovalResponse`/`OperatorMessageTemplate` schemas (reusing the existing `ApiError` schema for the 400/403/409 error bodies rather than introducing a duplicate — it already has the identical `{code, message}` shape).
- Bumps `info.version` `1.5.0` → `1.6.0` (additive, same `/v1` major, per ADR-0048). `openbank.api.version` in `application.yaml` stays `"1"` — the major axis is unaffected.
- Adds `OperatorMessageContractTest` pinning both paths' presence and the version floor, per root `CLAUDE.md` rule #3 ("API change ⇒ openapi.yaml updated + contract test").

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — spec parses, both new paths present.
- [x] `./gradlew :openbank-notification-service:detekt :openbank-notification-service:ktlintCheck :openbank-notification-service:compileKotlin :openbank-notification-service:compileTestKotlin` — green.
- [x] `./gradlew :openbank-notification-service:test --tests OperatorMessageContractTest` — green.

Closes #1387