### PR TITLE
fix(ci): alarm when the dependency-graph submission fails

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -105,3 +105,81 @@ jobs:
       # --continue: one module failing to resolve shouldn't blank out the graph for the rest.
       - name: Resolve fleet dependency graph
         run: ./gradlew assemble testClasses --continue --no-daemon
+
+  # ── The alarm (issue #1449) ───────────────────────────────────────────────────
+  # Why this exists: from 2026-07-14 to 2026-07-17 EVERY run of the job above died
+  # with `Java heap space` and the fleet's dependency graph silently stopped updating
+  # for three days. Nothing was broken about the signal — each run went red — but a
+  # push-triggered workflow's red status on main is addressed to nobody, so no one
+  # looked. Dependabot alerts and (since #1421) the PR-time Gradle dependency gate both
+  # read that graph, and a stale graph makes the gate green without checking anything.
+  #
+  # The heap is a RATCHET with nothing measuring it: 4g was fine until the fleet grew
+  # past it, and 6g will go the same way. This job cannot prevent that — it makes the
+  # next occurrence arrive as an addressed issue instead of three quiet days.
+  #
+  # Not gated on `schedule` (unlike fleet-attestation's equivalent): the OOM ran red on
+  # main PUSHES, and the schedule is only weekly, so a schedule-only alarm would have
+  # waited up to 7 days to say anything. pull_request IS excluded — a PR-run failure is
+  # already visible on the PR, and filing a repo issue for it would be noise.
+  raise-issue:
+    name: Raise issue on submission failure
+    needs: submit
+    if: ${{ failure() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5  # API calls only
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or refresh the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          TITLE="Dependency graph submission is failing — the Gradle vulnerability gate is running blind"
+          # Heredoc body is deliberately flush-left: `run: |` strips only the common YAML
+          # indent, so an indented body would carry leading spaces into the issue markdown.
+          # Body via a plain redirect + --body-file, NOT `BODY=$(cat <<EOF ...)`. A heredoc
+          # nested inside $( ) mis-parses an apostrophe as an opening quote on bash 3.2
+          # (still the default /bin/bash on macOS), so this step could not be dry-run
+          # locally in that form. CI runs bash 5 where it would have parsed, but a step
+          # that only its own CI can syntax-check is a step nobody tests before pushing.
+          # fleet-attestation.yml's equivalent survives that shape only because its body
+          # happens to contain no apostrophe.
+          cat > "${RUNNER_TEMP:-/tmp}/issue-body.md" <<EOF
+          \`dependency-submission.yml\` FAILED (trigger: \`${EVENT}\`), so the fleet's Gradle
+          dependency graph did not update.
+
+          **This is latent, not cosmetic.** Two things read that graph and neither goes red
+          when it is stale:
+
+          - **Dependabot security alerts** stop reflecting reality — no new alerts for the
+            Kotlin/Java fleet, which reads exactly like "no vulnerabilities".
+          - **The PR-time Gradle dependency gate** (\`dependency-review\`, #1419) diffs the PR
+            against this graph. A stale base makes the gate **pass without checking anything**.
+
+          Run: ${RUN_URL}
+
+          **Check the heap first.** The 2026-07-14..07-17 outage was \`Java heap space\` in
+          \`Resolve fleet dependency graph\`: \`-Xmx4g\` stopped fitting as the fleet grew, every
+          run died for three days, and nobody noticed because a red push-triggered workflow on
+          main is addressed to nobody. It is now \`-Xmx6g\`; that is a ratchet, not a fix. If the
+          log says \`Java heap space\`, raise \`GRADLE_OPTS\` in this workflow and match the
+          headroom \`security.yml\`'s CodeQL java-kotlin leg already proves on the same runner.
+
+          Note \`dependency-graph-continue-on-failure: true\` (setup-gradle's default): graph
+          submission is NOT gated on the resolve succeeding, so a partial graph may have been
+          submitted rather than none. Do not assume the previous good graph is still intact.
+
+          This issue is refreshed on each further failure; close it once a run is green.
+          EOF
+          existing=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md"
+          else
+            gh issue create --title "$TITLE" --body-file "${RUNNER_TEMP:-/tmp}/issue-body.md" \
+              --label tech-debt --label "severity:high"
+          fi


### PR DESCRIPTION
## Summary

The dependency graph rotted for **three days** (2026-07-14 → 07-17, `Java heap space`) and nobody was told — because a red push-triggered workflow on `main` is addressed to nobody. Since #1421 the PR-time Gradle vulnerability gate reads that graph, so a stale graph now makes that gate **pass without checking anything**. This makes the next occurrence arrive as an addressed issue instead of three quiet days.

## Type of change

- [x] fix (bug fix)
- [ ] feat / refactor / perf / docs / chore / security / breaking change

## Linked issues

Closes #1449

## Changes

- `dependency-submission.yml`: new `raise-issue` job — opens or refreshes a tracking issue when the submission fails, mirroring `fleet-attestation.yml`'s established escalation pattern. The issue body carries the heap diagnosis so the next person does not re-derive it.

## Design notes

- **Not gated on `schedule`** (unlike fleet-attestation's equivalent): the OOM ran red on main **pushes**, and the schedule is only weekly — a schedule-only alarm would have waited up to 7 days to say anything.
- **`pull_request` excluded**: a PR-run failure is already visible on the PR; a repo issue for it would be noise.
- **`--body-file` instead of `BODY=$(cat <<EOF ...)`** — see "What testing caught" below.

## When does it rot again?

The heap is a **ratchet with nothing measuring it**. 4g was fine until the fleet outgrew it; 6g will go the same way, and that cannot be predicted from here. So this PR does not try to prevent it — it makes it **loud**.

## What testing caught

Dry-ran the actual step body (extracted from the parsed YAML, `gh` stubbed so nothing was written):

1. **The first version would not even parse.** `BODY=$(cat <<EOF ... EOF)` with an apostrophe in the body (`the fleet's Gradle`, `setup-gradle's default`) breaks on bash 3.2 — a heredoc nested in `$( )` mis-parses the apostrophe as an opening quote. Isolated with a minimal repro: the same heredoc without an apostrophe is clean, with one it fails. **`fleet-attestation.yml`'s identical pattern survives only because its body happens to contain no apostrophe** — luck, not design. CI's bash 5 would have parsed it fine, so this was never going to be a CI failure; but a step that only its own CI can syntax-check is a step nobody tests before pushing. Rewritten as a plain redirect + `--body-file`, which is immune and dry-runnable.
2. **Both paths verified**: no-existing-issue → `create` with the right title/labels; existing-issue → `comment` (refresh, not duplicate).
3. **Body renders flush-left** (`od -c` on the rendered file — the file's own comment warns that YAML block-scalar indent would otherwise leak into the issue markdown), backticks intact, `${RUN_URL}` / `${EVENT}` expand.
4. `gh issue create/comment --body-file` support confirmed against the installed `gh`, not assumed.

## Definition of Done

- [x] Hexagonal layering preserved (workflow-only change).
- [ ] Unit/integration/contract tests — N/A (CI YAML).
- [x] No new lint warnings: `actionlint` + `yamllint` clean (linters validated against a known-positive first).
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — rationale lives in the job's own comment.

## Security checklist

- [x] No secrets, tokens, passwords, or PII. Uses `github.token` with `issues: write` scoped to this job only.
- [x] No new suppressions.
- [x] No new third-party dependency; no action SHA changed.
- [x] Supply-chain relevant: restores a signal for the data both Dependabot alerting and the PR-time Gradle gate depend on.

## Compliance impact

- [x] DORA — ICT vulnerability screening depends on this graph being current; the alarm makes its failure visible and owned rather than latent.

## Rollout / Rollback

- Deployment strategy: N/A (CI-only; fires on the next submission failure)
- Rollback plan: revert the commit
- Data migration reversible: N/A

## Reviewer notes

- **This cannot be tested end-to-end without breaking `main`** — forcing a real failure would mean pushing a deliberately broken submission, and PR runs are excluded from the alarm by design. So the step body was dry-run locally instead (both branches), which is what caught the bash 3.2 parse issue. The `if:` condition itself is plain enough to read.
- **Two gaps this does not close**, both recorded in #1449 rather than guessed at:
  - *Staleness with no failure* — if the workflow stops running at all (e.g. GitHub disables cron on an inactive repo), there is no failure to alarm on. A staleness check would need a threshold above the weekly cadence (>7 days), making detection slow.
  - *A partial graph that submits "successfully"* — `dependency-graph-continue-on-failure: true` (setup-gradle's default) means submission is not gated on the resolve succeeding. No evidence this has happened, and the snapshot JSON's schema could not be verified (the report dir is not uploaded as an artifact), so I did not invent a plausibility floor. The issue body warns not to assume the previous good graph is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)