### PR TITLE
test(notification): add Docker-availability guard to RedisTestResource, fix partial-start leak

### DIFF
--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/it/RedisTestResource.kt
@@ -5,6 +5,8 @@
 package com.openbank.notification.it
 
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 
@@ -13,16 +15,27 @@ import org.testcontainers.utility.DockerImageName
  * ADR-0176 D5). Separate from [PostgresTestResource] — most tests need only Postgres, and
  * `@QuarkusTestResource` composes cleanly, so a Redis-touching test adds this alongside it
  * rather than folding both into one resource. Mirrors
- * `openbank-lending-service/.../it/PostgresRedisTestResource.kt`'s Redis half.
+ * `openbank-lending-service/.../it/PostgresRedisTestResource.kt`'s Redis half — including,
+ * since issue #1395, its Docker-availability guard, which the first cut of this file only
+ * copied the container-start mechanics of, not the check itself.
  */
 class RedisTestResource : QuarkusTestResourceLifecycleManager {
 
     private var redis: GenericContainer<*>? = null
 
     override fun start(): Map<String, String> {
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
         val rd = GenericContainer(DockerImageName.parse("valkey/valkey:8-alpine")).withExposedPorts(6379)
-        rd.start()
+        // Assign the field BEFORE start() (issue #1395), not after: if start() throws after the
+        // container process was actually created on the Docker daemon (a wait-strategy timeout,
+        // as opposed to Docker being wholly unavailable), the field must still be reachable so
+        // stop() can tear it down. Assigning only on successful return left stop()'s `redis?.stop()`
+        // a silent no-op for exactly the partial-start case, leaking the container on a shared CI
+        // host with no external reaper other than Ryuk to eventually catch it.
         redis = rd
+        rd.start()
         return mapOf(
             "quarkus.redis.hosts" to "redis://${rd.host}:${rd.getFirstMappedPort()}",
         )


### PR DESCRIPTION
## Summary
- `RedisTestResource.kt`'s own KDoc claimed to mirror `openbank-lending-service`'s `PostgresRedisTestResource.kt` "Redis half" but only copied the container-start mechanics, not the `DockerClientFactory.instance().isDockerAvailable` guard (throwing `TestAbortedException` when absent). On a Docker-less runner, `ApprovalStoreWiringIT` failed with a raw Testcontainers exception instead of the graceful "Docker not available — skipping" abort lending's equivalent test gets.
- Separately, `start()` assigned the `redis` field only after `rd.start()` returned successfully. If `GenericContainer.start()` throws after the container process was actually created on the Docker daemon (e.g. a wait-strategy timeout, as opposed to Docker being wholly unavailable), the field stayed `null` and `stop()` (`redis?.stop()`) became a silent no-op — a leaked container relying entirely on Testcontainers' external Ryuk reaper on a shared CI host.
- Fix: add the guard, and assign the field before `.start()` so `stop()` can always reach a container that was actually created.

## Test plan
- [x] `./gradlew :openbank-notification-service:detekt :openbank-notification-service:ktlintCheck :openbank-notification-service:compileTestKotlin` — green.
- [x] `./gradlew :openbank-notification-service:test --tests ApprovalStoreWiringIT` — 1/1 green, exercising the real Testcontainers Redis start/stop path with the reordered assignment.

Closes #1395