### PR TITLE
fix(audit): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-audit-service/build.gradle.kts
+++ b/openbank-audit-service/build.gradle.kts
@@ -36,6 +36,13 @@ dependencies {
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
     testImplementation(libs.rest.assured.kotlin)
+
+    // #1201: isolated PostgreSQL per test JVM via Testcontainers (audit-service had no IT
+    // infra before AuditOutboxClaimIT — matches the pattern already used by sibling
+    // outbox-bearing services, e.g. openbank-sdd-service).
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.testcontainers.postgresql)
 }
 
 kover {

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/outbox/AuditOutboxDispatcher.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/outbox/AuditOutboxDispatcher.kt
@@ -16,6 +16,17 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 
+/**
+ * Drains the audit transactional outbox (ADR-0050 / ADR-0049 D3).
+ *
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously
+ * for the whole rollout duration, and both dispatch on their own tick. `AuditOutboxRepositoryImpl`
+ * therefore implements [OutboxRepository.claimProcessable] as an atomic `FOR UPDATE SKIP LOCKED`
+ * claim, not the unclaimed-peek default, so two concurrently running pods can never both select
+ * and publish the same row.
+ */
 @ApplicationScoped
 class AuditOutboxDispatcher(
     private val repo: AuditOutboxRepository,

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/entity/AuditOutboxEntity.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/entity/AuditOutboxEntity.kt
@@ -4,9 +4,21 @@
 package com.openbank.audit.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is audit-only — added straight on this entity, not the shared
+ * [PanacheOutboxEntity] (mapped by every outbox-bearing service — a shared-entity migration
+ * would need every service migrated in lockstep). Stamped by
+ * `AuditOutboxRepositoryImpl.claimProcessable`'s atomic claim query on DISPATCHING; read back
+ * by the same query to decide if a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "audit_outbox")
-class AuditOutboxEntity : PanacheOutboxEntity()
+class AuditOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/repository/AuditOutboxRepositoryImpl.kt
+++ b/openbank-audit-service/src/main/kotlin/com/openbank/audit/infrastructure/persistence/repository/AuditOutboxRepositoryImpl.kt
@@ -13,11 +13,13 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
-class AuditOutboxRepositoryImpl :
+class AuditOutboxRepositoryImpl(private val clock: Clock) :
     AuditOutboxRepository,
     PanacheRepository<AuditOutboxEntity> {
 
@@ -38,6 +40,37 @@ class AuditOutboxRepositoryImpl :
             OutboxStatus.FAILED.name,
         )
     }.awaitSuspending()
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer `UPDATE`
+     * flips exactly those rows to DISPATCHING and returns them — so two dispatcher instances
+     * racing this at the same instant can never both claim the same row. Also reclaims rows still
+     * DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was evicted
+     * before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it must not span the network publish call that
+     * follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, AuditOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun markSent(eventId: UUID, sentAt: Instant) {
         Panache.withTransaction {
@@ -75,5 +108,22 @@ class AuditOutboxRepositoryImpl :
         it.attemptCount = 0
         it.createdAt = createdAt
         it.updatedAt = createdAt
+    }
+
+    companion object {
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE audit_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM audit_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }

--- a/openbank-audit-service/src/main/resources/db/migration/V8__audit_outbox_claimed_at.sql
+++ b/openbank-audit-service/src/main/resources/db/migration/V8__audit_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE audit_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditOutboxClaimIT.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/integration/AuditOutboxClaimIT.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.audit.integration
+
+import com.openbank.audit.infrastructure.persistence.repository.AuditOutboxRepositoryImpl
+import com.openbank.audit.it.PostgresTestResource
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing [AuditOutboxRepositoryImpl]'s
+ * `claimProcessable` at the same instant (an Argo Rollouts canary window running old + new pod)
+ * must never both claim the same row, and a claim that never reaches `markSent`/`markFailed`
+ * (the claiming pod crashed or was evicted) must not strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class AuditOutboxClaimIT {
+
+    @Inject
+    lateinit var repository: AuditOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    private fun seedPending(count: Int): List<OutboxMessage> {
+        val messages = (1..count).map {
+            OutboxMessage(
+                aggregateId = Ids.newId(),
+                eventType = "test.event.claim",
+                payload = """{"seq":$it}""",
+                createdAt = Instant.now(),
+            )
+        }
+        messages.forEach { msg ->
+            onEventLoop { Panache.withTransaction { repository.persistInTransaction(msg) }.awaitSuspending() }
+        }
+        return messages
+    }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seeded = seedPending(50)
+        val seededIds = seeded.map { it.eventId }.toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seeded = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seeded.eventId)
+
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seeded.eventId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seeded.eventId)
+    }
+}

--- a/openbank-audit-service/src/test/kotlin/com/openbank/audit/it/PostgresTestResource.kt
+++ b/openbank-audit-service/src/test/kotlin/com/openbank/audit/it/PostgresTestResource.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.audit.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.opentest4j.TestAbortedException
+import org.testcontainers.DockerClientFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/** Isolated PostgreSQL per test JVM via Testcontainers (#1201 — audit-service had no IT infra yet). */
+class PostgresTestResource : QuarkusTestResourceLifecycleManager {
+
+    private var postgres: PostgreSQLContainer<*>? = null
+
+    override fun start(): Map<String, String> {
+        if (!DockerClientFactory.instance().isDockerAvailable) {
+            throw TestAbortedException("Docker not available — skipping Testcontainers IT")
+        }
+        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+            .withUsername("openbank")
+            .withPassword("openbank_secret")
+            .withDatabaseName("openbank_audit_it")
+        pg.start()
+        postgres = pg
+        val host = pg.host
+        val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
+        return mapOf(
+            "quarkus.datasource.reactive.url" to "vertx-reactive:postgresql://$host:$port/openbank_audit_it",
+            "quarkus.datasource.jdbc.url" to "jdbc:postgresql://$host:$port/openbank_audit_it",
+            "quarkus.datasource.username" to "openbank",
+            "quarkus.datasource.password" to "openbank_secret",
+            "quarkus.devservices.enabled" to "false",
+        )
+    }
+
+    override fun stop() {
+        postgres?.stop()
+    }
+}


### PR DESCRIPTION
## Summary
- Fleet rollout of the ledger-service reference fix (#1201, sub-item 1) to audit-service.
- `AuditOutboxRepositoryImpl` now overrides `OutboxRepository.claimProcessable` with an atomic native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement, so two dispatcher pods running simultaneously during an Argo Rollouts canary window can never claim and publish the same PENDING/FAILED row. Stale DISPATCHING rows (claiming pod crashed before markSent/markFailed) are reclaimed too.
- audit-service had no IT test infrastructure at all — added a `PostgresTestResource` (Testcontainers), matching the pattern every other outbox-bearing service already has.

## Test plan
- [x] `AuditOutboxClaimIT` (new): two concurrent claims never overlap; a stale DISPATCHING row is reclaimed.
- [x] Mutation-tested: reverted the atomic claim to a plain `listProcessable` passthrough, confirmed the concurrency test fails, restored it.
- [x] Full non-cached `:openbank-audit-service:test` (all IT + unit tests) + `ktlintCheck` + `detekt`, green.

Refs #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)