### PR TITLE
fix(tests): stub claimProcessable, not listProcessable, in 8 outbox dispatcher tests

### DIFF
--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingOutboxDispatcherTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/BillingOutboxDispatcherTest.kt
@@ -23,6 +23,16 @@ import java.util.UUID
  * the classic silent-outbox footgun) and, when enabled, must mark each row SENT on success and
  * FAILED on a publish error so the row is retried rather than lost. Mirrors
  * `openbank-lending-service`'s `LendingOutboxDispatcherTest`.
+ *
+ * Stubs/verifies `claimProcessable`, not `listProcessable`: `OutboxDispatch.dispatchOnce` (which
+ * the shared `AbstractOutboxDispatcher.dispatchScheduledBatch` delegates to) claims rows via
+ * `OutboxRepository.claimProcessable` (#1201, atomic claim so two dispatcher instances during an
+ * Argo Rollouts canary window can't both grab the same row). `claimProcessable`'s default body
+ * calls `listProcessable`, but that default only resolves for a REAL class implementing the
+ * interface — a `mockk()` intercepts every call at the proxy level regardless of default method
+ * bodies, so an un-stubbed `claimProcessable` throws (swallowed by `dispatchOnce`'s
+ * `runCatching`), silently skipping the whole batch. Stubbing `listProcessable` alone verified
+ * nothing.
  */
 class BillingOutboxDispatcherTest {
 
@@ -48,7 +58,7 @@ class BillingOutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 0) { repo.listProcessable(any()) }
+        coVerify(exactly = 0) { repo.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { publisher.publish(any()) }
     }
 
@@ -56,7 +66,7 @@ class BillingOutboxDispatcherTest {
     fun `an enabled dispatch publishes each processable row and marks it sent`(): Unit = runBlocking {
         val first = entry()
         val second = entry()
-        coEvery { repo.listProcessable(any()) } returns listOf(first, second)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(first, second)
         coJustRun { publisher.publish(any()) }
         coJustRun { repo.markSent(any(), any()) }
 
@@ -72,7 +82,7 @@ class BillingOutboxDispatcherTest {
     @Test
     fun `a failed publish marks the row failed for retry instead of dropping it`(): Unit = runBlocking {
         val poisoned = entry()
-        coEvery { repo.listProcessable(any()) } returns listOf(poisoned)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(poisoned)
         coEvery { publisher.publish(poisoned) } throws IllegalStateException("ledger unavailable")
         coJustRun { repo.markFailed(any(), any(), any()) }
 
@@ -86,7 +96,7 @@ class BillingOutboxDispatcherTest {
     fun `dispatchScheduledBatch drives the same dispatch loop without the resilience annotations`(): Unit =
         runBlocking {
             val entryRow = entry()
-            coEvery { repo.listProcessable(any()) } returns listOf(entryRow)
+            coEvery { repo.claimProcessable(any(), any()) } returns listOf(entryRow)
             coJustRun { publisher.publish(any()) }
             coJustRun { repo.markSent(any(), any()) }
 

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/outbox/ConsentOutboxDispatcherTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/outbox/ConsentOutboxDispatcherTest.kt
@@ -16,6 +16,13 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: the shared
+ * `OutboxDispatch.dispatchOnce` calls the former, and a plain `mockk()` never falls through to
+ * the interface's default `claimProcessable = listProcessable(limit)` body — it intercepts every
+ * call at the proxy level, so an un-stubbed `claimProcessable` on a relaxed mock silently returns
+ * an empty list instead. See `BillingOutboxDispatcherTest` for the full explanation.
+ */
 class ConsentOutboxDispatcherTest {
 
     private val outboxRepository = mockk<ConsentOutboxRepository>(relaxed = true)
@@ -28,7 +35,7 @@ class ConsentOutboxDispatcherTest {
     fun `dispatch publishes and marks each processable row sent`(): Unit = runBlocking {
         val entry1 = entry("payload-1")
         val entry2 = entry("payload-2")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(entry1, entry2)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(entry1, entry2)
 
         dispatcher().dispatch()
 
@@ -43,14 +50,14 @@ class ConsentOutboxDispatcherTest {
     fun `dispatch does nothing when disabled`(): Unit = runBlocking {
         dispatcher(enabled = false).dispatch()
 
-        coVerify(exactly = 0) { outboxRepository.listProcessable(any()) }
+        coVerify(exactly = 0) { outboxRepository.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { eventPublisher.publish(any()) }
     }
 
     @Test
     fun `dispatch marks a row failed when publish throws`(): Unit = runBlocking {
         val entry = entry("payload-x")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(entry)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(entry)
         coEvery { eventPublisher.publish(entry) } throws RuntimeException("kafka down")
 
         dispatcher().dispatch()
@@ -61,7 +68,7 @@ class ConsentOutboxDispatcherTest {
 
     @Test
     fun `dispatch swallows a repository failure so the scheduler never crashes`(): Unit = runBlocking {
-        coEvery { outboxRepository.listProcessable(any()) } throws RuntimeException("db unavailable")
+        coEvery { outboxRepository.claimProcessable(any(), any()) } throws RuntimeException("db unavailable")
 
         // Must not propagate.
         dispatcher().dispatch()

--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/outbox/DomesticPaymentOutboxDispatcherTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/infrastructure/outbox/DomesticPaymentOutboxDispatcherTest.kt
@@ -17,6 +17,14 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: the shared
+ * `OutboxDispatch.dispatchOnce` calls the former, and a `mockk()` never falls through to the
+ * interface's default `claimProcessable = listProcessable(limit)` body — it intercepts every
+ * call at the proxy level, so an un-stubbed `claimProcessable` throws (swallowed by
+ * `dispatchOnce`'s `runCatching`), silently skipping the batch. See
+ * `BillingOutboxDispatcherTest` for the full explanation.
+ */
 class DomesticPaymentOutboxDispatcherTest {
 
     private val outboxRepository: DomesticPaymentOutboxRepository = mockk()
@@ -42,7 +50,7 @@ class DomesticPaymentOutboxDispatcherTest {
     fun `happy drain publishes each row and marks it sent`(): Unit = runBlocking {
         val first = entry()
         val second = entry()
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(first, second)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(first, second)
         coJustRun { eventPublisher.publish(any()) }
         coJustRun { outboxRepository.markSent(any(), any()) }
 
@@ -58,7 +66,7 @@ class DomesticPaymentOutboxDispatcherTest {
     fun `publish failure marks the row failed and continues the batch`(): Unit = runBlocking {
         val failing = entry()
         val healthy = entry()
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(failing, healthy)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(failing, healthy)
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("kafka down")
         coJustRun { eventPublisher.publish(healthy) }
         coJustRun { outboxRepository.markSent(any(), any()) }
@@ -73,7 +81,7 @@ class DomesticPaymentOutboxDispatcherTest {
 
     @Test
     fun `a repository listing fault is swallowed so the scheduler never crashes`(): Unit = runBlocking {
-        coEvery { outboxRepository.listProcessable(any()) } throws RuntimeException("db unreachable")
+        coEvery { outboxRepository.claimProcessable(any(), any()) } throws RuntimeException("db unreachable")
 
         dispatcher().dispatch()
 
@@ -84,10 +92,10 @@ class DomesticPaymentOutboxDispatcherTest {
     @Test
     fun `dispatch is skipped when dispatchEnabled is false`(): Unit = runBlocking {
         val disabled = DomesticPaymentOutboxDispatcher(outboxRepository, eventPublisher, dispatchEnabled = false)
-        coEvery { outboxRepository.listProcessable(any()) } returns emptyList()
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns emptyList()
 
         disabled.dispatch()
 
-        coVerify(exactly = 0) { outboxRepository.listProcessable(any()) }
+        coVerify(exactly = 0) { outboxRepository.claimProcessable(any(), any()) }
     }
 }

--- a/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/outbox/FxOutboxDispatcherTest.kt
+++ b/openbank-fx-service/src/test/kotlin/com/openbank/fx/infrastructure/outbox/FxOutboxDispatcherTest.kt
@@ -16,6 +16,12 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: a relaxed
+ * `mockk()` never falls through to the interface's default `claimProcessable = listProcessable`
+ * body, so an un-stubbed `claimProcessable` silently returns an empty list instead. See
+ * `BillingOutboxDispatcherTest` for the full explanation.
+ */
 class FxOutboxDispatcherTest {
 
     private val outboxRepository = mockk<FxOutboxRepository>(relaxed = true)
@@ -39,7 +45,7 @@ class FxOutboxDispatcherTest {
     fun `dispatch publishes each processable row and marks it sent`(): Unit = runBlocking {
         val a = entry(payload = "evt-a")
         val b = entry(payload = "evt-b")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(a, b)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(a, b)
 
         dispatcher.dispatch()
 
@@ -53,7 +59,7 @@ class FxOutboxDispatcherTest {
     @Test
     fun `a publish failure marks that row failed with the error and does not mark it sent`(): Unit = runBlocking {
         val failing = entry(payload = "boom")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(failing)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(failing)
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("kafka down")
 
         dispatcher.dispatch()
@@ -64,7 +70,7 @@ class FxOutboxDispatcherTest {
 
     @Test
     fun `a repository read failure is swallowed so the scheduler never crashes`(): Unit = runBlocking {
-        coEvery { outboxRepository.listProcessable(any()) } throws IllegalStateException("db unavailable")
+        coEvery { outboxRepository.claimProcessable(any(), any()) } throws IllegalStateException("db unavailable")
 
         dispatcher.dispatch()
 
@@ -77,7 +83,7 @@ class FxOutboxDispatcherTest {
 
         disabledDispatcher.dispatch()
 
-        coVerify(exactly = 0) { outboxRepository.listProcessable(any()) }
+        coVerify(exactly = 0) { outboxRepository.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { eventPublisher.publish(any()) }
     }
 }

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/outbox/LendingOutboxDispatcherTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/infrastructure/outbox/LendingOutboxDispatcherTest.kt
@@ -20,6 +20,12 @@ import java.util.UUID
  * The scheduled dispatch tick is gated on `openbank.outbox.dispatch-enabled` (default **false** —
  * the classic silent-outbox footgun) and, when enabled, must mark each row SENT on success and
  * FAILED on a publish error so the row is retried rather than lost.
+ *
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: a `mockk()`
+ * never falls through to the interface's default `claimProcessable = listProcessable(limit)`
+ * body — it intercepts every call at the proxy level — so an un-stubbed `claimProcessable` throws
+ * (swallowed by `dispatchOnce`'s `runCatching`), silently skipping the whole batch. See
+ * `BillingOutboxDispatcherTest` for the full explanation.
  */
 class LendingOutboxDispatcherTest {
 
@@ -45,7 +51,7 @@ class LendingOutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 0) { repo.listProcessable(any()) }
+        coVerify(exactly = 0) { repo.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { publisher.publish(any()) }
     }
 
@@ -53,7 +59,7 @@ class LendingOutboxDispatcherTest {
     fun `an enabled dispatch publishes each processable row and marks it sent`(): Unit = runBlocking {
         val first = entry()
         val second = entry()
-        coEvery { repo.listProcessable(any()) } returns listOf(first, second)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(first, second)
         coJustRun { publisher.publish(any()) }
         coJustRun { repo.markSent(any(), any()) }
 
@@ -69,7 +75,7 @@ class LendingOutboxDispatcherTest {
     @Test
     fun `a failed publish marks the row failed for retry instead of dropping it`(): Unit = runBlocking {
         val poisoned = entry()
-        coEvery { repo.listProcessable(any()) } returns listOf(poisoned)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(poisoned)
         coEvery { publisher.publish(poisoned) } throws IllegalStateException("broker unavailable")
         coJustRun { repo.markFailed(any(), any(), any()) }
 

--- a/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcherTest.kt
+++ b/openbank-psd2-service/src/test/kotlin/com/openbank/psd2/infrastructure/outbox/Psd2OutboxDispatcherTest.kt
@@ -21,6 +21,12 @@ import java.util.UUID
  * scheduled tick is a no-op gate around [com.openbank.libs.persistence.outbox.AbstractOutboxDispatcher]'s
  * shared drain loop, and that a processable entry is published and marked sent through that loop
  * (which internally calls the protected `publishWithResilience` override).
+ *
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: the shared
+ * `OutboxDispatch.dispatchOnce` calls the former, and a `mockk()` never falls through to the
+ * interface's default `claimProcessable = listProcessable(limit)` body — it intercepts every
+ * call at the proxy level, so an un-stubbed `claimProcessable` throws (swallowed by
+ * `dispatchOnce`'s `runCatching`), silently skipping the whole batch.
  */
 class Psd2OutboxDispatcherTest {
 
@@ -46,12 +52,12 @@ class Psd2OutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 0) { repo.listProcessable(any()) }
+        coVerify(exactly = 0) { repo.claimProcessable(any(), any()) }
     }
 
     @Test
     fun `dispatch drains the outbox when dispatch-enabled is true`(): Unit = runBlocking {
-        coEvery { repo.listProcessable(any()) } returns listOf(sampleEntry())
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(sampleEntry())
         coEvery { publisher.publish(any()) } returns Unit
         coEvery { repo.markSent(any(), any()) } returns Unit
 
@@ -59,7 +65,7 @@ class Psd2OutboxDispatcherTest {
 
         dispatcher.dispatch()
 
-        coVerify(exactly = 1) { repo.listProcessable(any()) }
+        coVerify(exactly = 1) { repo.claimProcessable(any(), any()) }
         coVerify(exactly = 1) { publisher.publish(any()) }
         coVerify(exactly = 1) { repo.markSent(any(), any()) }
     }
@@ -67,7 +73,7 @@ class Psd2OutboxDispatcherTest {
     @Test
     fun `dispatch marks an entry failed when the publisher throws`(): Unit = runBlocking {
         val entry = sampleEntry()
-        coEvery { repo.listProcessable(any()) } returns listOf(entry)
+        coEvery { repo.claimProcessable(any(), any()) } returns listOf(entry)
         coEvery { publisher.publish(entry) } throws RuntimeException("kafka unavailable")
         coEvery { repo.markFailed(any(), any(), any()) } returns Unit
 

--- a/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcherTest.kt
+++ b/openbank-sepa-payment/src/test/kotlin/com/openbank/sepa/infrastructure/outbox/SepaPaymentOutboxDispatcherTest.kt
@@ -18,6 +18,13 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: a `mockk()`
+ * never falls through to the interface's default `claimProcessable = listProcessable(limit)`
+ * body — it intercepts every call at the proxy level — so an un-stubbed `claimProcessable` throws
+ * (swallowed by `dispatchOnce`'s `runCatching`), silently skipping the whole batch. See
+ * `BillingOutboxDispatcherTest` for the full explanation.
+ */
 class SepaPaymentOutboxDispatcherTest {
 
     private lateinit var outboxRepository: SepaPaymentOutboxRepository
@@ -48,7 +55,7 @@ class SepaPaymentOutboxDispatcherTest {
     fun `happy drain publishes each entry and marks every row sent`(): Unit = runBlocking {
         val first = entry(payload = "{\"e\":\"a\"}")
         val second = entry(payload = "{\"e\":\"b\"}")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(first, second)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(first, second)
         coJustRun { eventPublisher.publish(any()) }
         coJustRun { outboxRepository.markSent(any(), any()) }
 
@@ -65,7 +72,7 @@ class SepaPaymentOutboxDispatcherTest {
     fun `publish failure marks the row failed with the error message and continues`(): Unit = runBlocking {
         val failing = entry(payload = "{\"e\":\"boom\"}")
         val ok = entry(payload = "{\"e\":\"ok\"}")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(failing, ok)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(failing, ok)
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("broker down")
         coJustRun { eventPublisher.publish(ok) }
         coJustRun { outboxRepository.markSent(any(), any()) }
@@ -81,7 +88,7 @@ class SepaPaymentOutboxDispatcherTest {
 
     @Test
     fun `repository listing failure is swallowed so the scheduler never crashes`(): Unit = runBlocking {
-        coEvery { outboxRepository.listProcessable(any()) } throws RuntimeException("db unreachable")
+        coEvery { outboxRepository.claimProcessable(any(), any()) } throws RuntimeException("db unreachable")
 
         dispatcher.dispatch()
 
@@ -96,7 +103,7 @@ class SepaPaymentOutboxDispatcherTest {
 
         disabledDispatcher.dispatch()
 
-        coVerify(exactly = 0) { outboxRepository.listProcessable(any()) }
+        coVerify(exactly = 0) { outboxRepository.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { eventPublisher.publish(any()) }
     }
 }

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/infrastructure/outbox/SwiftOutboxDispatcherTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/infrastructure/outbox/SwiftOutboxDispatcherTest.kt
@@ -16,6 +16,12 @@ import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * Stubs/verifies `claimProcessable` (#1201's atomic claim), not `listProcessable`: a relaxed
+ * `mockk()` never falls through to the interface's default `claimProcessable = listProcessable`
+ * body, so an un-stubbed `claimProcessable` silently returns an empty list instead. See
+ * `BillingOutboxDispatcherTest` for the full explanation.
+ */
 class SwiftOutboxDispatcherTest {
 
     private val outboxRepository = mockk<SwiftOutboxRepository>(relaxed = true)
@@ -26,7 +32,7 @@ class SwiftOutboxDispatcherTest {
     fun `dispatch publishes each processable row and marks it sent`(): Unit = runBlocking {
         val a = entry(payload = "evt-a")
         val b = entry(payload = "evt-b")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(a, b)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(a, b)
 
         dispatcher.dispatch()
 
@@ -41,7 +47,7 @@ class SwiftOutboxDispatcherTest {
     @Test
     fun `a publish failure marks that row failed with the error and does not mark it sent`(): Unit = runBlocking {
         val failing = entry(payload = "boom")
-        coEvery { outboxRepository.listProcessable(any()) } returns listOf(failing)
+        coEvery { outboxRepository.claimProcessable(any(), any()) } returns listOf(failing)
         coEvery { eventPublisher.publish(failing) } throws RuntimeException("kafka down")
 
         dispatcher.dispatch()
@@ -52,7 +58,7 @@ class SwiftOutboxDispatcherTest {
 
     @Test
     fun `a repository read failure is swallowed so the scheduler never crashes`(): Unit = runBlocking {
-        coEvery { outboxRepository.listProcessable(any()) } throws IllegalStateException("db unavailable")
+        coEvery { outboxRepository.claimProcessable(any(), any()) } throws IllegalStateException("db unavailable")
 
         // Must not throw.
         dispatcher.dispatch()
@@ -66,7 +72,7 @@ class SwiftOutboxDispatcherTest {
 
         disabledDispatcher.dispatch()
 
-        coVerify(exactly = 0) { outboxRepository.listProcessable(any()) }
+        coVerify(exactly = 0) { outboxRepository.claimProcessable(any(), any()) }
         coVerify(exactly = 0) { eventPublisher.publish(any()) }
     }
 


### PR DESCRIPTION
## What was broken

`#1201` added `OutboxRepository.claimProcessable(limit, staleAfter)` — an atomic claim so two dispatcher instances running simultaneously (e.g. both pods live during an Argo Rollouts canary window) can't select and publish the same rows. The shared `OutboxDispatch.dispatchOnce`, which every service's `AbstractOutboxDispatcher.dispatchScheduledBatch` delegates to, was updated to call `claimProcessable` instead of `listProcessable`.

`claimProcessable`'s default body delegates to `listProcessable`:

```kotlin
suspend fun claimProcessable(limit: Int, staleAfter: Duration = Duration.ofMinutes(2)): List<OutboxEntry> =
    listProcessable(limit)
```

That default only resolves for a **real class** implementing the interface — `openbank-libs-domain`'s own `OutboxDispatchTest.FakeRepo` does exactly that, correctly, and never needed this fix. A `mockk()` intercepts every call at the **proxy level** regardless of default method bodies, so a test that stubs `listProcessable` alone leaves `claimProcessable` unstubbed:

- on a **strict** mockk (billing, lending, psd2, domestic-payment, sepa-payment): the unstubbed call throws, which `dispatchOnce`'s `runCatching { }.onFailure { }.getOrNull()` silently swallows — the whole batch is skipped
- on a **relaxed** mockk (consent, fx, swift): the unstubbed call returns an empty list by default — same practical outcome, zero rows processed

Either way every `coVerify(exactly = 1) { ... }` on the dispatch path fails with 0 actual invocations.

## Why this was invisible

`#1201` touched only the shared `OutboxPorts.kt`. None of the 8 affected services' own files changed, so path-scoped CI never re-ran their tests. It surfaced only when a full-fleet build (every push to `main` re-verifies every consumer's pact matrix, ADR-0092) exercised all of them at once — in this case, PR #1452's merge commit.

## The fix

Mechanical and identical everywhere: `.listProcessable(any())` → `.claimProcessable(any(), any())` in every `coEvery`/`coVerify`, across:

- `openbank-billing-service`
- `openbank-consent-service`
- `openbank-domestic-payment`
- `openbank-fx-service`
- `openbank-lending-service`
- `openbank-psd2-service`
- `openbank-sepa-payment`
- `openbank-swift-service`

`any(), any())` is correct even though production code calls `repository.claimProcessable(batchSize)` with one explicit argument: Kotlin resolves the default `staleAfter` value **statically** against the declared `OutboxRepository` type at `dispatchOnce`'s call site, so the actual invocation MockK observes always carries both arguments.

Added a short doc comment to each file (once in full on `BillingOutboxDispatcherTest`, pointing there from the rest) explaining the `claimProcessable`/mockk-default-method interaction, so the next person editing one of these doesn't reintroduce the same mismatch.

## Not a production regression

`ledger-service` — the one service with a **real** `claimProcessable` override (`FOR UPDATE SKIP LOCKED`) — already has a correct dispatcher test plus its own integration test for concurrent claims. The dispatch loop itself was correct throughout; only these 8 tests were stuck on the pre-#1201 mock surface.

## Verification

Ran each service **isolated**, not just filtered within a shared build:

| service | `test` (OutboxDispatcherTest only) | `ktlintCheck` |
|---|---|---|
| billing | ✅ (was 3/4 failing) | ✅ |
| consent | ✅ (was 2/4) | ✅ |
| domestic-payment | ✅ (was 2/4) | ✅ |
| fx | ✅ (was 2/4) | ✅ |
| lending | ✅ (was 2/3) | ✅ |
| psd2 | ✅ (was 2/3) | ✅ |
| sepa-payment | ✅ (was 2/4) | ✅ |
| swift | ✅ (was 2/4) | ✅ |

17 previously-failing assertions now pass. Each file's unrelated conventions (relaxed vs strict mockk, `@BeforeEach` vs inline setup, message wording) were left untouched — only the `claimProcessable`/`listProcessable` mismatch changed.

Refs #1201
