### PR TITLE
fix(notification): use UUIDv7 for consumer notification IDs

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.libs.audit.AuditEvent
 import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.libs.audit.AuditResult
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.notification.application.port.out.OversightWebhookPublisher
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
@@ -34,7 +35,6 @@ import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.Executor
 
 @ApplicationScoped
@@ -131,7 +131,7 @@ class NotificationConsumer {
     private fun dispatch(req: NotificationRequest): Uni<Void> {
         val (subject, body) = renderTemplate(req.template, req.variables)
         val entity = NotificationEntity().also {
-            it.notificationId = UUID.randomUUID()
+            it.notificationId = Ids.newId()
             it.partyId = req.partyId
             it.channel = req.channel.name
             it.template = req.template.name

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -70,12 +70,8 @@ class OperatorMessageService {
 
         val (subject, body) = render(request.template, request.variables)
         // notificationId is the entity's durable, indexed identifier (ADR-0106) — minted via
-        // Ids, a UUIDv7 generator, not a plain random UUID. Diverges from NotificationConsumer's
-        // existing rows (issue #1388): NotificationConsumer.dispatch still mints notificationId
-        // through a bare, unversioned java.util.UUID factory call (version 4), so
-        // `notifications.notification_id` is currently a mix of version-4 and version-7 UUIDs
-        // across the two write paths -- do not assume sort/version-bit consistency across them
-        // without checking NotificationConsumer first.
+        // Ids, a UUIDv7 generator, not a plain random UUID. Matches NotificationConsumer's
+        // durable notification identifiers.
         val notificationId = Ids.newId()
         val entity = NotificationEntity().also {
             it.notificationId = notificationId

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -95,6 +95,10 @@ class NotificationConsumerIT {
         Panache.withSession { repository.find("partyId", partyId).firstResult() }
     }?.body
 
+    private fun notificationIdFor(partyId: UUID): UUID? = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { repository.find("partyId", partyId).firstResult() }
+    }?.notificationId
+
     /** Drive one request through the in-memory inbound channel and wait for the ack. */
     private fun consumeAndAwait(request: NotificationRequest) {
         val source: InMemorySource<Message<String>> = connector.source("notification-events-in")
@@ -149,6 +153,7 @@ class NotificationConsumerIT {
         // SENT (the %test profile mocks the mailer, so the email leg succeeds).
         assertThat(countFor(partyId)).isEqualTo(1L)
         assertThat(statusFor(partyId)).isEqualTo("SENT")
+        assertThat(notificationIdFor(partyId)?.version()).isEqualTo(7)
     }
 
     /**


### PR DESCRIPTION
## Summary
- switch NotificationConsumer durable notification IDs from bare UUIDv4 to Ids.newId() UUIDv7
- update the OperatorMessageService comment now that both notification write paths use UUIDv7
- assert the persisted consumer notification ID is UUIDv7 in NotificationConsumerIT

Fixes #1388.

## Validation
- JAVA_HOME=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/jdks/jdk-21.0.11+10 ./gradlew :openbank-notification-service:test --tests com.openbank.notification.integration.NotificationConsumerIT
- JAVA_HOME=/home/polly/Documents/workspace/codex/oss-agent/oss-open-work/jdks/jdk-21.0.11+10 ./gradlew :openbank-notification-service:ktlintCheck
- git diff --check