### PR TITLE
fix(observability): point the Karpenter alerts at metrics that exist, add the cap alert

### DIFF
--- a/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
+++ b/openbank-infra/gitops/components/observability/prometheus-rules-finops.yaml
@@ -63,12 +63,20 @@ spec:
     - name: openbank.finops.karpenter-churn
       interval: 5m
       rules:
-        # D3: Node churn rate. Karpenter exports karpenter_nodes_total with
-        # lifecycle phase labels. High disruption/termination rate outside the
-        # maintenance window indicates misconfigured consolidation.
+        # D3: Node churn rate. High termination rate outside the maintenance window
+        # indicates misconfigured consolidation.
+        #
+        # These two rules were dead from the day they were written: they queried
+        # `karpenter_nodes_total{lifecycle="terminating"}`, and Karpenter 1.x exports
+        # neither that metric nor that label. `karpenter_nodes_total` exists only as a
+        # PREFIX of unrelated capacity gauges (`karpenter_nodes_total_pod_requests`,
+        # `..._daemon_limits`) — which is what made a grep for it look like a match.
+        # Nothing scraped Karpenter either (#1445), so the rules never evaluated and the
+        # wrong name never surfaced. Both now fixed; queries below were run against this
+        # cluster's Prometheus and return data.
         - alert: FinOpsKarpenterNodeChurnHigh
           expr: |
-            increase(karpenter_nodes_total{lifecycle="terminating"}[1h]) > 3
+            increase(karpenter_nodes_terminated_total[1h]) > 3
           for: 10m
           labels:
             severity: warning
@@ -84,7 +92,7 @@ spec:
         - alert: FinOpsKarpenterChurnOutsideMaintenance
           expr: |
             (hour() >= 7 and hour() < 20) and
-            increase(karpenter_nodes_total{lifecycle="terminating"}[30m]) > 2
+            increase(karpenter_nodes_terminated_total[30m]) > 2
           for: 5m
           labels:
             severity: critical
@@ -94,6 +102,30 @@ spec:
           annotations:
             summary: "Node churn during business hours — {{ $value }} nodes"
             description: "Karpenter terminated {{ $value }} nodes during business hours (07:00–20:00 UTC). This causes unnecessary EBS detach races and cross-AZ traffic spikes. Prometheus server UTC assumed."
+            runbook: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0002-karpenter-node-drain.md"
+
+        # A NodePool at its `limits` cap is invisible until it bites: Karpenter simply
+        # refuses to provision ("all available instance types exceed limits for nodepool"),
+        # pods sit Pending, and a Rollout eventually aborts on its progress deadline. That
+        # is how #1272 was found — and how #809 was found before it, at the previous cap.
+        # Twice discovered by a failure rather than a signal; this is the signal.
+        #
+        # The cap is a deliberate cost guardrail (without it Karpenter once provisioned
+        # 14x c6g.12xlarge, ~$235/day), so this must not read as "raise it" — it reads as
+        # "the pool has no room left; decide whether demand or the cap is wrong."
+        - alert: FinOpsKarpenterNodePoolNearCap
+          expr: |
+            100 * karpenter_nodepools_usage{resource_type="cpu"}
+              / on(nodepool) karpenter_nodepools_limit{resource_type="cpu"} >= 90
+          for: 15m
+          labels:
+            severity: warning
+            detector: D3
+            team: platform
+            route: finops-agent
+          annotations:
+            summary: "NodePool {{ $labels.nodepool }} at {{ $value | printf \"%.0f\" }}% of its CPU cap"
+            description: "Karpenter cannot add nodes to {{ $labels.nodepool }} once usage reaches the cap: pods stay Pending and Rollouts abort on progressDeadlineSeconds (#1272, #809). Decide whether declared requests grew honestly (raise the cap) or overstate demand (right-size them) — do not reflex-raise; the cap is the runaway-cost guardrail."
             runbook: "https://github.com/JiRaska/open-bank-oss/blob/main/docs/runbooks/0002-karpenter-node-drain.md"
 
     - name: openbank.finops.ebs-health


### PR DESCRIPTION
Follow-up to #1445, and a correction of it.

## I got #1445's central claim wrong

#1445 said scraping Karpenter would revive its two alerts, because "the metric is real — it simply had no scraper". I'd checked like this:

```
$ grep -c '^karpenter_nodes_total' /tmp/karp.txt
388
```

That is a **prefix match**. The 388 hits were `karpenter_nodes_total_pod_requests` and `karpenter_nodes_total_daemon_limits` — unrelated capacity gauges. The exact series `karpenter_nodes_total` **does not exist** in Karpenter 1.x, and neither does the `lifecycle="terminating"` label both rules select on.

Proven now that scraping is live, by exact-match query rather than grep:

```
karpenter_nodes_total present?  False
karpenter_nodes* that DO exist: _allocatable, _created_total, _drained_total,
                                _terminated_total, _system_overhead, …
```

So the two rules were dead for **two independent reasons**: nothing scraped Karpenter (#1445 fixed that) **and** the metric name was wrong (this PR). #1445 alone left them exactly as dead — just now provably so.

This is the same substring trap as `grep vop` matching `devops-agent`, and `grep -v SecretSynced` hiding `SecretSyncedError`, both of which bit earlier in this same session. I wrote the warning into `CLAUDE.md` yesterday and then walked into it.

## What this changes

**Both churn rules → `karpenter_nodes_terminated_total`** (the 1.x counter). Verified by running the query, not reading the name:

```
increase(karpenter_nodes_terminated_total[1h])
→ series with nodepool="default", job="karpenter"
```

**New `FinOpsKarpenterNodePoolNearCap`** — what #1272 asks for. A NodePool at its `limits` cap is invisible until it bites: Karpenter refuses to provision, pods sit Pending, a Rollout aborts on its progress deadline. That is how #1272 was found — and how **#809 was found before it, at the previous cap**. Twice discovered by a failure rather than a signal.

Run live, right now:

```
100 * karpenter_nodepools_usage{resource_type="cpu"}
  / on(nodepool) karpenter_nodepools_limit{resource_type="cpu"} >= 90

→ runners-warm  100
   (default is at 87.5%, below the threshold)
```

**So this alert fires the moment it lands, on a real condition.** That is the point: it should have been firing for #1272's whole life.

The annotation deliberately does **not** say "raise the cap". The cap is the runaway-cost guardrail — without it Karpenter once provisioned 14× `c6g.12xlarge` (~$235/day). It says: decide whether declared demand grew honestly, or overstates itself.

## Verification

- YAML parses; 9 rules total, 3 Karpenter.
- Every Karpenter expression executed against this cluster's Prometheus and returns data.
- No metric name in this PR was accepted from a grep.

Refs #1272, #809, #1445