### PR TITLE
fix(observability): PostgresInstanceDown could never fire; alert on `up`, not the dead exporter

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-db.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-db.yaml
@@ -26,13 +26,60 @@ spec:
     - name: openbank.db.postgres
       rules:
         - alert: PostgresInstanceDown
-          expr: cnpg_collector_up == 0
-          for: 2m
+          # Uses `up` (the SCRAPE result), NOT cnpg_collector_up (a metric the
+          # instance exports about itself). That distinction is the whole alert:
+          # a Postgres instance that is down stops exporting cnpg_* ENTIRELY, so
+          # the series VANISHES rather than going to 0, and `cnpg_collector_up == 0`
+          # — the previous expression here — can never match a down instance. It
+          # was asking a dead exporter to report its own death.
+          #
+          # Proven live on sanctions-db-1 (2026-07-17, issue #1432), over a 12h
+          # window while the instance was crashlooping:
+          #   cnpg_collector_up{pod="sanctions-db-1"}  127 samples, ZERO of them 0
+          #   up{pod="sanctions-db-1"}                 145 samples, 18 of them 0
+          # and fleet-wide at the same moment:
+          #   count(up{container="postgres"})  = 66   <- scrape targets
+          #   count(cnpg_collector_up)         = 65   <- the missing one IS the dead one
+          #
+          # Consequence: sanctions-service (money-path AML screening) sat at zero
+          # endpoints for hours and this alert never fired — not because it was
+          # missing, but because it was structurally incapable of firing.
+          #
+          # `up` survives because Prometheus itself writes it per target: a target
+          # that fails to scrape is recorded as 0, not dropped. Scoped by
+          # container="postgres" so it covers only CNPG instance pods.
+          expr: up{container="postgres"} == 0
+          for: 5m
           labels:
             severity: critical
           annotations:
-            summary: "Postgres {{ $labels.namespace }}/{{ $labels.pod }} exporter down"
-            description: "CNPG collector cannot reach Postgres on {{ $labels.pod }} for >2m — the instance is likely down or unreachable."
+            summary: "Postgres {{ $labels.namespace }}/{{ $labels.pod }} is down"
+            description: "Prometheus cannot scrape Postgres on {{ $labels.pod }} for >5m — the instance is down, crashlooping, or unreachable. Check `kubectl get cluster -n {{ $labels.namespace }}`: a CNPG cluster parked in phase `Not enough disk space` will NOT self-heal or fail over, by design — it waits for the PVC to be enlarged."
+        - alert: PostgresVolumeLow
+          # Preventive: catch a filling volume BEFORE it kills the instance, because
+          # once the pod is gone this series disappears too (kubelet only reports
+          # volume stats for a RUNNING pod) — so a low-disk threshold can never fire
+          # on the pod that already died. It has to fire while the patient is alive.
+          #
+          # Why this matters here: CNPG parks a cluster in phase `Not enough disk
+          # space` and deliberately does not fail over (promoting a replica with an
+          # identically sized PVC would hit the same wall). The parked state has no
+          # exit that does not involve a human — so a human has to be told.
+          #
+          # Threshold calibration (2026-07-17, 69 PVCs fleet-wide): every DB volume
+          # sits at 67%+ free except sanctions-db-2 at 28.8%. 30% is comfortably
+          # below the healthy population and fires only on a genuine outlier.
+          expr: |
+            100 * (
+              kubelet_volume_stats_available_bytes{persistentvolumeclaim=~".+-db-[0-9]+"}
+              / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~".+-db-[0-9]+"}
+            ) < 30
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Postgres volume {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} is {{ $value | printf \"%.1f\" }}% free"
+            description: "PVC {{ $labels.persistentvolumeclaim }} has under 30% free for >15m. A CNPG cluster that actually runs out parks in phase `Not enough disk space` and stops until a human enlarges the PVC — this alert exists to arrive before that. Check peak WAL generation, not just current size: a bulk job can write more WAL in one run than the volume holds (issue #1432)."
         - alert: PostgresConnectionsSaturated
           # Open backends approaching max_connections — the classic 'too many
           # clients already' precursor. Ratio joins the pool count to the


### PR DESCRIPTION
## The ask, and what it turned into

The request was "add an alert for the CNPG parked phase". **There is no metric for cluster phase** — all ~100 `cnpg_*` series come from the instance exporter inside the Postgres pod, none from the operator, and nothing exposes the `Cluster` CR's `status.phase`. So that alert cannot be written as asked.

Chasing that led somewhere more useful: **the alert that should have caught this already exists, and it cannot fire.**

```yaml
- alert: PostgresInstanceDown
  expr: cnpg_collector_up == 0        # <-- asks a dead exporter to report its own death
```

A Postgres instance that is down stops exporting `cnpg_*` **entirely**. The series *vanishes*; it does not go to 0. `== 0` never matches an absent series.

## Proof

12h window while `sanctions-db-1` was crashlooping (#1432):

| series | samples | samples equal to 0 |
|---|---|---|
| `cnpg_collector_up{pod="sanctions-db-1"}` | 127 | **0** |
| `up{pod="sanctions-db-1"}` | 145 | **18** |

Fleet-wide at the same moment — the whole bug in one line:

```
count(up{container="postgres"})  = 66     <- scrape targets
count(cnpg_collector_up)         = 65     <- the missing one IS the dead one
```

**Consequence:** `sanctions-service` (money-path AML screening) sat at zero endpoints for hours and nothing paged. Not because the alert was missing — because it was present and mute. That is strictly worse than having no alert, because the rule file reads like the case is covered.

## The fix

**`PostgresInstanceDown`** → `up{container="postgres"} == 0`. `up` is written by Prometheus per target: a target that fails to scrape is recorded as `0`, not dropped. It survives exactly the condition that kills `cnpg_collector_up`. Scoped by `container="postgres"` so it covers only CNPG instance pods.

**`PostgresVolumeLow`** (new, warning) — the preventive half. Once a pod is gone, kubelet stops reporting its volume stats, so a low-disk threshold *can never fire on the pod that already died*. It has to fire while the patient is alive. This matters specifically because CNPG parks a cluster in phase `Not enough disk space` and **deliberately does not fail over** — promoting a replica with an identically sized PVC would hit the same wall — so the parked state has no exit that does not involve a human. A human has to be told, and this is the last moment anything is still emitting.

## Verification — against live Prometheus, not promtool

| expression | result |
|---|---|
| **NEW** `up{container="postgres"} == 0` | **FIRES** — `sanctions-db-1 = 0` |
| **NEW** `PostgresVolumeLow` | **FIRES** — `sanctions-db-2 = 28.8% free` |
| **OLD** `cnpg_collector_up == 0` | **SILENT** — no series, during a live outage |

Neither new expression matches anything else across **66 scrape targets** and **69 PVCs**. The 30% threshold sits well below the healthy population: every other DB volume is 67%+ free, `sanctions-db-2` is the sole outlier at 28.8%.

Routing verified rather than assumed — `severity=critical` reaches `holmes-rca` → `slack-alerts` → `goalert` (page); `severity=warning` reaches `slack-alerts`. So instance-down pages, volume-low goes to Slack.

## Scope

Does not fix #1432 itself (the `PEP_GLOBAL` refresh writing ~1.9 GB WAL onto a 2 GiB volume). This is the "why did nobody know for days" half. The same shape as #1420: something that should have been moving stopped, and nothing was watching.

`PostgresWALArchiveFailing` (`rate(cnpg_pg_stat_archiver_failed_count[15m]) > 0`) has the same dead-exporter weakness and is left alone here — a failing archiver on a *live* instance still reports, so it is not equally broken, but it is worth a look.

## Linked issues

Refs #1432
