### PR TITLE
fix(ci): skip comment lines in ADR-0106 UUID.randomUUID() guard

### DIFF
--- a/.github/scripts/check-new-random-uuid.sh
+++ b/.github/scripts/check-new-random-uuid.sh
@@ -42,7 +42,12 @@ violations="$(
       '*/src/main/*.kt' ':(exclude)*/domain/identifiers/Ids.kt' 2>/dev/null \
     | awk '
         /^\+\+\+ /        { f=$2; sub(/^b\//,"",f); next }
-        /^\+/ && /UUID\.randomUUID\(\)/ { print f ":  " substr($0,2) }
+        /^\+/ && /UUID\.randomUUID\(\)/ {
+          line=substr($0,2)
+          trimmed=line
+          sub(/^[ \t]+/, "", trimmed)
+          if (trimmed !~ /^\/\//) print f ":  " line
+        }
       ' || true
 )"
 


### PR DESCRIPTION
## Summary
- `check-new-random-uuid.sh` (ADR-0106 identifier intent guard) matched added diff lines containing `UUID.randomUUID()` literally, including comments that merely mention the call in prose
- Reproduced live on PR #1430: a code comment describing `NotificationConsumer.dispatch` still minting IDs via a bare `UUID.randomUUID()` tripped the guard with zero actual code change, forcing a reword-to-dodge-the-string workaround
- Skip added lines whose trimmed content starts with `//` before matching; real code additions are unaffected

## Test plan
- [x] Ran the modified awk block against a synthetic diff with a full-line comment mentioning `UUID.randomUUID()` and a real bare call — comment line filtered, real call still flagged
- [ ] CI: `Validate manifests` job on this PR should pass (no src/main code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)