### PR TITLE
fix(billing): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/BillingOutboxDispatcher.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/BillingOutboxDispatcher.kt
@@ -25,8 +25,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout
  * ledger-posting, not event publication). The `dispatchEnabled` guard lets GitOps enable draining
  * per-environment without a redeploy (same convention as interest/standing-order/sepa-payment).
  *
- * **N4 — single writer.** `concurrentExecution = SKIP` prevents in-JVM overlap; the billing
- * Deployment should be pinned to `replicas: 1` (documented in the threat model / runbook).
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously for
+ * the whole rollout duration, and both dispatch on their own tick. `BillingOutboxRepositoryImpl`
+ * therefore implements [OutboxRepository.claimProcessable] as an atomic `FOR UPDATE SKIP LOCKED`
+ * claim, not the unclaimed-peek default, so two concurrently running pods can never both select
+ * and publish the same row.
  * Resilience policies apply on [publishWithResilience] (cross-bean CDI call through the proxy,
  * ADR-0013) — this is IN ADDITION to [com.openbank.billing.infrastructure.adapter.LedgerPostingAdapter]'s
  * own inner resilience on the raw HTTP call; the outer retry here covers a failure anywhere in

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/BillingOutboxRepositoryImpl.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/outbox/BillingOutboxRepositoryImpl.kt
@@ -18,6 +18,8 @@ import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
@@ -31,7 +33,7 @@ import java.util.UUID
  * (rather than assuming every row is a charge) since this table now carries two payload shapes.
  */
 @ApplicationScoped
-class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepository) :
+class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepository, private val clock: Clock) :
     OutboxRepository,
     PanacheRepository<BillingOutboxEntity> {
 
@@ -48,6 +50,37 @@ class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepo
     override suspend fun countProcessable(): Long = Panache.withSession {
         count("status in (?1, ?2)", OutboxStatus.PENDING.name, OutboxStatus.FAILED.name)
     }.awaitSuspending()
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer
+     * `UPDATE` flips exactly those rows to DISPATCHING and returns them — so two dispatcher
+     * instances racing this at the same instant can never both claim the same row. Also reclaims
+     * rows still DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was
+     * evicted before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it does not need to (and must not) span the
+     * network publish call that follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, BillingOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun markSent(eventId: UUID, sentAt: Instant) {
         Panache.withTransaction {
@@ -138,6 +171,21 @@ class BillingOutboxRepositoryImpl(private val assessments: BillingAssessmentRepo
 
         /** Mirrors `LedgerOutboxEventPublisher.REVERSAL_INTENT_EVENT_TYPE` (ADR-0143 phase 2e). */
         const val REVERSAL_INTENT_EVENT_TYPE = "billing.fee.reversal-intent.v1"
+
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE billing_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM billing_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }
 

--- a/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/persistence/entity/BillingOutboxEntity.kt
+++ b/openbank-billing-service/src/main/kotlin/com/openbank/billing/infrastructure/persistence/entity/BillingOutboxEntity.kt
@@ -5,9 +5,23 @@
 package com.openbank.billing.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is billing-only — added straight on this entity, not on the shared
+ * [PanacheOutboxEntity], because that base class is mapped by every outbox-bearing service and
+ * adding a column there would break every other service's table until it also migrated (#1201
+ * fleet rollout is deliberately follow-up, not this change). Stamped by
+ * `BillingOutboxRepositoryImpl.claimProcessable`'s atomic claim query when a row moves to
+ * [com.openbank.libs.persistence.outbox.OutboxStatus.DISPATCHING]; read back by the same query
+ * to decide whether a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "billing_outbox")
-class BillingOutboxEntity : PanacheOutboxEntity()
+class BillingOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-billing-service/src/main/resources/db/migration/V5__billing_outbox_claimed_at.sql
+++ b/openbank-billing-service/src/main/resources/db/migration/V5__billing_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE billing_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingOutboxDispatcherTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingOutboxDispatcherTest.kt
@@ -48,7 +48,7 @@ class BillingOutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 0) { repo.listProcessable(any()) }
+        coVerify(exactly = 0) { repo.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { publisher.publish(any()) }
     }
 
@@ -56,7 +56,7 @@ class BillingOutboxDispatcherTest {
     fun `an enabled dispatch publishes each processable row and marks it sent`(): Unit = runBlocking {
         val first = entry()
         val second = entry()
-        coEvery { repo.listProcessable(any()) } returns listOf(first, second)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(first, second)
         coJustRun { publisher.publish(any()) }
         coJustRun { repo.markSent(any(), any()) }
 
@@ -72,7 +72,7 @@ class BillingOutboxDispatcherTest {
     @Test
     fun `a failed publish marks the row failed for retry instead of dropping it`(): Unit = runBlocking {
         val poisoned = entry()
-        coEvery { repo.listProcessable(any()) } returns listOf(poisoned)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(poisoned)
         coEvery { publisher.publish(poisoned) } throws IllegalStateException("ledger unavailable")
         coJustRun { repo.markFailed(any(), any(), any()) }
 
@@ -86,7 +86,7 @@ class BillingOutboxDispatcherTest {
     fun `dispatchScheduledBatch drives the same dispatch loop without the resilience annotations`(): Unit =
         runBlocking {
             val entryRow = entry()
-            coEvery { repo.listProcessable(any()) } returns listOf(entryRow)
+            coEvery { repo.claimProcessable(any(), any()) } returns listOf(entryRow)
             coJustRun { publisher.publish(any()) }
             coJustRun { repo.markSent(any(), any()) }
 

--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/integration/BillingOutboxClaimIT.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/integration/BillingOutboxClaimIT.kt
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.billing.integration
+
+import com.openbank.billing.infrastructure.outbox.BillingOutboxRepositoryImpl
+import com.openbank.billing.infrastructure.persistence.entity.BillingOutboxEntity
+import com.openbank.billing.it.PostgresRedisTestResource
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing [BillingOutboxRepositoryImpl]'s
+ * `claimProcessable` at the same instant (an Argo Rollouts canary window running old + new pod)
+ * must never both claim the same row, and a claim that never reaches `markSent`/`markFailed`
+ * (the claiming pod crashed or was evicted) must not strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class BillingOutboxClaimIT {
+
+    @Inject
+    lateinit var repository: BillingOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    // The @QuarkusTest Postgres is shared across test classes in one JVM session — without this,
+    // backlog rows other IT classes left behind get scooped up by this test's claim too.
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    private fun seedEntity(seq: Int): UUID {
+        val eventId = Ids.newId()
+        onEventLoop {
+            Panache.withTransaction {
+                val e = BillingOutboxEntity()
+                e.eventId = eventId
+                e.aggregateId = Ids.newId()
+                e.eventType = "test.event.claim"
+                e.payload = """{"seq":$seq}"""
+                e.status = OutboxStatus.PENDING.name
+                e.attemptCount = 0
+                e.createdAt = Instant.now()
+                e.updatedAt = Instant.now()
+                repository.persist(e)
+            }.awaitSuspending()
+        }
+        return eventId
+    }
+
+    private fun seedPending(count: Int): List<UUID> = (1..count).map { seedEntity(it) }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seededIds = seedPending(50).toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seededId = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seededId)
+
+        // Simulate the claiming pod crashing before markSent/markFailed: back-date claimed_at
+        // far enough that any staleAfter window has already elapsed.
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seededId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seededId)
+    }
+}


### PR DESCRIPTION
## Why

Fleet rollout of the ledger-service reference fix (#1415, #1201 proposed fix 1, sub-item 1): an Argo Rollouts canary window runs two pods simultaneously for the whole rollout duration, and both run every `@Scheduled` bean on their own tick regardless of traffic-weight split, so a plain unclaimed `listProcessable()` lets two pods select and publish the same PENDING/FAILED rows — for billing this means the same fee-posting or reversal-intent row getting posted to ledger-service twice.

## Fix

`BillingOutboxRepositoryImpl` now overrides `OutboxRepository.claimProcessable` (shared default already on `main` since #1415, delegates to `listProcessable` unchanged for every service that doesn't override it) with a single native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement — atomic, and reclaims rows stuck `DISPATCHING` past a stale-claim window (the claiming pod crashed before `markSent`/`markFailed`). `markFailed`'s existing posting_status-flip logic on terminal `DEAD` is untouched.

`BillingOutboxDispatcherTest` updated: `OutboxDispatch.dispatchOnce` (already on `main` since #1415) calls `claimProcessable`, not `listProcessable`, so the existing mockk stubs/verifies needed the same rename — unrelated to this PR's own feature, just a fixture that had gone stale relative to `main`.

## Verified

- `BillingOutboxClaimIT` (new): two concurrent claims never return an overlapping row; a stale `DISPATCHING` row is reclaimed. Mutation-tested — reverted the atomic claim to a plain `listProcessable` passthrough and confirmed the concurrency test fails, then restored it.
- Full non-cached `:openbank-billing-service:test` (all IT + unit tests) + `ktlintCheck` + `detekt`, green.
- Diff scope: exactly the 6 files this touches, no ktlintFormat collateral.

Refs #1201, follows #1415/#1440/#1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)