### PR TITLE
fix(interest): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/outbox/InterestOutboxDispatcher.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/outbox/InterestOutboxDispatcher.kt
@@ -24,8 +24,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout
  * the `@Scheduled` annotation so the CDI proxy intercepts on the concrete bean (ADR-0013). The
  * `dispatchEnabled` guard lets GitOps enable draining per-environment without a redeploy.
  *
- * **N4 — single writer.** `concurrentExecution = SKIP` prevents in-JVM overlap; the interest
- * Deployment is pinned to `replicas: 1`. Resilience policies ([CircuitBreaker], [Retry],
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously for
+ * the whole rollout duration, and both dispatch on their own tick. `InterestOutboxRepositoryImpl`
+ * therefore implements [OutboxRepository.claimProcessable] as an atomic `FOR UPDATE SKIP LOCKED`
+ * claim, not the unclaimed-peek default, so two concurrently running pods can never both select
+ * and publish the same row. Resilience policies ([CircuitBreaker], [Retry],
  * [Timeout]) are applied on [publishWithResilience], which is called as a cross-bean CDI call
  * through the proxy.
  */

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestOutboxEntity.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestOutboxEntity.kt
@@ -4,9 +4,23 @@
 package com.openbank.interest.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is interest-only — added straight on this entity, not on the shared
+ * [PanacheOutboxEntity], because that base class is mapped by every outbox-bearing service and
+ * adding a column there would break every other service's table until it also migrated (#1201
+ * fleet rollout is deliberately incremental, one service's migration at a time). Stamped by
+ * `InterestOutboxRepositoryImpl.claimProcessable`'s atomic claim query when a row moves to
+ * [com.openbank.libs.persistence.outbox.OutboxStatus.DISPATCHING]; read back by the same query
+ * to decide whether a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "interest_outbox")
-class InterestOutboxEntity : PanacheOutboxEntity()
+class InterestOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestOutboxRepositoryImpl.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestOutboxRepositoryImpl.kt
@@ -15,11 +15,13 @@ import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
-class InterestOutboxRepositoryImpl :
+class InterestOutboxRepositoryImpl(private val clock: Clock) :
     InterestOutboxRepository,
     PanacheRepository<InterestOutboxEntity> {
 
@@ -32,6 +34,37 @@ class InterestOutboxRepositoryImpl :
             OutboxStatus.FAILED.name,
         ).range(0, limit.coerceAtLeast(1) - 1).list()
     }.awaitSuspending().map { it.toEntry() }
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer
+     * `UPDATE` flips exactly those rows to DISPATCHING and returns them — so two dispatcher
+     * instances racing this at the same instant can never both claim the same row. Also reclaims
+     * rows still DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was
+     * evicted before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it does not need to (and must not) span the
+     * network publish call that follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, InterestOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun countProcessable(): Long = countProcessableUni().awaitSuspending()
 
@@ -114,5 +147,20 @@ class InterestOutboxRepositoryImpl :
         val MAX_ATTEMPTS: Int = OutboxFailurePolicy.DEFAULT_MAX_ATTEMPTS
 
         fun statusAfterFailure(attemptCount: Int): OutboxStatus = OutboxFailurePolicy.statusAfterFailure(attemptCount)
+
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE interest_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM interest_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }

--- a/openbank-interest-service/src/main/resources/db/migration/V8__interest_outbox_claimed_at.sql
+++ b/openbank-interest-service/src/main/resources/db/migration/V8__interest_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE interest_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestOutboxClaimIT.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/integration/InterestOutboxClaimIT.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.interest.integration
+
+import com.openbank.interest.infrastructure.persistence.repository.InterestOutboxRepositoryImpl
+import com.openbank.interest.it.PostgresRedisTestResource
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing [InterestOutboxRepositoryImpl]'s
+ * `claimProcessable` at the same instant (an Argo Rollouts canary window running old + new pod)
+ * must never both claim the same row, and a claim that never reaches `markSent`/`markFailed`
+ * (the claiming pod crashed or was evicted) must not strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class InterestOutboxClaimIT {
+
+    @Inject
+    lateinit var repository: InterestOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    // The @QuarkusTest Postgres is shared across test classes in one JVM session — without this,
+    // backlog rows other IT classes left behind get scooped up by this test's claim too.
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    private fun seedPending(count: Int): List<OutboxMessage> {
+        val messages = (1..count).map {
+            OutboxMessage(
+                aggregateId = Ids.newId(),
+                eventType = "test.event.claim",
+                payload = """{"seq":$it}""",
+                createdAt = Instant.now(),
+            )
+        }
+        messages.forEach { msg ->
+            onEventLoop { Panache.withTransaction { repository.persistInTransaction(msg) }.awaitSuspending() }
+        }
+        return messages
+    }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seeded = seedPending(50)
+        val seededIds = seeded.map { it.eventId }.toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seeded = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seeded.eventId)
+
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seeded.eventId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seeded.eventId)
+    }
+}


### PR DESCRIPTION
## Why

#1201 names interest-service's dispatcher by name as carrying the same false "N4 — single writer" claim ledger-service's did: an Argo Rollouts canary window runs two pods simultaneously for the whole rollout duration, and both run every `@Scheduled` bean on their own tick regardless of traffic-weight split, so a plain unclaimed `listProcessable()` lets two pods select and publish the same PENDING/FAILED rows.

## Fix

`InterestOutboxRepositoryImpl` now overrides `OutboxRepository.claimProcessable` (shared default already on `main`, delegates to `listProcessable` unchanged for every service that doesn't override it) with a single native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement — atomic, and reclaims rows stuck `DISPATCHING` past a stale-claim window (the claiming pod crashed before `markSent`/`markFailed`). Unrelated to the existing `V7` accrual-capitalizing-claim migration/logic, which this does not touch.

## Verified

- `InterestOutboxClaimIT` (new): two concurrent claims never return an overlapping row; a stale `DISPATCHING` row is reclaimed. Mutation-tested — reverted the atomic claim to a plain `listProcessable` passthrough and confirmed the concurrency test fails, then restored it.
- Full non-cached `:openbank-interest-service:test` (all IT + unit tests, including the pre-existing accrual-capitalizing tests, unaffected) + `ktlintCheck` + `detekt`, green.
- Diff scope: exactly the 5 files this touches, no ktlintFormat collateral.

Refs #1201, follows #1415/#1440/#1451 (all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)