### PR TITLE
feat(notification): wire APNs push adapter for sandbox TestFlight delivery

### DIFF
--- a/openbank-infra/gitops/components/notifications/apns-externalsecret.yaml
+++ b/openbank-infra/gitops/components/notifications/apns-externalsecret.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+#
+# APNs signing credentials for notification-service PUSH delivery (ApnsPushSender),
+# projected from Vault by the External Secrets Operator (ClusterSecretStore
+# `vault-kv`) into the in-namespace Secret `notification-service-apns`.
+#
+# The .p8 EC private key (APNS_PRIVATE_KEY) is the sensitive asset — anyone holding
+# it can mint provider JWTs for the Apple Developer team. It lives ONLY in Vault,
+# never in Git or the Deployment manifest; only this reference does. Same shape as
+# webhook-externalsecret.yaml.
+#
+# Until an operator writes the Vault keys the ExternalSecret stays pending and the
+# Secret is absent — which is fine: the Deployment's secretKeyRefs are `optional:true`,
+# so the pod starts and ApnsPushSender returns a per-send CONFIG failure (it never
+# crashes the service; it is @ApplicationScoped and validates on send, not boot).
+# To enable delivery: write the three Vault keys, then restart notification-service
+# so the secret env is re-read.
+#
+#   bao kv patch openbank/notification-service \
+#     APNS_KEY_ID=<10-char Key ID> \
+#     APNS_TEAM_ID=<10-char Apple Team ID> \
+#     APNS_PRIVATE_KEY=@AuthKey_XXXXXXXXXX.p8
+#
+# APNS_SANDBOX / APNS_ENABLED / APNS_BUNDLE_ID are non-secret and set inline in the
+# Deployment env (sandbox=false: TestFlight/App Store use the Release config, which
+# signs aps-environment=production, so tokens are on the APNs production gateway).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: notification-service-apns
+  namespace: notifications
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: notification-service-apns
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: APNS_KEY_ID
+      remoteRef:
+        key: notification-service
+        property: APNS_KEY_ID
+    - secretKey: APNS_TEAM_ID
+      remoteRef:
+        key: notification-service
+        property: APNS_TEAM_ID
+    - secretKey: APNS_PRIVATE_KEY
+      remoteRef:
+        key: notification-service
+        property: APNS_PRIVATE_KEY

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -130,6 +130,44 @@ spec:
                   name: notification-webhook
                   key: SLACK_WEBHOOK_URL
                   optional: true
+            # PUSH delivery via APNs (ApnsPushSender). Adapter ON for the TestFlight
+            # pilot. sandbox=FALSE → api.push.apple.com: TestFlight and App Store builds
+            # use the Release config, which signs aps-environment=production (see
+            # openbank-app iosApp/project.yml), so their device tokens belong to the APNs
+            # PRODUCTION gateway. Only a local Xcode Debug build (aps-environment=
+            # development) would register on the sandbox host. The signing key (.p8), Key
+            # ID and Team ID come from Vault via apns-externalsecret.yaml; the secretKeyRefs
+            # are optional:true so a not-yet-seeded Vault leaves the pod healthy —
+            # ApnsPushSender is @ApplicationScoped and returns a per-send CONFIG failure,
+            # never a boot crash. bundle-id must equal the app's bundle identifier.
+            - name: APNS_ENABLED
+              value: "true"
+            - name: APNS_SANDBOX
+              value: "false"
+            # Must equal the app's bundle identifier (openbank-app project.yml:
+            # PRODUCT_BUNDLE_IDENTIFIER=tech.openbank.app) — it becomes the apns-topic
+            # header. NOT the ApnsPushSender default cz.openbank.app, which is wrong for
+            # this app and would be rejected BadTopic.
+            - name: APNS_BUNDLE_ID
+              value: tech.openbank.app
+            - name: APNS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-apns
+                  key: APNS_KEY_ID
+                  optional: true
+            - name: APNS_TEAM_ID
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-apns
+                  key: APNS_TEAM_ID
+                  optional: true
+            - name: APNS_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: notification-service-apns
+                  key: APNS_PRIVATE_KEY
+                  optional: true
             # Dotted-key YAML config bug workaround (issue #686): load the
             # notification-events-in / party-events-in group.id and auto.offset.reset
             # override (notification-service-msg-override ConfigMap, mounted below) as

--- a/openbank-infra/scripts/seed-notification-apns.sh
+++ b/openbank-infra/scripts/seed-notification-apns.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Uloží APNs Auth Key (.p8) + Key ID + Team ID do OpenBao KV openbank/notification-service
+# a vynutí refresh ExternalSecretu notifications/notification-service-apns (apns-externalsecret.yaml).
+#
+# `kv patch` = MERGE: zachová stávající SLACK_WEBHOOK_URL, nepřepíše ho (na rozdíl od `kv put`).
+#
+# Spuštění — nic dalšího netřeba, vše se dopočítá:
+#   ./openbank-infra/scripts/seed-notification-apns.sh
+#
+#   Token:   po řadě $VAULT_TOKEN → $BAO_TOKEN → $RT (operator token s write na openbank/*,
+#            stejný fallback jako seed-control-liveness-sentinel-secrets.sh)
+#   .p8:     nejnovější ~/Downloads/AuthKey_*.p8            (override: APNS_P8=/cesta/AuthKey_XXX.p8)
+#   Key ID:  z názvu souboru AuthKey_<KeyID>.p8             (override: APNS_KEY_ID=<10 znaků>)
+#   Team ID: DEV_TEAM_ID z openbank-app iosApp/fastlane/.env (override: APNS_TEAM_ID=<10 znaků>)
+#
+# Vyžaduje kubectl nakonfigurovaný na sandbox cluster.
+#
+# APNS_SANDBOX (produkce vs sandbox host) NENÍ v tomto klíči — je to non-secret env v
+# notification-service.yaml. Klíč "OpenBank APNs" je registrovaný jako Sandbox & Production,
+# takže funguje na oba hosty; správný host se ověří testem po seedu.
+set -euo pipefail
+
+# --- operator token: env fallback + interaktivní prompt (jako seed-control-liveness-sentinel-secrets.sh) ---
+prompt_secret() { # var_name prompt_text
+  local __var="$1" __prompt="$2" __val
+  if [[ -n "${!__var:-}" ]]; then return; fi
+  read -r -s -p "$__prompt: " __val
+  echo >&2
+  printf -v "$__var" '%s' "$__val"
+}
+if [[ -z "${VAULT_TOKEN:-}" ]]; then
+  if [[ -n "${BAO_TOKEN:-}" ]]; then VAULT_TOKEN="$BAO_TOKEN"
+  elif [[ -n "${RT:-}" ]]; then VAULT_TOKEN="$RT"; fi
+fi
+prompt_secret VAULT_TOKEN "OpenBao operator token — nenalezen v \$VAULT_TOKEN/\$BAO_TOKEN/\$RT, vlož ho"
+[[ -n "${VAULT_TOKEN:-}" ]] || { echo "ERR: prázdný operator token" >&2; exit 1; }
+
+# --- .p8 soubor ---
+# shellcheck disable=SC2012  # AuthKey_<10 alnum>.p8 filenames — no spaces/newlines; ls -t = newest by mtime
+P8="${APNS_P8:-$(ls -t "$HOME"/Downloads/AuthKey_*.p8 2>/dev/null | head -1 || true)}"
+[[ -n "$P8" && -f "$P8" ]] || { echo "ERR: .p8 nenalezen v ~/Downloads. Nastav APNS_P8=/cesta/AuthKey_XXX.p8" >&2; exit 1; }
+grep -q "BEGIN PRIVATE KEY" "$P8" || { echo "ERR: $P8 nevypadá jako PKCS#8 .p8 (chybí -----BEGIN PRIVATE KEY-----)" >&2; exit 1; }
+
+# --- Key ID z názvu AuthKey_<KeyID>.p8 ---
+KEY_ID="${APNS_KEY_ID:-$(basename "$P8" | sed -n -E 's/^AuthKey_([A-Z0-9]{10})\.p8$/\1/p')}"
+[[ "$KEY_ID" =~ ^[A-Z0-9]{10}$ ]] || { echo "ERR: Key ID nejde odvodit z názvu ($P8). Nastav APNS_KEY_ID=<10 znaků>" >&2; exit 1; }
+
+# --- Team ID z fastlane .env (DEV_TEAM_ID) ---
+ENV_FILE="${APNS_ENV_FILE:-$HOME/Downloads/openbank-app/iosApp/fastlane/.env}"
+TEAM_ID="${APNS_TEAM_ID:-$(sed -n -E 's/^(export[[:space:]]+)?DEV_TEAM_ID=["'\'']?([A-Z0-9]{10}).*/\2/p' "$ENV_FILE" 2>/dev/null | head -1)}"
+[[ "$TEAM_ID" =~ ^[A-Z0-9]{10}$ ]] || { echo "ERR: Team ID nejde načíst z $ENV_FILE. Nastav APNS_TEAM_ID=<10 znaků>" >&2; exit 1; }
+
+# --- base64 celého .p8 (ApnsPushSender.parseKey base64-dekóduje hodnotu bez 'BEGIN') ---
+P8_B64="$(base64 < "$P8" | tr -d '\n')"
+
+echo "APNs seed → openbank/notification-service"
+echo "  .p8:     $P8"
+echo "  Key ID:  $KEY_ID"
+echo "  Team ID: $TEAM_ID"
+echo
+
+echo "[1/3] vault kv patch (merge — zachová SLACK_WEBHOOK_URL)..."
+kubectl -n vault exec -i openbao-0 -- \
+  env VAULT_TOKEN="$VAULT_TOKEN" VAULT_ADDR=http://127.0.0.1:8200 \
+  vault kv patch openbank/notification-service \
+    APNS_KEY_ID="$KEY_ID" APNS_TEAM_ID="$TEAM_ID" APNS_PRIVATE_KEY="$P8_B64" >/dev/null
+echo "      OK"
+
+echo "[2/3] ověřuji klíče v KV (jen názvy, ne hodnoty)..."
+kubectl -n vault exec -i openbao-0 -- \
+  env VAULT_TOKEN="$VAULT_TOKEN" VAULT_ADDR=http://127.0.0.1:8200 \
+  vault kv get -format=json openbank/notification-service \
+  | grep -oE '"(APNS_KEY_ID|APNS_TEAM_ID|APNS_PRIVATE_KEY|SLACK_WEBHOOK_URL)"' | sort -u | sed 's/^/      /'
+
+echo "[3/3] force-refresh ExternalSecret (no-op dokud není smergovaný PR #1528)..."
+if kubectl -n notifications annotate externalsecret notification-service-apns \
+     force-sync="$(date +%s)" --overwrite >/dev/null 2>&1; then
+  echo "      refreshed"
+else
+  echo "      (ExternalSecret notification-service-apns zatím neexistuje — vznikne po merge #1528)"
+fi
+
+echo
+echo "Hotovo. Vault má APNs creds. Další krok (Claude): merge #1528 → restart notification-service → test hostů → push."


### PR DESCRIPTION
## What

Enables real APNs push delivery from `notification-service` in the sandbox cluster. Until now the PUSH channel fanned out to device tokens but `ApnsPushSender` was OFF by default — every PUSH was written `SENT` while the adapter returned `skipped()` and **nothing egressed**. No APNs credentials, ExternalSecret or wiring existed.

## Changes

- **`apns-externalsecret.yaml`** (new): projects `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_PRIVATE_KEY` from Vault (`openbank/notification-service`) via ClusterSecretStore `vault-kv` into Secret `notification-service-apns`. Same shape as `webhook-externalsecret.yaml`. The `.p8` lives **only in Vault**, never in Git.
- **`notification-service.yaml`**: `APNS_ENABLED=true`; the three credential envs are `secretKeyRef` **optional:true** (a not-yet-seeded Vault leaves the pod healthy — `ApnsPushSender` is `@ApplicationScoped`, validates on send, returns a per-send `CONFIG` failure, never a boot crash). Two non-secret values matched to the openbank-app iOS project (verified against `iosApp/project.yml`):
  - `APNS_SANDBOX=false` — TestFlight/App Store use the **Release** config → `aps-environment=production` → tokens on the APNs **production** gateway (`api.push.apple.com`). Only local Xcode Debug builds are sandbox.
  - `APNS_BUNDLE_ID=tech.openbank.app` — must equal `PRODUCT_BUNDLE_IDENTIFIER` (the `apns-topic`). Overrides the wrong `ApnsPushSender` default `cz.openbank.app`.

## Rollout order (important)

The signing key is **not yet in Vault**. Before/at merge, an operator seeds it (the `.p8` is created by hand in the Apple Developer portal — Apple exposes no API for APNs key creation):

```
bao kv patch openbank/notification-service \
  APNS_KEY_ID=<10-char Key ID> \
  APNS_TEAM_ID=<DEV_TEAM_ID> \
  APNS_PRIVATE_KEY=@AuthKey_XXXXXXXXXX.p8
```

Then ArgoCD sync rolls the pod with the creds and PUSH delivery goes live. If merged before seeding, the pod stays healthy and pushes fail `CONFIG` until the keys land + a restart.

## Notes

- Egress: the NetworkPolicy is ingress-only and `allow-internet-egress` is already set (Slack webhook), so `:443` to Apple is permitted.
- No release: files are under `openbank-infra/`, not the service dir, so release-please does not cut a notification-service version.
- Follow-up worth filing: fix the `ApnsPushSender` default `bundle-id` (`cz.openbank.app` → `tech.openbank.app`) so an unconfigured deploy isn't silently BadTopic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues
Refs #1548
