### PR TITLE
fix(infra): raise sanctions-db storage from 2Gi to 10Gi

### DIFF
--- a/openbank-infra/gitops/components/sanctions-service/postgres.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/postgres.yaml
@@ -36,9 +36,15 @@ spec:
         matchLabels:
           cnpg.io/cluster: sanctions-db
   imageName: ghcr.io/cloudnative-pg/postgresql:18.1
+  # 2Gi (the fleet's default) was exhausted at 1.4Gi used / 561Mi available (71%): CNPG's
+  # low-disk-space guard stopped the primary outright (issue #1486, sanctions-service down
+  # for hours). gp3 supports online expansion, so CNPG grows the PVC group in place — no
+  # data migration. 10Gi is ~7x the observed usage: sanctions/PEP screening lists are
+  # append-heavy and grow with every feed update, not a fixed-size dataset like most of the
+  # fleet's other 2Gi single-owner DBs, so headroom matters more here than a uniform default.
   storage:
     storageClass: gp3
-    size: 2Gi
+    size: 10Gi
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary
`sanctions-db`'s 2Gi volume (the fleet default) filled to 71% (1.4Gi used / 561Mi
available). CNPG's low-disk-space guard deliberately stopped the primary —
by design, not a crash — and `sanctions-service` (money-path) has been in
CrashLoopBackOff for hours as a result (#1486).

## Fix
Raise `spec.storage.size` to 10Gi. gp3 supports online PVC expansion, so
CNPG grows the volume group in place — no data migration, no downtime beyond
the pod restart CNPG itself will schedule.

## Why 10Gi, not another round number
~7x current usage. Sanctions/PEP screening lists are append-heavy and grow
with every feed update — a different growth shape than most of the fleet's
other single-owner DBs, which sit comfortably at the uniform 2Gi default.

## Not in scope here (tracked in #1486)
- Alerting on the invariant (`cnpg_collector_ready`/cluster phase) rather than
  the symptom, so the next exhausted volume announces itself before
  PostgreSQL stops.
- A fleet-wide disk-headroom alert.
- Auditing other CNPG clusters for the same 2Gi-too-small risk.

Closes #1486 (the immediate outage) — the two follow-up alerting items above
still need separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)