### PR TITLE
docs: mark the merge_group triggers as inert — no queue is possible here

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,11 @@ jobs:
       # merge ref). Residual gap: a PR whose last CI run predates the competing
       # merge and that merges with no later run is still unseen by ANY run-time
       # base choice — that needs required-up-to-date branches or a merge queue.
+      # A merge queue is NOT available: it requires an organization-owned repo and this
+      # one is personal, so the ruleset rejects the rule outright (#1465). The
+      # merge_group branch below is therefore inert — kept correct for the day the repo
+      # moves under an org, but it closes nothing today. The gap above stays open unless
+      # strict_required_status_checks_policy (require branches up to date) is turned on.
       - name: "resolve PR diff base (current merge-base, not creation-time base.sha)"
         # merge_group too: every diff-scoped gate below reads PR_DIFF_BASE, so if this step
         # skipped in the queue they would all skip with it and `Validate manifests` would go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,15 @@ fire from *outside* it, so they stay here:
   `GIT_SEQUENCE_EDITOR=true git rebase -i --exec 'git commit --amend --no-edit -S' origin/main`,
   then verify via the API (`gh api .../pulls/<N>/commits --jq '.[].commit.verification'`) — not
   `gh pr view`.
+- **The `merge_group:` triggers in the required-check workflows are DEAD CODE — there is no merge
+  queue and there cannot be one.** GitHub merge queue requires an **organization-owned** repo; this
+  one is owned by a personal account, so adding a `merge_queue` rule to the ruleset returns
+  `422 Invalid rule 'merge_queue'` (issue #1465 has the isolation proof). The support was built
+  before that was checked; it is kept because it is correct and inert (the trigger simply never
+  fires) and would be needed the day the repo moves under an org — but do not read it as a working
+  gate, and do not "fix" a queue that isn't there. Consequence: the frozen-`base.sha` race
+  (#481 × #524) stays open, and `strict_required_status_checks_policy` (require branches up to
+  date) is the only remaining lever that works on a personal account.
 
 ### Dependency graph & PR-time CVE gating
 Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate` (authoritative).


### PR DESCRIPTION
## Summary

The `merge_group:` support merged in #1467 **can never fire**: GitHub merge queue requires an organization-owned repository, and this one is personal. Left unannotated it reads as a working gate. This says so in the two places a reader actually lands.

## Type of change

- [x] docs
- [ ] feat / fix / refactor / perf / chore / security / breaking change

## Linked issues

Refs #1465

## The finding

`PUT /repos/JiRaska/open-bank-oss/rulesets/18325357` with a `merge_queue` rule returns:

```
HTTP 422  Validation Failed
errors: ["Invalid rule 'merge_queue': "]
```

The empty detail is misleading. Isolated it with a throwaway ruleset on a **nonexistent branch** at `enforcement: disabled` — zero interaction with any other rule — and got the **same 422**. So it is not the parameters; the feature does not exist for this account. Merge queue is free for public repos *owned by an organization*, and Enterprise Cloud for private ones; personal accounts cannot use it at all ([docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue), [community #51483](https://github.com/orgs/community/discussions/51483)). The obvious workaround is likely closed too — [user→organization transformation was deprecated 2026-01-12](https://github.blog/changelog/2026-01-12-deprecation-of-user-to-organization-account-transformation/).

**Nothing was mutated.** Both attempts failed before writing; verified against a snapshot taken beforehand — name, target, enforcement, conditions, rules and bypass actors all identical, `updated_at` never moved, no stray probe ruleset. `main-protection` still carries exactly its five required checks.

## Changes

- **`CLAUDE.md`** — one bullet in the CI section: the triggers are dead code, why they are kept anyway, don't "fix" a queue that isn't there, and what the consequence is.
- **`ci.yml`** — the comment above the diff-base step has offered "required-up-to-date branches **or a merge queue**" as the two ways to close the frozen-base gap. Half of that is now known to be unavailable, and this is precisely where someone hitting the race will be reading.

## Why keep #1467 at all

It is correct, it is inert (the trigger cannot fire, so there is no runtime effect), and it is exactly what the repo needs the day it moves under an org. Reverting would only re-lose work that is already paid for. What it must not do is *look* like a gate.

## Consequence, stated plainly

The frozen-`base.sha` race (#481 × #524) **stays open**. `strict_required_status_checks_policy` (require branches up to date) is the only remaining lever that works on a personal account — and it forces a rebase on every PR whose base moved, which at ~100 merges/day here is most of them. Separate decision, not taken.

## Definition of Done

- [x] Hexagonal layering preserved (comments only — no executable change).
- [ ] Tests — N/A.
- [x] No new lint warnings: `actionlint` finding set on `ci.yml` **identical to `origin/main`** (1 shellcheck, pre-existing); `yamllint` clean; linter validated against a known-positive first.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — this PR is the docs.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency; no action SHA changed.
- [x] Removes a false impression that a merge gate is active when it cannot be.

## Compliance impact

- [x] None — documentation only; no control changed. It *records* that a control we hoped for is unavailable.

## Rollout / Rollback

- Deployment strategy: N/A (comments)
- Rollback plan: revert
- Data migration reversible: N/A

## Reviewer notes

- **My miss, stated for the record:** I built #1467 without ever verifying the queue could be enabled. Three times I called it "your call" instead of checking whether it was on the table. The `.claude` notes already carry the rule this violated — verify the task's premise against live state — and the same private note now records the 422 so the next attempt starts from the answer.
- `CLAUDE.md` goes 223 → 232. Against the trim in #1456, but this is the bullet that stops someone re-attempting a 422 for an afternoon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)