### PR TITLE
ci: make the 5 required checks report correctly in a merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,19 @@ on:
   push:
     branches: [main]
   pull_request:
+  # `Validate manifests` is a required check, so it must also report in the merge queue's
+  # `merge_group` context or the queue stalls forever waiting for a status that can never
+  # arrive. Note the diff-scoped gates below are extended to merge_group individually —
+  # adding only the trigger would report green while checking nothing.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a queue check — a cancelled run reports no status and the entry hangs.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -36,11 +42,22 @@ jobs:
         with:
           fetch-depth: 0
       - id: check
+        env:
+          # Empty except on merge_group; the PR/push paths never read it.
+          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
             # Post-merge main build always includes admin-ui.
             echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ -n "${MQ_BASE_SHA}" ]; then
+            # merge_group: base_sha is the tree this entry was built on. `github.base_ref` is
+            # EMPTY here, so the PR path below would fetch "":refs/remotes/origin/" and then
+            # diff "origin/...HEAD" — a hard error that would wedge the queue.
+            git fetch --depth=1 origin "${MQ_BASE_SHA}" 2>/dev/null || true
+            N=$(git diff --name-only "${MQ_BASE_SHA}" HEAD -- openbank-admin-ui/ | wc -l | tr -d ' ')
+            echo "changed=$( [ "$N" -gt 0 ] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
+            echo "Admin UI files changed (merge_group base ${MQ_BASE_SHA}): $N"
           else
             BASE="origin/${{ github.base_ref }}"
             # Force the remote-tracking ref to the true tip (persistent self-hosted
@@ -385,19 +402,33 @@ jobs:
       # merge and that merges with no later run is still unseen by ANY run-time
       # base choice — that needs required-up-to-date branches or a merge queue.
       - name: "resolve PR diff base (current merge-base, not creation-time base.sha)"
-        if: github.event_name == 'pull_request'
+        # merge_group too: every diff-scoped gate below reads PR_DIFF_BASE, so if this step
+        # skipped in the queue they would all skip with it and `Validate manifests` would go
+        # green having checked nothing — the queue would be theatre.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
         run: |
           set -euo pipefail
-          base="${EVENT_BASE_SHA}"
-          git fetch --depth=2 origin "${GITHUB_SHA}" 2>/dev/null || true
-          if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
-            base="$(git rev-parse 'HEAD^1')"
-          else
+          if [ -n "${MQ_BASE_SHA}" ]; then
+            # In the queue there is nothing to derive: base_sha IS the tree this entry was
+            # built on (main + the entries ahead of it). That is also the base this gate
+            # always wanted — the whole #481 x #524 race was the PR-time base going stale
+            # when a competing PR merged first, which by construction cannot happen here.
+            base="${MQ_BASE_SHA}"
             git fetch --depth=1 origin "${base}" 2>/dev/null || true
+            echo "merge_group diff base: ${base}"
+          else
+            base="${EVENT_BASE_SHA}"
+            git fetch --depth=2 origin "${GITHUB_SHA}" 2>/dev/null || true
+            if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
+              base="$(git rev-parse 'HEAD^1')"
+            else
+              git fetch --depth=1 origin "${base}" 2>/dev/null || true
+            fi
+            echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
           fi
-          echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
           echo "PR_DIFF_BASE=${base}" >> "$GITHUB_ENV"
 
       # ADR-0030 D2, diff-aware half (issue #265): when a PR moves a money-path
@@ -409,7 +440,8 @@ jobs:
       # ADR-0144) — findings are ::warning annotations; add --enforce to flip.
       # PR-only: the gate diffs against the resolved PR diff base (see above).
       - name: "threat-model updated on trust-boundary change (ADR-0030 D2, advisory)"
-        if: github.event_name == 'pull_request'
+        # merge_group too — it diffs against PR_DIFF_BASE, which the queue sets.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_DIFF_BASE}"
 
       # CLAUDE.md rule 3 / ADR-0029: a module is a released component iff it has
@@ -430,6 +462,9 @@ jobs:
       # (finrep-service 0.4.0). Harmless but noisy; classifies from the PR title since the squash
       # commit doesn't exist yet at PR-CI time. PR-only: no PR title to classify on a push to main.
       - name: "release-scope-mismatch gate (rules.yaml release_scope_mismatch, advisory)"
+        # Stays pull_request-only ON PURPOSE: it classifies from the PR title/body, which a
+        # merge_group payload does not carry. Nothing is lost — it already ran on the PR, and
+        # queueing cannot change a commit type or scope.
         if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -602,7 +637,8 @@ jobs:
       # creation-time event base.sha — the #524 × #481 ledger merge race);
       # pushes to main have already been classified.
       - name: "api-contract gate — OpenAPI diff classification (ADR-0048 D5, enforced)"
-        if: github.event_name == 'pull_request'
+        # merge_group too: the race a merge queue exists to close (#481 x #524): two spec PRs both claiming one info.version.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         env:
           OASDIFF_VERSION: "1.22.0"
           OASDIFF_SHA256: "8b972accaf49f984cf40702af8b29360126ac9436594ccf6ac1ae662209a5fe6"
@@ -623,7 +659,8 @@ jobs:
       # startup with `checksum mismatch`). PR-only and diff-scoped against the
       # resolved PR diff base, same as api-contract above.
       - name: "db-migration gate — rollback note + forward-only (rules.yaml db_change, advisory)"
-        if: github.event_name == 'pull_request'
+        # merge_group too — it diffs against PR_DIFF_BASE, which the queue sets.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: python3 openbank-infra/scripts/check-db-migration.py --base "${PR_DIFF_BASE}"
 
       # rules.yaml event_change / ADR-0006: schema-compat gate. The fleet's event
@@ -649,7 +686,8 @@ jobs:
       # ADVISORY until the rules.yaml schema-compat gate graduates
       # (target 2026-09-15, ADR-0144) — flip = --enforce. stdlib-only.
       - name: "schema-compat gate — event backward-compatibility (event_change, advisory)"
-        if: github.event_name == 'pull_request'
+        # merge_group too — it diffs against PR_DIFF_BASE, which the queue sets.
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: python3 .github/scripts/check-event-schema-compat.py --base "${PR_DIFF_BASE}"
 
       # DomainEvent.occurredAt constructor guard (PR #2662 / #2709).

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -19,13 +19,21 @@ name: Issue hygiene
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  # A required check must also report in the merge queue's `merge_group` context or the
+  # queue stalls forever waiting for a status that can never arrive.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: issue-hygiene-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # `github.event.pull_request.number` is EMPTY on merge_group, which would collapse every
+  # queue entry into one shared group and let them cancel each other — a wedged queue. Fall
+  # back to github.ref, which on merge_group is the per-entry
+  # refs/heads/gh-readonly-queue/main/pr-N-<sha> and is therefore unique.
+  group: issue-hygiene-${{ github.event.pull_request.number || github.ref }}
+  # Never cancel a queue check: a cancelled run reports nothing and the entry hangs.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   issue-hygiene:
@@ -34,7 +42,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # measured max 6s
     steps:
+      # Deliberate pass-through in the merge queue. This gate lints the PR *body*, which a
+      # merge_group payload does not carry — and unlike a code check it cannot go stale
+      # between PR and queue, because queueing does not alter the body it already passed on.
+      # Branch on the STEP, not the job: a job skipped by an `if:` still reports its own
+      # status, so two jobs sharing the name `issue-hygiene` would report two conflicting
+      # statuses for one required check.
+      - name: Merge queue — already enforced on the pull request
+        if: github.event_name == 'merge_group'
+        run: echo "merge_group carries no PR body to lint; this gate ran on the PR itself, which queueing does not alter."
+
       - name: Lint PR "Linked issues"
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -21,13 +21,17 @@ on:
   push:
     branches: [main]
   pull_request:
+  # A required check must also report in the merge queue's `merge_group` context, or the
+  # queue stalls forever waiting for a status that can never arrive.
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
   group: opa-policy-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a queue check — a cancelled run reports no status and the entry hangs.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -61,8 +65,16 @@ jobs:
             PATTERN="${PATTERN}|^$(printf '%s' "$dir" | sed 's/\./\\./g')/"
           done < <(find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' -exec dirname {} \; | sort -u)
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "Event push -> always verify (post-merge; keeps the deployed-bundle check current)."
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
+            # push: post-merge, keeps the deployed-bundle check current.
+            # merge_group: always verify rather than re-deriving a diff. `github.base_ref` is
+            # EMPTY on merge_group, so the diff path below would compute BASE="origin/" and die
+            # on `git diff origin/ HEAD` — wedging the queue. Verifying unconditionally is also
+            # the safer direction (this repo's rule is over-verify, never under-verify) and the
+            # gate is cheap (~19s median), and it is precisely the case a queue exists for: the
+            # bundle regeneration must be re-checked against main + the entries ahead of this
+            # one, since a competing governance PR restamps all 44 bundle files.
+            echo "Event ${{ github.event_name }} -> always verify."
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             BASE="origin/${{ github.base_ref }}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # A required check must also report in the merge queue's `merge_group` context, or the
+  # queue stalls forever waiting for a status that can never arrive.
+  merge_group:
   schedule:
     - cron: "0 4 * * 1"  # weekly Monday 04:00 UTC
 
@@ -15,7 +18,8 @@ permissions:
 # scheduled history scan (same fix as security.yml).
 concurrency:
   group: secret-scan-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a queue check — a cancelled run reports no status and the entry hangs.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   gitleaks:
@@ -54,6 +58,10 @@ jobs:
       # range keeps the custom rules + allowlist intact while ensuring a false
       # positive on a different branch can't fail this PR.
       #   - pull_request: scan BASE..HEAD (this PR's commits only)
+      #   - merge_group:  scan the queue entry's base..head (same reasoning; without this
+      #                   branch merge_group falls through to the unscoped full-history
+      #                   scan, which is exactly the cross-branch poisoning described above
+      #                   — a stranger's finding would fail the queue entry)
       #   - push:         scan before..sha (the pushed range)
       #   - schedule/manual: full-history scan (no range)
       # An empty range (no new commits) scans nothing and passes.
@@ -61,6 +69,8 @@ jobs:
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MQ_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           PUSH_AFTER_SHA: ${{ github.sha }}
         run: |
@@ -68,6 +78,8 @@ jobs:
           LOG_OPTS=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             LOG_OPTS="--log-opts=--no-merges ${PR_BASE_SHA}..${PR_HEAD_SHA}"
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            LOG_OPTS="--log-opts=--no-merges ${MQ_BASE_SHA}..${MQ_HEAD_SHA}"
           elif [ "${{ github.event_name }}" = "push" ]; then
             # github.event.before is all-zeroes for the first push of a branch.
             if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -24,6 +24,10 @@ on:
   schedule:
     - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch: {}
+  # `all-green` is a required check, so it must also report in the merge queue's
+  # `merge_group` context or the queue stalls forever waiting for a status that can
+  # never arrive.
+  merge_group:
 
 permissions:
   contents: read
@@ -41,8 +45,12 @@ concurrency:
   # (issue #846). Key push-to-main by SHA so every commit gets its own lane and is never
   # cancelled; PR pushes keep the superseding behavior (a new push to the same branch
   # should cancel the old run).
+  # merge_group needs the same never-cancel treatment as push-to-main, for a different
+  # reason: a cancelled queue run reports no status, so the entry waits on it forever.
+  # (Its github.ref is the per-entry gh-readonly-queue/... branch, so entries never share
+  # a lane anyway — this only guards a re-run of the same entry.)
   group: services-ci-${{ github.ref }}-${{ github.event_name == 'schedule' && 'nightly' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci') }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -60,6 +68,10 @@ jobs:
         with:
           fetch-depth: 0
       - id: detect
+        env:
+          # Empty on every event except merge_group; the `:-` default keeps `set -u` from
+          # killing the step on the PR/push paths, which never read it.
+          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
         run: |
           set -euo pipefail
           # Canonical Gradle module list — DISCOVERED from the tree exactly like
@@ -110,24 +122,39 @@ jobs:
               CHANGED="$ALL"
             fi
           else
-            BASE="origin/${{ github.base_ref }}"
-            # Persistent self-hosted runners REUSE the git workdir between jobs,
-            # so the `origin/<base>` remote-tracking ref can be stale from an
-            # earlier run. Force it to the true remote tip with an explicit
-            # refspec (a bare `git fetch origin main` updates FETCH_HEAD but does
-            # NOT reliably move refs/remotes/origin/main). A stale base silently
-            # mis-computes the diff and under-builds changed services — a
-            # branch-protection hole. Full depth (no --depth=1): a shallow graft
-            # would break merge-base once main advances past this PR's base.
-            git fetch --no-tags --force origin \
-              "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
-              >/dev/null 2>&1 || true
-            # Compute the merge-base explicitly rather than leaning on the
-            # three-dot shorthand's ref resolution, then diff from it. Equivalent
-            # to BASE...HEAD but observable and robust to odd ref state.
-            MB=$(git merge-base "$BASE" HEAD 2>/dev/null || echo "$BASE")
+            # pull_request AND merge_group share every decision below — only the diff base
+            # differs. The queue must fan out by the same rules as the PR, or it would build
+            # a different set of services than the one the PR was reviewed on.
+            if [ "${{ github.event_name }}" = "merge_group" ]; then
+              # The queue already built this entry on main + the entries ahead of it, and
+              # `merge_group.base_sha` IS that base: nothing to derive, no stale-ref hazard.
+              # Note `github.base_ref` is EMPTY on merge_group, so the PR path below would
+              # compute BASE="origin/" and die on `git diff origin/ HEAD` — a wedged queue.
+              # base_sha..HEAD is exactly this PR's changes as they land on the real
+              # post-merge tree, which is the point of queueing.
+              MB="${MQ_BASE_SHA}"
+              echo "Detect: merge_group base_sha=${MB}"
+            else
+              BASE="origin/${{ github.base_ref }}"
+              # Persistent self-hosted runners REUSE the git workdir between jobs,
+              # so the `origin/<base>` remote-tracking ref can be stale from an
+              # earlier run. Force it to the true remote tip with an explicit
+              # refspec (a bare `git fetch origin main` updates FETCH_HEAD but does
+              # NOT reliably move refs/remotes/origin/main). A stale base silently
+              # mis-computes the diff and under-builds changed services — a
+              # branch-protection hole. Full depth (no --depth=1): a shallow graft
+              # would break merge-base once main advances past this PR's base.
+              git fetch --no-tags --force origin \
+                "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
+                >/dev/null 2>&1 || true
+              # Compute the merge-base explicitly rather than leaning on the
+              # three-dot shorthand's ref resolution, then diff from it. Equivalent
+              # to BASE...HEAD but observable and robust to odd ref state.
+              MB=$(git merge-base "$BASE" HEAD 2>/dev/null || echo "$BASE")
+              echo "Detect: base=$BASE merge-base=$MB"
+            fi
             FILES=$(git diff --name-only "$MB" HEAD)
-            echo "Detect: base=$BASE merge-base=$MB changed-files=$(echo "$FILES" | grep -c . || true)"
+            echo "Detect: changed-files=$(grep -c . <<< "$FILES" || true)"
             echo "Changed files:"; echo "$FILES" | sed 's/^/  /'
 
             # Code-global inputs every module compiles/tests against -> rebuild all.


### PR DESCRIPTION
## Summary

Prerequisite for a merge queue. **Inert until one exists** — a `merge_group:` trigger simply never fires without a queue — so this lands and gets reviewed on its own, and the ruleset flip stays a separate, deliberate step.

Enabling a queue today would wedge the repo: none of the five required checks subscribes to `merge_group`, so none would report and every entry would hang. **The trigger alone would be worse than nothing**: `ci.yml`'s diff-scoped gates are each `if: github.event_name == 'pull_request'`, so in a queue they would all skip and `Validate manifests` would go green having checked nothing — and the api-contract gate is the *entire reason* to want a queue here (#481 × #524: two spec PRs each claiming one `info.version`, both green).

## Type of change

- [x] ci (build / tooling)
- [ ] feat / fix / refactor / perf / docs / chore / security / breaking change

## Linked issues

Refs #1465

## Changes

| workflow | what it needed |
|---|---|
| `ci.yml` | resolve the diff base from `merge_group.base_sha`; extend the 4 diff-scoped gates (api-contract, db-migration, schema-compat, threat-model) to `merge_group`; fix `changes-ui`, which crashed on the empty `github.base_ref` |
| `services-ci.yml` | share every fan-out decision with the PR path, differing only in the diff base |
| `secret-scan.yml` | scan `base_sha..head_sha` — without it `merge_group` falls through to the **unscoped full-history scan**, the cross-branch poisoning its own comment warns about |
| `opa-policy.yml` | always verify, like `push` — cheap (~19 s), cannot go vacuous, and is exactly what a queue is for (a competing governance PR restamps all 44 bundles) |
| `issue-hygiene.yml` | deliberate pass-through: it lints a PR body `merge_group` has none of |

Fleet-wide: **`cancel-in-progress` is now false on `merge_group`** everywhere. A cancelled queue run reports *no status*, so the entry hangs. `issue-hygiene`'s concurrency group also falls back to `github.ref` — `pull_request.number` is empty on `merge_group`, collapsing every entry into one lane where they cancel each other.

Two things deliberately stay `pull_request`-only, and say so in place:
- **`release-scope-mismatch`** — classifies from the PR title/body, which `merge_group` does not carry; queueing cannot change a commit type.
- **`issue-hygiene`'s lint** — same reason. Branched on the **step**, not the job: a job skipped by an `if:` still reports its own status, so two jobs sharing the name `issue-hygiene` would report two statuses for one required check.

## Evidence

`merge_group` cannot be rehearsed (the event only exists once a queue does), so I tested the real step bodies extracted from the parsed YAML:

- **merge_group path** resolves `base_sha` and never touches `base_ref`.
- **PR path unchanged** — regression check on the same script.
- **Fan-out actually fires**: against a base carrying real service edits, the queue path selected the same **3 modules** the PR path does (`ledger`, `notification`, `+ simulation` via the money-path DST edge). An earlier run of this test found 0 changed files and proved nothing — re-ran it against a known-positive base.
- **Empty `base_sha` fails loudly** rather than passing vacuously. That is the safe direction: a wedged queue is recoverable and obvious; a green that checked nothing is neither.
- `actionlint` finding set **identical to `origin/main`** (4 shellcheck, all pre-existing); linters validated against a known-positive first. A scripted audit asserts all five have the trigger, guard `cancel-in-progress`, and have no collapsing concurrency group — `actionlint` cannot check any of that.

## Definition of Done

- [x] Hexagonal layering preserved (CI only).
- [ ] Unit/integration/contract tests — N/A (CI YAML).
- [x] No new lint warnings (see above).
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — rationale lives in each workflow's comments.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency; no action SHA changed.
- [x] The point of the PR is that gates keep *checking* in the queue rather than reporting vacuous green.

## Compliance impact

- [x] DORA — preserves ICT change-gate coverage in a second merge context; no control weakened.

## Rollout / Rollback

- Deployment strategy: **inert on merge.** No behaviour changes until a queue is enabled in the ruleset — a separate step, on your say-so.
- Rollback plan: revert the commit
- Data migration reversible: N/A

## Reviewer notes

- **The ruleset flip is NOT in this PR.** It changes the merge path for ~100 merges/day (measured) and 8 in-flight PRs from parallel agents, and cannot be rehearsed. Worth doing when someone can watch it; if the queue wedges, disabling it restores the old path immediately.
- **A queue will not fix the OPA-bundle ripple** (#1452 today): that is a *textual* conflict — a conflicting PR cannot enter a queue and still needs a rebase. What it does fix is the *semantic* class: the frozen-base race the `ci.yml` comment and `.claude/rules/ci-github.md` both call out as needing "required-up-to-date branches or a merge queue".
- **Throughput**: required checks are fast in the common case (medians: gitleaks 12 s, opa 19 s, services-ci 21 s, ci 46 s), so a queue at ~100 merges/day should keep up, especially with batching. The tail is `services-ci` at ~9 min when a PR touches many modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)