### PR TITLE
feat(observability): scrape the ArgoCD application-controller

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -338,6 +338,30 @@ resource "helm_release" "argocd" {
       name  = "controller.resources.limits.memory"
       value = "3584Mi"
     },
+    # Application-controller metrics. Both default to false in argo-cd 9.5.21, which is
+    # why Prometheus holds 4128 metric names and NOT ONE starts with `argocd`: nothing was
+    # ever scraped, so no rule could be written and none was. The cost was concrete — two
+    # apps sat Degraded for ~2 days (document-service's unseeded signing keystore, and a
+    # KEDA scaler broken for 44 days, #1284) and were found by an unrelated investigation
+    # rather than by a page. `argocd_app_info{health_status="Degraded"}` comes from this
+    # controller; enabling it is what makes that alertable at all.
+    #
+    # Only the controller: `argocd_app_info` lives here. server/repoServer/applicationSet
+    # metrics are separate values and answer different questions (API latency, sync perf) —
+    # not this gap, so not in this change.
+    {
+      name  = "controller.metrics.enabled"
+      value = "true"
+    },
+    # The chart's own ServiceMonitor — no hand-written one needed (contrast
+    # servicemonitor-karpenter.yaml, where the chart is terraform-managed but the Service
+    # already existed, so gitops could take it without an apply). The cluster Prometheus
+    # has empty serviceMonitorSelector AND serviceMonitorNamespaceSelector ({}), verified,
+    # so it discovers this with no additionalLabels.
+    {
+      name  = "controller.metrics.serviceMonitor.enabled"
+      value = "true"
+    },
   ]
 }
 


### PR DESCRIPTION
Prometheus holds **4128** metric names. Not one starts with `argocd`.

The argo-cd chart defaults `controller.metrics.enabled` and `controller.metrics.serviceMonitor.enabled` to `false`, and this release never set them. So no argocd metric has ever existed — which means no rule could be written against one, and none was.

## What that cost

Two apps sat `Degraded` for ~2 days, both correctly:

- **document-service** — its signing keystore is unseeded, so it seals PDFs with a throwaway cert (#1284)
- **notifications** — a KEDA scaler broken for its entire 44-day life (#1400)

Both were found by an unrelated investigation, not by a page. `argocd_app_info{health_status="Degraded"}` comes from the application-controller; enabling it is what makes that alertable **at all**.

This is the third and last leg of the control-plane gap: Karpenter is now scraped (#1445) with its two long-dead alerts repointed at metrics that exist (#1447). KEDA remains — it needs its own chart values and is a separate change.

## Scope: controller only

`argocd_app_info` lives there. `server` / `repoServer` / `applicationSet` metrics are separate values answering different questions (API latency, sync performance) — not this gap, so not here.

## Verified by rendering the chart, not by trusting value names

Given the session that produced this PR included shipping a claim based on a prefix-matching `grep`, every assertion below was executed:

```
controller.metrics.enabled              default: False   (9.5.21)
controller.metrics.serviceMonitor.enabled  default: False
```

Rendering with exactly these two values:

```
Service:         argocd-application-controller-metrics   ports: [('http-metrics', 8082)]
ServiceMonitor:  argocd-application-controller           endpoints: ['http-metrics']

SM selector: {app.kubernetes.io/name: argocd-metrics, ...}
Service labels: {app.kubernetes.io/name: argocd-metrics, ...}
  ==> SELECTOR MATCHES: True
```

- `8082` is the port the controller pod already declares — checked against the live pod.
- The selector/label join is checked explicitly: **a ServiceMonitor whose selector misses is the same dead-coverage shape this whole thread is about.**
- The chart guards the SM on `.Capabilities.APIVersions`, so `helm template` omits it unless you pass `--api-versions monitoring.coreos.com/v1`. In-cluster the CRD is present. Worth knowing before someone renders it locally and concludes the SM isn't created.
- No `additionalLabels` needed: this cluster's Prometheus has **empty** `serviceMonitorSelector` and `serviceMonitorNamespaceSelector`, verified.

`tofu fmt` clean.

## This does not apply itself

`platform-tofu.yml` runs `plan` on PR and applies **only** on a manual `workflow_dispatch` against main. Merging changes nothing in the cluster — read the plan preview on this PR first, then dispatch the apply deliberately. That gate is the workflow's design, not an oversight.

## After apply

`argocd_app_info` starts existing, and an alert like `argocd_app_info{health_status="Degraded"} > 0 for: 1h` becomes writable. I've deliberately **not** included that rule here: it will be written against a query proven to return data, the same way #1447's cap alert was — not against a name that merely looks right.

Refs #1284, #1272, #1445, #1447