### PR TITLE
docs: give the institutional seal a key-table row and the runbook a restart step

### DIFF
--- a/docs/adr/0172-cryptographic-key-management-and-lifecycle.md
+++ b/docs/adr/0172-cryptographic-key-management-and-lifecycle.md
@@ -33,6 +33,7 @@ secret rotation (ADR-0099).
 | **DNSSEC** | `aws_kms_key.dnssec` (Route53 KSK) | AWS KMS, OpenTofu | **Disabled** (`enable_key_rotation = false`) |
 | **Transport CA** | Strimzi cluster CA + clients CA, ~33 KafkaUser certs | Strimzi operator, `messaging` ns | Strimzi defaults — **not configured, not documented** |
 | **Document signing** | `pki-document-signing` root (RSA-2048, 10y) → per-ceremony leaf (300s, `no_store`) | OpenBao PKI, in-cluster | Root: **none**. Leaf: ephemeral |
+| **Institutional seal** | the bank's own long-lived PAdES-sealing PKCS12 — `openbank/document-service-signing-seal` (`KEYSTORE_P12_BASE64` + `KEYSTORE_PASSWORD`). Distinct from the row above: that mints the *client's* one-time cert, this is the *bank's* identity on every sealed document | OpenBao KV, seeded out-of-band by an operator (runbook 0008) | **None** — and **not yet seeded**: `PdfBoxPadesSealAdapter` falls back to a DEV-ONLY ephemeral cert (#1284) |
 | **Agent identity** | `pki-agent` CA (ADR-0031 D3b) | OpenBao PKI | Not documented |
 | **Credential issuance** | EUDI issuer EC P-256 private JWK — signs every PID/(Q)EAA | OpenBao KV | **None** |
 | **PII index** | RČ pepper (HMAC-SHA256, `BlindIndex`) | OpenBao KV | Manual + re-index (`index_key_version`) |

--- a/docs/runbooks/0008-openbao-document-signing-pki.md
+++ b/docs/runbooks/0008-openbao-document-signing-pki.md
@@ -83,6 +83,18 @@ The `document-service-signing-keystore` ExternalSecret picks this up on its next
 (1h) or immediately via `kubectl annotate externalsecret document-service-signing-keystore -n
 documents force-sync=$(date +%s) --overwrite`.
 
+**Then restart document-service — the projected Secret alone is not enough:**
+
+```sh
+kubectl rollout restart deploy/document-service -n documents
+```
+
+`PdfBoxPadesSealAdapter` resolves the seal identity **once**, in its `init {}`, into a `val`. A
+keystore file appearing under a running pod changes nothing: the process keeps the ephemeral dev
+identity it picked at startup and goes on applying seals that are worthless as evidence — while
+`bao kv get` and `kubectl get secret` both look correct. Since #1299 the adapter is `@Startup`, so
+that decision (and its warning) happen at boot, which is why the boot is what must be repeated.
+
 ## Verify
 
 ```sh


### PR DESCRIPTION
Two gaps found while working out how #1284's remaining half actually gets resolved.

## 1. ADR-0172's key register is missing the seal

The table is the register of every key the platform holds. The **Document signing** row covers `pki-document-signing`'s per-ceremony leaf — the *client's* one-time cert. The bank's **institutional seal** is a different key entirely: a long-lived PKCS12 in OpenBao KV (`openbank/document-service-signing-seal`) that signs *as the bank* on every sealed document.

It has no row, no rotation story, and is **not seeded today** — so `PdfBoxPadesSealAdapter` falls back to a DEV-ONLY ephemeral cert (#1284). That is precisely the kind of fact a key register exists to surface, and it was invisible because the key wasn't in it.

Added as its own row, marked unseeded.

## 2. Runbook 0008 stops one step short of a working seal

It tells the operator to seed the KV secret and force-sync the ExternalSecret. That is not enough:

> `PdfBoxPadesSealAdapter` resolves the seal identity **once**, in its `init {}`, into a `val`.

A keystore file appearing under a running pod changes nothing. The process keeps the ephemeral identity it chose at boot and goes on applying seals that are worthless as evidence — while `bao kv get` and `kubectl get secret` both look correct. The runbook's own verify step (`grep -i EPHEMERAL` should print nothing) would then pass or fail for the wrong reason.

Added `kubectl rollout restart deploy/document-service -n documents`, and why it is required.

Worth noting the omission **predates #1299** and isn't a regression from it: the bean was CDI-lazy then, so the first ceremony would have re-read the identity. `@Startup` moved the decision to boot — which is what makes the restart the thing that has to happen, and also what makes the runbook's `grep -i EPHEMERAL` check meaningful at all (before #1299 that warning never appeared at startup, so the grep would have been silent either way).

## Verification

- ADR-0172's table: 17 rows, all 5 columns, 0 malformed.
- `check-adr-registry.sh` → `OK — 169 ADRs, unique numbers, headings match filenames, index fresh.`
- Diff is purely additive: +1 / +12, no deletions.

Docs only. Does not seed anything — the seal keystore remains the operator's one-time, out-of-band step, as runbook 0008 intends.

Refs #1284, #1299