### PR TITLE
fix(sanctions): stop rewriting every row twice on every PEP_GLOBAL refresh

### DIFF
--- a/openbank-sanctions-service/build.gradle.kts
+++ b/openbank-sanctions-service/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
     testImplementation(libs.quarkus.junit5)
     testImplementation(libs.assertj)
     testImplementation(libs.mockk)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit)
+    testImplementation(libs.testcontainers.postgresql)
 }
 
 kover {

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/port/out/SanctionsEntryRepository.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/port/out/SanctionsEntryRepository.kt
@@ -26,12 +26,39 @@ interface SanctionsEntryRepository {
 
     /**
      * Upsert a batch of entries (insert or update on list_type + external_id).
-     * @return number of rows affected.
+     *
+     * Idempotent: a row whose content is byte-identical to what is already stored is left
+     * untouched (no new tuple version, no WAL) — only `active` is unconditionally forced true, so
+     * a previously-deactivated entry that reappears is always reactivated. This matters at the
+     * scale of PEP_GLOBAL (~776k rows, barely changing day to day): rewriting the unchanged
+     * majority on every refresh generated ~1.9 GB of WAL on a 2Gi volume in a single run (issue
+     * #1432), enough by itself to crash the CNPG primary.
+     *
+     * @return number of rows actually written (inserted, reactivated, or content-changed) — NOT
+     *   the number of input entries, since an unchanged row is skipped.
      */
     suspend fun upsertAll(entries: List<SanctionsEntry>): Int
 
-    /** Soft-delete all entries for a list type (before re-importing). */
-    suspend fun deactivateByListType(listType: SanctionsListType): Int
+    /**
+     * Soft-delete every active entry of [listType] whose `external_id` is NOT in
+     * [presentExternalIds] — i.e. it was dropped from the upstream source between this refresh
+     * and the last one.
+     *
+     * Call this ONCE, after the full source has been streamed and upserted — never before. The
+     * previous contract (`deactivateByListType`) deactivated the WHOLE list up front, unconditionally,
+     * then relied on [upsertAll] to reactivate every row still present: every entry was rewritten
+     * TWICE per refresh regardless of whether anything changed, which was half of the WAL cost in
+     * #1432. Deactivating first was also a correctness gap — a refresh that failed partway (network
+     * drop mid-stream) had already wiped the whole list before the failure, leaving real sanctions
+     * entries deactivated with only the partial replacement reactivated. Calling this only after a
+     * successful full pass means a failed refresh leaves existing entries untouched (the swallowed
+     * exception in [com.openbank.sanctions.application.usecase.SanctionsImportService.importList]
+     * never reaches this call), which is the same "keep existing entries" contract that comment
+     * already promises.
+     *
+     * @return number of rows deactivated.
+     */
+    suspend fun deactivateMissing(listType: SanctionsListType, presentExternalIds: Set<String>): Int
 
     suspend fun countByListType(listType: SanctionsListType): Long
 }

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsImportService.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/application/usecase/SanctionsImportService.kt
@@ -244,11 +244,15 @@ class SanctionsImportService(private val entryRepo: SanctionsEntryRepository, pr
             return 0
         }
 
-        // Deactivate stale entries before streaming new data in
-        entryRepo.deactivateByListType(listType)
-
         var total = 0
         val batch = mutableListOf<SanctionsEntry>()
+        // Present-set for the end-of-stream reconciliation sweep below — NOT a deactivate-first
+        // pass. Deactivating stale entries used to run BEFORE this loop, unconditionally, for
+        // every row in the list; that made a failed refresh (network drop mid-stream) leave the
+        // whole list wiped with only the partial replacement reactivated, and doubled the WAL
+        // cost of every successful refresh by rewriting the still-present majority twice
+        // (deactivate, then reactivate on upsert). See #1432.
+        val seenExternalIds = mutableSetOf<String>()
 
         fun col(cols: List<String>, idx: Int) = if (idx >= 0) cols.getOrElse(idx) { "" }.trim() else ""
 
@@ -267,6 +271,7 @@ class SanctionsImportService(private val entryRepo: SanctionsEntryRepository, pr
                 val programRaw = col(cols, idxProgramIds)
 
                 if (name.isBlank()) continue
+                id.takeIf { it.isNotBlank() }?.let { seenExternalIds += it }
 
                 val aliases = aliasesRaw.split(";")
                     .map { it.trim() }
@@ -312,7 +317,17 @@ class SanctionsImportService(private val entryRepo: SanctionsEntryRepository, pr
         }
 
         if (batch.isNotEmpty()) total += entryRepo.upsertAll(batch)
-        Log.infof("Imported %d OpenSanctions entries for %s", total, listType)
+
+        // Only reached if the loop above completed without throwing — a mid-stream failure
+        // (network drop, malformed line) propagates out of this function instead, and the
+        // existing list is left untouched rather than partially wiped.
+        val deactivated = entryRepo.deactivateMissing(listType, seenExternalIds)
+        Log.infof(
+            "Imported %d OpenSanctions entries for %s (%d no longer present, deactivated)",
+            total,
+            listType,
+            deactivated,
+        )
         return total
     }
 

--- a/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImpl.kt
+++ b/openbank-sanctions-service/src/main/kotlin/com/openbank/sanctions/infrastructure/persistence/repository/SanctionsEntryRepositoryImpl.kt
@@ -11,6 +11,8 @@ import com.openbank.sanctions.domain.model.*
 import io.quarkus.logging.Log
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Row
+import io.vertx.mutiny.sqlclient.RowSet
 import io.vertx.mutiny.sqlclient.Tuple
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.Clock
@@ -79,6 +81,16 @@ class SanctionsEntryRepositoryImpl(private val pool: PgPool, private val clock: 
                 search_text  = EXCLUDED.search_text,
                 active       = true,
                 updated_at   = NOW()
+            WHERE
+                sanctions_entries.active        IS NOT TRUE
+                OR sanctions_entries.entity_type   IS DISTINCT FROM EXCLUDED.entity_type
+                OR sanctions_entries.primary_name  IS DISTINCT FROM EXCLUDED.primary_name
+                OR sanctions_entries.aliases_json  IS DISTINCT FROM EXCLUDED.aliases_json
+                OR sanctions_entries.date_of_birth IS DISTINCT FROM EXCLUDED.date_of_birth
+                OR sanctions_entries.nationalities IS DISTINCT FROM EXCLUDED.nationalities
+                OR sanctions_entries.programs      IS DISTINCT FROM EXCLUDED.programs
+                OR sanctions_entries.search_text   IS DISTINCT FROM EXCLUDED.search_text
+            RETURNING 1
         """.trimIndent()
 
         // CoreTuple.wrap(List) handles arbitrary number of params; then wrap in mutiny Tuple
@@ -100,22 +112,43 @@ class SanctionsEntryRepositoryImpl(private val pool: PgPool, private val clock: 
             )
         }
 
-        // Batch in chunks of 500 to avoid oversized messages
+        // Batch in chunks of 500 to avoid oversized messages. Count via RETURNING, not chunk.size:
+        // before the WHERE-guard above existed, every conflicting row always got written, so
+        // "rows submitted" and "rows written" happened to be the same number and this bug was
+        // invisible. Now that an unchanged row is correctly skipped, chunk.size would silently
+        // over-report — "Imported 776,000 entries" every single refresh even when almost nothing
+        // changed, which is exactly the kind of number nobody would think to question.
         var total = 0
         for (chunk in tuples.chunked(500)) {
-            pool.preparedQuery(sql).executeBatch(chunk).awaitSuspending()
-            total += chunk.size
+            var rowSet: RowSet<Row>? = pool.preparedQuery(sql).executeBatch(chunk).awaitSuspending()
+            while (rowSet != null) {
+                total += rowSet.size()
+                rowSet = rowSet.next()
+            }
         }
         return total
     }
 
-    override suspend fun deactivateByListType(listType: SanctionsListType): Int {
+    override suspend fun deactivateMissing(listType: SanctionsListType, presentExternalIds: Set<String>): Int {
+        // Array-parameter anti-join, not a temp table: vertx-pg-client binds a Kotlin
+        // Array<String> as a native Postgres text[] parameter, so this is one round trip
+        // regardless of set size (~776k for PEP_GLOBAL) and needs no session-scoped state to
+        // clean up. `NOT (external_id = ANY($2))` — not `NOT IN` — because `NOT IN` returns
+        // NULL (not TRUE) the moment the array contains any NULL, silently matching zero rows;
+        // `= ANY` has no such trap, and an empty presentExternalIds array still deactivates
+        // everything as intended (a genuinely empty upstream feed).
         val result = pool
             .preparedQuery(
-                "UPDATE sanctions_entries SET active = false, updated_at = NOW()" +
-                    " WHERE list_type = $1 AND active = true",
+                """
+                UPDATE sanctions_entries
+                SET active = false, updated_at = NOW()
+                WHERE list_type = $1
+                  AND active = true
+                  AND external_id IS NOT NULL
+                  AND NOT (external_id = ANY($2))
+                """.trimIndent(),
             )
-            .execute(Tuple.of(listType.name))
+            .execute(Tuple.of(listType.name, presentExternalIds.toTypedArray()))
             .awaitSuspending()
         return result.rowCount()
     }

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsImportServiceTest.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/application/usecase/SanctionsImportServiceTest.kt
@@ -10,6 +10,8 @@ import com.openbank.sanctions.domain.model.SanctionsEntry
 import com.openbank.sanctions.domain.model.SanctionsListType
 import com.sun.net.httpserver.HttpServer
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
@@ -170,9 +172,9 @@ class SanctionsImportServiceTest {
             "os-2,Organization,Acme Sanctioned Co,,,,,,,,,\"EU-SANCTIONS\",,,,\n"
         val url = serveOnce(csv, "text/csv")
 
-        coEvery { entryRepo.deactivateByListType(SanctionsListType.PEP_GLOBAL) } returns 0
         val entriesSlot = slot<List<SanctionsEntry>>()
         coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 2
+        coEvery { entryRepo.deactivateMissing(SanctionsListType.PEP_GLOBAL, setOf("os-1", "os-2")) } returns 0
 
         val count = service.importList(SanctionsListType.PEP_GLOBAL, url)
 
@@ -209,7 +211,9 @@ class SanctionsImportServiceTest {
             "os-3,Person,,,,,,,,,,,,,,\n"
         val url = serveOnce(csv, "text/csv")
 
-        coEvery { entryRepo.deactivateByListType(SanctionsListType.UN_CONSOLIDATED) } returns 0
+        // Both rows are skipped (blank line, blank name) — the reconciliation sweep at the end
+        // still runs (the stream completed without error), just with an empty present set.
+        coEvery { entryRepo.deactivateMissing(SanctionsListType.UN_CONSOLIDATED, emptySet()) } returns 0
 
         val count = service.importList(SanctionsListType.UN_CONSOLIDATED, url)
 
@@ -224,9 +228,9 @@ class SanctionsImportServiceTest {
             "os-5,Aircraft,N12345,,,,,,,,,,,,,\n"
         val url = serveOnce(csv, "text/csv")
 
-        coEvery { entryRepo.deactivateByListType(SanctionsListType.HM_TREASURY) } returns 0
         val entriesSlot = slot<List<SanctionsEntry>>()
         coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 2
+        coEvery { entryRepo.deactivateMissing(SanctionsListType.HM_TREASURY, setOf("os-4", "os-5")) } returns 0
 
         service.importList(SanctionsListType.HM_TREASURY, url)
 
@@ -242,12 +246,54 @@ class SanctionsImportServiceTest {
             "os-6,Person,\"Doe, John \"\"The Rock\"\"\",,,,,,,,,,,,,\n"
         val url = serveOnce(csv, "text/csv")
 
-        coEvery { entryRepo.deactivateByListType(SanctionsListType.PEP_GLOBAL) } returns 0
         val entriesSlot = slot<List<SanctionsEntry>>()
         coEvery { entryRepo.upsertAll(capture(entriesSlot)) } returns 1
+        coEvery { entryRepo.deactivateMissing(SanctionsListType.PEP_GLOBAL, setOf("os-6")) } returns 0
 
         service.importList(SanctionsListType.PEP_GLOBAL, url)
 
         assertThat(entriesSlot.captured.single().primaryName).isEqualTo("""Doe, John "The Rock"""")
+    }
+
+    // ──── deactivateMissing — the mark-and-sweep reconciliation contract ─────
+
+    @Test
+    fun `a mid-stream failure never calls deactivateMissing, leaving existing entries untouched`(): Unit = runBlocking {
+        val csv = "id,schema,name,aliases,birth_date,countries,addresses,identifiers,sanctions," +
+            "phones,emails,program_ids,dataset,first_seen,last_seen,last_change\n" +
+            "os-1,Person,First Entry,,,,,,,,,,,,,\n" +
+            "os-2,Person,Second Entry,,,,,,,,,,,,,\n"
+        val url = serveOnce(csv, "text/csv")
+
+        // The batch flush throws partway through the stream (simulates a DB hiccup between
+        // reading rows) — this must propagate out of importOpenSanctionsCsv, get swallowed by
+        // importList's catch-all, and never reach deactivateMissing.
+        coEvery { entryRepo.upsertAll(any()) } throws RuntimeException("connection reset")
+
+        val count = service.importList(SanctionsListType.PEP_GLOBAL, url)
+
+        assertThat(count).isZero()
+        coVerify(exactly = 0) { entryRepo.deactivateMissing(any(), any()) }
+    }
+
+    @Test
+    fun `deactivateMissing runs once, after every batch has been upserted, not before`(): Unit = runBlocking {
+        // Force two batches by dropping the batch size threshold via a large-enough row count
+        // is impractical here (IMPORT_BATCH_SIZE = 500); instead assert call ORDER directly:
+        // upsertAll must be recorded before deactivateMissing for the same run.
+        val csv = "id,schema,name,aliases,birth_date,countries,addresses,identifiers,sanctions," +
+            "phones,emails,program_ids,dataset,first_seen,last_seen,last_change\n" +
+            "os-1,Person,First Entry,,,,,,,,,,,,,\n"
+        val url = serveOnce(csv, "text/csv")
+
+        coEvery { entryRepo.upsertAll(any()) } returns 1
+        coEvery { entryRepo.deactivateMissing(SanctionsListType.PEP_GLOBAL, setOf("os-1")) } returns 0
+
+        service.importList(SanctionsListType.PEP_GLOBAL, url)
+
+        coVerifyOrder {
+            entryRepo.upsertAll(any())
+            entryRepo.deactivateMissing(SanctionsListType.PEP_GLOBAL, setOf("os-1"))
+        }
     }
 }

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/PostgresTestResource.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/PostgresTestResource.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.it
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/** Isolated PostgreSQL per test JVM (mirrors openbank-ledger-service's PostgresTestResource). */
+class PostgresTestResource : QuarkusTestResourceLifecycleManager {
+    private var postgres: PostgreSQLContainer<*>? = null
+    override fun start(): Map<String, String> {
+        val pg = PostgreSQLContainer(DockerImageName.parse("postgres:16.3-alpine"))
+            .withUsername("openbank").withPassword("openbank_secret").withDatabaseName("openbank_sanctions_it")
+        pg.start()
+        postgres = pg
+        val host = pg.host
+        val port = pg.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
+        return mapOf(
+            "quarkus.datasource.reactive.url" to "vertx-reactive:postgresql://$host:$port/openbank_sanctions_it",
+            "quarkus.datasource.jdbc.url" to "jdbc:postgresql://$host:$port/openbank_sanctions_it",
+            "quarkus.datasource.username" to "openbank",
+            "quarkus.datasource.password" to "openbank_secret",
+            "quarkus.devservices.enabled" to "false",
+        )
+    }
+    override fun stop() {
+        postgres?.stop()
+    }
+}

--- a/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsEntryRepositoryUpsertIT.kt
+++ b/openbank-sanctions-service/src/test/kotlin/com/openbank/sanctions/it/SanctionsEntryRepositoryUpsertIT.kt
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.sanctions.it
+
+import com.openbank.sanctions.domain.model.EntityType
+import com.openbank.sanctions.domain.model.SanctionsEntry
+import com.openbank.sanctions.domain.model.SanctionsListType
+import com.openbank.sanctions.infrastructure.persistence.repository.SanctionsEntryRepositoryImpl
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import io.vertx.mutiny.pgclient.PgPool
+import io.vertx.mutiny.sqlclient.Tuple
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Real-Postgres verification for the #1432 fix (a PEP_GLOBAL refresh wrote ~1.9GB of WAL onto a
+ * 2Gi volume by rewriting all 776k rows on every run, unconditionally, twice — once via
+ * `deactivateByListType`'s blanket sweep, once via `upsertAll`'s unconditional `DO UPDATE`).
+ *
+ * Two claims here were verified against a REAL database rather than assumed, because both are
+ * exactly the kind of external-behavior detail that is wrong to guess:
+ *
+ * 1. `V5__create_sanctions_entries.sql` declares `UNIQUE NULLS NOT DISTINCT (list_type,
+ *    external_id)` — a full-table constraint, no partial predicate. `upsertAll`'s
+ *    `ON CONFLICT (list_type, external_id) WHERE external_id IS NOT NULL` targets a PARTIAL
+ *    unique index by that exact predicate. Whether Postgres accepts a full unique constraint as
+ *    the arbiter for a partial ON CONFLICT clause is not something to reason out from memory of
+ *    the docs — it either compiles against real Postgres or it throws
+ *    "no unique or exclusion constraint matching the ON CONFLICT specification". It does compile
+ *    (this test would fail immediately at `upsertAll` otherwise) — Postgres accepts a
+ *    non-partial unique constraint as an arbiter for an ON CONFLICT clause whose predicate is a
+ *    subset condition, because every row satisfying the constraint already satisfies the
+ *    predicate; a truly partial *index* is only required when the constraint ITSELF is partial.
+ * 2. `deactivateMissing` binds a Kotlin `Array<String>` as a Postgres `text[]` parameter via
+ *    vertx-pg-client, for the `= ANY($2)` anti-join. No other repository in the fleet binds an
+ *    array parameter this way — confirmed working here rather than assumed.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresTestResource::class)
+class SanctionsEntryRepositoryUpsertIT {
+
+    @Inject
+    lateinit var repository: SanctionsEntryRepositoryImpl
+
+    @Inject
+    lateinit var pool: PgPool
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    @BeforeEach
+    fun clearTable() {
+        onEventLoop { pool.query("DELETE FROM sanctions_entries").execute().awaitSuspending() }
+    }
+
+    private fun entry(
+        externalId: String,
+        primaryName: String = "Test Entry $externalId",
+        listType: SanctionsListType = SanctionsListType.PEP_GLOBAL,
+    ) = SanctionsEntry(
+        listType = listType,
+        externalId = externalId,
+        entityType = EntityType.INDIVIDUAL,
+        primaryName = primaryName,
+        aliases = emptyList(),
+        searchText = primaryName.lowercase(),
+    )
+
+    /** Postgres's own tuple-version marker: changes on any UPDATE that writes a new row version. */
+    private fun xmin(externalId: String): Long = onEventLoop {
+        pool.preparedQuery("SELECT xmin::text::bigint AS x FROM sanctions_entries WHERE external_id = $1")
+            .execute(Tuple.of(externalId))
+            .awaitSuspending()
+            .iterator().next().getLong("x")
+    }
+
+    private fun activeFlag(externalId: String): Boolean = onEventLoop {
+        pool.preparedQuery("SELECT active FROM sanctions_entries WHERE external_id = $1")
+            .execute(Tuple.of(externalId))
+            .awaitSuspending()
+            .iterator().next().getBoolean("active")
+    }
+
+    private fun rowCount(): Long = onEventLoop {
+        pool.query("SELECT count(*) AS c FROM sanctions_entries").execute().awaitSuspending()
+            .iterator().next().getLong("c")
+    }
+
+    // ──── claim 1: the ON CONFLICT clause matches the real V5 constraint ──────
+
+    @Test
+    fun `upsertAll inserts against the real UNIQUE NULLS NOT DISTINCT constraint`(): Unit = runBlocking {
+        val count = onEventLoop { repository.upsertAll(listOf(entry("pep-1"))) }
+
+        assertThat(count).isEqualTo(1)
+        assertThat(rowCount()).isEqualTo(1)
+    }
+
+    @Test
+    fun `a second upsertAll for the same external_id hits the ON CONFLICT arbiter, not a duplicate-key error`(): Unit =
+        runBlocking {
+            onEventLoop { repository.upsertAll(listOf(entry("pep-1", primaryName = "Original Name"))) }
+
+            // If Postgres could not infer the arbiter (the theoretical constraint-mismatch risk),
+            // this would throw a duplicate-key violation on the unique constraint instead of
+            // routing through DO UPDATE.
+            onEventLoop { repository.upsertAll(listOf(entry("pep-1", primaryName = "Updated Name"))) }
+
+            assertThat(rowCount()).isEqualTo(1)
+        }
+
+    // ──── claim 2 (the actual #1432 fix): unchanged rows are not rewritten ────
+
+    @Test
+    fun `a mixed batch reports the true count of rows actually written, not the batch size`(): Unit = runBlocking {
+        onEventLoop {
+            repository.upsertAll(listOf(entry("unchanged"), entry("will-change", primaryName = "Before")))
+        }
+
+        // unchanged: identical content, must be skipped and NOT counted.
+        // will-change: content differs, must be written and counted.
+        // brand-new: not present before, must be inserted and counted.
+        val affected = onEventLoop {
+            repository.upsertAll(
+                listOf(
+                    entry("unchanged"),
+                    entry("will-change", primaryName = "After"),
+                    entry("brand-new"),
+                ),
+            )
+        }
+
+        assertThat(affected).isEqualTo(2)
+    }
+
+    @Test
+    fun `re-upserting byte-identical content does not write a new tuple version`(): Unit = runBlocking {
+        onEventLoop { repository.upsertAll(listOf(entry("pep-1"))) }
+        val xminAfterInsert = xmin("pep-1")
+
+        val affected = onEventLoop { repository.upsertAll(listOf(entry("pep-1"))) }
+
+        assertThat(affected).isZero() // no row was actually written
+        assertThat(xmin("pep-1")).isEqualTo(xminAfterInsert) // and Postgres agrees: same tuple version
+    }
+
+    @Test
+    fun `re-upserting with changed content DOES write a new tuple version`(): Unit = runBlocking {
+        onEventLoop { repository.upsertAll(listOf(entry("pep-1", primaryName = "Original Name"))) }
+        val xminAfterInsert = xmin("pep-1")
+
+        val affected = onEventLoop { repository.upsertAll(listOf(entry("pep-1", primaryName = "Changed Name"))) }
+
+        assertThat(affected).isEqualTo(1)
+        assertThat(xmin("pep-1")).isNotEqualTo(xminAfterInsert)
+    }
+
+    @Test
+    fun `reactivating a deactivated row always writes, even with identical content`(): Unit = runBlocking {
+        onEventLoop { repository.upsertAll(listOf(entry("pep-1"))) }
+        onEventLoop { repository.deactivateMissing(SanctionsListType.PEP_GLOBAL, presentExternalIds = emptySet()) }
+        assertThat(activeFlag("pep-1")).isFalse()
+        val xminWhileInactive = xmin("pep-1")
+
+        // Same content as the original insert — but the row is inactive, so `active IS NOT TRUE`
+        // must force the write even though nothing else changed.
+        val affected = onEventLoop { repository.upsertAll(listOf(entry("pep-1"))) }
+
+        assertThat(affected).isEqualTo(1)
+        assertThat(activeFlag("pep-1")).isTrue()
+        assertThat(xmin("pep-1")).isNotEqualTo(xminWhileInactive)
+    }
+
+    // ──── claim 3: the array-parameter anti-join in deactivateMissing works ───
+
+    @Test
+    fun `deactivateMissing deactivates only rows absent from the present set`(): Unit = runBlocking {
+        onEventLoop { repository.upsertAll(listOf(entry("pep-1"), entry("pep-2"), entry("pep-3"))) }
+
+        val deactivated = onEventLoop {
+            repository.deactivateMissing(SanctionsListType.PEP_GLOBAL, presentExternalIds = setOf("pep-1", "pep-3"))
+        }
+
+        assertThat(deactivated).isEqualTo(1)
+        assertThat(activeFlag("pep-1")).isTrue()
+        assertThat(activeFlag("pep-2")).isFalse()
+        assertThat(activeFlag("pep-3")).isTrue()
+    }
+
+    @Test
+    fun `deactivateMissing with an empty present set deactivates everything for that list type`(): Unit = runBlocking {
+        onEventLoop { repository.upsertAll(listOf(entry("pep-1"), entry("pep-2"))) }
+
+        val deactivated = onEventLoop {
+            repository.deactivateMissing(SanctionsListType.PEP_GLOBAL, presentExternalIds = emptySet())
+        }
+
+        assertThat(deactivated).isEqualTo(2)
+        assertThat(activeFlag("pep-1")).isFalse()
+        assertThat(activeFlag("pep-2")).isFalse()
+    }
+
+    @Test
+    fun `deactivateMissing does not touch a different list type`(): Unit = runBlocking {
+        onEventLoop {
+            repository.upsertAll(
+                listOf(entry("shared-1", listType = SanctionsListType.PEP_GLOBAL)),
+            )
+            repository.upsertAll(
+                listOf(entry("shared-1", listType = SanctionsListType.EU_CONSOLIDATED)),
+            )
+        }
+
+        onEventLoop { repository.deactivateMissing(SanctionsListType.PEP_GLOBAL, presentExternalIds = emptySet()) }
+
+        val euActive = onEventLoop {
+            pool.preparedQuery("SELECT active FROM sanctions_entries WHERE external_id = $1 AND list_type = $2")
+                .execute(Tuple.of("shared-1", SanctionsListType.EU_CONSOLIDATED.name))
+                .awaitSuspending()
+                .iterator().next().getBoolean("active")
+        }
+        assertThat(euActive).isTrue()
+    }
+
+    @Test
+    fun `re-running deactivateMissing with the same present set does not rewrite already-inactive rows`(): Unit =
+        runBlocking {
+            onEventLoop { repository.upsertAll(listOf(entry("pep-1"))) }
+            onEventLoop { repository.deactivateMissing(SanctionsListType.PEP_GLOBAL, presentExternalIds = emptySet()) }
+            val xminAfterFirstDeactivation = xmin("pep-1")
+
+            // The `active = true` guard in the WHERE clause must exclude already-inactive rows
+            // from being touched again — otherwise every reconciliation pass rewrites the whole
+            // inactive tail forever, the same class of waste this fix removes from the other side.
+            val deactivated = onEventLoop {
+                repository.deactivateMissing(SanctionsListType.PEP_GLOBAL, presentExternalIds = emptySet())
+            }
+
+            assertThat(deactivated).isZero()
+            assertThat(xmin("pep-1")).isEqualTo(xminAfterFirstDeactivation)
+        }
+}


### PR DESCRIPTION
## The outage this addresses

`sanctions-db-1` has been crashlooping for 4 days (`Not enough disk space`, 92+ restarts as of this writing) — `sanctions-service` has had zero endpoints the whole time. AML sanctions screening, money-path, `severity:high` (#1432).

## Root cause

A full `PEP_GLOBAL` refresh wrote **~1.9GB of WAL in a single run onto a 2Gi volume**. Every one of the ~776k rows was rewritten **twice**, unconditionally, on every scheduled refresh:

1. `importOpenSanctionsCsv` called `entryRepo.deactivateByListType(listType)` **before** streaming — a blanket `UPDATE` flipping every currently-active row to inactive, regardless of whether it would be re-upserted moments later, unchanged.
2. `upsertAll`'s `ON CONFLICT ... DO UPDATE` had no guard — every conflicting row got a full rewrite (7 content columns + `updated_at = NOW()`) even when the source data was byte-identical to what was already stored.

**Deactivating before streaming was also a correctness gap, not just a WAL cost.** A refresh that failed partway (network drop mid-CSV) had already wiped the whole list before the failure, and `importList`'s catch-all only logs and returns 0 — silently leaving real sanctions entries deactivated with just the partial replacement reactivated.

## What changed

- **`upsertAll`** gained a `WHERE` guard on the `DO UPDATE` (`IS DISTINCT FROM` per content column, plus `active IS NOT TRUE` to always force reactivation): an unchanged, already-active row is now skipped entirely — no new tuple version, no WAL.
- **`deactivateByListType(listType)` → `deactivateMissing(listType, presentExternalIds)`** — a targeted anti-join (`NOT (external_id = ANY($2))`, not `NOT IN`, which returns `NULL` and silently matches nothing the moment the array contains any `NULL`) that deactivates only rows genuinely absent from the current refresh. Called **once, after** the full stream completes successfully — a mid-stream failure now leaves existing entries untouched.
- **`SanctionsImportService`** accumulates seen `external_id`s while streaming, calls `deactivateMissing` after the trailing batch flush, not before the loop starts.

## A second bug the fix surfaced (and fixed)

`upsertAll`'s return value was `total += chunk.size` — it **never actually consumed the query result**. Before this fix that was invisible, because every conflict always wrote, so "rows submitted" and "rows written" happened to be the same number. My IT caught it immediately: the idempotent guard worked correctly (confirmed via Postgres's own `xmin`, unchanged across a no-op re-upsert), but the reported count did not — a no-op re-upsert reported `affected=1`. Fixed with `RETURNING 1` + summing the real per-statement `RowSet` chain across the batch. Without this, "Imported 776,000 entries" would print on every refresh regardless of how few rows actually changed.

## Two things verified against real Postgres, not assumed

Sanctions-service had **zero** integration-test infrastructure before this PR — added Testcontainers (mirrors `openbank-ledger-service`'s `PostgresTestResource`), because both of these are exactly the kind of external-behavior detail wrong to guess on a production AML data path:

1. `V5__create_sanctions_entries.sql` declares `UNIQUE NULLS NOT DISTINCT (list_type, external_id)` — a full-table constraint, no partial predicate — while `upsertAll`'s `ON CONFLICT` clause specifies `WHERE external_id IS NOT NULL`. Confirmed Postgres accepts the full constraint as the arbiter for a subset predicate; a full unique constraint doesn't need a matching partial index.
2. `vertx-pg-client` correctly binds a Kotlin `Array<String>` as a Postgres `text[]` parameter for `= ANY($2)` — no other repository in the fleet binds an array this way.

## Verification

| | |
|---|---|
| New IT tests (real Postgres 16, Testcontainers) | **10/10 green** |
| `SanctionsImportServiceTest` | **13/13 green** (11 existing + 2 new) |
| Full `openbank-sanctions-service` test suite | green |
| `ktlintCheck` + `detekt` | green |

IT coverage: ON CONFLICT arbiter matching, no-op skip verified via `xmin` (not just a returned count), reactivation-always-writes, targeted deactivation (present / absent / different-list-type / re-running-is-a-no-op), and a mixed batch reporting the true written count (2 of 3, not 3).

## Not done here

Sizing the `sanctions-db` PVC. That should be based on peak refresh WAL, not current data size — this fix is what makes that number stop being ~2GB per refresh in the first place, so it's worth revisiting (likely no longer needed at all) once this is live and a refresh has actually run against it.

## Linked issues

Refs #1432
