### PR TITLE
fix(ledger): Postgres advisory-lock cross-pod exclusion for once-per-cluster schedulers (#1201)

### DIFF
--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/partition/JournalPartitionMaintainer.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/partition/JournalPartitionMaintainer.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.ledger.infrastructure.partition
 
+import com.openbank.libs.persistence.lock.ClusterLock
 import com.openbank.libs.persistence.partition.PartitionMaintenance
 import com.openbank.libs.persistence.partition.PartitionPolicy
 import io.quarkus.scheduler.Scheduled
@@ -24,6 +25,10 @@ import java.time.LocalDate
  *  - Roll-forward CREATE is idempotent and always runs, so the partition horizon never lapses.
  *  - Retention is DETACH-only and dry-run by default; physical DROP requires explicit config.
  *  - Every action is recorded in the immutable `partition_lifecycle_audit` table.
+ *  - Cross-pod exclusion (#1201): an Argo Rollouts canary window runs two pods, and both fire
+ *    `@Scheduled` beans on their own tick — without coordination, two pods could race the same
+ *    partition CREATE/DETACH/DROP DDL. [ClusterLock.tryRunExclusively] wraps the run in a
+ *    transaction-scoped advisory lock so only one pod's tick executes.
  */
 @ApplicationScoped
 class JournalPartitionMaintainer(
@@ -41,41 +46,52 @@ class JournalPartitionMaintainer(
 
     @ConfigProperty(name = "openbank.ledger.partition.dry-run", defaultValue = "true")
     private val dryRun: Boolean,
+
+    private val clusterLock: ClusterLock,
 ) {
     @Scheduled(every = "24h", delayed = "30s", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
     suspend fun maintain() {
-        try {
-            val policy = PartitionPolicy(
-                parentTable = PARENT_TABLE,
-                prefix = PARENT_TABLE,
-                futureYears = futureYears,
-                retentionYears = retentionYears,
-                dropEnabled = dropEnabled,
-                dryRun = dryRun,
-            )
-            val report = PartitionMaintenance.maintain(LocalDate.now(clock), policy, executor)
-            if (report.executed.isNotEmpty() || report.skippedDryRun.isNotEmpty() || report.defaultPartitionRows > 0) {
-                log.infof(
-                    "journal_entries partition maintenance: executed=%d, dryRunSkipped=%d, defaultRows=%d",
-                    report.executed.size,
-                    report.skippedDryRun.size,
-                    report.defaultPartitionRows,
+        val ran = clusterLock.tryRunExclusively(JOB_NAME) {
+            try {
+                val policy = PartitionPolicy(
+                    parentTable = PARENT_TABLE,
+                    prefix = PARENT_TABLE,
+                    futureYears = futureYears,
+                    retentionYears = retentionYears,
+                    dropEnabled = dropEnabled,
+                    dryRun = dryRun,
                 )
+                val report = PartitionMaintenance.maintain(LocalDate.now(clock), policy, executor)
+                if (report.executed.isNotEmpty() ||
+                    report.skippedDryRun.isNotEmpty() ||
+                    report.defaultPartitionRows > 0
+                ) {
+                    log.infof(
+                        "journal_entries partition maintenance: executed=%d, dryRunSkipped=%d, defaultRows=%d",
+                        report.executed.size,
+                        report.skippedDryRun.size,
+                        report.defaultPartitionRows,
+                    )
+                }
+                if (report.defaultPartitionRows > 0) {
+                    log.warnf(
+                        "journal_entries_default holds %d row(s) — inserts are being misrouted; check the partition horizon",
+                        report.defaultPartitionRows,
+                    )
+                }
+            } catch (ex: Exception) {
+                // The scheduler must never crash; a failed pass is retried on the next tick.
+                log.error("journal_entries partition maintenance failed", ex)
             }
-            if (report.defaultPartitionRows > 0) {
-                log.warnf(
-                    "journal_entries_default holds %d row(s) — inserts are being misrouted; check the partition horizon",
-                    report.defaultPartitionRows,
-                )
-            }
-        } catch (ex: Exception) {
-            // The scheduler must never crash; a failed pass is retried on the next tick.
-            log.error("journal_entries partition maintenance failed", ex)
+        }
+        if (ran == null) {
+            log.infof("journal_entries partition maintenance: another pod already holds this tick's lock — skipping")
         }
     }
 
     companion object {
         private const val PARENT_TABLE = "journal_entries"
+        private const val JOB_NAME = "ledger.partition-maintenance"
         private val log: Logger = Logger.getLogger(JournalPartitionMaintainer::class.java)
     }
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/FxRevaluationScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/FxRevaluationScheduler.kt
@@ -6,6 +6,7 @@ package com.openbank.ledger.infrastructure.schedule
 
 import com.openbank.ledger.application.port.`in`.FxRevaluationUseCase
 import com.openbank.ledger.application.port.`in`.RevalueFxCommand
+import com.openbank.libs.persistence.lock.ClusterLock
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.runBlocking
@@ -16,11 +17,19 @@ import java.time.ZoneId
 /**
  * Daily job that marks foreign FX positions to the ČNB fixing (ADR-0046) at 15:00 Europe/Prague —
  * after fx-service has ingested the day's fixing (~14:40). The revaluation is idempotent per
- * business day, so a missed or repeated run is harmless; failures are logged and swallowed (the
- * scheduler must never crash) and the manual `POST /api/v1/ledger/fx-revaluation` covers backfill.
+ * business day (`fx-reval-{date}` idempotency key), so a concurrent-revalue race loser gets the
+ * winner's *posting* back safely — but it still separately publishes a second, non-outboxed
+ * `openbank.ledger.fx.revalued` event and logs "posted" (#1201, L-12). `concurrentExecution =
+ * SKIP` only stops in-JVM overlap; an Argo Rollouts canary window runs the old and new pod
+ * simultaneously for the whole rollout, and the 15:00 run landing inside a deploy window is not
+ * hypothetical — deploys happen during business hours. [ClusterLock.tryRunExclusively] wraps the
+ * run in a transaction-scoped advisory lock so only one pod actually revalues and publishes per
+ * day; the losing pod's tick is a no-op. A missed or repeated run is still harmless independent
+ * of this — the manual `POST /api/v1/ledger/fx-revaluation` covers backfill — this only removes
+ * the double-publish.
  */
 @ApplicationScoped
-class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase) {
+class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase, private val clusterLock: ClusterLock) {
     private val log: Logger = Logger.getLogger(FxRevaluationScheduler::class.java)
     private val zone: ZoneId = ZoneId.of("Europe/Prague")
 
@@ -30,15 +39,24 @@ class FxRevaluationScheduler(private val useCase: FxRevaluationUseCase) {
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     fun revalueDaily() = runBlocking {
-        try {
-            val result = useCase.revalue(RevalueFxCommand(LocalDate.now(zone)))
-            if (result.posted) {
-                log.infof("Daily FX revaluation posted for %s: %s", result.date, result.movements)
-            } else {
-                log.infof("Daily FX revaluation for %s: no movement", result.date)
+        val ran = clusterLock.tryRunExclusively(JOB_NAME) {
+            try {
+                val result = useCase.revalue(RevalueFxCommand(LocalDate.now(zone)))
+                if (result.posted) {
+                    log.infof("Daily FX revaluation posted for %s: %s", result.date, result.movements)
+                } else {
+                    log.infof("Daily FX revaluation for %s: no movement", result.date)
+                }
+            } catch (ex: Exception) {
+                log.errorf(ex, "Daily FX revaluation failed: %s", ex.message)
             }
-        } catch (ex: Exception) {
-            log.errorf(ex, "Daily FX revaluation failed: %s", ex.message)
         }
+        if (ran == null) {
+            log.infof("Daily FX revaluation: another pod already holds this tick's lock — skipping")
+        }
+    }
+
+    private companion object {
+        const val JOB_NAME = "ledger.fx-revaluation"
     }
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdog.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdog.kt
@@ -6,6 +6,7 @@ package com.openbank.ledger.infrastructure.schedule
 
 import com.openbank.ledger.application.port.out.TieOutRunRepository
 import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.libs.persistence.lock.ClusterLock
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -25,9 +26,18 @@ import java.time.Instant
  * PrometheusRule on the break counter; this watchdog covers the two cases the counter
  * cannot: the run not happening at all, and the run erroring before it could check.
  * Read-only; never touches the journal.
+ *
+ * Cross-pod exclusion (#1201): read-only and idempotent, so two pods both checking is not a
+ * correctness bug — but during every canary window it would otherwise double every log line and
+ * double-fire the Loki alert for the same incident. [ClusterLock.tryRunExclusively] wraps the
+ * check so only one pod's tick actually logs.
  */
 @ApplicationScoped
-class TieOutFreshnessWatchdog(private val runRepository: TieOutRunRepository, private val clock: Clock) {
+class TieOutFreshnessWatchdog(
+    private val runRepository: TieOutRunRepository,
+    private val clock: Clock,
+    private val clusterLock: ClusterLock,
+) {
     private val log = Logger.getLogger(TieOutFreshnessWatchdog::class.java)
 
     // The daily run fires at 06:00, so a healthy record is at most ~24h old; allow a 1h grace
@@ -40,42 +50,45 @@ class TieOutFreshnessWatchdog(private val runRepository: TieOutRunRepository, pr
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     suspend fun checkFreshness() {
-        val latest = runRepository.findLatest()
-        if (latest == null) {
-            log.error(
-                "Tie-out freshness: NO tie-out run has ever been recorded — the daily " +
-                    "GL control-account ⇄ sub-ledger tie-out (ADR-0039 Phase B) is absent. Investigate.",
-            )
-            return
-        }
-        val ageHours = Duration.between(latest.runAt, Instant.now(clock)).toHours()
-        when {
-            ageHours > staleAfter.toHours() -> log.errorf(
-                "Tie-out freshness: STALE — last run was %dh ago (as-of %s, status %s), past the " +
-                    "%dh daily SLA; a scheduled run was likely missed.",
-                ageHours,
-                latest.asOf,
-                latest.status,
-                staleAfter.toHours(),
-            )
-            latest.status == TieOutRunStatus.ERROR -> log.errorf(
-                "Tie-out freshness: last run (as-of %s) ended in ERROR — %d of %d control-account " +
-                    "checks failed; the day's control is incomplete. Investigate and re-run.",
-                latest.asOf,
-                latest.errors,
-                latest.errors + latest.accountsChecked,
-            )
-            else -> log.debugf(
-                "Tie-out freshness OK: last run %dh ago (as-of %s, status %s).",
-                ageHours,
-                latest.asOf,
-                latest.status,
-            )
+        clusterLock.tryRunExclusively(JOB_NAME) {
+            val latest = runRepository.findLatest()
+            if (latest == null) {
+                log.error(
+                    "Tie-out freshness: NO tie-out run has ever been recorded — the daily " +
+                        "GL control-account ⇄ sub-ledger tie-out (ADR-0039 Phase B) is absent. Investigate.",
+                )
+                return@tryRunExclusively
+            }
+            val ageHours = Duration.between(latest.runAt, Instant.now(clock)).toHours()
+            when {
+                ageHours > staleAfter.toHours() -> log.errorf(
+                    "Tie-out freshness: STALE — last run was %dh ago (as-of %s, status %s), past the " +
+                        "%dh daily SLA; a scheduled run was likely missed.",
+                    ageHours,
+                    latest.asOf,
+                    latest.status,
+                    staleAfter.toHours(),
+                )
+                latest.status == TieOutRunStatus.ERROR -> log.errorf(
+                    "Tie-out freshness: last run (as-of %s) ended in ERROR — %d of %d control-account " +
+                        "checks failed; the day's control is incomplete. Investigate and re-run.",
+                    latest.asOf,
+                    latest.errors,
+                    latest.errors + latest.accountsChecked,
+                )
+                else -> log.debugf(
+                    "Tie-out freshness OK: last run %dh ago (as-of %s, status %s).",
+                    ageHours,
+                    latest.asOf,
+                    latest.status,
+                )
+            }
         }
     }
 
     private companion object {
         // 24h daily cadence + 1h grace for run duration / a delayed scheduler.
         const val DAILY_SLA_HOURS = 25L
+        const val JOB_NAME = "ledger.tieout.freshness"
     }
 }

--- a/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
+++ b/openbank-ledger-service/src/main/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutScheduler.kt
@@ -12,6 +12,7 @@ import com.openbank.ledger.domain.model.GlAccount
 import com.openbank.ledger.domain.model.TieOutRunRecord
 import com.openbank.ledger.domain.model.TieOutRunStatus
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.lock.ClusterLock
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.quarkus.scheduler.Scheduled
@@ -48,6 +49,15 @@ import java.time.ZoneId
  * there to yesterday, oldest day first — the same healing shape as `CloseCalendar`'s
  * oldest-first catch-up in statement-service, for the same reason: capping to the *newest* N
  * days would strand the oldest gap forever, since the cursor here only ever moves forward too.
+ *
+ * **Cross-pod exclusion (#1201).** `concurrentExecution = SKIP` only stops in-JVM overlap; an
+ * Argo Rollouts canary window runs the old and new pod simultaneously for the whole rollout, and
+ * both fire this trigger on their own tick. Without coordination, two pods would both walk the
+ * same catch-up gap and both double-increment `openbank.subledger.tieout.break` plus write two
+ * run records for the same `as_of`. [ClusterLock.tryRunExclusively] wraps the whole run in a
+ * transaction-scoped advisory lock so only one pod's tick actually executes; the losing pod's
+ * tick is a no-op — not a missed day, since the winning pod still covers the full catch-up gap
+ * above.
  */
 @ApplicationScoped
 class TieOutScheduler(
@@ -57,6 +67,7 @@ class TieOutScheduler(
     private val clock: Clock,
     @ConfigProperty(name = "openbank.ledger.tieout.max-catchup-days", defaultValue = "7")
     private val maxCatchUpDays: Int,
+    private val clusterLock: ClusterLock,
     registry: MeterRegistry,
 ) {
     private val log: Logger = Logger.getLogger(TieOutScheduler::class.java)
@@ -72,18 +83,24 @@ class TieOutScheduler(
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     fun runTieOut(): Unit = runBlocking {
-        // clock.withZone(zone), NOT LocalDate.now(zone): the latter is `Clock.system(zone)` —
-        // it silently ignores the injected `clock` and reads the JVM's real wall clock. Harmless
-        // in production (the CDI clock is `Clock.systemUTC()`, so both give the same instant and
-        // therefore the same Prague date), but it makes this method untestable with a fixed clock
-        // — exactly the class of clock-injection violation flagged fleet-wide in the closing audit
-        // (docs/audits/2026-07-16-closing-audit.md, systemic root cause 1).
-        val through = LocalDate.now(clock.withZone(zone)).minusDays(1)
-        val dates = catchUpDates(through)
-        if (dates.isEmpty()) {
-            log.infof("Sub-ledger tie-out: already checked through %s — nothing to do", through)
+        val ran = clusterLock.tryRunExclusively(JOB_NAME) {
+            // clock.withZone(zone), NOT LocalDate.now(zone): the latter is `Clock.system(zone)` —
+            // it silently ignores the injected `clock` and reads the JVM's real wall clock.
+            // Harmless in production (the CDI clock is `Clock.systemUTC()`, so both give the same
+            // instant and therefore the same Prague date), but it makes this method untestable
+            // with a fixed clock — exactly the class of clock-injection violation flagged
+            // fleet-wide in the closing audit (docs/audits/2026-07-16-closing-audit.md, systemic
+            // root cause 1).
+            val through = LocalDate.now(clock.withZone(zone)).minusDays(1)
+            val dates = catchUpDates(through)
+            if (dates.isEmpty()) {
+                log.infof("Sub-ledger tie-out: already checked through %s — nothing to do", through)
+            }
+            dates.forEach { asOf -> runTieOutFor(asOf) }
         }
-        dates.forEach { asOf -> runTieOutFor(asOf) }
+        if (ran == null) {
+            log.infof("Sub-ledger tie-out: another pod already holds this tick's lock — skipping")
+        }
     }
 
     /**
@@ -201,5 +218,9 @@ class TieOutScheduler(
             // The freshness watchdog will surface the missing row within its SLA.
             log.errorf(ex, "Tie-out run record persist failed (status=%s asOf=%s): %s", status, asOf, ex.message)
         }
+    }
+
+    private companion object {
+        const val JOB_NAME = "ledger.tieout"
     }
 }

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdogTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutFreshnessWatchdogTest.kt
@@ -7,6 +7,7 @@ package com.openbank.ledger.infrastructure.schedule
 import com.openbank.ledger.application.port.out.TieOutRunRepository
 import com.openbank.ledger.domain.model.TieOutRunRecord
 import com.openbank.ledger.domain.model.TieOutRunStatus
+import com.openbank.libs.testing.lock.NoOpClusterLock
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -28,7 +29,7 @@ class TieOutFreshnessWatchdogTest {
     private val now = Instant.parse("2026-07-16T10:00:00Z")
     private val clock = Clock.fixed(now, ZoneOffset.UTC)
     private val runs = mockk<TieOutRunRepository>()
-    private val watchdog = TieOutFreshnessWatchdog(runs, clock)
+    private val watchdog = TieOutFreshnessWatchdog(runs, clock, NoOpClusterLock())
 
     private fun run(age: Duration, status: TieOutRunStatus) = TieOutRunRecord(
         id = UUID.randomUUID(),

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/infrastructure/schedule/TieOutSchedulerTest.kt
@@ -13,6 +13,7 @@ import com.openbank.ledger.domain.model.GlAccountType
 import com.openbank.ledger.domain.model.TieOutRunRecord
 import com.openbank.ledger.domain.model.TieOutRunStatus
 import com.openbank.libs.domain.money.CurrencyCode
+import com.openbank.libs.testing.lock.NoOpClusterLock
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,7 +36,15 @@ class TieOutSchedulerTest {
     private val registry = SimpleMeterRegistry()
     private val clock = Clock.fixed(Instant.parse("2026-07-16T04:00:00Z"), ZoneOffset.UTC)
 
-    private val scheduler = TieOutScheduler(ledger, glAccounts, runs, clock, maxCatchUpDays = 7, registry)
+    private val scheduler = TieOutScheduler(
+        ledger,
+        glAccounts,
+        runs,
+        clock,
+        maxCatchUpDays = 7,
+        NoOpClusterLock(),
+        registry,
+    )
 
     private fun runRecord(asOf: LocalDate) = TieOutRunRecord(
         id = UUID.randomUUID(),
@@ -190,7 +199,7 @@ class TieOutSchedulerTest {
         // A 5-day gap (11th..15th) capped to 2: takeLast would strand the 11th/12th forever,
         // since the cursor only ever moves forward from the latest saved as_of (the #1201-class
         // bug CloseCalendar had). take() keeps 11th, 12th and leaves 13th-15th for the next run.
-        val capped = TieOutScheduler(ledger, glAccounts, runs, clock, maxCatchUpDays = 2, registry)
+        val capped = TieOutScheduler(ledger, glAccounts, runs, clock, maxCatchUpDays = 2, NoOpClusterLock(), registry)
         val account = control("2100")
         coEvery { glAccounts.findByCode(any()) } returns null
         coEvery { glAccounts.findByCode("2100") } returns account

--- a/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/ClusterLockIT.kt
+++ b/openbank-ledger-service/src/test/kotlin/com/openbank/ledger/integration/ClusterLockIT.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.ledger.integration
+
+import com.openbank.ledger.it.PostgresTestResource
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.lock.ClusterLock
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Holds the current transaction open for [seconds] via Postgres's own `pg_sleep`, not
+ * `kotlinx.coroutines.delay` — `delay` resumes on whatever thread its scheduler picks, which
+ * breaks the Vert.x duplicated-context affinity Hibernate Reactive's session needs, throwing
+ * `IllegalStateException` from Vert.x's own context assertions. A native query is just another
+ * suspend DB call on the same context, so it holds the surrounding
+ * [ClusterLock.tryRunExclusively] transaction (and its advisory lock) open for real, measured
+ * wall-clock time without ever leaving that context.
+ */
+private suspend fun holdTransactionOpen(seconds: Double) {
+    Panache.getSession().chain { session ->
+        session.createNativeQuery<Any>("SELECT pg_sleep($seconds)").singleResult
+    }.awaitSuspending()
+}
+
+/**
+ * Regression coverage for #1201 proposed fix 2: [ClusterLock.tryRunExclusively] against a real
+ * Postgres proves the `pg_try_advisory_xact_lock` claim actually excludes a second concurrent
+ * caller for the same job name, does not cross-block unrelated job names, and releases cleanly
+ * (a stale-lock/never-releases bug here would silently wedge a scheduler forever, since there is
+ * no separate reclaim path the way there is for the outbox claim's DISPATCHING status).
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class ClusterLockIT {
+
+    @Inject
+    lateinit var clusterLock: ClusterLock
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @Test
+    fun `two concurrent calls for the same job name never both run — the loser gets null`() {
+        val jobName = "test.job.${Ids.newId()}"
+        var executions = 0
+        // A fixed head-start delay before launching the second call is flaky: how long `a`
+        // actually takes to reach its lock-acquire statement varies with connection-pool /
+        // Testcontainers overhead, so a delay picked too short lets `b` win the race instead of
+        // losing it as intended, spuriously failing the exclusivity assertion below (observed:
+        // 1 flaky failure in 3 manual reruns before this fix). Signal from inside the winner's
+        // block instead — `b` is only launched once `a` has *provably* already acquired the lock
+        // and is mid-transaction, which is deterministic regardless of scheduling jitter.
+        val lockHeld = CompletableDeferred<Unit>()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) {
+                onEventLoop {
+                    clusterLock.tryRunExclusively(jobName) {
+                        executions++
+                        lockHeld.complete(Unit)
+                        holdTransactionOpen(0.3)
+                        "winner"
+                    }
+                }
+            }
+            lockHeld.await()
+            val b = async(Dispatchers.IO) { onEventLoop { clusterLock.tryRunExclusively(jobName) { "loser" } } }
+            awaitAll(a, b)
+        }
+
+        assertThat(executions).describedAs("block() body ran exactly once across both calls").isEqualTo(1)
+        assertThat(listOf(first, second).count { it != null })
+            .describedAs("exactly one of the two concurrent calls acquired the lock")
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `different job names do not block each other`() {
+        val jobA = "test.job.a.${Ids.newId()}"
+        val jobB = "test.job.b.${Ids.newId()}"
+
+        val (resultA, resultB) = runBlocking {
+            val a = async(Dispatchers.IO) {
+                onEventLoop {
+                    clusterLock.tryRunExclusively(jobA) {
+                        holdTransactionOpen(0.2)
+                        "a"
+                    }
+                }
+            }
+            val b = async(Dispatchers.IO) {
+                onEventLoop {
+                    clusterLock.tryRunExclusively(jobB) {
+                        holdTransactionOpen(0.2)
+                        "b"
+                    }
+                }
+            }
+            awaitAll(a, b)
+        }
+
+        assertThat(resultA).isEqualTo("a")
+        assertThat(resultB).isEqualTo("b")
+    }
+
+    @Test
+    fun `the lock releases after commit — a later sequential call for the same job succeeds`() {
+        val jobName = "test.job.${Ids.newId()}"
+
+        val first = onEventLoop { clusterLock.tryRunExclusively(jobName) { "first" } }
+        val second = onEventLoop { clusterLock.tryRunExclusively(jobName) { "second" } }
+
+        assertThat(first).isEqualTo("first")
+        assertThat(second)
+            .describedAs("the first call's transaction committed, so its advisory lock must already be released")
+            .isEqualTo("second")
+    }
+}

--- a/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/lock/ClusterLock.kt
+++ b/openbank-libs-domain/src/main/kotlin/com/openbank/libs/persistence/lock/ClusterLock.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.persistence.lock
+
+import java.util.zip.CRC32
+
+/**
+ * Cross-pod mutual exclusion for a `@Scheduled` bean (#1201 proposed fix 2).
+ *
+ * `replicas: 1` is steady-state only — an Argo Rollouts canary window runs the old and new pod
+ * simultaneously for the whole rollout duration, and both fire every `@Scheduled` bean on their
+ * own tick regardless of traffic-weight split. For a job with its own idempotency (the outbox
+ * dispatcher) that's handled by a row claim instead (`OutboxRepository.claimProcessable`,
+ * #1201 proposed fix 1). This port is for the other kind: a job with **no per-row claim to
+ * make** — a whole-tick job like a daily control check, a revaluation run, or partition DDL —
+ * where the correct behaviour is simply "only one pod runs this tick at all."
+ *
+ * An injectable port (not a bare static object) so a scheduler's own pure unit tests can
+ * substitute a trivial always-runs fake instead of needing a live Postgres — the real exclusion
+ * behaviour is proven separately against a real database (`PostgresClusterLock`'s IT coverage).
+ */
+interface ClusterLock {
+    /**
+     * Runs [block] only if this job's lock is free right now; returns its result, or `null` if
+     * another instance already holds the lock for [jobName] (routine during a canary window —
+     * the losing pod simply skips this tick, same as `concurrentExecution = SKIP` already does
+     * for a same-JVM overlap).
+     *
+     * Not a queue: a losing pod does not wait for the lock and does not retry within this call —
+     * the job's own next scheduled tick is the retry.
+     */
+    suspend fun <T> tryRunExclusively(jobName: String, block: suspend () -> T): T?
+}
+
+/**
+ * Stable, deterministic mapping from a job name to the `bigint` key a Postgres advisory lock
+ * takes. CRC32 rather than `String.hashCode()`: both are stable across JVM versions (the latter
+ * is specified in the `String.hashCode` Javadoc), but CRC32 is the conventional choice for a
+ * lock/partition key specifically, and its always-non-negative 32-bit range is plenty for the
+ * handful of once-per-cluster jobs any one service has — collision risk is negligible at that
+ * count. Advisory lock keys are scoped to the current Postgres **database**, not the whole
+ * server instance, so no cross-service namespacing is needed as long as each service owns its
+ * own database (true for every service in this fleet).
+ *
+ * A pure function, kept separate from the [ClusterLock] port itself, so it is testable without
+ * any DB/CDI context.
+ */
+object ClusterLockKey {
+    fun of(jobName: String): Long {
+        val crc = CRC32()
+        crc.update(jobName.toByteArray(Charsets.UTF_8))
+        return crc.value
+    }
+}

--- a/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/lock/ClusterLockKeyTest.kt
+++ b/openbank-libs-domain/src/test/kotlin/com/openbank/libs/persistence/lock/ClusterLockKeyTest.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.libs.persistence.lock
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-function coverage for [ClusterLockKey] (#1201 proposed fix 2). The real cross-pod
+ * mutual-exclusion behaviour ([PostgresClusterLock] against a live Postgres) is proven in
+ * `openbank-ledger-service`'s IT suite — this class has no Quarkus/DB context, same split as
+ * every other pure-logic-vs-real-wiring pair in this codebase.
+ */
+class ClusterLockKeyTest {
+
+    @Test
+    fun `same job name always maps to the same key`() {
+        assertThat(ClusterLockKey.of("ledger.tieout")).isEqualTo(ClusterLockKey.of("ledger.tieout"))
+    }
+
+    @Test
+    fun `different job names map to different keys`() {
+        val keys = listOf(
+            "ledger.tieout",
+            "ledger.tieout.freshness",
+            "ledger.fx-revaluation",
+            "ledger.partition-maintenance",
+        ).map { ClusterLockKey.of(it) }
+
+        assertThat(keys.toSet()).describedAs("no collision among this service's own job names").hasSize(keys.size)
+    }
+
+    @Test
+    fun `key is a stable, non-negative CRC32 value (pinned so a future change is deliberate)`() {
+        // A stable key is load-bearing: it is the identity a running pod and the pod it is
+        // racing during a canary window both derive independently from the same job name string,
+        // with no shared state — if this function's output ever changed, every in-flight lock
+        // key would silently change too, defeating the exclusion mid-rollout.
+        assertThat(ClusterLockKey.of("ledger.tieout")).isEqualTo(3_510_320_410L)
+        assertThat(ClusterLockKey.of("ledger.tieout")).isGreaterThanOrEqualTo(0L)
+    }
+}

--- a/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/lock/PostgresClusterLock.kt
+++ b/openbank-libs-runtime/src/main/kotlin/com/openbank/libs/persistence/lock/PostgresClusterLock.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.persistence.lock
+
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.jboss.logging.Logger
+
+/**
+ * [ClusterLock] via a **transaction-scoped** Postgres advisory lock, `pg_try_advisory_xact_lock`
+ * — not the session-scoped `pg_try_advisory_lock` the #1201 issue text names. Session-scoped
+ * locks are held by the underlying DB *connection*, and Hibernate Reactive's session is a
+ * connection borrowed from a pool for the duration of one `Panache.withTransaction`/`withSession`
+ * block — nothing stops that connection being returned to the pool and reused elsewhere while a
+ * session-scoped lock taken on it is still logically "held" by this job, unless every call site
+ * remembers to pair `pg_advisory_lock`/`pg_advisory_unlock` and never lets an exception skip the
+ * unlock. The transaction-scoped variant needs no unlock call at all: Postgres releases it
+ * automatically at COMMIT or ROLLBACK, and Hibernate Reactive always commits or rolls back at the
+ * end of a `Panache.withTransaction` block — so the lock cannot leak, and [block] runs (and any
+ * nested `Panache.withTransaction`/`withSession` calls it makes participate in the same
+ * transaction, per Hibernate Reactive's context-bound session propagation) for exactly the
+ * lifetime the lock is held.
+ */
+@ApplicationScoped
+class PostgresClusterLock : ClusterLock {
+    private val log: Logger = Logger.getLogger(PostgresClusterLock::class.java)
+
+    override suspend fun <T> tryRunExclusively(jobName: String, block: suspend () -> T): T? {
+        val key = ClusterLockKey.of(jobName)
+        val result = Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(TRY_LOCK_SQL, java.lang.Boolean::class.java)
+                    .setParameter("key", key)
+                    .singleResult
+                    .chain<T?> { acquired ->
+                        if (acquired == true) {
+                            uni<T?>(CoroutineScope(Dispatchers.Unconfined)) { block() }
+                        } else {
+                            Uni.createFrom().nullItem()
+                        }
+                    }
+            }
+        }.awaitSuspending()
+        if (result == null) {
+            log.debugf("cluster-lock job=%s key=%d: not acquired (another pod holds this tick)", jobName, key)
+        }
+        return result
+    }
+
+    private companion object {
+        const val TRY_LOCK_SQL = "SELECT pg_try_advisory_xact_lock(:key)"
+    }
+}

--- a/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/lock/NoOpClusterLock.kt
+++ b/openbank-libs-testing/src/main/kotlin/com/openbank/libs/testing/lock/NoOpClusterLock.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.libs.testing.lock
+
+import com.openbank.libs.persistence.lock.ClusterLock
+
+/**
+ * Always runs [ClusterLock.tryRunExclusively]'s block, unconditionally — for a scheduler's own
+ * pure unit tests (mocked repositories, no Quarkus/DB context), which are testing that
+ * scheduler's business logic, not [ClusterLock]'s cross-pod exclusion. The real exclusion
+ * behaviour is proven separately against a live Postgres (`PostgresClusterLock`'s IT coverage in
+ * `openbank-ledger-service`).
+ */
+class NoOpClusterLock : ClusterLock {
+    override suspend fun <T> tryRunExclusively(jobName: String, block: suspend () -> T): T = block()
+}


### PR DESCRIPTION
## Why

Four `@Scheduled` beans in ledger-service — `TieOutScheduler` (06:00 daily control check), `FxRevaluationScheduler` (15:00 daily FX revaluation), `TieOutFreshnessWatchdog` (hourly staleness check), `JournalPartitionMaintainer` (24h partition DDL) — each documented their safety as "one JVM instance", the same false assumption #1201/#1415 already fixed for the outbox dispatcher: `replicas: 1` is steady-state only, an Argo Rollouts canary window runs the old and new pod simultaneously for the whole rollout, and both fire every `@Scheduled` bean on their own tick. None of these four jobs has a per-row claim to make the way the outbox dispatcher does — each is a single whole-tick unit of work — so the fix here is different: a Postgres advisory lock, keyed by job name, so only one pod's tick actually runs.

## Fix

`ClusterLock.tryRunExclusively` wraps a job in `pg_try_advisory_xact_lock`, not the session-scoped `pg_try_advisory_lock` the #1201 issue text suggests. Session-scoped locks are held by the underlying DB connection, and Hibernate Reactive's session is a connection borrowed from a pool for one `Panache.withTransaction` block — nothing stops that connection being returned to the pool and reused while a session-scoped lock taken on it is still logically "held", unless every call site remembers to pair lock/unlock and never lets an exception skip the unlock. The transaction-scoped variant needs no unlock call: Postgres releases it automatically at COMMIT or ROLLBACK, which Hibernate Reactive always does at the end of a `withTransaction` block, so the lock cannot leak.

Port (`ClusterLock`, `openbank-libs-domain`) split from its Panache implementation (`PostgresClusterLock`, `openbank-libs-runtime`) — same shape as `OutboxRepository`/`LedgerOutboxRepositoryImpl`. **A bare static object, tried first, broke every one of these schedulers' own pure unit tests** ("No current Vertx context found" — `PostgresClusterLock` needs a live Hibernate Reactive session, which a mockk-based unit test has no way to provide). Constructor-injecting the interface lets those tests substitute `NoOpClusterLock` (`openbank-libs-testing`, runs the block unconditionally) instead, so a scheduler's own business-logic tests stay isolated from the cross-pod exclusion mechanism, proven separately (`ClusterLockIT`, against a real Postgres).

Not every job needs a lock for correctness — `TieOutFreshnessWatchdog` is read-only and idempotent, so two pods both checking isn't a data bug — but every canary window would otherwise double every log line and double-fire the Loki alert for the same incident, so it's wrapped too.

## Not in scope here

Rolling the same lock to schedulers in other services (balance-service's 23:30 reconciliation is the one #1201 names by example), and #1201's remaining proposed fixes 3 (outbox `FxRevaluedEvent`) and 4 (correct the interest-service dispatcher's N4 docstring) — tracked as follow-up on #1201.

## Verified

- `ClusterLockIT` (new, against real Postgres): two concurrent calls for the same job name never both run; different job names don't block each other; the lock releases after commit so a later sequential call succeeds. First version was flaky (1 failure in 3 manual reruns) from a fixed-delay race between launching the two concurrent calls — rewritten to synchronize deterministically via a `CompletableDeferred` signal from inside the winning call instead of timing.
- Mutation-tested: reverted the lock-acquire check to always run the block regardless of lock result, confirmed the exclusivity assertion fails (not vacuous), restored it.
- `ClusterLockKeyTest` (`openbank-libs-domain`, pure, no DB): same job name always maps to the same key, different job names don't collide, the CRC32 value is pinned so a future change to the derivation is deliberate, not silent.
- Full non-cached test suite for `openbank-ledger-service`, `openbank-libs-domain`, `openbank-libs-runtime` (all IT + unit tests, including the two pre-existing scheduler unit test classes this otherwise would have broken) + `ktlintCheck` + `detekt` across all three modules, green — with Gradle/Kotlin daemons killed and build directories cleared first, after an earlier run intermittently loaded stale bytecode for the old object-based `ClusterLock` mid-refactor.
- Diff scope: exactly the 11 files this touches, no ktlintFormat collateral.

Refs #1201, follows #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)