### PR TITLE
chore(ci): remove the merge_group support — it is dead code, not a spare part

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-  # `Validate manifests` is a required check, so it must also report in the merge queue's
-  # `merge_group` context or the queue stalls forever waiting for a status that can never
-  # arrive. Note the diff-scoped gates below are extended to merge_group individually —
-  # adding only the trigger would report green while checking nothing.
-  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
   group: ci-${{ github.ref }}
-  # Never cancel a queue check — a cancelled run reports no status and the entry hangs.
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -42,22 +36,11 @@ jobs:
         with:
           fetch-depth: 0
       - id: check
-        env:
-          # Empty except on merge_group; the PR/push paths never read it.
-          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
             # Post-merge main build always includes admin-ui.
             echo "changed=true" >> "$GITHUB_OUTPUT"
-          elif [ -n "${MQ_BASE_SHA}" ]; then
-            # merge_group: base_sha is the tree this entry was built on. `github.base_ref` is
-            # EMPTY here, so the PR path below would fetch "":refs/remotes/origin/" and then
-            # diff "origin/...HEAD" — a hard error that would wedge the queue.
-            git fetch --depth=1 origin "${MQ_BASE_SHA}" 2>/dev/null || true
-            N=$(git diff --name-only "${MQ_BASE_SHA}" HEAD -- openbank-admin-ui/ | wc -l | tr -d ' ')
-            echo "changed=$( [ "$N" -gt 0 ] && echo 'true' || echo 'false' )" >> "$GITHUB_OUTPUT"
-            echo "Admin UI files changed (merge_group base ${MQ_BASE_SHA}): $N"
           else
             BASE="origin/${{ github.base_ref }}"
             # Force the remote-tracking ref to the true tip (persistent self-hosted
@@ -402,45 +385,33 @@ jobs:
       # merge and that merges with no later run is still unseen by ANY run-time
       # base choice — that needs required-up-to-date branches or a merge queue.
       # Neither prevention is in force, so that gap is not PREVENTED — it is DETECTED:
-      #   * a merge queue is NOT available (needs an org-owned repo; this account is
-      #     personal, so the ruleset rejects the rule outright — 422, #1465). The
-      #     merge_group branch below is therefore inert, kept correct for the day the
-      #     repo moves under an org.
-      #   * required-up-to-date branches would work, but measured too expensive here:
-      #     main takes a merge every ~93 s, so a service PR needs ~8 CI re-runs and
-      #     ~70 min to land — a tax on every merge to close a race that needs two PRs
-      #     on one spec, when 1 in 60 PRs touches a spec at all.
+      #   * a merge queue is NOT available at all: it needs an ORG-owned repo and this
+      #     account is personal, so the ruleset rejects the rule outright (422, #1465).
+      #     Don't build for it — support was written once and removed again as dead code.
+      #   * required-up-to-date branches WOULD work. Rejected on the benefit, not the
+      #     cost: it taxes every one of ~100 merges/day to close a race that needs TWO
+      #     PRs on the SAME spec inside one CI window, and only 1 of the last 60 PRs
+      #     touched a spec at all. (Its cost is genuinely unclear — main's merge gap is
+      #     wildly skewed, ~93 s median against a ~806 s mean, and defensible models put
+      #     the re-run tax anywhere from ~1 to ~8 CI runs per service PR. That spread is
+      #     why the decision rests on the benefit being tiny.)
       # api-contract-post-merge.yml re-classifies each spec landing on main against what
       # main actually was, and raises an issue if it is mis-versioned. That catches this
       # gap after the fact rather than closing it — the bad merge still happens.
       - name: "resolve PR diff base (current merge-base, not creation-time base.sha)"
-        # merge_group too: every diff-scoped gate below reads PR_DIFF_BASE, so if this step
-        # skipped in the queue they would all skip with it and `Validate manifests` would go
-        # green having checked nothing — the queue would be theatre.
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request'
         env:
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
         run: |
           set -euo pipefail
-          if [ -n "${MQ_BASE_SHA}" ]; then
-            # In the queue there is nothing to derive: base_sha IS the tree this entry was
-            # built on (main + the entries ahead of it). That is also the base this gate
-            # always wanted — the whole #481 x #524 race was the PR-time base going stale
-            # when a competing PR merged first, which by construction cannot happen here.
-            base="${MQ_BASE_SHA}"
-            git fetch --depth=1 origin "${base}" 2>/dev/null || true
-            echo "merge_group diff base: ${base}"
+          base="${EVENT_BASE_SHA}"
+          git fetch --depth=2 origin "${GITHUB_SHA}" 2>/dev/null || true
+          if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
+            base="$(git rev-parse 'HEAD^1')"
           else
-            base="${EVENT_BASE_SHA}"
-            git fetch --depth=2 origin "${GITHUB_SHA}" 2>/dev/null || true
-            if git rev-parse -q --verify 'HEAD^2' >/dev/null 2>&1; then
-              base="$(git rev-parse 'HEAD^1')"
-            else
-              git fetch --depth=1 origin "${base}" 2>/dev/null || true
-            fi
-            echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
+            git fetch --depth=1 origin "${base}" 2>/dev/null || true
           fi
+          echo "PR diff base: ${base} (event base.sha: ${EVENT_BASE_SHA})"
           echo "PR_DIFF_BASE=${base}" >> "$GITHUB_ENV"
 
       # ADR-0030 D2, diff-aware half (issue #265): when a PR moves a money-path
@@ -452,8 +423,7 @@ jobs:
       # ADR-0144) — findings are ::warning annotations; add --enforce to flip.
       # PR-only: the gate diffs against the resolved PR diff base (see above).
       - name: "threat-model updated on trust-boundary change (ADR-0030 D2, advisory)"
-        # merge_group too — it diffs against PR_DIFF_BASE, which the queue sets.
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request'
         run: python3 openbank-infra/scripts/check-threat-model-diff.py --base "${PR_DIFF_BASE}"
 
       # CLAUDE.md rule 3 / ADR-0029: a module is a released component iff it has
@@ -474,9 +444,6 @@ jobs:
       # (finrep-service 0.4.0). Harmless but noisy; classifies from the PR title since the squash
       # commit doesn't exist yet at PR-CI time. PR-only: no PR title to classify on a push to main.
       - name: "release-scope-mismatch gate (rules.yaml release_scope_mismatch, advisory)"
-        # Stays pull_request-only ON PURPOSE: it classifies from the PR title/body, which a
-        # merge_group payload does not carry. Nothing is lost — it already ran on the PR, and
-        # queueing cannot change a commit type or scope.
         if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -659,11 +626,7 @@ jobs:
       # (#1465). Detection, not prevention: it cannot block a merge that already
       # happened — see that workflow's header for why neither prevention was viable.
       - name: "api-contract gate — OpenAPI diff classification (ADR-0048 D5, enforced)"
-        # merge_group is listed for completeness only — it can never fire: a merge queue
-        # needs an org-owned repo and this account is personal (#1465). If that ever
-        # changes, the queue closes the residual gap and the post-merge guard becomes a
-        # backstop rather than the only net.
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request'
         env:
           OASDIFF_VERSION: "1.22.0"
           OASDIFF_SHA256: "8b972accaf49f984cf40702af8b29360126ac9436594ccf6ac1ae662209a5fe6"
@@ -684,8 +647,7 @@ jobs:
       # startup with `checksum mismatch`). PR-only and diff-scoped against the
       # resolved PR diff base, same as api-contract above.
       - name: "db-migration gate — rollback note + forward-only (rules.yaml db_change, advisory)"
-        # merge_group too — it diffs against PR_DIFF_BASE, which the queue sets.
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request'
         run: python3 openbank-infra/scripts/check-db-migration.py --base "${PR_DIFF_BASE}"
 
       # rules.yaml event_change / ADR-0006: schema-compat gate. The fleet's event
@@ -711,8 +673,7 @@ jobs:
       # ADVISORY until the rules.yaml schema-compat gate graduates
       # (target 2026-09-15, ADR-0144) — flip = --enforce. stdlib-only.
       - name: "schema-compat gate — event backward-compatibility (event_change, advisory)"
-        # merge_group too — it diffs against PR_DIFF_BASE, which the queue sets.
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        if: github.event_name == 'pull_request'
         run: python3 .github/scripts/check-event-schema-compat.py --base "${PR_DIFF_BASE}"
 
       # DomainEvent.occurredAt constructor guard (PR #2662 / #2709).

--- a/.github/workflows/issue-hygiene.yml
+++ b/.github/workflows/issue-hygiene.yml
@@ -19,21 +19,13 @@ name: Issue hygiene
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-  # A required check must also report in the merge queue's `merge_group` context or the
-  # queue stalls forever waiting for a status that can never arrive.
-  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  # `github.event.pull_request.number` is EMPTY on merge_group, which would collapse every
-  # queue entry into one shared group and let them cancel each other — a wedged queue. Fall
-  # back to github.ref, which on merge_group is the per-entry
-  # refs/heads/gh-readonly-queue/main/pr-N-<sha> and is therefore unique.
-  group: issue-hygiene-${{ github.event.pull_request.number || github.ref }}
-  # Never cancel a queue check: a cancelled run reports nothing and the entry hangs.
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  group: issue-hygiene-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   issue-hygiene:
@@ -42,18 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10  # measured max 6s
     steps:
-      # Deliberate pass-through in the merge queue. This gate lints the PR *body*, which a
-      # merge_group payload does not carry — and unlike a code check it cannot go stale
-      # between PR and queue, because queueing does not alter the body it already passed on.
-      # Branch on the STEP, not the job: a job skipped by an `if:` still reports its own
-      # status, so two jobs sharing the name `issue-hygiene` would report two conflicting
-      # statuses for one required check.
-      - name: Merge queue — already enforced on the pull request
-        if: github.event_name == 'merge_group'
-        run: echo "merge_group carries no PR body to lint; this gate ran on the PR itself, which queueing does not alter."
-
       - name: Lint PR "Linked issues"
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |

--- a/.github/workflows/opa-policy.yml
+++ b/.github/workflows/opa-policy.yml
@@ -21,17 +21,13 @@ on:
   push:
     branches: [main]
   pull_request:
-  # A required check must also report in the merge queue's `merge_group` context, or the
-  # queue stalls forever waiting for a status that can never arrive.
-  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
   group: opa-policy-${{ github.ref }}
-  # Never cancel a queue check — a cancelled run reports no status and the entry hangs.
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   changes:
@@ -65,16 +61,8 @@ jobs:
             PATTERN="${PATTERN}|^$(printf '%s' "$dir" | sed 's/\./\\./g')/"
           done < <(find openbank-infra/gitops/components -name 'gen-*opa-bundle*.sh' -exec dirname {} \; | sort -u)
 
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
-            # push: post-merge, keeps the deployed-bundle check current.
-            # merge_group: always verify rather than re-deriving a diff. `github.base_ref` is
-            # EMPTY on merge_group, so the diff path below would compute BASE="origin/" and die
-            # on `git diff origin/ HEAD` — wedging the queue. Verifying unconditionally is also
-            # the safer direction (this repo's rule is over-verify, never under-verify) and the
-            # gate is cheap (~19s median), and it is precisely the case a queue exists for: the
-            # bundle regeneration must be re-checked against main + the entries ahead of this
-            # one, since a competing governance PR restamps all 44 bundle files.
-            echo "Event ${{ github.event_name }} -> always verify."
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "Event push -> always verify (post-merge; keeps the deployed-bundle check current)."
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             BASE="origin/${{ github.base_ref }}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  # A required check must also report in the merge queue's `merge_group` context, or the
-  # queue stalls forever waiting for a status that can never arrive.
-  merge_group:
   schedule:
     - cron: "0 4 * * 1"  # weekly Monday 04:00 UTC
 
@@ -18,8 +15,7 @@ permissions:
 # scheduled history scan (same fix as security.yml).
 concurrency:
   group: secret-scan-${{ github.event_name }}-${{ github.ref }}
-  # Never cancel a queue check — a cancelled run reports no status and the entry hangs.
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  cancel-in-progress: true
 
 jobs:
   gitleaks:
@@ -58,10 +54,6 @@ jobs:
       # range keeps the custom rules + allowlist intact while ensuring a false
       # positive on a different branch can't fail this PR.
       #   - pull_request: scan BASE..HEAD (this PR's commits only)
-      #   - merge_group:  scan the queue entry's base..head (same reasoning; without this
-      #                   branch merge_group falls through to the unscoped full-history
-      #                   scan, which is exactly the cross-branch poisoning described above
-      #                   — a stranger's finding would fail the queue entry)
       #   - push:         scan before..sha (the pushed range)
       #   - schedule/manual: full-history scan (no range)
       # An empty range (no new commits) scans nothing and passes.
@@ -69,8 +61,6 @@ jobs:
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha }}
-          MQ_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           PUSH_AFTER_SHA: ${{ github.sha }}
         run: |
@@ -78,8 +68,6 @@ jobs:
           LOG_OPTS=""
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             LOG_OPTS="--log-opts=--no-merges ${PR_BASE_SHA}..${PR_HEAD_SHA}"
-          elif [ "${{ github.event_name }}" = "merge_group" ]; then
-            LOG_OPTS="--log-opts=--no-merges ${MQ_BASE_SHA}..${MQ_HEAD_SHA}"
           elif [ "${{ github.event_name }}" = "push" ]; then
             # github.event.before is all-zeroes for the first push of a branch.
             if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then

--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -24,10 +24,6 @@ on:
   schedule:
     - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch: {}
-  # `all-green` is a required check, so it must also report in the merge queue's
-  # `merge_group` context or the queue stalls forever waiting for a status that can
-  # never arrive.
-  merge_group:
 
 permissions:
   contents: read
@@ -45,12 +41,8 @@ concurrency:
   # (issue #846). Key push-to-main by SHA so every commit gets its own lane and is never
   # cancelled; PR pushes keep the superseding behavior (a new push to the same branch
   # should cancel the old run).
-  # merge_group needs the same never-cancel treatment as push-to-main, for a different
-  # reason: a cancelled queue run reports no status, so the entry waits on it forever.
-  # (Its github.ref is the per-entry gh-readonly-queue/... branch, so entries never share
-  # a lane anyway — this only guards a re-run of the same entry.)
   group: services-ci-${{ github.ref }}-${{ github.event_name == 'schedule' && 'nightly' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || 'ci') }}
-  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') && github.event_name != 'merge_group' }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
 
 jobs:
   changes:
@@ -68,10 +60,6 @@ jobs:
         with:
           fetch-depth: 0
       - id: detect
-        env:
-          # Empty on every event except merge_group; the `:-` default keeps `set -u` from
-          # killing the step on the PR/push paths, which never read it.
-          MQ_BASE_SHA: ${{ github.event.merge_group.base_sha || '' }}
         run: |
           set -euo pipefail
           # Canonical Gradle module list — DISCOVERED from the tree exactly like
@@ -122,39 +110,24 @@ jobs:
               CHANGED="$ALL"
             fi
           else
-            # pull_request AND merge_group share every decision below — only the diff base
-            # differs. The queue must fan out by the same rules as the PR, or it would build
-            # a different set of services than the one the PR was reviewed on.
-            if [ "${{ github.event_name }}" = "merge_group" ]; then
-              # The queue already built this entry on main + the entries ahead of it, and
-              # `merge_group.base_sha` IS that base: nothing to derive, no stale-ref hazard.
-              # Note `github.base_ref` is EMPTY on merge_group, so the PR path below would
-              # compute BASE="origin/" and die on `git diff origin/ HEAD` — a wedged queue.
-              # base_sha..HEAD is exactly this PR's changes as they land on the real
-              # post-merge tree, which is the point of queueing.
-              MB="${MQ_BASE_SHA}"
-              echo "Detect: merge_group base_sha=${MB}"
-            else
-              BASE="origin/${{ github.base_ref }}"
-              # Persistent self-hosted runners REUSE the git workdir between jobs,
-              # so the `origin/<base>` remote-tracking ref can be stale from an
-              # earlier run. Force it to the true remote tip with an explicit
-              # refspec (a bare `git fetch origin main` updates FETCH_HEAD but does
-              # NOT reliably move refs/remotes/origin/main). A stale base silently
-              # mis-computes the diff and under-builds changed services — a
-              # branch-protection hole. Full depth (no --depth=1): a shallow graft
-              # would break merge-base once main advances past this PR's base.
-              git fetch --no-tags --force origin \
-                "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
-                >/dev/null 2>&1 || true
-              # Compute the merge-base explicitly rather than leaning on the
-              # three-dot shorthand's ref resolution, then diff from it. Equivalent
-              # to BASE...HEAD but observable and robust to odd ref state.
-              MB=$(git merge-base "$BASE" HEAD 2>/dev/null || echo "$BASE")
-              echo "Detect: base=$BASE merge-base=$MB"
-            fi
+            BASE="origin/${{ github.base_ref }}"
+            # Persistent self-hosted runners REUSE the git workdir between jobs,
+            # so the `origin/<base>` remote-tracking ref can be stale from an
+            # earlier run. Force it to the true remote tip with an explicit
+            # refspec (a bare `git fetch origin main` updates FETCH_HEAD but does
+            # NOT reliably move refs/remotes/origin/main). A stale base silently
+            # mis-computes the diff and under-builds changed services — a
+            # branch-protection hole. Full depth (no --depth=1): a shallow graft
+            # would break merge-base once main advances past this PR's base.
+            git fetch --no-tags --force origin \
+              "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
+              >/dev/null 2>&1 || true
+            # Compute the merge-base explicitly rather than leaning on the
+            # three-dot shorthand's ref resolution, then diff from it. Equivalent
+            # to BASE...HEAD but observable and robust to odd ref state.
+            MB=$(git merge-base "$BASE" HEAD 2>/dev/null || echo "$BASE")
             FILES=$(git diff --name-only "$MB" HEAD)
-            echo "Detect: changed-files=$(grep -c . <<< "$FILES" || true)"
+            echo "Detect: base=$BASE merge-base=$MB changed-files=$(echo "$FILES" | grep -c . || true)"
             echo "Changed files:"; echo "$FILES" | sed 's/^/  /'
 
             # Code-global inputs every module compiles/tests against -> rebuild all.


### PR DESCRIPTION
## Summary

Reverts #1467 and the comments #1474/#1490 added to explain why it was dead. **I argued for keeping it; that was wrong.** This PR is me overruling myself, with the reasoning.

## Type of change

- [x] chore (build / tooling)
- [ ] feat / fix / refactor / perf / docs / security / breaking change

## Linked issues

Refs #1465

## Why I changed my mind

A merge queue needs an **org-owned** repo; this account is personal, so the ruleset rejects the rule outright (`422`, #1465). The trigger cannot fire and there is no path on which it will — the user→org conversion is itself deprecated.

I kept it anyway, arguing: correct, inert, ready if the repo ever moves. Two things wrong with that:

1. **It helps nothing today and taxes every reader.** Anyone opening ci.yml's api-contract gate reads a paragraph about a merge queue that does not exist. That is cognitive load on the hot path of the five most important workflows, bought with nothing.
2. **"Inert" is not "safe."** `services-ci`'s `merge_group` base-selection is a *separate branch that nothing executes*. It would silently drift from the PR path it must mirror — nobody edits code they can't run. The day someone did enable a queue, they would get stale logic reporting green: **the exact vacuous-green failure this whole session was spent removing.** Dead code that looks live is worse than absent.

The counter-argument I raised for myself still partly holds — in ci.yml the gates are one `pull_request || merge_group` condition, which cannot drift. That is why this was a genuine call and not an obvious one. But it does not cover services-ci, and it does not answer the reading cost. The work is in git history; if the account ever moves under an org, `git revert` this and re-verify against the 422 first.

## Also: I removed a number I made up

The comment claimed required-up-to-date branches cost **"~8 CI re-runs and ~70 min"** per service PR. That was **one reading** of a badly skewed distribution (~93 s median against a ~806 s **mean**). Poisson and length-biased models of the same data give **~1–2 re-runs**. Three defensible models spanning 13%–87%, and I quoted one as settled.

The recommendation against strict checks **stands** — but on the **benefit** being tiny (two PRs on the *same* spec, when 1 in 60 PRs touches a spec at all), not on an invented cost. The comment now states the spread and says the decision rests on the benefit. Same sin I spent the day criticising the audit for; it should not be cemented into the repo.

## Kept

#1490's correction that main was never pre-classified, and the pointer to `api-contract-post-merge.yml` (#1481) — which is what actually covers the gap.

## Evidence

- **`services-ci`, `opa-policy`, `secret-scan`, `issue-hygiene`: byte-identical** (`shasum`) to their pre-#1467 state.
- **`ci.yml` differs in comments only** — `diff` against pre-#1467 filtered to non-comment lines is empty, so no executable line changed.
- **`actionlint` finding set matches the pre-#1467 baseline** (4 shellcheck, all pre-existing); linter validated against a known-positive first.
- All five parse, with their original triggers restored.
- **This PR is its own test**: it touches all five required-check workflows, so if the PR path broke, its own required checks fail.
- `grep`: zero `merge_group` references remain in the five workflows.

## Definition of Done

- [x] Hexagonal layering preserved (CI only).
- [ ] Unit/integration/contract tests — N/A (CI YAML).
- [x] No new lint warnings (baseline-matched).
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — ci.yml's comment now says "don't build for it", so the next person checks the 422 before spending an hour as I did.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency; no action SHA changed.
- [x] Removes an unexecutable code path from five required checks; the PR-time gates are unchanged and still enforced.

## Compliance impact

- [x] None — removes code that never ran. The ADR-0048 contract gate is unchanged on the PR path and now backed post-merge by #1481.

## Rollout / Rollback

- Deployment strategy: N/A (CI-only; restores the pre-#1467 PR path)
- Rollback plan: revert this commit (which restores #1467)
- Data migration reversible: N/A

## Reviewer notes

- **The risk here is me breaking the PR path while removing the queue path.** That is why 4 of 5 files are asserted byte-identical to pre-#1467 rather than "looks fine", and why ci.yml is asserted comment-only.
- Net effect of the merge-queue detour: #1467 (+144 lines) → #1474/#1490 (comments) → this (−144). Zero. That hour is the price of not checking availability first, and #1465 + the private rules now record the 422 so the next attempt starts from the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)