### PR TITLE
docs(adr): correct ADR-0126 D2/D3 — mismarked Shipped, actually Partial

### DIFF
--- a/docs/adr/0126-unified-consent-lifecycle.md
+++ b/docs/adr/0126-unified-consent-lifecycle.md
@@ -10,6 +10,15 @@
 | Supersedes       | —                              |
 | Superseded by    | —                              |
 
+**Delivery note (updated 2026-07-17):** the header `Partial` is accurate, but two decision points below
+were mismarked "Shipped". D1, D4, D5 shipped — D5 in particular is real: consent-service runs live at
+`AUTHZ_ENFORCE=true` (`openbank-infra/gitops/components/consent/consent-service.yaml`). **D2 and D3 are
+Partial:** D2's `/validate` response omits the promised `scope`/`grantedAccounts`/`frequencyPerDay`
+(returns only `{valid, reason, code}`); D3's revoke/reject publishes via a direct Kafka emitter, **not**
+the transactional outbox this ADR's D3 text promises — a dual-write with no atomic guarantee on a
+money-path revoke. (Aside: ADR-0034's "consent still advisory, pending #266" line is itself stale —
+OPA enforcement is live here.)
+
 ## Context
 
 OpenBank handles three overlapping consent regimes that previously lacked a unified ADR:
@@ -61,13 +70,17 @@ The `Consent` aggregate root enforces these caps in its `init` block.
 
 `POST /api/v1/consents` creates a `PENDING_SCA` record. The TPP (or bank agent) then drives SCA via `openbank-sca-service`; `POST /api/v1/consents/{id}/activate` completes the binding after SCA succeeds. SCA session ID is stored on the consent for non-repudiation.
 
-### D2 — Consent validation by resource servers (Shipped)
+### D2 — Consent validation by resource servers (Partial)
 
 `POST /api/v1/consents/{id}/validate` is the machine-to-machine gate called by `account-service`, `balance-service`, `transaction-service` etc. before returning data. Response: `{valid: true/false}` with `scope`, `grantedAccounts`, `frequencyPerDay`. No PII in the response.
 
-### D3 — Revocation propagation (Shipped)
+> **Delivery reality (2026-07-17):** the endpoint and its checks (grantee match, `isActive`, `hasScope`, `coversAccount`) are live, but the response DTO is `ConsentValidationResponse(valid, reason, code)` — it does **not** yet carry `scope`/`grantedAccounts`/`frequencyPerDay`, so a resource server cannot cache "for the configured `frequencyPerDay` window" as the Consequences section assumes. Partial until the DTO is completed.
+
+### D3 — Revocation propagation (Partial)
 
 `DELETE /api/v1/consents/{id}` (customer-initiated) or `POST /api/v1/consents/{id}/reject` (SCA failure) publishes `ConsentRevoked` / `ConsentRejected` via the transactional outbox to the `consent.events` Kafka topic. Idempotency key prevents duplicate processing.
+
+> **Delivery reality (2026-07-17):** events ARE published, but by `KafkaConsentEventPublisher` — a direct `@Channel` `MutinyEmitter.send`, **not** the transactional outbox described above (the outbox path is wired only into D4's expiration sweep). Revoke/reject is therefore a dual-write: a crash between the DB commit and the Kafka send drops the `ConsentRevoked`/`ConsentRejected` event with no retry, on a money-path service. Partial until revoke/reject moves onto the outbox.
 
 ### D4 — Scheduled expiration sweep (✅ Shipped)
 


### PR DESCRIPTION
## What

Corrects ADR-0126 (unified consent lifecycle), the last Tier-1 item in #1521. Unlike the other Tier-1 ADRs, its **header** `Delivery-Status: Partial` was already correct — the drift is in the **body**, which marked D2 and D3 as "Shipped" when they are not.

## Verified against origin/main (per decision point)

- **D1 / D4 / D5 — Shipped** (confirmed). D5 in particular: consent-service runs live at `AUTHZ_ENFORCE=true` (`gitops/components/consent/consent-service.yaml`).
- **D2 (M2M `/validate`) — Partial**: the response DTO is `ConsentValidationResponse(valid, reason, code)`; it omits the `scope`/`grantedAccounts`/`frequencyPerDay` the ADR promises — the very fields the Consequences section tells resource servers to cache on.
- **D3 (revocation propagation) — Partial**: revoke/reject publishes via `KafkaConsentEventPublisher` — a direct `@Channel MutinyEmitter.send`, **not** the transactional outbox the D3 text claims (the outbox is wired only into D4). A dual-write with no atomic guarantee **on a money-path revoke**: a crash between the DB commit and the Kafka send silently drops the `ConsentRevoked`/`ConsentRejected` event.

## Note surfaced (separate)

Verifying D5 established that **ADR-0034's "14 money-path services still advisory, pending #266" note is stale** — consent, account, balance, ledger, fx, lending, sca, fraud, billing and the payments cluster all run `AUTHZ_ENFORCE=true` in gitops. Correcting ADR-0034 is tracked separately (it reverses an earlier "not drift" call in #1521).

## Scope

Doc-only. `Delivery-Status` header unchanged, so `docs/adr/README.md` is byte-identical (verified). `docs` type does not release.

Refs #1521