### PR TITLE
docs(governance): record the PR-time CVE gate and the CI lessons behind it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,34 @@ These are real, repeatable gotchas — worth knowing before they cost you a debu
   steps); if the job has dependents (`needs:`), make the guard its own job instead — failing in
   place would skip them. In `release-please.yml` that would have stripped an already-cut tag of its
   evidence bundle.
+- **`git rebase` drops the signature off EVERY rebased commit, and `--amend -S` only fixes the
+  tip.** A 3-commit branch rebased and re-signed with `--amend` still strands on
+  `required_signatures` with two unsigned commits behind the tip. Re-sign the whole range:
+  `GIT_SEQUENCE_EDITOR=true git rebase -i --exec 'git commit --amend --no-edit -S' origin/main`,
+  then verify via the API (`gh api .../pulls/<N>/commits --jq '.[].commit.verification'`) — not
+  `gh pr view`.
+
+### Dependency graph & PR-time CVE gating (ADR-0030; `rules.yaml: dependencies.pr_time_cve_gate`)
+- **`dependency-review` only ever diffs *submitted* dependency graphs — so `dependency-submission`
+  MUST keep its `pull_request` trigger, or the Gradle half of the gate silently passes.** GitHub
+  parses npm/pip/docker/actions manifests natively but **not Gradle**; the PR-head graph exists only
+  because `dependency-submission.yml` also runs on `pull_request` (#1421). Nothing else covers it:
+  Trivy's Java support is JAR / `pom.xml` / `gradle.lockfile` / `*.sbt.lock` only and this repo has
+  **zero** lockfiles, and CodeQL is neither a dependency scanner nor a required check. Delete that
+  trigger as "redundant CI" and `block_on_cve_severity` becomes decoration — green, checking nothing.
+- **`retry-on-snapshot-warnings` retries even when no submission is coming.** GitHub answers
+  `No snapshots were found for the head SHA` whether or not a graph is on its way, so armed
+  unconditionally it burns its whole window on every PR that touches no manifest (measured: **>11
+  min**). Arm it only on dependency-touching PRs. Size the window from the **end-to-end** wait, not
+  the resolve: the fleet resolve takes ~734 s but the snapshot only becomes queryable ~24 min in
+  (GitHub indexes the graph *after* the submission API returns), so gradle/actions' documented 600 s
+  cannot work here.
+- **A red push-triggered workflow on `main` is addressed to nobody.** `dependency-submission` died
+  of `Java heap space` for three days; every run went red and no one looked, while Dependabot alerts
+  and the PR-time gate both quietly read the stale graph — neither goes red when it is stale. Any
+  workflow whose *output* something else silently depends on needs an escalation path (raise/refresh
+  a tracking issue, as `fleet-attestation.yml` and now `dependency-submission.yml` do). Its
+  `GRADLE_OPTS` heap is a ratchet with nothing measuring it — expect to raise it again.
 
 ### Reviewing a diff
 - **Use 3-dot diff for pre-merge review:** `git diff origin/main...origin/<branch>` is the actual

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "8e3c4c9a57f575bd"
+    openbank.tech/policy-checksum: "a5bc59f8f55a1d55"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2144,6 +2144,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8e3c4c9a57f575bd"
+        openbank.tech/policy-checksum: "a5bc59f8f55a1d55"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "6f48b1fac731e8a9"
+    openbank.tech/policy-checksum: "d438fc0594d5e1c4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2087,6 +2087,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f48b1fac731e8a9"
+        openbank.tech/policy-checksum: "d438fc0594d5e1c4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "4bd762fe44b9e0b8"
+    openbank.tech/policy-checksum: "071c4251f7d463f7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2188,6 +2188,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4bd762fe44b9e0b8"
+        openbank.tech/policy-checksum: "071c4251f7d463f7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "0652c76e74063727"
+    openbank.tech/policy-checksum: "f3568c0ee591502c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2093,6 +2093,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0652c76e74063727"
+        openbank.tech/policy-checksum: "f3568c0ee591502c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "738734254108648b"
+    openbank.tech/policy-checksum: "664e3e99bc7662af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2125,6 +2125,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "738734254108648b"
+        openbank.tech/policy-checksum: "664e3e99bc7662af"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "55539db40d126e33"
+    openbank.tech/policy-checksum: "a3f6ee02956115fb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2176,6 +2176,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "55539db40d126e33"
+        openbank.tech/policy-checksum: "a3f6ee02956115fb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "f13c9dc267e9e541"
+    openbank.tech/policy-checksum: "d545b0cff6d765fa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1361,6 +1361,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f13c9dc267e9e541"
+        openbank.tech/policy-checksum: "d545b0cff6d765fa"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "f13c9dc267e9e541"
+    openbank.tech/policy-checksum: "d545b0cff6d765fa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1361,6 +1361,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f13c9dc267e9e541"
+        openbank.tech/policy-checksum: "d545b0cff6d765fa"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "a18151fd1f8a0bad"
+    openbank.tech/policy-checksum: "319c7acc08a9de50"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2104,6 +2104,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a18151fd1f8a0bad"
+        openbank.tech/policy-checksum: "319c7acc08a9de50"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "dc9935d7ba7998db"
+    openbank.tech/policy-checksum: "960af7fa4b340232"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2155,6 +2155,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dc9935d7ba7998db"
+        openbank.tech/policy-checksum: "960af7fa4b340232"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "6d48314631667c12"
+    openbank.tech/policy-checksum: "333b903c2a5dabd6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2089,6 +2089,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6d48314631667c12"
+        openbank.tech/policy-checksum: "333b903c2a5dabd6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "5bb2b0327ce984f1"
+    openbank.tech/policy-checksum: "e105334f8747e18b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2202,6 +2202,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5bb2b0327ce984f1"
+        openbank.tech/policy-checksum: "e105334f8747e18b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "75d9264ae072bd96"
+    openbank.tech/policy-checksum: "c2fd26153a58d9f4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2157,6 +2157,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "75d9264ae072bd96"
+        openbank.tech/policy-checksum: "c2fd26153a58d9f4"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "f13c9dc267e9e541"
+    openbank.tech/policy-checksum: "d545b0cff6d765fa"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1361,6 +1361,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "f13c9dc267e9e541"
+        openbank.tech/policy-checksum: "d545b0cff6d765fa"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "bd1d1e47c4b851e5"
+    openbank.tech/policy-checksum: "7fc1a328ffbe0fd7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2110,6 +2110,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "32bf2b5e5cb6c914"
+    openbank.tech/policy-checksum: "5091c85cab01e1fe"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2147,6 +2147,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "27f927edc01ae80d"
+    openbank.tech/policy-checksum: "4ef08a307d9c82b6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2132,6 +2132,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "9a52b0897270c124" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "7f59d5e6766ec9ef" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "de0b65484f7becaa"
+        openbank.tech/policy-checksum: "e46b393d2db5cc57"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "27f927edc01ae80d" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "4ef08a307d9c82b6" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "430fd0d1fe92f4ab"
+        openbank.tech/policy-checksum: "a6f0bab938c0f77c"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "32bf2b5e5cb6c914" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "5091c85cab01e1fe" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bd1d1e47c4b851e5"
+        openbank.tech/policy-checksum: "7fc1a328ffbe0fd7"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "5fe8a87b5beaa86d" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "7ffdbc897b010ba4" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b4e8ee8885d24848"
+        openbank.tech/policy-checksum: "8b530623c2d55c58"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "1f8977ee9c49a269"
+        openbank.tech/policy-checksum: "03f86f515cf03e29"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "430fd0d1fe92f4ab"
+    openbank.tech/policy-checksum: "a6f0bab938c0f77c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2105,6 +2105,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "de0b65484f7becaa"
+    openbank.tech/policy-checksum: "e46b393d2db5cc57"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2126,6 +2126,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "5fe8a87b5beaa86d"
+    openbank.tech/policy-checksum: "7ffdbc897b010ba4"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2106,6 +2106,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b4e8ee8885d24848"
+    openbank.tech/policy-checksum: "8b530623c2d55c58"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2109,6 +2109,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "9a52b0897270c124"
+    openbank.tech/policy-checksum: "7f59d5e6766ec9ef"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2162,6 +2162,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1f8977ee9c49a269"
+    openbank.tech/policy-checksum: "03f86f515cf03e29"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2113,6 +2113,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "6c9a4805a12dfab4"
+    openbank.tech/policy-checksum: "0809d7e0a7535800"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2115,6 +2115,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6c9a4805a12dfab4"
+        openbank.tech/policy-checksum: "0809d7e0a7535800"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "b6cc5ebbf0df7c80"
+    openbank.tech/policy-checksum: "2951a1c928e9ffc1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2093,6 +2093,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b6cc5ebbf0df7c80"
+        openbank.tech/policy-checksum: "2951a1c928e9ffc1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "f6b084a95bd2d150"
+    openbank.tech/policy-checksum: "bd61242b84c42b69"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2129,6 +2129,28 @@ data:
           adr: ADR-0136
       block_on_cve_severity: [CRITICAL, HIGH]
       catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+      # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+      # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+      # above was declared but unenforced for Gradle, the fleet's primary language.
+      pr_time_cve_gate:
+        gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+        invariant: >
+          dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+          npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+          because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+          gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+          visible failure.
+        requires:
+          - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+          - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+          - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+        not_covered_by:
+          trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+          codeql: "not a dependency scanner, and not a required check"
+        fork_prs: >
+          Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+          review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+          workflow_run job holding contents:write over a fork-authored artifact.
       artifact_integrity:
         # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
         # every resolved artifact — a repository-level tamper or dependency-confusion swap of an

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f6b084a95bd2d150"
+        openbank.tech/policy-checksum: "bd61242b84c42b69"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -831,6 +831,28 @@ dependencies:
       adr: ADR-0136
   block_on_cve_severity: [CRITICAL, HIGH]
   catalog: openbank-libs/gradle/libs.versions.toml  # version catalog is the single dependency source
+  # HOW block_on_cve_severity is actually enforced at PR time -- and why it is load-bearing
+  # that dependency-submission runs on pull_request (#1419/#1421). Until it did, the rule
+  # above was declared but unenforced for Gradle, the fleet's primary language.
+  pr_time_cve_gate:
+    gate: .github/workflows/dependency-review.yml   # fail-on-severity: high
+    invariant: >
+      dependency-review only ever diffs SUBMITTED dependency graphs. GitHub natively parses
+      npm/pip/docker/actions manifests but NOT Gradle, so the graph for a PR head exists only
+      because dependency-submission.yml also runs on pull_request. Remove that trigger and the
+      gate keeps reporting green while checking nothing about Gradle -- a silent hole, not a
+      visible failure.
+    requires:
+      - ".github/workflows/dependency-submission.yml runs on pull_request with the same path filter"
+      - "dependency-review arms retry-on-snapshot-warnings ONLY on dependency-touching PRs"
+      - "dependency-submission failures raise a tracking issue (a stale graph makes the gate vacuous)"
+    not_covered_by:
+      trivy_fs: "Trivy's Java coverage is JAR / pom.xml / gradle.lockfile / *.sbt.lock only; this repo has zero lockfiles, so Trivy fs sees no Gradle dependency"
+      codeql: "not a dependency scanner, and not a required check"
+    fork_prs: >
+      Fork PRs get a read-only token, so the submission cannot run and they receive dependency
+      review for the natively-parsed ecosystems only, not Gradle. Deliberate: closing it needs a
+      workflow_run job holding contents:write over a fork-authored artifact.
   artifact_integrity:
     # Gradle dependency verification (gradle/verification-metadata.xml): SHA-256 pins for
     # every resolved artifact — a repository-level tamper or dependency-confusion swap of an


### PR DESCRIPTION
## Summary

Captures what the 2026-07-17 pipeline audit (#1399, #1408, #1414, #1421, #1450) taught, routed per `rules.yaml: knowledge_capture` — the hard rule to `rules.yaml`, the footguns to `CLAUDE.md`. The most load-bearing item: `dependencies.block_on_cve_severity: [CRITICAL, HIGH]` was **declared but, for Gradle, enforced by nothing** until #1421, and the trigger that now enforces it looks exactly like redundant CI to anyone tidying up.

## Type of change

- [x] docs
- [ ] feat / fix / refactor / perf / chore / security / breaking change

## Linked issues

Refs #1419, #1449

## Changes

**`openbank-libs/governance/rules.yaml`** — new `dependencies.pr_time_cve_gate` recording how the existing `block_on_cve_severity` rule is actually enforced:
- the gate (`dependency-review.yml`, `fail-on-severity: high`);
- the invariant — dependency-review only ever diffs **submitted** graphs, GitHub does not parse Gradle natively, so `dependency-submission.yml`'s `pull_request` trigger is what makes the rule real. Remove it and the gate stays green while checking nothing;
- what does **not** cover it (Trivy's Java support needs a JAR/`pom.xml`/`gradle.lockfile` — this repo has zero lockfiles; CodeQL is neither a dependency scanner nor a required check);
- the deliberate fork-PR gap.

**`CLAUDE.md`** — four bullets, in the existing pitfall style:
- the gate footgun above, stated as "don't delete this trigger";
- `retry-on-snapshot-warnings` retries even when no submission is coming (**>11 min** measured on a PR touching no manifest) → arm it conditionally, and size the window from the measured **~24 min end-to-end**, not the 734 s resolve (gradle/actions' documented 600 s cannot work here);
- a red push-triggered workflow on `main` is addressed to nobody — the graph died of `Java heap space` for three days while Dependabot and the gate quietly read it stale; anything whose *output* others depend on needs an escalation path, and the heap is a ratchet with nothing measuring it;
- `git rebase` drops the signature off **every** rebased commit and `--amend -S` fixes only the tip.

## Routing — what deliberately did NOT go in this PR

Per the public-repo rule, local-environment and runner-pool specifics stay in the gitignored `.claude/rules/` (already written, not part of this diff):
- **macOS bash 3.2 mis-parses an apostrophe inside a heredoc nested in `$( )`** — a local-testability trap, not a CI failure (CI runs bash 5). Notably `fleet-attestation.yml`'s `raise-issue` survives that shape only because its body happens to contain no apostrophe, so it is recorded as *don't copy that one*.
- **Measure exec time separately from queue time before optimizing a workflow** — `runner-image` reads as a 137-min median run whose build is **93 s**; the rest is scale-to-zero queue. Includes the per-job/per-step `gh api` recipe that found the 199 s admin-ui step staging zero SBOMs (#1407).

## Definition of Done

- [x] Hexagonal layering preserved (docs/governance only).
- [ ] Tests — N/A (documentation).
- [x] No new lint warnings: `yamllint` finding set on `rules.yaml` is **identical** to `origin/main` (8 colons / 9 commas / 12 comments-indentation, all pre-existing), using the config extracted from `ci.yml`'s own gate rather than a guessed one. `rules.yaml` parses; `check-duplicate-yaml-keys.sh` clean.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — this PR is the docs.

## Security checklist

- [x] No secrets, tokens, passwords, or PII. No private hostnames, AWS specifics, or incident detail beyond what is already public in this repo's own PR/issue history.
- [x] No new suppressions.
- [x] No new third-party dependency.
- [x] Records a supply-chain control that was previously undocumented and therefore easy to remove by accident.

## Compliance impact

- [x] DORA — documents the enforcement path for ICT dependency vulnerability screening; no control changes, only their description.

## Rollout / Rollback

- Deployment strategy: N/A (documentation)
- Rollback plan: revert
- Data migration reversible: N/A

## Reviewer notes

- **`CLAUDE.md` is now 290 → ~318 lines**, over the "keep it lean" intent. I kept only items that would otherwise cost a debugging session or open a silent hole, and pushed everything environment-specific to the private path-scoped rules. Worth a trim pass at some point, separately.
- `rules.yaml` is the authoritative half — `CLAUDE.md`'s bullet is the human summary of it, per `knowledge_capture`'s `hard_rule` routing ("add a CI guard where feasible; summarize in CLAUDE.md"). **No CI guard is feasible for "the trigger still exists"** without a meta-test asserting on workflow YAML; not built, so the rule is documented, not enforced. That is the honest state, and worth knowing when reading `rules.yaml` as gospel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)