### PR TITLE
fix(psd2): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcher.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcher.kt
@@ -16,6 +16,15 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 
+/**
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously for
+ * the whole rollout duration, and both dispatch on their own tick. `Psd2OutboxRepositoryImpl`
+ * therefore implements [OutboxRepository.claimProcessable] as an atomic `FOR UPDATE SKIP LOCKED`
+ * claim, not the unclaimed-peek default, so two concurrently running pods can never both select
+ * and publish the same row.
+ */
 @ApplicationScoped
 class Psd2OutboxDispatcher(
     private val repo: Psd2OutboxRepository,

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/persistence/entity/Psd2OutboxEntity.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/persistence/entity/Psd2OutboxEntity.kt
@@ -4,9 +4,23 @@
 package com.openbank.psd2.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is psd2-only — added straight on this entity, not on the shared
+ * [PanacheOutboxEntity], because that base class is mapped by every outbox-bearing service and
+ * adding a column there would break every other service's table until it also migrated (#1201
+ * fleet rollout is deliberately follow-up, not this change). Stamped by
+ * `Psd2OutboxRepositoryImpl.claimProcessable`'s atomic claim query when a row moves to
+ * [com.openbank.libs.persistence.outbox.OutboxStatus.DISPATCHING]; read back by the same query
+ * to decide whether a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "psd2_outbox")
-class Psd2OutboxEntity : PanacheOutboxEntity()
+class Psd2OutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/persistence/repository/Psd2OutboxRepositoryImpl.kt
+++ b/openbank-psd2-service/src/main/kotlin/com/openbank/psd2/infrastructure/persistence/repository/Psd2OutboxRepositoryImpl.kt
@@ -13,11 +13,13 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
-class Psd2OutboxRepositoryImpl :
+class Psd2OutboxRepositoryImpl(private val clock: Clock) :
     Psd2OutboxRepository,
     PanacheRepository<Psd2OutboxEntity> {
 
@@ -38,6 +40,37 @@ class Psd2OutboxRepositoryImpl :
             OutboxStatus.FAILED.name,
         )
     }.awaitSuspending()
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer
+     * `UPDATE` flips exactly those rows to DISPATCHING and returns them — so two dispatcher
+     * instances racing this at the same instant can never both claim the same row. Also reclaims
+     * rows still DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was
+     * evicted before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it does not need to (and must not) span the
+     * network publish call that follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, Psd2OutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun markSent(eventId: UUID, sentAt: Instant) {
         Panache.withTransaction {
@@ -75,5 +108,22 @@ class Psd2OutboxRepositoryImpl :
         it.attemptCount = 0
         it.createdAt = createdAt
         it.updatedAt = createdAt
+    }
+
+    companion object {
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE psd2_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM psd2_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }

--- a/openbank-psd2-service/src/main/resources/application.yaml
+++ b/openbank-psd2-service/src/main/resources/application.yaml
@@ -101,6 +101,15 @@ quarkus:
     # health/metrics on the main port in tests — RestAssured targets a single port
     management:
       enabled: false
+    # Unlike sibling services (account/card-issuance/document/aml), this service has no
+    # unconditional `flyway.migrate-at-start: true` in the main config above — the GitOps
+    # manifest injects QUARKUS_FLYWAY_MIGRATE_AT_START=true instead (psd2-service.yaml), so
+    # production migrates fine. But @QuarkusTest never sees that env var, so without this the
+    # Testcontainers Postgres from PostgresRedisTestResource never gets migrated and every IT
+    # touching psd2_outbox fails with "relation does not exist" (found while adding
+    # Psd2OutboxClaimIT, #1201).
+    flyway:
+      migrate-at-start: true
 
 opa:
   url: "${OPA_URL:http://localhost:8181}"

--- a/openbank-psd2-service/src/main/resources/db/migration/V3__psd2_outbox_claimed_at.sql
+++ b/openbank-psd2-service/src/main/resources/db/migration/V3__psd2_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE psd2_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcherTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcherTest.kt
@@ -46,12 +46,12 @@ class Psd2OutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 0) { repo.listProcessable(any()) }
+        coVerify(exactly = 0) { repo.claimProcessable(any(), any()) }
     }
 
     @Test
     fun `dispatch drains the outbox when dispatch-enabled is true`(): Unit = runBlocking {
-        coEvery { repo.listProcessable(any()) } returns listOf(sampleEntry())
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(sampleEntry())
         coEvery { publisher.publish(any()) } returns Unit
         coEvery { repo.markSent(any(), any()) } returns Unit
 
@@ -59,7 +59,7 @@ class Psd2OutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 1) { repo.listProcessable(any()) }
+        coVerify(exactly = 1) { repo.claimProcessable(any(), any()) }
         coVerify(exactly = 1) { publisher.publish(any()) }
         coVerify(exactly = 1) { repo.markSent(any(), any()) }
     }
@@ -67,7 +67,7 @@ class Psd2OutboxDispatcherTest {
     @Test
     fun `dispatch marks an entry failed when the publisher throws`(): Unit = runBlocking {
         val entry = sampleEntry()
-        coEvery { repo.listProcessable(any()) } returns listOf(entry)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(entry)
         coEvery { publisher.publish(entry) } throws RuntimeException("kafka unavailable")
         coEvery { repo.markFailed(any(), any(), any()) } returns Unit
 

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/integration/Psd2OutboxClaimIT.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/integration/Psd2OutboxClaimIT.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.psd2.integration
+
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import com.openbank.psd2.infrastructure.persistence.repository.Psd2OutboxRepositoryImpl
+import com.openbank.psd2.it.PostgresRedisTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing [Psd2OutboxRepositoryImpl]'s
+ * `claimProcessable` at the same instant (an Argo Rollouts canary window running old + new pod)
+ * must never both claim the same row, and a claim that never reaches `markSent`/`markFailed`
+ * (the claiming pod crashed or was evicted) must not strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class Psd2OutboxClaimIT {
+
+    @Inject
+    lateinit var repository: Psd2OutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    // The @QuarkusTest Postgres is shared across test classes in one JVM session — without this,
+    // backlog rows other IT classes left behind get scooped up by this test's claim too.
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    private fun seedPending(count: Int): List<OutboxMessage> {
+        val messages = (1..count).map {
+            OutboxMessage(
+                aggregateId = Ids.newId(),
+                eventType = "test.event.claim",
+                payload = """{"seq":$it}""",
+                createdAt = Instant.now(),
+            )
+        }
+        messages.forEach { msg ->
+            onEventLoop { Panache.withTransaction { repository.persistInTransaction(msg) }.awaitSuspending() }
+        }
+        return messages
+    }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seeded = seedPending(50)
+        val seededIds = seeded.map { it.eventId }.toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seeded = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seeded.eventId)
+
+        // Simulate the claiming pod crashing before markSent/markFailed: back-date claimed_at
+        // far enough that any staleAfter window has already elapsed.
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seeded.eventId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seeded.eventId)
+    }
+}


### PR DESCRIPTION
## Why

Fleet rollout of the ledger-service reference fix (#1415, #1201 proposed fix 1, sub-item 1): an Argo Rollouts canary window runs two pods simultaneously for the whole rollout duration, and both run every `@Scheduled` bean on their own tick regardless of traffic-weight split, so a plain unclaimed `listProcessable()` lets two pods select and publish the same PENDING/FAILED rows.

## Fix

`Psd2OutboxRepositoryImpl` now overrides `OutboxRepository.claimProcessable` (shared default already on `main` since #1415, delegates to `listProcessable` unchanged for every service that doesn't override it) with a single native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement — atomic, and reclaims rows stuck `DISPATCHING` past a stale-claim window (the claiming pod crashed before `markSent`/`markFailed`).

**Also**: `application.yaml` now sets `quarkus.flyway.migrate-at-start: true` unconditionally. Unlike sibling services, psd2 previously relied on the GitOps manifest injecting `QUARKUS_FLYWAY_MIGRATE_AT_START=true` rather than baking it into the app config — fine in production, but `@QuarkusTest` never sees that env var, so the Testcontainers Postgres never got migrated and every IT touching `psd2_outbox` (including the new one below) failed with "relation does not exist" without this.

`Psd2OutboxDispatcherTest` updated: `OutboxDispatch.dispatchOnce` (already on `main` since #1415) calls `claimProcessable`, not `listProcessable`, so the existing mockk stubs/verifies needed the same rename — unrelated to this PR's own feature, just a fixture that had gone stale relative to `main`.

## Verified

- `Psd2OutboxClaimIT` (new): two concurrent claims never return an overlapping row; a stale `DISPATCHING` row is reclaimed. Mutation-tested — reverted the atomic claim to a plain `listProcessable` passthrough and confirmed the concurrency test fails, then restored it.
- Full non-cached `:openbank-psd2-service:test` (all IT + unit tests) + `ktlintCheck` + `detekt`, green.
- Diff scope: exactly the 7 files this touches, no ktlintFormat collateral.

Refs #1201, follows #1415/#1440/#1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)