### PR TITLE
docs(adr): correct stale Delivery-Status on 5 shipped ADRs (0124/0161/0162/0169/0176)

### DIFF
--- a/docs/adr/0124-oss-readiness-and-public-launch-hardening.md
+++ b/docs/adr/0124-oss-readiness-and-public-launch-hardening.md
@@ -2,15 +2,18 @@
 
 Date: 2026-06-27
 Status: Accepted
-Delivery-Status: Planned
+Decision-Status: Accepted
+Delivery-Status: Partial
 
-**Delivery note (updated 2026-06-30):**
-Engineering practice is production-quality (hexagonal arch, CI gates, threat models, release-please,
-signed commits). Pre-cutover work done: CI artifact tracking cleaned (A1), PII filter applied (A3),
-SECURITY.md + GOVERNANCE.md + ARCHITECTURE.md + CONTRIBUTING.md + onboarding docs live. Blocking
-cutover work not yet started: git filter-repo history rewrite (A2, ~190 MB CI artifacts), GitHub
-Dependabot/CodeQL/secret-scanning enablement (B), OSS discoverability metadata + Discussions (C),
-OpenSSF Scorecard wiring (D1-D4). Move to Planned until cutover window is scheduled.
+**Delivery note (updated 2026-07-17):** the go-public cutover executed; a governance-enforcement tail remains.
+The repo is public (topics, homepage, Discussions), history is clean of the ~190 MB CI artifacts (A1/A2), and
+GitHub-native security is fully on (secret scanning + push protection + Dependabot + CodeQL, B). Also shipped:
+community-health docs, discoverability (C), post-build image scan (D1), coverage ratchet (D2), OpenSSF Scorecard
+workflow + README badge (D3), Dependabot auto-merge (D4), README slim + `docs/ARCHITECTURE.md` (G), and an honest
+single-maintainer `GOVERNANCE.md` (F). Remaining: **E1** — 2 of 4 advisory rules (db-migration, pitest) are still
+advisory behind their ADR-0144 deadlines; **E2** — a parseable-ADR-status CI check (this ADR is itself being
+migrated to the two-axis `Decision-Status`/`Delivery-Status` header as part of that). Partial, not Planned (the
+cutover happened) and not Shipped (E1/E2 open).
 Author(s): @JiRaska
 
 ## Context

--- a/docs/adr/0161-object-storage-standard-for-application-documents.md
+++ b/docs/adr/0161-object-storage-standard-for-application-documents.md
@@ -1,9 +1,20 @@
 # ADR-0161 — Object-storage standard for application binary artifacts
 
 Date: 2026-07-13
-Decision-Status: Proposed
-Delivery-Status: Planned
+Decision-Status: Accepted
+Delivery-Status: Partial
 Author(s): jiri.raska
+
+**Delivery note (updated 2026-07-17):** D1 + D2 shipped, D3 pending.
+- **D1 (`ObjectStorePort` in domain libs)** — ✅ Shipped: `openbank-libs-domain/.../storage/ObjectStorePort.kt`
+  (framework-free `put`/`get`/`exists`/`presignGet`, service-namespaced keys).
+- **D2 (S3 + Postgres adapters behind one config key)** — ✅ Shipped: `S3ObjectStore` + `PostgresBlobStore`
+  in `openbank-libs-runtime` (AWS SDK v2 in the version catalog); the Postgres backend is consumed by
+  `openbank-document-service`'s `V4__add_object_store_blobs.sql`. Caveat: the S3 adapter applies SSE-AES256
+  and defers SSE-KMS + Object-Lock WORM to the D3 bucket.
+- **D3 (reusable Terraform documents bucket, WORM by default)** — ⬜ Pending: no `openbank-documents-<env>`
+  bucket or reusable module exists; document-service gitops notes the real S3 adapter is "deliberately NOT
+  wired here". Until D3 ships, the SSE-KMS / WORM-at-rest guarantee D2 defers to it is unrealized.
 
 ## Context
 

--- a/docs/adr/0162-document-management-templating-and-e-signature-architecture.md
+++ b/docs/adr/0162-document-management-templating-and-e-signature-architecture.md
@@ -1,9 +1,28 @@
 # ADR-0162 — Document management, templating & e-signature architecture
 
 Date: 2026-07-13
-Decision-Status: Proposed
-Delivery-Status: Planned
+Decision-Status: Accepted
+Delivery-Status: Partial
 Author(s): jiri.raska
+
+**Delivery note (updated 2026-07-17):** D1–D5 + D7 shipped; D6 partial; D4 phase-2 deferred by this ADR.
+- **D1 (`openbank-document-service` bounded context)** — ✅ Shipped: released 0.8.4, gitops + threat model;
+  product-catalog `Product.documentTemplateCode`.
+- **D2 (versioned templating)** — ✅ Shipped: `HandlebarsTemplateRenderer` + one-published-per-code partial
+  unique index (`V5`), atomic `publishReplacing`.
+- **D3 (HTML→PDF)** — ✅ Shipped: `openbank-document-renderer` WeasyPrint sidecar (default leg). Gotenberg/Typst
+  opt-in adapters are ADR-framed future, not built.
+- **D4 (signature ceremony + seal)** — ✅ Shipped (phase-1): `SignatureCeremonyService`, PAdES-B via
+  `PdfBoxPadesSealAdapter` (PDFBox + BouncyCastle), two-tier signing via OpenBao PKI. Phase-2 (QES/QSeal, EU DSS
+  PAdES-LTA, HSM) deliberately deferred — no DSS dep, `QUALIFIED` unused. Deviation: orchestrated via
+  transactional outbox, not Temporal as the D4 prose sketched.
+- **D5 (WORM store + metadata index)** — ✅ Shipped: via ADR-0161 `ObjectStorePort`; `governance.yaml`
+  restricted / 10-year retention / single-tenant.
+- **D6 (admin template management)** — ⬜ Partial: `/document-templates` route + RBAC shipped; the graphical
+  WYSIWYG editor (GrapesJS/TipTap) is a textarea (deferred in-code) and the ADR-0155 four-eyes maker-checker
+  for PUBLISH of a money-path template is absent.
+- **D7 (onboarding wiring)** — ✅ Shipped: `AccountCreatedConsumer` + `OnboardingDocumentService`, idempotent
+  (`V6__onboarding_idempotency`).
 
 ## Context
 

--- a/docs/adr/0169-customer-document-access-and-sca-bound-signing.md
+++ b/docs/adr/0169-customer-document-access-and-sca-bound-signing.md
@@ -1,9 +1,22 @@
 # ADR-0169 — Customer document access & SCA-bound signing over customer-edge
 
 Date: 2026-07-15
-Decision-Status: Proposed
-Delivery-Status: Planned
+Decision-Status: Accepted
+Delivery-Status: Shipped
 Author(s): jiri.raska
+
+**Delivery note (updated 2026-07-17):** all four decisions shipped.
+- **D1 (customer-edge document/signature routes)** — ✅ Shipped: `CustomerDocumentResource` (ROLE_CUSTOMER,
+  token-forced partyRef, IDOR-scoped). One convenience route from the D1 table — `GET /documents` (list) — is
+  not implemented; the onboarding sign flow works without it.
+- **D2 (document-bound SCA / dynamic linking)** — ✅ Shipped: sca `V6__document_signing_binding`,
+  `ScaPurpose.DOCUMENT_SIGNING`, mismatch → 409; `SignatureCeremonyService` passes the real `document.sha256`
+  + `ceremonyId` end-to-end (not a stub).
+- **D3 (language-correct idempotent onboarding agreement)** — ✅ Shipped: `OnboardingDocumentService`
+  `ensureOnboardingAgreement` (4-branch spec), document-service `V6__onboarding_idempotency`.
+- **D4 (sign-what-you-saw: the sealed PDF is the served one)** — ✅ Shipped (backend obligation):
+  content-addressed `GET /documents/{id}/content` + D2's hash binding. The app-side "don't re-render" rule is
+  ADR-0170 (separate repo), out of this ADR's scope.
 
 ## Context
 

--- a/docs/adr/0176-operator-initiated-customer-messaging.md
+++ b/docs/adr/0176-operator-initiated-customer-messaging.md
@@ -1,8 +1,8 @@
 # ADR-0176 — Operator-initiated customer messaging
 
 Date: 2026-07-16
-Decision-Status: Proposed
-Delivery-Status: Planned
+Decision-Status: Accepted
+Delivery-Status: Partial
 Author(s): jiri.raska
 
 **Correction note (2026-07-16, issue #1331).** The first version of this ADR shipped with a false
@@ -13,6 +13,25 @@ fact. Force 3, D6 and D1 are rewritten below; the false rejection of an alternat
 compliance citations are downgraded to unverified. **What is corrected is recorded, not
 overwritten** — the errors are as instructive as the decisions, and an ADR that quietly rewrites its
 own reasoning teaches nothing.
+
+**Delivery note (updated 2026-07-17):** D1/D4/D5/D7 shipped; D2 partial; D3/D6 pending.
+- **D1 (closed template variable schema)** — ✅ Shipped: `NotificationTemplate` closed schema, exhaustive
+  `renderTemplate` (no `else`), undeclared-key rejection.
+- **D2 (operator compose + approval)** — ⬜ Partial: the backend is real — `OperatorMessageService`/
+  `OperatorMessageResource` (`POST /api/v1/notifications/messages`), `OperatorMessageTemplate` catalogue, no
+  free-text body. But the admin-ui compose UI (`opsMessageApi`) targets a non-existent `/opsmessages` contract
+  (wrong paths, template `OPERATOR_ACCOUNT_NOTICE`, extra `purpose` field) and 404s through the pass-through
+  BFF — an operator cannot yet compose from the console. Tracked as a bug separately.
+- **D3 (push wake-signal)** — ⬜ Pending: `sendPush` still ships full rendered content; operator PUSH is
+  refused (EMAIL-only), blocked on #1182. Deferred to `openbank-app`.
+- **D4 (`opsmessage.*` authz namespace)** — ✅ Shipped: `opsmessage.compose` / `opsmessage.approval.decide`;
+  `rest.rego` excludes service-accounts and the edge; pinned in `rest_test.rego`.
+- **D5 (four-eyes on compose)** — ✅ Shipped: `rules.yaml four_eyes.actions=[opsmessage.compose]`,
+  `RedisApprovalStore`, `ApprovalResource` with self-approval guard.
+- **D6 (purpose / lawful-basis binding + marketing hard-deny)** — ⬜ Pending: no purpose field; marketing is
+  only implicitly excluded (no template), with no API hard-deny. Blocked on the #1331 consent-authority decision.
+- **D7 (per-customer message history)** — ✅ Shipped: admin-ui `MessagesTab`, metadata-only,
+  `notifications:view` gate.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -132,7 +132,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0121](0121-service-self-reported-sbom-and-supply-chain-attestation.md) | Service self-reported SBOM and supply-chain attestation | Accepted | Partial | — |
 | [0122](0122-split-openbank-libs-into-domain-and-runtime.md) | Split openbank-libs into domain and runtime modules | Accepted | Partial | — |
 | [0123](0123-relicense-to-apache-2.0.md) | Relicense the platform from MPL-2.0 to Apache-2.0 | Accepted | Shipped | — |
-| [0124](0124-oss-readiness-and-public-launch-hardening.md) | OSS-readiness and public-launch hardening | Accepted | Planned | — |
+| [0124](0124-oss-readiness-and-public-launch-hardening.md) | OSS-readiness and public-launch hardening | Accepted | Partial | — |
 | [0125](0125-same-account-currency-exchange.md) | Same-account currency exchange (the app's currency swap) | Superseded by ADR-0110 | Superseded | — |
 | [0126](0126-unified-consent-lifecycle.md) | Unified Consent Lifecycle and GDPR Linkage | Accepted | Partial | — |
 | [0132](0132-customer-edge-per-party-rate-limiting.md) | Per-party request rate limiting at the customer edge | Accepted | Shipped | — |
@@ -163,22 +163,22 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0158](0158-account-opening-validates-against-product-catalog.md) | Account opening validates against product-catalog | Accepted | Complete | — |
 | [0159](0159-cnpg-ha-money-path.md) | High-availability CNPG for money-path databases | Accepted | Shipped | — |
 | [0160](0160-end-to-end-integration-liveness-and-drift-detection-standard.md) | End-to-end integration liveness and drift-detection standard | Accepted | Partial | — |
-| [0161](0161-object-storage-standard-for-application-documents.md) | Object-storage standard for application binary artifacts | Proposed | Planned | — |
-| [0162](0162-document-management-templating-and-e-signature-architecture.md) | Document management, templating & e-signature architecture | Proposed | Planned | — |
+| [0161](0161-object-storage-standard-for-application-documents.md) | Object-storage standard for application binary artifacts | Accepted | Partial | — |
+| [0162](0162-document-management-templating-and-e-signature-architecture.md) | Document management, templating & e-signature architecture | Accepted | Partial | — |
 | [0163](0163-control-liveness-sentinel-ai-agent.md) | Control-liveness-sentinel AI agent | Accepted | Partial | — |
 | [0164](0164-governance-auditor-ai-agent.md) | Governance-auditor AI agent | Accepted | Partial | — |
 | [0165](0165-release-steward-ai-agent.md) | Release-steward AI agent | Accepted | Partial | — |
 | [0166](0166-docs-truth-agent-ai-agent.md) | docs-truth-agent AI agent | Accepted | Partial | — |
 | [0167](0167-authz-policy-auditor-ai-agent.md) | authz-policy-auditor AI agent | Accepted | Partial | — |
 | [0168](0168-flaky-test-hunter-ai-agent.md) | flaky-test-hunter AI agent | Accepted | Partial | — |
-| [0169](0169-customer-document-access-and-sca-bound-signing.md) | Customer document access & SCA-bound signing over customer-edge | Proposed | Planned | — |
+| [0169](0169-customer-document-access-and-sca-bound-signing.md) | Customer document access & SCA-bound signing over customer-edge | Accepted | Shipped | — |
 | [0170](0170-onboarding-e-signature-flow-in-the-customer-app.md) | Onboarding e-signature flow in the customer app | Proposed | Planned | — |
 | [0171](0171-verification-of-payee-for-outbound-credit-transfers.md) | Verification of Payee for outbound credit transfers | Accepted | Partial | — |
 | [0172](0172-cryptographic-key-management-and-lifecycle.md) | Cryptographic key management and lifecycle | Accepted | Partial | — |
 | [0173](0173-capacity-management-and-headroom.md) | Capacity management and headroom | Accepted | Partial | — |
 | [0174](0174-ict-third-party-dependencies-and-exit-strategy.md) | ICT third-party dependencies and exit strategy | Accepted | Partial | — |
 | [0175](0175-data-residency-and-sovereignty.md) | Data residency and sovereignty | Accepted | Partial | — |
-| [0176](0176-operator-initiated-customer-messaging.md) | Operator-initiated customer messaging | Proposed | Planned | — |
+| [0176](0176-operator-initiated-customer-messaging.md) | Operator-initiated customer messaging | Accepted | Partial | — |
 
 ---
 


### PR DESCRIPTION
## What

Corrects the `Decision-Status`/`Delivery-Status` on the 5 Tier-1 ADRs from #1521 whose code has shipped but whose headers still read `Proposed`/`Planned`.

## The key finding: this is NOT five clean "Shipped"

Each ADR was verified per-decision-point against `origin/main` before editing (a raw grep would have set all five to `Shipped` and created 4 new *overstate* drifts). Only one is fully shipped:

| ADR | new status | why not Shipped |
|----:|-----------|-----------------|
| **0169** | Accepted / **Shipped** | D1–D4 all merged; only a non-critical `GET /documents` list route missing |
| **0161** | Accepted / **Partial** | D1/D2 shipped; **D3** (Terraform documents bucket, WORM) never built — SSE-KMS/WORM-at-rest unrealized |
| **0162** | Accepted / **Partial** | document-service D1–D5/D7 shipped; **D6** WYSIWYG editor + four-eyes maker-checker absent; D4 phase-2 QES/HSM deferred by the ADR |
| **0176** | Accepted / **Partial** | D1/D4/D5/D7 shipped; **D2** admin-ui compose UI 404s a non-existent `/opsmessages` contract; D3/D6 pending |
| **0124** | Accepted / **Partial** | go-public cutover executed (public repo, clean history, native security, Scorecard/CodeQL); **E1/E2** governance tail open |

Each ADR now carries a per-D delivery note stating exactly what shipped and what remains. 0124 also gains the two-axis `Decision-Status` header (its own E2 item).

## Scope

Doc-only. `docs/adr/README.md` regenerated (`gen-index.sh`, deterministic, verified). No shipped code changes; `docs` type does not release.

## Spun off, not in this PR

Verifying 0176 surfaced a **real bug** (not a docs issue): the admin-ui operator-compose UI is wired to a fictitious `/opsmessages` API and 404s against the real `POST /api/v1/notifications/messages` backend — an operator cannot compose from the console. Flagged separately.

## Linked issues

Refs #1521