### PR TITLE
fix(sepa-payment): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcher.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcher.kt
@@ -17,6 +17,17 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 
+/**
+ * Drains the SEPA-payment transactional outbox (ADR-0050 / ADR-0049 D3).
+ *
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously for
+ * the whole rollout duration, and both dispatch on their own tick. `SepaPaymentOutboxRepositoryImpl`
+ * therefore implements [OutboxRepository.claimProcessable] as an atomic `FOR UPDATE SKIP LOCKED`
+ * claim, not the unclaimed-peek default, so two concurrently running pods can never both select
+ * and publish the same row.
+ */
 @ApplicationScoped
 class SepaPaymentOutboxDispatcher(
     private val repo: SepaPaymentOutboxRepository,

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/entity/SepaPaymentOutboxEntity.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/entity/SepaPaymentOutboxEntity.kt
@@ -5,9 +5,23 @@
 package com.openbank.sepa.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is sepa-payment-only — added straight on this entity, not on the shared
+ * [PanacheOutboxEntity], because that base class is mapped by every outbox-bearing service and
+ * adding a column there would break every other service's table until it also migrated (#1201
+ * fleet rollout is deliberately incremental, one service's migration at a time). Stamped by
+ * `SepaPaymentOutboxRepositoryImpl.claimProcessable`'s atomic claim query when a row moves to
+ * [com.openbank.libs.persistence.outbox.OutboxStatus.DISPATCHING]; read back by the same query
+ * to decide whether a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "sepa_payment_outbox")
-class SepaPaymentOutboxEntity : PanacheOutboxEntity()
+class SepaPaymentOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/repository/SepaPaymentOutboxRepositoryImpl.kt
+++ b/openbank-sepa-payment/src/main/kotlin/com/openbank/sepa/infrastructure/persistence/repository/SepaPaymentOutboxRepositoryImpl.kt
@@ -15,16 +15,49 @@ import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
-class SepaPaymentOutboxRepositoryImpl :
+class SepaPaymentOutboxRepositoryImpl(private val clock: Clock) :
     SepaPaymentOutboxRepository,
     PanacheRepository<SepaPaymentOutboxEntity> {
 
     fun persistWithinCurrentTransaction(message: SepaPaymentOutboxMessage): Uni<SepaPaymentOutboxEntity> =
         persist(message.toEntity())
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer
+     * `UPDATE` flips exactly those rows to DISPATCHING and returns them — so two dispatcher
+     * instances racing this at the same instant can never both claim the same row. Also reclaims
+     * rows still DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was
+     * evicted before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it does not need to (and must not) span the
+     * network publish call that follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, SepaPaymentOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun listProcessable(limit: Int): List<OutboxEntry> = Panache.withSession {
         find(
@@ -82,5 +115,22 @@ class SepaPaymentOutboxRepositoryImpl :
         it.attemptCount = 0
         it.createdAt = createdAt
         it.updatedAt = createdAt
+    }
+
+    companion object {
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE sepa_payment_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM sepa_payment_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }

--- a/openbank-sepa-payment/src/main/resources/db/migration/V6__sepa_payment_outbox_claimed_at.sql
+++ b/openbank-sepa-payment/src/main/resources/db/migration/V6__sepa_payment_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE sepa_payment_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcherTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcherTest.kt
@@ -48,7 +48,7 @@ class SepaPaymentOutboxDispatcherTest {
     fun `happy drain publishes each entry and marks every row sent`(): Unit = runBlocking {
         val first = entry(payload = "{\"e\":\"a\"}")
         val second = entry(payload = "{\"e\":\"b\"}")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(first, second)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(first, second)
         coJustRun { eventPublisher.publish(any()) }
         coJustRun { outboxRepository.markSent(any(), any()) }
 
@@ -65,7 +65,7 @@ class SepaPaymentOutboxDispatcherTest {
     fun `publish failure marks the row failed with the error message and continues`(): Unit = runBlocking {
         val failing = entry(payload = "{\"e\":\"boom\"}")
         val ok = entry(payload = "{\"e\":\"ok\"}")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(failing, ok)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(failing, ok)
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("broker down")
         coJustRun { eventPublisher.publish(ok) }
         coJustRun { outboxRepository.markSent(any(), any()) }
@@ -81,7 +81,7 @@ class SepaPaymentOutboxDispatcherTest {
 
     @Test
     fun `repository listing failure is swallowed so the scheduler never crashes`(): Unit = runBlocking {
-        coEvery { outboxRepository.listProcessable(any()) } throws RuntimeException("db unreachable")
+        coEvery { outboxRepository.claimProcessable(any(), any()) } throws RuntimeException("db unreachable")
 
         dispatcher.dispatch()
 
@@ -96,7 +96,7 @@ class SepaPaymentOutboxDispatcherTest {
 
         disabledDispatcher.dispatch()
 
-        coVerify(exactly = 0) { outboxRepository.listProcessable(any()) }
+        coVerify(exactly = 0) { outboxRepository.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { eventPublisher.publish(any()) }
     }
 }

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/SepaPaymentOutboxClaimIT.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/integration/SepaPaymentOutboxClaimIT.kt
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.sepa.integration
+
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import com.openbank.sepa.application.port.out.SepaPaymentOutboxMessage
+import com.openbank.sepa.infrastructure.persistence.repository.SepaPaymentOutboxRepositoryImpl
+import com.openbank.sepa.it.PostgresRedisTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing
+ * [SepaPaymentOutboxRepositoryImpl]'s `claimProcessable` at the same instant (an Argo Rollouts
+ * canary window running old + new pod) must never both claim the same row, and a claim that
+ * never reaches `markSent`/`markFailed` (the claiming pod crashed or was evicted) must not
+ * strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class SepaPaymentOutboxClaimIT {
+
+    @Inject
+    lateinit var repository: SepaPaymentOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    // The @QuarkusTest Postgres is shared across test classes in one JVM session — without this,
+    // backlog rows other IT classes left behind get scooped up by this test's claim too.
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    private fun seedPending(count: Int): List<SepaPaymentOutboxMessage> {
+        val messages = (1..count).map {
+            SepaPaymentOutboxMessage(
+                aggregateId = Ids.newId(),
+                eventType = "test.event.claim",
+                payload = """{"seq":$it}""",
+                createdAt = Instant.now(),
+            )
+        }
+        messages.forEach { msg ->
+            onEventLoop {
+                Panache.withTransaction { repository.persistWithinCurrentTransaction(msg) }.awaitSuspending()
+            }
+        }
+        return messages
+    }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seeded = seedPending(50)
+        val seededIds = seeded.map { it.eventId }.toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seeded = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seeded.eventId)
+
+        // Simulate the claiming pod crashing before markSent/markFailed: back-date claimed_at
+        // far enough that any staleAfter window has already elapsed.
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seeded.eventId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seeded.eventId)
+    }
+}


### PR DESCRIPTION
## Why

Fleet rollout of the ledger-service reference fix (#1415, #1201 proposed fix 1, sub-item 1): an Argo Rollouts canary window runs two pods simultaneously for the whole rollout duration, and both run every `@Scheduled` bean on their own tick regardless of traffic-weight split, so a plain unclaimed `listProcessable()` lets two pods select and publish the same PENDING/FAILED rows.

## Fix

`SepaPaymentOutboxRepositoryImpl` now overrides `OutboxRepository.claimProcessable` (shared default already on `main`, delegates to `listProcessable` unchanged for every service that doesn't override it) with a single native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement — atomic, and reclaims rows stuck `DISPATCHING` past a stale-claim window (the claiming pod crashed before `markSent`/`markFailed`).

`SepaPaymentOutboxDispatcherTest` updated: `OutboxDispatch.dispatchOnce` (already on `main` since #1415) calls `claimProcessable`, not `listProcessable`, so the existing mockk stubs/verifies needed the same rename — unrelated to this PR's own feature, just a fixture that had gone stale relative to `main`.

## Verified

- `SepaPaymentOutboxClaimIT` (new): two concurrent claims never return an overlapping row; a stale `DISPATCHING` row is reclaimed. Mutation-tested — reverted the atomic claim to a plain `listProcessable` passthrough and confirmed the concurrency test fails, then restored it.
- Full non-cached `:openbank-sepa-payment:test` (all IT + unit tests) + `ktlintCheck` + `detekt`, green.
- Diff scope: exactly the 6 files this touches, no ktlintFormat collateral.

Refs #1201, follows #1415/#1440/#1451 (all merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)