### PR TITLE
fix(infra): add missing ScheduledBackup for vop-db

### DIFF
--- a/openbank-infra/gitops/components/payments/vop-postgres.yaml
+++ b/openbank-infra/gitops/components/payments/vop-postgres.yaml
@@ -61,3 +61,19 @@ spec:
         compression: gzip
       data:
         compression: gzip
+---
+# WAL without a base backup is unrestorable (issue #1487): vop-db declared barmanObjectStore
+# (above) but never had a ScheduledBackup, so continuous archiving ran for weeks with nothing to
+# restore it onto. #1444's sweep fixed the two cohorts it identified — no-store and no-IAM-
+# association — but this cluster already had a store, so it fell in neither and kept archiving
+# into a dead end. Matches the sibling pattern (e.g. accounts/postgres.yaml).
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: vop-db-daily
+  namespace: payments
+spec:
+  schedule: "0 41 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: vop-db


### PR DESCRIPTION
## Summary
`vop-db` (money-path) declares `barmanObjectStore` and continuously archives
WAL, but had no `ScheduledBackup` — WAL without a base backup cannot be
restored. It's the only CNPG cluster of 51 in this state (#1487).

## Why it fell through
#1444's sweep covered two cohorts: clusters with a store but no IAM
association (fixed by association only), and clusters with no store at all
(fixed with store + daily `ScheduledBackup` + association). `vop-db` already
had a store, so it landed in neither cohort and kept archiving into a dead
end.

## Fix
Add a daily `ScheduledBackup` matching the sibling pattern used by every
other CNPG cluster with a store (e.g. `accounts/postgres.yaml`). Schedule
`02:41` UTC — checked against the fleet's existing schedules to avoid
clustering backups at the same minute.

## Not in scope here (per #1487's own suggestion, tracked separately)
- A CI guard asserting every `barmanObjectStore` cluster has a matching
  `ScheduledBackup` — same invariant class as #1444's pod-identity check,
  worth building but a separate, fleet-wide change.
- The runtime counterpart alert on `cnpg_collector_first_recoverability_point`.

Closes #1487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)