### PR TITLE
feat(observability): scrape the KEDA operator

### DIFF
--- a/openbank-infra/aws/envs/sandbox-platform/main.tf
+++ b/openbank-infra/aws/envs/sandbox-platform/main.tf
@@ -477,6 +477,27 @@ resource "helm_release" "keda" {
       name  = "resources.operator.limits.memory"
       value = "512Mi"
     },
+    # Operator Prometheus metrics. Off by default in chart 2.19.0 — and not merely
+    # unexposed: the operator is launched with `--enable-prometheus-metrics=false`, so
+    # keda_scaler_errors and friends are not produced at all. Consequence: a ScaledObject
+    # can sit Ready=False forever with no signal. notification-service's did, for its
+    # entire 44-day life, and was found only because an unrelated investigation happened
+    # to read `kubectl get scaledobject` (#1400).
+    #
+    # Do NOT be misled by `keda-operator-metrics-apiserver:8080` already existing — that
+    # is the HPA external-metrics API and serves only keda_internal_metricsservice_*
+    # gRPC counters. The scaler metrics live on the keda-operator Service, which today
+    # exposes only metricsservice:9666; this value adds metrics:8080 to it.
+    {
+      name  = "prometheus.operator.enabled"
+      value = "true"
+    },
+    # The chart's own ServiceMonitor (selector app.kubernetes.io/name=keda-operator,
+    # namespaceSelector keda) — no hand-written one needed, same as argo-cd in #1453.
+    {
+      name  = "prometheus.operator.serviceMonitor.enabled"
+      value = "true"
+    },
   ]
 }
 


### PR DESCRIPTION
The last unscraped leg of the control plane. Karpenter is covered (#1445, #1447), ArgoCD is (#1453 applied, #1459) — KEDA had **zero** metrics in Prometheus, so a broken scaler was unobservable.

## Not merely unexposed — actively disabled

```
live:    --enable-prometheus-metrics=false    ports: [metricsservice:9666]
render:  --enable-prometheus-metrics=true     ports: [metrics:8080, metricsservice:9666]
         --metrics-bind-address=:8080
```

`keda_scaler_errors` and its siblings are **not produced at all**. So notification-service's ScaledObject sat `Ready=False` for its entire **44-day life** and was found only because an unrelated investigation happened to run `kubectl get scaledobject` (#1400). Nothing could have paged — there was no series to page on.

## The decoy that cost me time

`keda-operator-metrics-apiserver:8080` **already exists**, which makes it look like KEDA is exposing metrics. It isn't: that's the HPA external-metrics API, and curling it returns only `keda_internal_metricsservice_*` gRPC counters. The scaler metrics live on the `keda-operator` Service — which today exposes only `metricsservice:9666`. Recorded in the code comment so the next person doesn't repeat it.

I also missed the `keda-operator` Service entirely at first, because I listed services with `grep -iE "metrics|NAME"` — and `keda-operator` has no "metrics" in its name. That's the fourth filtered-out truth in this session; see #1447 for the one that shipped before I caught it.

## Verified by rendering + diffing against live

```
ServiceMonitor keda-operator
  selector:          app.kubernetes.io/name=keda-operator
  namespaceSelector: [keda]
  endpoint:          metrics

Service keda-operator   name-label='keda-operator'   MATCH=True
  ports after the value: [metricsservice:9666, metrics:8080]
```

The selector/label join is checked explicitly — a ServiceMonitor whose selector misses is exactly the dead-coverage shape this thread exists to remove (#1447 was precisely that failure).

`prometheus.operator.enabled` and `prometheus.operator.serviceMonitor.enabled` both default **false** in chart 2.19.0. `tofu fmt` clean.

## Alert rules deliberately not here

They'll be written once this is applied and the queries provably return data — the same discipline as #1447 (cap alert verified firing on `runners-warm` 100%) and #1459 (verified firing on `document-service`). `keda_scaler_errors > 0` is the obvious candidate: it is the exact signal that was missing for 44 days.

## Does not apply itself

`platform-tofu.yml` plans on PR and applies only on a manual `workflow_dispatch`. Read the plan preview here first.

Refs #1400, #1284