### PR TITLE
fix(libs-runtime): log when four_eyes_required but fourEyesEnforce=false

### DIFF
--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt
@@ -271,6 +271,17 @@ class AuthorizeInterceptor {
             // so a fleet where authz.four-eyes.enforce is false everywhere (the current default,
             // and never overridden in gitops) looked exactly like a fleet with no flagged actions.
             meters?.authzFourEyes(annotation.action, "required_not_enforced")
+            // debug, not warn (issue #1391): this is normal/expected state fleet-wide today, not a
+            // misconfiguration — flipping authz.four-eyes.enforce is a deliberate, separate
+            // operational decision. But the metric above wasn't paired with any log line, so this
+            // advisory state was invisible to anyone tailing logs rather than querying metrics —
+            // asymmetric with the ApprovalStore-missing branch below, which does log loudly for
+            // exactly this class of "silently not enforcing" gap.
+            log.debugf(
+                "four-eyes: action=%s is flagged four_eyes_required but authz.four-eyes.enforce=false " +
+                    "— proceeding without the second-approver gate (advisory)",
+                annotation.action,
+            )
             return ctx.proceed()
         }
         if (!approvalStore.isResolvable) {


### PR DESCRIPTION
## Summary
- `AuthorizeInterceptor.requireFourEyesOrProceed`'s `!fourEyesEnforce` branch (`openbank-libs-runtime/src/main/kotlin/com/openbank/libs/authz/AuthorizeInterceptor.kt`) recorded a metric (`authzFourEyes(..., "required_not_enforced")`) but had no log line at all — asymmetric with the ApprovalStore-missing branch immediately below it, which was fixed in an earlier code-review round to log loudly for exactly this class of silent gap.
- An action flagged `four_eyes_required=true` by OPA but running with `AUTHZ_FOUR_EYES_ENFORCE=false` produced zero operator-visible trail distinguishing "correctly not enforcing yet" from "fully wired and forgot to flip enforce=true" for anyone tailing logs rather than querying metrics.
- Added a `debug`-level log line (not `warn` — this is normal/expected fleet-wide state today, not a misconfiguration) so the advisory state is observable on demand.

No behavior change — `ctx.proceed()` still happens unconditionally in this branch.

## Test plan
- [x] `./gradlew :openbank-libs-runtime:detekt :openbank-libs-runtime:ktlintCheck :openbank-libs-runtime:test` — green, including `four_eyes_required with enforcement off is counted, not silently dropped` and the other existing `AuthorizeInterceptorTest` four-eyes cases (log line addition doesn't change asserted behavior).

Closes #1391