### PR TITLE
fix(admin-ui): call the actual merged #1368 opsmessage endpoints, not #1370's original dead ones

### DIFF
--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -11,7 +11,7 @@ import { useAuth } from '@/lib/auth/useAuth'
 import { hasPermission } from '@/lib/auth/roles'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { opsMessageApi, type OperatorMessage } from '@/lib/api'
+import { opsMessageApi } from '@/lib/api'
 
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
@@ -99,7 +99,7 @@ export default function NotificationsPage() {
         ))}
       </div>
 
-      {canApprove && <PendingOperatorMessages />}
+      {canApprove && <DecideApproval />}
 
       {unavailable && (
         <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
@@ -167,117 +167,97 @@ export default function NotificationsPage() {
 }
 
 /**
- * Operator-initiated customer messages awaiting a second approver (ADR-0176 D5). Backed by
- * OperatorMessageResource.listPending — reuses the opsmessage.approve grant, since
- * ApprovalStore itself has no query to list pending approvals (see that endpoint's KDoc).
+ * Decide a pending operator-message approval (ADR-0176 D5, #1368). There is no list-pending
+ * endpoint — ApprovalStore itself cannot be listed (ApprovalResource's own KDoc), and #1368
+ * did not add a persisted-draft table an earlier, superseded design did. A checker therefore
+ * needs the approval id told to them out-of-band by the maker (chat, verbally); this is a
+ * decide-by-id form, not a browsable queue.
  *
  * A DIFFERENT operator than the one who composed the message must decide it —
- * SelfApprovalNotAllowedException refuses it server-side if the same operator tries. This
- * component doesn't try to hide the "compose" button from the maker (there's no reliable
- * client-side way to know in advance who composed which row before deciding), it just
- * surfaces the server's rejection as a plain error if it happens.
+ * ApprovalStore.decide refuses it server-side if the same operator tries (self-approval). This
+ * form doesn't try to guess who composed which message, it just surfaces that rejection as a
+ * plain error if it happens.
  */
-function PendingOperatorMessages() {
+function DecideApproval() {
   const { t } = useLanguage()
-  const [rows, setRows] = useState<OperatorMessage[]>([])
-  const [loading, setLoading] = useState(true)
-  const [busyId, setBusyId] = useState<string | null>(null)
-  const [rowError, setRowError] = useState<Record<string, string>>({})
+  const [approvalId, setApprovalId] = useState('')
+  const [busy, setBusy] = useState<'approve' | 'reject' | null>(null)
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null)
 
-  const load = useCallback(async () => {
-    setLoading(true)
+  const decide = async (approve: boolean) => {
+    const id = approvalId.trim()
+    if (!id) return
+    setBusy(approve ? 'approve' : 'reject')
+    setResult(null)
     try {
-      const { items } = await opsMessageApi.listPending()
-      setRows(items)
+      const decided = await opsMessageApi.decide(id, approve)
+      setResult({
+        ok: true,
+        message: approve
+          ? t('Schváleno. Autor teď může zprávu znovu odeslat.', 'Approved. The maker can now retry sending it.')
+          : t('Zamítnuto — zpráva se neodešle.', 'Rejected — the message will not be sent.'),
+      })
+      void decided
+      setApprovalId('')
     } catch {
-      setRows([])
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => { load() }, [load])
-
-  const decide = async (row: OperatorMessage, approve: boolean) => {
-    setBusyId(row.id)
-    setRowError(prev => { const next = { ...prev }; delete next[row.id]; return next })
-    try {
-      if (approve) await opsMessageApi.approve(row.id)
-      else await opsMessageApi.reject(row.id)
-      await load()
-    } catch {
-      // Most often SelfApprovalNotAllowedException (the maker tried to decide their own
-      // message) — never surface the raw backend message for a user-initiated write.
-      setRowError(prev => ({
-        ...prev,
-        [row.id]: t(
-          'Rozhodnutí se nezdařilo. Jiný operátor už možná rozhodl, nebo jste zprávu sami vytvořili.',
-          'The decision failed. Another operator may have already decided it, or you composed this message yourself.',
+      // Most often "no pending approval with id=..." (already decided, or a typo) or a
+      // self-approval refusal — never surface the raw backend message for a user-initiated write.
+      setResult({
+        ok: false,
+        message: t(
+          'Rozhodnutí se nezdařilo. Zkontrolujte approvalId — buď už bylo rozhodnuto, nebo jste zprávu sami vytvořili.',
+          'The decision failed. Check the approval id — it may already be decided, or you composed this message yourself.',
         ),
-      }))
+      })
     } finally {
-      setBusyId(null)
+      setBusy(null)
     }
   }
 
-  if (!loading && rows.length === 0) return null
-
   return (
-    <div className="card" style={{ overflow: 'hidden', marginBottom: '16px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '16px 20px', borderBottom: '1px solid var(--border)' }}>
+    <div className="card" style={{ padding: '16px 20px', marginBottom: '16px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '10px' }}>
         <Clock size={15} style={{ color: 'var(--yellow)' }} />
         <span style={{ fontWeight: 600, fontSize: '13px' }}>
-          {t('Zprávy čekající na schválení', 'Messages awaiting approval')}
+          {t('Rozhodnout o schválení zprávy', 'Decide a message approval')}
         </span>
-        {!loading && <span className="tag" style={{ marginLeft: 'auto' }}>{rows.length}</span>}
       </div>
-      <table className="data-table">
-        <thead>
-          <tr>
-            <th>{t('Šablona', 'Template')}</th>
-            <th>{t('Reference', 'Reference')}</th>
-            <th>{t('Účel', 'Purpose')}</th>
-            <th>{t('Akce', 'Actions')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading && Array.from({ length: 2 }).map((_, i) => (
-            <tr key={i}>{Array.from({ length: 4 }).map((_, j) => (
-              <td key={j}><div className="skeleton" style={{ height: '14px', width: '80px' }} /></td>
-            ))}</tr>
-          ))}
-          {!loading && rows.map(row => (
-            <tr key={row.id}>
-              <td><span className="tag">{row.template}</span></td>
-              <td style={{ fontSize: '12px', fontFamily: 'var(--font-mono)' }}>{row.referenceId}</td>
-              <td><span className="tag">{row.purpose}</span></td>
-              <td>
-                <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-                  <button
-                    className="btn btn-secondary"
-                    style={{ color: 'var(--green)' }}
-                    onClick={() => decide(row, true)}
-                    disabled={busyId === row.id}
-                  >
-                    <Check size={13} /> {t('Schválit', 'Approve')}
-                  </button>
-                  <button
-                    className="btn btn-secondary"
-                    style={{ color: 'var(--red)' }}
-                    onClick={() => decide(row, false)}
-                    disabled={busyId === row.id}
-                  >
-                    <X size={13} /> {t('Zamítnout', 'Reject')}
-                  </button>
-                  {rowError[row.id] && (
-                    <span style={{ fontSize: '11px', color: 'var(--red)' }}>{rowError[row.id]}</span>
-                  )}
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <p style={{ fontSize: '12px', color: 'var(--text-muted)', margin: '0 0 10px' }}>
+        {t(
+          'Autor zprávy vám sdělí approvalId (mimo tuto appku). Zde ho vložte a rozhodněte.',
+          'The message\'s author gives you the approvalId out of band. Paste it here and decide.',
+        )}
+      </p>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <input
+          type="text"
+          value={approvalId}
+          onChange={e => setApprovalId(e.target.value)}
+          placeholder="approvalId"
+          style={{ flex: 1, fontSize: '12px', fontFamily: 'var(--font-mono)', padding: '6px 10px', borderRadius: '6px', border: '1px solid var(--border)', background: 'var(--surface)', color: 'var(--text-primary)' }}
+        />
+        <button
+          className="btn btn-secondary"
+          style={{ color: 'var(--green)' }}
+          onClick={() => decide(true)}
+          disabled={!approvalId.trim() || busy !== null}
+        >
+          <Check size={13} /> {busy === 'approve' ? t('Schvaluji…', 'Approving…') : t('Schválit', 'Approve')}
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ color: 'var(--red)' }}
+          onClick={() => decide(false)}
+          disabled={!approvalId.trim() || busy !== null}
+        >
+          <X size={13} /> {busy === 'reject' ? t('Zamítám…', 'Rejecting…') : t('Zamítnout', 'Reject')}
+        </button>
+      </div>
+      {result && (
+        <div style={{ marginTop: '8px', fontSize: '12px', color: result.ok ? 'var(--green)' : 'var(--red)' }}>
+          {result.message}
+        </div>
+      )}
     </div>
   )
 }

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -14,7 +14,12 @@ import { hasPermission } from '@/lib/auth/roles'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { opsMessageApi } from '@/lib/api'
+import {
+  opsMessageApi,
+  OPERATOR_MESSAGE_TEMPLATE_VARIABLES,
+  type OperatorMessageTemplate,
+  type ComposeMessageRequest,
+} from '@/lib/api'
 
 const PAGE_SIZE = 25
 
@@ -262,11 +267,14 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
   const canCompose = hasPermission(roles, 'opsmessage:compose')
   const [sending, setSending] = useState(false)
   const [composeError, setComposeError] = useState<string | null>(null)
-  // Set once the maker's first submit call returns 202 — nothing here polls automatically
+  // Set once the maker's first compose call returns 202 — nothing here polls automatically
   // (ADR-0176 introduces the fleet's first 202/X-Approval-Id UI flow; a real approval
   // notification channel is a separate, larger piece of work). The maker clicks "Retry send"
-  // themselves once a colleague has approved it.
-  const [pendingSubmit, setPendingSubmit] = useState<{ id: string; approvalId?: string } | null>(null)
+  // themselves once a colleague has approved it. The retry resends `request` VERBATIM — the
+  // backend binds the pending approval to the request body's own content fingerprint
+  // (OperatorMessageResource KDoc), so anything other than a byte-identical resend would create
+  // a new, never-approved pending approval instead of satisfying the existing one.
+  const [pendingCompose, setPendingCompose] = useState<{ request: ComposeMessageRequest; approvalId: string } | null>(null)
   const [retrying, setRetrying] = useState(false)
 
   const load = useCallback(async (nextPage: number) => {
@@ -302,30 +310,50 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
   // The endpoint is offset-paged (page/size/total), not cursor-paged like party search.
   const hasNextPage = (page + 1) * PAGE_SIZE < total
 
-  const REFERENCE_ID_PATTERN = /^[A-Za-z0-9-]{1,40}$/
+  // Deliberately simple, client-side pre-check only — the backend (OperatorMessageService)
+  // validates authoritatively and is the one that actually matters for rejecting a malformed
+  // address.
+  const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-  // ADR-0176 D2: OPERATOR_ACCOUNT_NOTICE is the only composable template today, so the operator
-  // supplies just a reference code — never free text. Two calls, mirroring
-  // OperatorMessageResource's own KDoc: draft persists the content, submit is the four-eyes
-  // -gated one and pauses (202) until a different operator approves it.
+  // ADR-0176 D2: a closed, reviewed template catalogue — the operator never supplies free text,
+  // only the declared variables for whichever template they pick. Sequential window.prompt()
+  // calls mirror this codebase's existing single-field pattern (accounts/[id]'s doAction) rather
+  // than introducing new form UI, chained since this action needs more than one field.
   async function sendMessage() {
-    const referenceId = window.prompt(
-      t('Referenční kód (např. TICKET-123):', 'Reference (e.g. TICKET-123):'),
-    )
-    if (referenceId === null) return
-    if (!REFERENCE_ID_PATTERN.test(referenceId)) {
-      setComposeError(t(
-        'Referenční kód musí obsahovat 1–40 alfanumerických znaků nebo pomlček.',
-        'Reference must be 1-40 alphanumeric characters or hyphens.',
-      ))
+    const recipient = window.prompt(t('E-mail příjemce:', 'Recipient email:'))
+    if (recipient === null) return
+    if (!EMAIL_PATTERN.test(recipient)) {
+      setComposeError(t('Zadejte platnou e-mailovou adresu.', 'Enter a valid email address.'))
       return
     }
+
+    const templateChoice = window.prompt(
+      t(
+        'Šablona — napište GENERIC_NOTICE (obecné oznámení) nebo SUPPORT_FOLLOWUP (návaznost na tiket):',
+        'Template — type GENERIC_NOTICE (general notice) or SUPPORT_FOLLOWUP (support ticket follow-up):',
+      ),
+      'SUPPORT_FOLLOWUP',
+    )
+    if (templateChoice === null) return
+    const template = templateChoice.trim().toUpperCase() as OperatorMessageTemplate
+    if (!(template in OPERATOR_MESSAGE_TEMPLATE_VARIABLES)) {
+      setComposeError(t('Neznámá šablona.', 'Unknown template.'))
+      return
+    }
+
+    const variables: Record<string, string> = {}
+    for (const key of OPERATOR_MESSAGE_TEMPLATE_VARIABLES[template]) {
+      const value = window.prompt(`${key}:`)
+      if (value === null) return
+      variables[key] = value
+    }
+
+    const request: ComposeMessageRequest = { partyId, template, recipient, variables }
     setSending(true); setComposeError(null)
     try {
-      const drafted = await opsMessageApi.draft({ partyId, template: 'OPERATOR_ACCOUNT_NOTICE', referenceId, purpose: 'SERVICE' })
-      const result = await opsMessageApi.submit(drafted.id)
-      if (result.status === 'PENDING_APPROVAL') {
-        setPendingSubmit({ id: drafted.id, approvalId: result.approvalId })
+      const result = await opsMessageApi.compose(request)
+      if (result.status === 'PENDING_APPROVAL' && result.approvalId) {
+        setPendingCompose({ request, approvalId: result.approvalId })
       } else {
         // Only reached if four-eyes enforcement is off in this environment — still a real
         // send, so refresh the history to show it.
@@ -341,19 +369,18 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
   }
 
   async function retrySubmit() {
-    if (!pendingSubmit) return
+    if (!pendingCompose) return
     setRetrying(true)
     try {
-      const result = await opsMessageApi.submit(pendingSubmit.id, pendingSubmit.approvalId)
+      const result = await opsMessageApi.compose(pendingCompose.request, pendingCompose.approvalId)
       if (result.status !== 'PENDING_APPROVAL') {
-        setPendingSubmit(null)
+        setPendingCompose(null)
         load(0)
       }
       // Still PENDING_APPROVAL: nobody has decided it yet — leave the banner up.
     } catch {
-      // A 409 (already resolved) or 403 (rejected/self-approval) most often means someone
-      // already decided it — leave the banner up rather than guessing; the Pending approvals
-      // queue on the Notifications page has the authoritative status.
+      // A 409/403 (already resolved, or self-approval refused) most often means someone
+      // already decided it — leave the banner up rather than guessing.
     } finally { setRetrying(false) }
   }
 
@@ -361,7 +388,7 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
     <>
       {canCompose && (
         <div className="card" style={{ padding: '14px 20px', marginBottom: '16px' }}>
-          {pendingSubmit ? (
+          {pendingCompose ? (
             <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
               <Clock size={15} style={{ color: 'var(--yellow)' }} />
               <span style={{ fontSize: '13px' }}>

--- a/openbank-admin-ui/src/lib/api.ts
+++ b/openbank-admin-ui/src/lib/api.ts
@@ -99,47 +99,60 @@ export const accountApi = {
     apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/unfreeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
 }
 
-// Operator-initiated customer messaging (ADR-0176). draft/submit is a two-call maker
-// step — see openbank-notification-service's OperatorMessageResource KDoc for why a single
-// annotated endpoint cannot both create the row and be the four-eyes-gated one.
-export interface OperatorMessage {
-  id: string; partyId: string; template: string; referenceId: string; purpose: string; status: string
+// Operator-initiated customer messaging (ADR-0176), against the merged #1368 backend
+// (openbank-notification-service OperatorMessageResource / ApprovalResource) — a single
+// compose call, not a draft+submit split. The four-eyes retry is the SAME POST resent with an
+// X-Approval-Id header: AuthorizeInterceptor binds `resource` to the request body's own
+// content-derived fingerprint (`resource = "#request"`, backend KDoc), so a byte-identical
+// resend matches the same PendingApproval — the caller must resend the exact same JSON, not
+// reference a separately-created draft id (there is no draft step or draft id in this design).
+export type OperatorMessageTemplate = 'GENERIC_NOTICE' | 'SUPPORT_FOLLOWUP'
+
+// Declares which `variables` keys each template needs (OperatorMessageTemplate.kt on the
+// backend — kept in sync by hand since the backend enum isn't exposed over the wire).
+export const OPERATOR_MESSAGE_TEMPLATE_VARIABLES: Record<OperatorMessageTemplate, string[]> = {
+  GENERIC_NOTICE: ['subject', 'note'],
+  SUPPORT_FOLLOWUP: ['ticketReference'],
 }
-// The 202-pending shape AuthorizeInterceptor returns on submit's first (un-approved) call.
-// Shares `status` with OperatorMessage so callers can branch on one field regardless of which
-// shape actually came back.
-export interface OpsMessageSubmitResult {
-  status: string; approvalId?: string; id?: string
+
+export interface ComposeMessageRequest {
+  partyId: string
+  template: OperatorMessageTemplate
+  recipient: string
+  variables: Record<string, string>
+}
+
+// The two possible response shapes from POST .../messages: the 202-pending pause
+// (AuthorizeInterceptor, {status, approvalId}) or success ({id: notificationId}, no `status`
+// field on the backend's CREATED response — treat a response with no `status` as sent).
+export interface ComposeMessageResult {
+  status?: string
+  approvalId?: string
+  id?: string
+}
+
+export interface DecideApprovalResult {
+  id: string; action: string; resourceId: string | null; status: string; decidedBy: string | null
 }
 
 export const opsMessageApi = {
-  draft: (data: { partyId: string; template: string; referenceId: string; purpose: string }) =>
-    apiFetchSimple<OperatorMessage>(`${NOTIFICATION_SERVICE}/api/v1/opsmessages`, {
-      method: 'POST',
-      body: JSON.stringify(data),
-    }),
-  // No approvalId yet -> first call, expect back {status:"PENDING_APPROVAL", approvalId}.
-  // With approvalId (the maker's retry, once a different operator has approved) -> expect back
-  // the sent OperatorMessage, status "SENT".
-  submit: (id: string, approvalId?: string) =>
-    apiFetchSimple<OpsMessageSubmitResult>(`${NOTIFICATION_SERVICE}/api/v1/opsmessages/${id}/submit`, {
+  // approvalId omitted -> the maker's first attempt. Passed -> the maker's retry, once a
+  // different operator has approved; `request` must be the SAME object as the first call.
+  compose: (request: ComposeMessageRequest, approvalId?: string) =>
+    apiFetchSimple<ComposeMessageResult>(`${NOTIFICATION_SERVICE}/api/v1/notifications/messages`, {
       method: 'POST',
       headers: approvalId ? { 'X-Approval-Id': approvalId } : undefined,
+      body: JSON.stringify(request),
     }),
-  listPending: (page = 0, size = 20) =>
-    apiFetchSimple<{ items: OperatorMessage[]; total: number }>(
-      `${NOTIFICATION_SERVICE}/api/v1/opsmessages?page=${page}&size=${size}`,
-    ),
-  approve: (id: string) =>
-    apiFetchSimple<{ id: string; status: string }>(
-      `${NOTIFICATION_SERVICE}/api/v1/opsmessages/approvals/${id}/approve`,
-      { method: 'POST' },
-    ),
-  reject: (id: string) =>
-    apiFetchSimple<{ id: string; status: string }>(
-      `${NOTIFICATION_SERVICE}/api/v1/opsmessages/approvals/${id}/reject`,
-      { method: 'POST' },
-    ),
+  // There is no list-pending-approvals endpoint — ApprovalStore itself cannot be listed (see
+  // the checker-facing PATCH's own KDoc), and #1368 did not add a persisted-draft table the way
+  // an earlier, superseded design did. A checker decides an approval by id, told to them
+  // out-of-band by the maker (chat, verbally) — there is no in-app queue to browse.
+  decide: (id: string, approve: boolean) =>
+    apiFetchSimple<DecideApprovalResult>(`${NOTIFICATION_SERVICE}/api/v1/notifications/approvals/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ approve }),
+    }),
 }
 
 const LEDGER_SERVICE = '/api/svc/ledger-service'

--- a/openbank-admin-ui/src/lib/auth/roles.ts
+++ b/openbank-admin-ui/src/lib/auth/roles.ts
@@ -71,12 +71,12 @@ export const PERMISSIONS = {
   // call the endpoint directly. This decides what we *render*, not what they can *fetch*.
   // Real metadata/body separation needs a policy change — issue #1326.
   "notifications:view":       [ROLES.ADMIN, ROLES.OPERATOR],
-  // Operator-initiated customer messaging (ADR-0176 D4/D5). Matches the backend's actual rego
-  // grants exactly (opsmessage-compose / opsmessage-approve in rest.rego) — any
-  // ROLE_OPERATOR/ROLE_ADMIN may compose or decide, with self-approval refused server-side by
-  // SelfApprovalNotAllowedException, not by a narrower UI-side role split. Unlike
-  // notifications:view above, this one DOES mirror a real backend check (opsmessage.compose is
-  // also four-eyes gated, which no UI permission could substitute for either way).
+  // Operator-initiated customer messaging (ADR-0176 D4/D5, #1368). Matches the backend's actual
+  // rego actions exactly — opsmessage.compose (POST .../messages) and opsmessage.approval.decide
+  // (PATCH .../approvals/{id}) both grant any ROLE_OPERATOR/ROLE_ADMIN, with self-approval
+  // refused server-side (ApprovalStore.decide), not by a narrower UI-side role split. Unlike
+  // notifications:view above, this DOES mirror a real backend check (compose is also four-eyes
+  // gated, which no UI permission could substitute for either way).
   "opsmessage:compose":       [ROLES.ADMIN, ROLES.OPERATOR],
   "opsmessage:approve":       [ROLES.ADMIN, ROLES.OPERATOR],
   // System


### PR DESCRIPTION
## What

`#1370` (this repo's admin-ui side of ADR-0176) was built against `#1369`'s backend design (draft+submit split, `/api/v1/opsmessages/*`, `referenceId`-only templates). `#1369` was closed as superseded by `#1368`, which shipped a materially different backend design — but `#1370` merged anyway with its original endpoint calls unchanged, so **the compose/approve UI has been live on `main` calling a backend that does not exist.** Confirmed directly: `git show origin/main:openbank-admin-ui/src/lib/api.ts` still had `/api/v1/opsmessages/*` after both PRs landed.

## The real contract, read from the merged backend source (not the PR diff or description)

- **`POST /api/v1/notifications/messages`** (`opsmessage.compose`) — **one** call, not draft+submit. Body: `{partyId, template, recipient, variables}`. The four-eyes retry is the *same request resent* with `X-Approval-Id` — the backend binds `resource` to the request body's own content-derived fingerprint (`OperatorMessageResource`'s own KDoc explains why: there's no pre-existing entity id to bind to for a create-with-rich-body action, so it hashes `request.toString()` instead). There is no draft id in this design — the client must resend the *identical* object, not something merely equivalent.
- **`PATCH /api/v1/notifications/approvals/{id}`** with `{approve: boolean}` — one decide endpoint (mirrors `lending-service`'s own `ApprovalResource`), not the two separate `POST .../approve` + `.../reject` endpoints `#1370` originally called.
- **`recipient`** is a real, operator-supplied, server-validated email address — channel is EMAIL only (PUSH was dropped in `#1368`, blocked on the still-open ADR-0135 §3 payload issue, `#1182`) — not the auto-derived placeholder `#1370` used to satisfy its own now-dead template shape.
- **Two real templates** from `OperatorMessageTemplate.kt`: `GENERIC_NOTICE` (`subject`+`note`), `SUPPORT_FOLLOWUP` (`ticketReference`) — not the single fictional `OPERATOR_ACCOUNT_NOTICE` `#1369` invented.

## A capability gap this surfaced — the "pending approvals" list never had anything to call

Removed the "Messages awaiting approval" list on the Notifications page. It never had a real backend under it in *either* design: `ApprovalStore` itself has no query to list pending approvals (confirmed in both `#1368`'s `ApprovalResource` KDoc and my own earlier research before `#1369` was written) — showing a list page against a capability that doesn't exist would just always render empty or error.

Replaced with a **decide-by-id** form: the maker gives a checker the `approvalId` out of band (chat, verbally — there is genuinely no in-app queue to browse in this design), the checker pastes it in and approves/rejects. This is what the actual backend supports, not a scaled-down version of what `#1370` assumed existed.

## Test plan

- [x] `npm run type-check` — clean.
- [x] `npm run lint` — 0 errors, same 72 pre-existing warnings as the rest of the codebase (no new ones introduced — the rewritten `DecideApproval` component has no `useEffect` at all, since there's no list to load).
- [x] Full `vitest run` — 593/593 passing.
- [x] Cross-checked every request/response shape directly against the merged backend source on `origin/main` (`OperatorMessageResource.kt`, `ApprovalResource.kt`, `OperatorMessageService.kt`, `OperatorMessageTemplate.kt`) — not against `#1368`'s PR diff or its own description, in case of drift between what was proposed and what actually merged.
- [x] Dev server boots clean (Turbopack, `Ready in 353ms`), no console errors beyond the pre-existing dev-mode CSP `eval()` warning, route protection still redirects unauthenticated requests correctly.
- [ ] Full interactive E2E (compose → 202 → a different operator decides by id → retry → sent) needs a live Keycloak + the deployed backend; not achievable in this sandbox — noted rather than silently skipped.

Refs #1368, #1370, `docs/adr/0176-operator-initiated-customer-messaging.md`
