### PR TITLE
fix(product-catalog): hold at min:1 — onboarding calls it synchronously, off the interceptor

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "cc688e017c968930"
+    openbank.tech/policy-checksum: "a5946c8286d36b9c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2525,7 +2525,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cc688e017c968930"
+        openbank.tech/policy-checksum: "a5946c8286d36b9c"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/accounts/product-catalog-http-scaledobject.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog-http-scaledobject.yaml
@@ -1,34 +1,42 @@
-# HTTPScaledObject — ADR-0083 T1 (HTTP → 0) pilot for product-catalog.
+# HTTPScaledObject — ADR-0083 T1 (HTTP → 0) for product-catalog, held at min: 1.
 #
-# product-catalog is the nominated T1 pilot: it is a stateless, non-money-path,
-# read-only HTTP service with near-zero CPU utilisation at rest (~0.004 cores
-# per the ADR-0057 tier classifier). It has no synchronous inbound callers from
-# other services at runtime — the only callers are the admin-UI and the fees
-# vertical (ADR-0051), both of which can tolerate a first-request cold-start
-# latency rather than a 5xx.
+# THE T1 PREMISE WAS WRONG, AND IT TOOK ONBOARDING DOWN. This file used to open with:
 #
-# How it works:
-#   1. This object registers product-catalog with the KEDA HTTP add-on.
-#   2. Inbound traffic must be routed through the interceptor Service
-#      (keda-add-ons-http-interceptor.keda.svc:8080) — see the Ingress annotation
-#      in product-catalog.yaml. The interceptor holds the first request while
-#      KEDA scales the Deployment 0 → 1; subsequent requests are forwarded
-#      directly once a pod is Ready.
-#   3. After `scaledownPeriod` seconds of inactivity the interceptor signals
-#      KEDA to scale back to zero, and Karpenter consolidates the idle node.
+#   "It has no synchronous inbound callers from other services at runtime — the only
+#    callers are the admin-UI and the fees vertical (ADR-0051), both of which can
+#    tolerate a first-request cold-start latency rather than a 5xx."
 #
-# minReplicas: 0 — the T1 goal; safe because:
-#   - product-catalog is NOT on the money path (rules.yaml money_path_services).
-#   - The interceptor parks the first request (no 5xx on cold start).
-#   - Native image cold-start is targeted at ≤ 300 ms p95 (ADR-0083 SLO gate);
-#     until that SLO is measured and confirmed, minReplicas can be raised to 1
-#     as a conservative fallback without any manifest change to this file.
+# Both halves are false. product-catalog has TWO synchronous in-cluster callers on the
+# onboarding path, and neither goes through the interceptor — they dial the ClusterIP
+# directly, which is the only thing that can wake a scaled-to-zero pod:
+#
+#   - account-service  → AccountService.openAccount, validating the product (issue #668)
+#   - document-service → OnboardingDocumentService.issueOnboardingDocument, resolving the
+#                        product's documentTemplateCode (ADR-0162 D7)
+#
+# So the pod never woke, and every call got `Connection refused` instead of a cold start.
+# The two callers then failed in different directions, which is why this stayed invisible:
+#
+#   - account-service fails OPEN (reference data, not money path) — accounts still opened,
+#     product validation silently skipped. A WARN, no more.
+#   - document-service treats an unresolvable template code as "this product has no
+#     document" and returns — logging it at INFO. So no onboarding document was created,
+#     no signature ceremony existed, and the customer had nothing to sign. Registration
+#     still returned 201.
+#
+# Held at min: 1 until BOTH are true:
+#   1. every in-cluster caller reaches product-catalog through the interceptor (or the
+#      callers stop being synchronous), and
+#   2. the ADR-0083 §5 cold-start SLO is actually MEASURED — it never was. T1 was
+#      declared complete on the strength of the premise above rather than on data.
+#
+# Keeping the HTTPScaledObject (rather than deleting it) preserves the scale-UP path and
+# the ADR-0083 wiring, so re-testing T1 later is a one-line change back to min: 0 once
+# the callers are fixed. maxReplicas/scaledownPeriod/targetPendingRequests are unchanged
+# and only matter above 1 replica.
 #
 # maxReplicas: 3 — generous cap for a read-only seed store; revise once live
 #   traffic data is available.
-#
-# scaledownPeriod: 300 s (5 min) — gives a short-lived admin-UI browsing session
-#   time to complete before the pod is torn down. Tune after ADR-0083 §5 measurement.
 #
 # targetPendingRequests: 100 — the interceptor scales 1 replica per 100 in-flight
 #   requests. At product-catalog's expected fan-out this means a single warm pod
@@ -41,7 +49,7 @@ metadata:
   labels:
     app.kubernetes.io/name: product-catalog
     app.kubernetes.io/part-of: accounts
-    openbank.io/finops-tier: T1
+    openbank.io/finops-tier: T0     # held at min:1 — see header; T1 reverted in rules.yaml
     openbank.io/adr: "0083"
 spec:
   hosts:
@@ -57,7 +65,9 @@ spec:
     apiVersion: apps/v1
     port: 8104
   replicas:
-    min: 0
+    # 0 → 1: see the header. Onboarding calls this service synchronously and does not go
+    # through the interceptor, so at 0 it is not a cold start — it is a connection refused.
+    min: 1
     max: 3
   scaledownPeriod: 300
   targetPendingRequests: 100

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "94fb9317d1e546c8"
+    openbank.tech/policy-checksum: "76a08b4d9d4d2018"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2468,7 +2468,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "94fb9317d1e546c8"
+        openbank.tech/policy-checksum: "76a08b4d9d4d2018"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "98b484dad264da06"
+    openbank.tech/policy-checksum: "ec9e54ea1ca21c56"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2569,7 +2569,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "98b484dad264da06"
+        openbank.tech/policy-checksum: "ec9e54ea1ca21c56"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "800313ee06f5cca3"
+    openbank.tech/policy-checksum: "b5a01beb81aae0f5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2474,7 +2474,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "800313ee06f5cca3"
+        openbank.tech/policy-checksum: "b5a01beb81aae0f5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "9893139f415bf59e"
+    openbank.tech/policy-checksum: "12e29e852bbac57b"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2506,7 +2506,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "9893139f415bf59e"
+        openbank.tech/policy-checksum: "12e29e852bbac57b"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "49c7d06e5eb41c83"
+    openbank.tech/policy-checksum: "995020bb2a0ca60d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2557,7 +2557,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "49c7d06e5eb41c83"
+        openbank.tech/policy-checksum: "995020bb2a0ca60d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "01d876b79a494c16"
+    openbank.tech/policy-checksum: "0b72b728395f99a0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1742,7 +1742,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01d876b79a494c16"
+        openbank.tech/policy-checksum: "0b72b728395f99a0"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "01d876b79a494c16"
+    openbank.tech/policy-checksum: "0b72b728395f99a0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1742,7 +1742,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "01d876b79a494c16"
+        openbank.tech/policy-checksum: "0b72b728395f99a0"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "c68dfec7b2148dd3"
+    openbank.tech/policy-checksum: "98460b8aee6c23dd"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2485,7 +2485,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c68dfec7b2148dd3"
+        openbank.tech/policy-checksum: "98460b8aee6c23dd"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "801bc723ad8ab9e4"
+    openbank.tech/policy-checksum: "67e9bc4721bb1265"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2536,7 +2536,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "801bc723ad8ab9e4"
+        openbank.tech/policy-checksum: "67e9bc4721bb1265"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "e852193297f87d71"
+    openbank.tech/policy-checksum: "a0a1c40ac6138f21"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2470,7 +2470,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e852193297f87d71"
+        openbank.tech/policy-checksum: "a0a1c40ac6138f21"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "a4c40b4916a0b6ad"
+    openbank.tech/policy-checksum: "51984a9f751c7d14"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2583,7 +2583,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a4c40b4916a0b6ad"
+        openbank.tech/policy-checksum: "51984a9f751c7d14"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "d4b1632f6d31dfb2"
+    openbank.tech/policy-checksum: "f05a43bde8d84df8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2538,7 +2538,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d4b1632f6d31dfb2"
+        openbank.tech/policy-checksum: "f05a43bde8d84df8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "01d876b79a494c16"
+    openbank.tech/policy-checksum: "0b72b728395f99a0"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1742,7 +1742,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "01d876b79a494c16"
+        openbank.tech/policy-checksum: "0b72b728395f99a0"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "71bfbfd8f41dec2b"
+    openbank.tech/policy-checksum: "265e577332e787f9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2491,7 +2491,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "50188a04dbd8f23e"
+    openbank.tech/policy-checksum: "8baca7891517b387"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2528,7 +2528,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e025b9b9e407ce75"
+    openbank.tech/policy-checksum: "596fef249e7dcb87"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2513,7 +2513,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a0352a3837bcd6ff" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "22cab2de33830db3" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d95d861ba9c2630f"
+        openbank.tech/policy-checksum: "877324988bd38612"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e025b9b9e407ce75" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "596fef249e7dcb87" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a1cf0ac4da3b6bb5"
+        openbank.tech/policy-checksum: "b2601edd1e46dda2"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "50188a04dbd8f23e" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "8baca7891517b387" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "71bfbfd8f41dec2b"
+        openbank.tech/policy-checksum: "265e577332e787f9"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "254f6a470587e8f2" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "5fcf06ca69b2f841" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7909a2bc56ec03a5"
+        openbank.tech/policy-checksum: "eaec93e677cb4324"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "280d6c39d338c9dc"
+        openbank.tech/policy-checksum: "60b321bc8c5651b7"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a1cf0ac4da3b6bb5"
+    openbank.tech/policy-checksum: "b2601edd1e46dda2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2486,7 +2486,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d95d861ba9c2630f"
+    openbank.tech/policy-checksum: "877324988bd38612"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2507,7 +2507,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "254f6a470587e8f2"
+    openbank.tech/policy-checksum: "5fcf06ca69b2f841"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2487,7 +2487,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7909a2bc56ec03a5"
+    openbank.tech/policy-checksum: "eaec93e677cb4324"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2490,7 +2490,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a0352a3837bcd6ff"
+    openbank.tech/policy-checksum: "22cab2de33830db3"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2543,7 +2543,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "280d6c39d338c9dc"
+    openbank.tech/policy-checksum: "60b321bc8c5651b7"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2494,7 +2494,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "5c830e8f08096056"
+    openbank.tech/policy-checksum: "a8b40645189c2df8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2496,7 +2496,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "5c830e8f08096056"
+        openbank.tech/policy-checksum: "a8b40645189c2df8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "8235569463e3b051"
+    openbank.tech/policy-checksum: "65c32d9d724a432e"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2474,7 +2474,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8235569463e3b051"
+        openbank.tech/policy-checksum: "65c32d9d724a432e"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "0e323e28b70cef7b"
+    openbank.tech/policy-checksum: "480adbe253024c25"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2510,7 +2510,19 @@ data:
         # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
         # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
         # Kubernetes control-plane + admission-webhook overhead, not the image).
-        openbank-product-catalog: T1
+        openbank-product-catalog: T0
+        # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+        # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+        # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+        # callers — account-service (openAccount product validation, #668) and document-service
+        # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+        # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+        # click. document-service reads that as "product has no document template" and issues no
+        # onboarding document, so no signature ceremony is ever created: onboarding silently could
+        # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+        # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+        # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+        # Original T1 rationale kept below for the record.
         # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
         # already runs the native image + tuned probes (startupProbe/readinessProbe
         # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0e323e28b70cef7b"
+        openbank.tech/policy-checksum: "480adbe253024c25"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -1212,7 +1212,19 @@ finops_tiers:
     # tuned probes ≤5s p95 (met on a small sample, ~4.4s avg/5.0s worst-of-3; probe
     # tuning alone cut ~28% off the untuned 3.5-8.8s, the residual ~4s floor is
     # Kubernetes control-plane + admission-webhook overhead, not the image).
-    openbank-product-catalog: T1
+    openbank-product-catalog: T0
+    # Reverted T1 -> T0 on 2026-07-17: the T1 measurement was real but measured the wrong
+    # path. Every number below was taken THROUGH the KEDA HTTP interceptor, which parks the
+    # first request while the pod scales 0->1. But product-catalog's actual onboarding-path
+    # callers — account-service (openAccount product validation, #668) and document-service
+    # (OnboardingDocumentService template-code resolution, ADR-0162 D7) — dial the ClusterIP
+    # directly, NOT the interceptor. At min:0 they got `Connection refused`, not a slow first
+    # click. document-service reads that as "product has no document template" and issues no
+    # onboarding document, so no signature ceremony is ever created: onboarding silently could
+    # not complete (registration still 201). Zero accounts completed onboarding 2026-06-24..
+    # 2026-07-17. The HTTPScaledObject is held at min:1; re-declare T1 only once every
+    # in-cluster caller goes through the interceptor AND the SLO is re-measured on that path.
+    # Original T1 rationale kept below for the record.
     # Declared 2026-07-07 (#253): the live sandbox Deployment (accounts namespace)
     # already runs the native image + tuned probes (startupProbe/readinessProbe
     # periodSeconds:1, failureThreshold:10). A 10-sample end-to-end scale-from-zero


### PR DESCRIPTION
## What this fixes

product-catalog scaled to zero under ADR-0083 T1, and it took **onboarding** down with it. No account completed onboarding in sandbox from **2026-06-24 to 2026-07-17**.

The T1 premise, verbatim from the manifest header:

> "It has no synchronous inbound callers from other services at runtime — the only callers are the admin-UI and the fees vertical, both of which can tolerate a first-request cold-start latency rather than a 5xx."

Both halves are false. Two services call product-catalog **synchronously on the onboarding path**, and neither goes through the KEDA HTTP interceptor — the only thing that can wake a scaled-to-zero pod. They dial the ClusterIP directly:

- `account-service` → `AccountService.openAccount`, product validation (#668)
- `document-service` → `OnboardingDocumentService.issueOnboardingDocument`, template-code resolution (ADR-0162 D7)

At `min:0` they got `Connection refused`, not a cold start.

## Why it stayed invisible for three weeks

The two callers fail in opposite directions:

- **account-service fails open** (reference data, not money path) — accounts still opened, product validation silently skipped. A `WARN`.
- **document-service** reads an unresolvable template code as *"this product has no document"* and issues none — logged at `INFO`. So no onboarding document, no signature ceremony, nothing to sign. Registration still returns `201`.

Nothing is red. The customer just never gets a document to sign.

## The T1 numbers measured the wrong path

Every scale-from-zero sample in `rules.yaml` was taken **through the interceptor**, which parks the first request. The in-cluster callers never touch it, so the measured ~5s cold start was latency the real callers never experience — they get a refused connection instead.

## Changes

- `product-catalog-http-scaledobject.yaml`: `replicas.min` 0 → 1; header rewritten to record the false premise. Kept (not deleted) so the scale-up path and ADR-0083 wiring survive — re-testing T1 is a one-line change once the callers are fixed.
- `rules.yaml`: `openbank-product-catalog` T1 → T0, original rationale kept for the record. finops-tier validator green.

Re-declare T1 only once every in-cluster caller reaches product-catalog through the interceptor **and** the SLO is re-measured on that path.

## Verified live

End-to-end registration through the live sandbox now opens CURRENT + SAVINGS (both ACTIVE) — the first accounts opened since 2026-06-24. Deploying this is the last step before an onboarding document is issued and the signature ceremony is created.

## Linked issues

Refs #1497
