### PR TITLE
feat(observability): scrape Karpenter, so its two alerts can actually fire

### DIFF
--- a/openbank-infra/gitops/components/observability/servicemonitor-karpenter.yaml
+++ b/openbank-infra/gitops/components/observability/servicemonitor-karpenter.yaml
@@ -1,0 +1,38 @@
+# Scrape Karpenter's Prometheus metrics. Nothing did, and the cost was not theoretical:
+# `prometheus-rules-finops.yaml` has carried two Karpenter alerts since it was written —
+# FinOpsKarpenterNodeChurnHigh (warning) and FinOpsKarpenterChurnOutsideMaintenance
+# (**critical**) — both keyed on `karpenter_nodes_total`. That series has never existed in
+# Prometheus, so neither rule could ever evaluate, let alone fire. They read as coverage and
+# delivered none. The metric is real (Karpenter serves 388 `karpenter_nodes_total` samples on
+# its own /metrics right now); it simply had no scraper.
+#
+# Karpenter is a terraform helm_release (`main.tf`), and its chart can emit this itself via
+# `serviceMonitor.enabled` — but the `karpenter` Service already exposes `http-metrics`:8080, so a
+# ServiceMonitor here picks it up with no terraform apply. Same shape and rationale as
+# servicemonitor-kyverno.yaml: lives in `observability`, selects cross-namespace, and the cluster
+# Prometheus has empty SM selectors so it is discovered automatically.
+#
+# This also unblocks the NodePool-cap alert #1272 asks for: `karpenter_nodepools_limit` and
+# `karpenter_nodepools_usage` (note: nodepool**s**, plural — the 1.x names) are exposed and are
+# what would have caught `default` pinned at 48/48 CPU before it aborted a rollout, instead of
+# after.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: karpenter
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: karpenter
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karpenter
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics
+      honorLabels: true


### PR DESCRIPTION
`prometheus-rules-finops.yaml` carries two Karpenter alerts — `FinOpsKarpenterNodeChurnHigh` (warning) and `FinOpsKarpenterChurnOutsideMaintenance` (**critical**) — both keyed on `karpenter_nodes_total`.

**Prometheus has never held that series.** Neither rule has ever evaluated, let alone fired. They read as coverage and deliver none — and a critical alert that *cannot* fire is worse than no alert, because it occupies the space where someone would otherwise notice the gap.

## The rules aren't wrong. Nothing scrapes Karpenter.

```
$ curl karpenter.kube-system.svc:8080/metrics | grep -c '^karpenter_nodes_total'
388
```

The metric is right there. Meanwhile, of **4128** metric names in Prometheus:

```
argocd     : 0 scraped
keda       : 0 scraped
karpenter  : 0 scraped
```

The control plane is entirely unmonitored. That is the root cause behind most of what this session found by accident: ArgoCD `Degraded` for 2 days (#1284), a KEDA ScaledObject `Ready=False` for 44 days (#1400), and the `default` NodePool pinned at 48/48 CPU discovered only when it aborted a rollout (#1272).

## Scope — one of three, and I'd rather say so

| | metrics endpoint | fix |
|---|---|---|
| **Karpenter** | **works** (`karpenter` svc, `http-metrics`:8080) | **this PR** — ServiceMonitor, no terraform |
| KEDA | not exposed (`keda-operator` declares only `metricsservice:9666`) | Helm values → terraform apply |
| ArgoCD | no metrics Service exists at all | Helm values → terraform apply |

All three are terraform `helm_release`s. Karpenter's chart could emit this itself via `serviceMonitor.enabled`, but its Service already exposes the port, so a ServiceMonitor here needs no apply. KEDA and ArgoCD genuinely cannot be fixed this way — flagged, not silently skipped.

Modelled on `servicemonitor-kyverno.yaml`, which exists for the identical reason ("metrics exposed but nothing scraped them — so the SOC dashboard's panels were dark").

## Verified against the live cluster, not by inspection

- Selector matches: `kubectl -n kube-system get svc -l app.kubernetes.io/name=karpenter` → the `karpenter` Service.
- `http-metrics` is a real port name on it.
- Cluster Prometheus has **empty** `serviceMonitorSelector` / `serviceMonitorNamespaceSelector` (`{}`), so this is discovered automatically — the kyverno file's claim, checked rather than trusted.

## The alert for #1272 is deliberately not here

`karpenter_nodepools_limit` and `karpenter_nodepools_usage` are exposed (**nodepools**, plural — the 1.x names; my first probe used the singular and got a false "ABSENT"). They are exactly what would have caught `default` at 48/48 *before* it aborted a rollout.

That alert lands in a follow-up, written against a query **proven to return data** in this cluster — not against a name that merely looks right. Shipping an alert whose metric isn't scraped is precisely the mistake this PR exists to undo; doing it again in the same breath would be absurd.

**Expected effect after merge:** Prometheus starts holding `karpenter_*`, and the two existing alerts begin evaluating for the first time. Worth watching whether `FinOpsKarpenterChurnOutsideMaintenance` (critical) fires immediately on real churn — it has been blind for its whole life, so nobody knows what it will say.

Refs #1272, #1284