### PR TITLE
fix(party-service): finish the mTLS migration that locked it out of its own topics

### DIFF
--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -76,10 +76,44 @@ spec:
             # localhost, the producer can never connect, party events stay undispatched
             # in the outbox, and the onboarding-service funnel stays empty. Points at the
             # Strimzi bootstrap, same as onboarding-service.
+            # Kafka → Strimzi tls:9093 (mTLS, ADR-0137 #2665 Tier 1). party-service was the
+            # last plaintext:9092 client in the fleet, and 9092 authenticates as ANONYMOUS.
+            # That was survivable only while its topics had no ACLs: Strimzi's simple
+            # authorizer allows an unlisted principal ONLY on a topic no ACL names, so the
+            # moment the party-service KafkaUser was created (its ACLs bind these very
+            # topics to CN=party-service), ANONYMOUS lost access to them — and party-service
+            # locked itself out of its own topics.
+            #
+            # Failure mode was total and silent from the outside: party.events could not be
+            # produced and kyc/aml events could not be consumed, so a new customer's
+            # party.created never left the outbox, no account was ever opened, no onboarding
+            # document or signature ceremony was ever created, and KYC sat at NOT_STARTED
+            # forever. Onboarding simply did not complete. Found by running a real
+            # registration through the live sandbox, not by a failing check.
             - name: KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
             - name: QUARKUS_SMALLRYE_REACTIVE_MESSAGING_KAFKA_BOOTSTRAP_SERVERS
-              value: openbank-cluster-kafka-bootstrap.messaging.svc:9092
+              value: openbank-cluster-kafka-bootstrap.messaging.svc:9093
+            - name: KAFKA_SECURITY_PROTOCOL
+              value: SSL
+            - name: KAFKA_SSL_KEYSTORE_LOCATION
+              value: /mnt/kafka/keystore/user.p12
+            - name: KAFKA_SSL_KEYSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_KEYSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: party-service-kafka-keystore
+                  key: user.password
+            - name: KAFKA_SSL_TRUSTSTORE_LOCATION
+              value: /mnt/kafka/truststore/ca.p12
+            - name: KAFKA_SSL_TRUSTSTORE_TYPE
+              value: PKCS12
+            - name: KAFKA_SSL_TRUSTSTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-cluster-ca-truststore
+                  key: ca.password
           startupProbe:
             tcpSocket:
               port: management
@@ -106,6 +140,12 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            - name: kafka-keystore
+              mountPath: /mnt/kafka/keystore
+              readOnly: true
+            - name: kafka-truststore
+              mountPath: /mnt/kafka/truststore
+              readOnly: true
           resources:
             requests:
               cpu: 200m
@@ -168,6 +208,14 @@ spec:
         - name: feature-flags
           configMap:
             name: party-feature-flags
+        # Already projected into this namespace 17 days ago by the ADR-0137 rollout — only
+        # the Deployment above was never switched over to actually use them.
+        - name: kafka-keystore
+          secret:
+            secretName: party-service-kafka-keystore
+        - name: kafka-truststore
+          secret:
+            secretName: kafka-cluster-ca-truststore
   strategy:
     canary:
       stableService: party-service


### PR DESCRIPTION
## Impact

**No new customer can complete onboarding in sandbox.** Registration returns `201`, and then nothing else ever happens: no account is opened, no onboarding document or signature ceremony is created, and KYC stays `NOT_STARTED` forever.

Found by registering a real customer through the live sandbox — not by a failing check. Nothing is red: `party-service` is `1/1 Running`, its `KafkaUser` is `Ready=True`, and the edge answers `201`. The failure is entirely inside party-service's logs.

## Root cause

`party-service` is the last plaintext `:9092` client in the fleet. Everyone else moved to `:9093` (mTLS) under ADR-0137 #2665:

| service | bootstrap |
|---|---|
| account-service | `…messaging.svc:9093` |
| kyc-service | `…messaging.svc:9093` |
| document-service | `…messaging.svc:9093` |
| **party-service** | **`…messaging.svc:9092`** |

`:9092` authenticates as `ANONYMOUS`. That was survivable only while party-service's topics had no ACLs — Strimzi's `simple` authorizer allows an unlisted principal **only** on a topic no ACL names. The `party-service` KafkaUser binds exactly those topics to `CN=party-service`, so creating it flipped them closed and party-service locked itself out of its own topics:

```
TopicAuthorizationException: Not authorized to access topics: [openbank.party.events]
TopicAuthorizationException: Not authorized to access topics: [openbank.kyc.events]
```

So `party.created` can never be produced (it nacks and stays in the outbox → `party_outbox` is empty because the write never lands) and kyc/aml events can never be consumed → `deriveStatus` never sees `KycStatus.APPROVED` → party is stuck `PENDING_KYC` → account-service never opens CURRENT/SAVINGS → `account.created` never fires → `OnboardingDocumentService.issueOnboardingDocument` never runs.

## Fix

Switch party-service's Deployment to `:9093` + `SSL` + the keystore/truststore mounts, mirroring account-service exactly.

The credentials **already exist and have for 17 days** — `party-service-kafka-keystore` (`user.p12`, `user.password`) and `kafka-cluster-ca-truststore` (`ca.p12`, `ca.password`) are already projected into the `party` namespace with byte-identical key names to the `accounts` namespace. The ADR-0137 rollout provisioned party-service's certs and ACLs and then never switched the Deployment over. This is finishing that migration for its last straggler, not new work.

## Why nothing caught it

- The ACL flip is silent: adding a KafkaUser changes the authorization outcome for *other* principals on the same topics, with no signal on either side.
- party-service stays `Running` and `Ready` — its probes are `tcpSocket` on http/management, which a Kafka producer failure does not touch.
- Nothing alerts on nacked outbox messages.

Worth following up separately: a check that no workload still points at `:9092`, so the next straggler is caught by CI rather than by a customer who cannot open an account.

## Linked issues

Closes #1476
