### PR TITLE
docs(adr): correct ADR-0138 delivery note — phases 1b and 2 shipped, not pending

### DIFF
--- a/docs/adr/0138-configuration-driven-product-fee-rule-engine.md
+++ b/docs/adr/0138-configuration-driven-product-fee-rule-engine.md
@@ -2,12 +2,30 @@
 
 Date: 2026-06-29
 Decision-Status: Accepted   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
-Delivery-Status: Partial    <!-- Planned | Partial | Shipped | N/A — decision-only; phase 1a shipped, phases 1b/2/3 deferred -->
+Delivery-Status: Partial    <!-- Planned | Partial | Shipped | N/A — decision-only; phases 1a/1b shipped, phase 2 shipped under ADR-0143, phase 3 pending -->
 Author(s): Jiri Raska
 
-**Delivery note (updated 2026-06-30):**
-- **Phase 1a (parser/evaluator)** — ✅ Shipped: structured whitelisted predicate model (`WaiveConditionParser`/`WaiverEvaluator`) in `product-catalog` domain layer with tests.
-- **Phase 1b and Phase 2** — ⬜ Pending: promoting to `openbank-libs` (Phase 1b) and billing-service fee posting with four-eyes ledger verb (Phase 2) are phased; money-path posting deploy-gated.
+**Delivery note (updated 2026-07-17):**
+- **Phase 1a (parser/evaluator)** — ✅ Shipped: structured whitelisted predicate model
+  (`WaiveConditionParser`/`WaiverEvaluator`) with tests.
+- **Phase 1b (promote to `openbank-libs`; surface the rule on `/api/v1/fees`)** — ✅ Shipped: the
+  predicate model and evaluator are in `openbank-libs-domain`
+  (`com.openbank.libs.product.WaiveCondition` / `WaiverEvaluator`; ADR-0122 later moved
+  `openbank-libs` into the domain/runtime split). `product-catalog`'s `FeeRuleEvaluator` is now a
+  fee-typed adapter over the shared evaluator rather than a second copy, and `FeeScheduleItem`
+  carries `waiverEvaluable` + `waiverRule`, so `/api/v1/fees` exposes both the parsed rule and
+  whether it is machine-evaluable.
+- **Phase 2 (runtime fee posting)** — ✅ Shipped, under its own **ADR-0143** (runtime product fee
+  posting via a dedicated billing service): `openbank-billing-service` assesses fees per cycle and
+  books them through the ledger + outbox, four-eyes gated on `billing.post`, with the
+  `billing-fee-conservation` DST invariant and a threat model
+  (`docs/threat-models/openbank-billing-service.md`). ADR-0143 carries that work's delivery status —
+  real-environment e2e verification and the four-eyes enforcement flip are tracked there, not here.
+- **Phase 3 (interest + eligibility)** — ⬜ Pending, and the only phase of this ADR still open.
+  `Product.bonusRateCondition` remains free text (seeded `"No withdrawals in calendar month"`). It
+  does **not** fit the phase-1 grammar `<attribute-phrase> <op> <number> [currency]` — it is a
+  temporal/event predicate, not a comparison — so phase 3 has to extend the vocabulary, not merely
+  reuse the evaluator as this ADR's "Deferred" section assumed.
 
 ## Context
 
@@ -149,6 +167,9 @@ above are covered by the grammar and proven to parse in tests.
 
 - ADR-0002 — hexagonal architecture per service (domain has zero framework imports)
 - ADR-0013 / ADR-0014 / ADR-0049 — openbank-libs shared primitives (phase 1b target)
+- ADR-0122 — openbank-libs domain/runtime split (where the phase 1b evaluator lives today)
+- ADR-0143 — runtime product fee posting via a dedicated billing service (phase 2 was
+  delivered under that ADR; its delivery status is tracked there)
 - ADR-0033 / ADR-0038 — withholding tax: precedent for policy currently hard-coded
   in a service rather than driven by configuration
 - ADR-0048 — API contract version axis (relevant to the phase 1b `/api/v1/fees` change)


### PR DESCRIPTION
## What

Corrects [ADR-0138](docs/adr/0138-configuration-driven-product-fee-rule-engine.md)'s delivery note, which recorded phases 1b and 2 as ⬜ Pending after both had shipped.

## Why

The note is dated `updated 2026-06-30`. Phase 1b had merged the **day before** — `b3d62a676`, whose subject literally reads `(ADR-0138 phase 1b)`. On `origin/main` today both of 1b's declared deliverables exist (`WaiverEvaluator` in `openbank-libs-domain`; `waiverRule`/`waiverEvaluable` on `/api/v1/fees`), and phase 2 shipped under its own **ADR-0143** — which ADR-0138 never referenced, so phase 2 was unfindable from 0138.

A stale "pending" on a differentiator ADR invites duplicate work; the repo has paid that cost before (#944 → #950).

## Changes

- Rewrite the delivery note: 1a/1b ✅, phase 2 ✅ under ADR-0143 (with pointer + threat-model reference), phase 3 marked the only open phase.
- Add ADR-0122 and ADR-0143 to References.

Phase 3's premise re-verified against code: `Product.bonusRateCondition` is still free text and does not fit the phase-1 comparison grammar (it is temporal), so phase 3 extends the vocabulary rather than reusing the evaluator.

## Scope

Doc-only. No shipped code changes; `docs` type does not trigger a release. `gen-index.sh` re-run — the ADR index (`README.md`) is byte-unchanged (Delivery-Status stays `Partial`).

## Linked issues

Closes #1507