### PR TITLE
perf(notification): scoped bulk UPDATE for opsmessage.compose's terminal status transition

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -91,23 +91,12 @@ class OperatorMessageService {
             .onFailure().invoke { e ->
                 log.warnf(e, "opsmessage.compose: mail send failed notificationId=%s", notificationId)
             }
-            .onFailure().recoverWithUni { _ ->
-                Panache.withTransaction {
-                    notificationRepo.find("notificationId", notificationId).firstResult()
-                        .map { e -> e?.also { it.status = "FAILED" } }
-                }.replaceWithVoid()
-            }
-            .chain { _ ->
-                Panache.withTransaction {
-                    notificationRepo.find("notificationId", notificationId).firstResult()
-                        .map { e ->
-                            e?.also {
-                                it.status = "SENT"
-                                it.sentAt = Instant.now(clock)
-                            }
-                        }
-                }.replaceWithVoid()
-            }
+            .onFailure().recoverWithUni { _ -> notificationRepo.markTerminalStatus(notificationId, "FAILED") }
+            // Scoped bulk UPDATE, not find-then-map-then-persist (issue #1393): the prior code
+            // SELECTed the full row (pulling subject/body HTML back out) before UPDATEing it —
+            // an extra DB round-trip this repository's own markRead/markAllRead idiom already
+            // avoided elsewhere in this file.
+            .chain { _ -> notificationRepo.markTerminalStatus(notificationId, "SENT", Instant.now(clock)) }
             // Only reachable if the mail genuinely went out (the FAILED path above already
             // recovered any send failure into a completed Uni). Never marks the row FAILED —
             // that would be a lie about a message that was actually delivered — logs loudly

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationRepository.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationRepository.kt
@@ -7,6 +7,7 @@ package com.openbank.notification.infrastructure.persistence.repository
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.Instant
@@ -68,4 +69,20 @@ class NotificationRepository : PanacheRepository<NotificationEntity> {
     suspend fun markAllRead(partyId: UUID): Int = Panache.withTransaction {
         update("readAt = ?1 where partyId = ?2 and readAt is null", Instant.now(), partyId)
     }.awaitSuspending()
+
+    /**
+     * Scoped bulk UPDATE, not find-then-map-then-persist (issue #1393): the terminal status
+     * transition inside [OperatorMessageService.compose]'s Mutiny chain used to SELECT the full
+     * row (pulling subject/body HTML back out) before UPDATEing it, an extra DB round-trip this
+     * file's own [markRead]/[markAllRead] idiom already avoided. `Uni<Void>`, not `suspend`,
+     * because the caller composes it directly inside a `mailer.send(...)` reactive chain rather
+     * than a coroutine. `sentAt == null` (the FAILED transition) leaves that column untouched.
+     */
+    fun markTerminalStatus(id: UUID, status: String, sentAt: Instant? = null): Uni<Void> = Panache.withTransaction {
+        if (sentAt != null) {
+            update("status = ?1, sentAt = ?2 where notificationId = ?3", status, sentAt, id)
+        } else {
+            update("status = ?1 where notificationId = ?2", status, id)
+        }
+    }.replaceWithVoid()
 }


### PR DESCRIPTION
## Summary
- `OperatorMessageService.compose()` re-queried the full `NotificationEntity` by `notificationId` (SELECT + UPDATE) before flipping status to `SENT` or `FAILED`, instead of a scoped bulk update — each terminal status transition cost a full-row SELECT (pulling subject/body HTML back out) plus an UPDATE.
- `NotificationRepository.markRead`/`markAllRead` (same repository class) already establish the bulk `update("status = ?1 ... where notificationId = ?2", ...)` idiom this code didn't follow.
- Added `NotificationRepository.markTerminalStatus(id, status, sentAt = null)` — a single scoped bulk `update()` covering both the SENT (`sentAt` set) and FAILED (`sentAt` untouched) transitions in one function, keeping the repository under detekt's `TooManyFunctions` threshold. `Uni<Void>`, not `suspend`, since `compose()` composes it directly inside its `mailer.send(...)` Mutiny chain rather than a coroutine.
- No behavior change; cuts one DB round-trip per `compose()` call.

## Test plan
- [x] `./gradlew :openbank-notification-service:detekt :openbank-notification-service:ktlintCheck :openbank-notification-service:compileKotlin :openbank-notification-service:compileTestKotlin` — green.
- [x] `./gradlew :openbank-notification-service:test --tests OperatorMessageServiceIT --tests OperatorMessageResourceTest` — 2/2 and 3/3 green (existing SENT/FAILED-path coverage, now exercised against the scoped-update path).

Closes #1393