### PR TITLE
fix(product-catalog): bind the account-contract template to the CZK onboarding products

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/ProductSeed.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/ProductSeed.kt
@@ -791,6 +791,13 @@ object ProductSeed {
                     url = "https://openbank.example/tac/savings-czk/v1.1",
                     effectiveFrom = LocalDate.of(2024, 12, 1),
                     language = "cs",
+                    // ADR-0162 D1: bind the account contract by CODE (current PUBLISHED version
+                    // resolved at render time), mirroring CURRENT_PERSONAL. Without this,
+                    // OnboardingDocumentService.issueOnboardingDocument finds no template for the
+                    // onboarding product and issues no account-contract document — the eager
+                    // account.created path no-ops. This is the retail CZK onboarding product
+                    // (id ...c3), so the omission meant every onboarding skipped it.
+                    documentTemplateCode = "UCET_SMLOUVA_CS",
                 ),
             ),
             versionHistory = listOf(
@@ -1099,6 +1106,13 @@ object ProductSeed {
                     effectiveFrom = LocalDate.of(2025, 1, 1),
                     language = "cs",
                     summary = "Korunový běžný účet — obchodní podmínky v1.0",
+                    // ADR-0162 D1: bind the account contract by CODE (current PUBLISHED version
+                    // resolved at render time), mirroring CURRENT_PERSONAL. Without this,
+                    // OnboardingDocumentService.issueOnboardingDocument finds no template for the
+                    // onboarding product and issues no account-contract document. This is THE
+                    // retail CZK onboarding current account (id ...c2), so the omission meant the
+                    // eager account.created path no-op'd for every new customer.
+                    documentTemplateCode = "UCET_SMLOUVA_CS",
                 ),
             ),
             versionHistory = listOf(

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/domain/OnboardingProductTemplateBindingTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/domain/OnboardingProductTemplateBindingTest.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.productcatalog.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the onboarding products' account-contract binding. CURRENT_CZK (id ...c2) and SAVINGS_CZK
+ * (id ...c3) are what account-service opens for every self-service onboarding
+ * (openbank.account.onboarding.default-product-id / savings-product-id). document-service's
+ * eager OnboardingDocumentService.issueOnboardingDocument resolves the account-contract template
+ * off the product's documentTemplateCode; when it was absent the whole eager path silently
+ * no-op'd for every new customer (no account-contract document, only an INFO log). This test
+ * makes that omission a failing build, not a live discovery.
+ */
+class OnboardingProductTemplateBindingTest {
+
+    @Test
+    fun `the CZK onboarding products bind an account-contract document template`() {
+        for (code in listOf("CURRENT_CZK", "SAVINGS_CZK")) {
+            val product = ProductSeed.products.single { it.code == code }
+            val bound = product.termsAndConditions.mapNotNull { it.documentTemplateCode }
+            assertThat(bound)
+                .describedAs("%s must bind a documentTemplateCode so onboarding can issue its contract", code)
+                .contains("UCET_SMLOUVA_CS")
+        }
+    }
+}


### PR DESCRIPTION
## What

`CURRENT_CZK` (id `...c2`) and `SAVINGS_CZK` (id `...c3`) — the products account-service opens for every self-service onboarding — carried no `documentTemplateCode`, while the non-onboarding `CURRENT_PERSONAL` did. So document-service's eager `OnboardingDocumentService.issueOnboardingDocument` found no template off `account.created` and issued no account-contract document, logging it at INFO:

```
Product 00000000-0000-0000-0000-0000000000c2 has no documentTemplateCode bound — no onboarding document to issue
```

The eager path silently no-op'd for every new customer.

## Fix

Bind both to `UCET_SMLOUVA_CS` by CODE (current PUBLISHED version resolved at render time, ADR-0162 D1), mirroring `CURRENT_PERSONAL`. The framework-agreement path (`ensureOnboardingAgreement` → `RAMCOVA_SMLOUVA`, per-party, on demand — what the app SIGN screen drives) is a different document with a different key and is unaffected.

`OnboardingProductTemplateBindingTest` pins the binding so this omission is a failing build, not a live discovery. test + detekt + ktlint green.

## Deploy note

`ProductCatalogSeeder` seeds **only an empty store** and never overwrites operator edits, so this corrects fresh deploys. The already-seeded sandbox rows need a one-off DB patch, applied separately after this merges.

## Linked issues

Refs #1497