### PR TITLE
fix(account-service): stop acking-and-dropping party events that only failed transiently

### DIFF
--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/kafka/PartyEventConsumer.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/kafka/PartyEventConsumer.kt
@@ -14,11 +14,21 @@ import com.openbank.account.domain.model.AccountStatus
 import com.openbank.account.domain.model.AccountType
 import com.openbank.libs.domain.money.CurrencyCode
 import jakarta.enterprise.context.ApplicationScoped
+import kotlinx.coroutines.delay
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.reactive.messaging.Incoming
 import org.jboss.logging.Logger
 import java.math.BigDecimal
 import java.util.UUID
+
+/** The subset of the party-event envelope this consumer projects. */
+private data class PartyEvent(
+    val type: String,
+    val partyId: UUID,
+    val partyType: String,
+    val legalName: String,
+    val status: String,
+)
 
 /**
  * Onboarding account lifecycle driven by party domain events (ADR-0073).
@@ -33,9 +43,18 @@ import java.util.UUID
  * - party SUSPENDED → freeze any active account (defence in depth).
  *
  * Idempotent: one onboarding account per party AND type; re-delivered events are no-ops.
- * Poison-pill safe: any parse/projection failure is logged and acked so a single bad event
- * cannot wedge the consumer group (the party service remains the source of truth and can be
- * replayed).
+ *
+ * Failure handling distinguishes two cases that an earlier catch-all conflated — a conflation
+ * that turned a transient outage into permanent, silent data loss (a whole cohort of customers
+ * had their PARTY_CREATED acked-and-dropped and never got an account, 2026-06-24..2026-07-17):
+ *  - **Poison pill** — unparseable, or missing the partyId. It can never succeed, so it is logged
+ *    and acked (returning): retrying or dead-lettering it would only wedge or fill the DLQ.
+ *  - **Transient projection failure** — a well-formed event we simply could not project yet
+ *    because a dependency was momentarily down (a scaled-to-zero cold start, a DB blip). A short
+ *    bounded retry absorbs the blip; if it still fails the exception ESCAPES, and SmallRye routes
+ *    the record to the dead-letter topic (`failure-strategy: dead-letter-queue`, application.yaml)
+ *    — parked for replay, never destroyed, and the consumer keeps moving. The party service
+ *    remains the source of truth and the DLQ record is recoverable.
  */
 @ApplicationScoped
 // Constructor width comes from @ConfigProperty injection (the bonus feature alone is a
@@ -77,31 +96,95 @@ class PartyEventConsumer(
 
     @Incoming("party-events-in")
     suspend fun consume(payload: String) {
-        try {
-            val node = objectMapper.readTree(payload)
-            // Wire contract = the DEPLOYED producer (party-service KafkaPartyEventPublisher):
-            // a FLAT envelope on topic openbank.party.events —
-            //   {"eventType":"PARTY_CREATED","partyId":...,"partyType":"INDIVIDUAL",
-            //    "status":"PENDING_KYC","legalName":...,"email":...,"occurredAt":...}
-            // (NOT the pid-service nested {aggregateId,payload} form — pid publishes to a
-            //  different topic `party.events` and is not deployed. See ADR-0072 migration.)
-            val type = node.path("eventType").asText()
-            val partyId = runCatching { UUID.fromString(node.path("partyId").asText()) }.getOrNull() ?: return
-            when (type) {
-                "PARTY_CREATED" ->
-                    openPendingAccount(
-                        partyId = partyId,
-                        partyType = node.path("partyType").asText(""),
-                        legalName = node.path("legalName").asText("").trim(),
+        val event = parseEnvelope(payload)
+        if (event == null) {
+            // Poison pill: unparseable, or no usable partyId. It can never succeed — acking it (by
+            // returning) is correct. Do NOT let it reach the retry/DLQ path: retrying is pointless
+            // and dead-lettering it just fills the DLQ with events nothing can ever process.
+            log.warnf("Dropping unprocessable party event (poison pill): %.300s", payload)
+            return
+        }
+        // A well-formed event; a projection failure here is transient (dependency momentarily
+        // down), so it must NOT be swallowed. A short bounded retry absorbs a blip (e.g. a
+        // scaled-to-zero dependency's cold start); if it still fails the exception escapes and
+        // SmallRye dead-letters the record for replay (failure-strategy in application.yaml).
+        withBoundedRetry(event) { dispatch(event) }
+    }
+
+    /**
+     * Wire contract = the DEPLOYED producer (party-service KafkaPartyEventPublisher): a FLAT
+     * envelope on topic openbank.party.events —
+     *   {"eventType":"PARTY_CREATED","partyId":...,"partyType":"INDIVIDUAL",
+     *    "status":"PENDING_KYC","legalName":...,"email":...,"occurredAt":...}
+     * (NOT the pid-service nested {aggregateId,payload} form — pid publishes to a different topic
+     *  `party.events` and is not deployed. See ADR-0072 migration.)
+     *
+     * Returns null only for a genuine poison pill — malformed JSON, or a missing/non-UUID partyId.
+     * An unknown eventType is NOT poison: it parses fine and [dispatch] simply no-ops on it.
+     */
+    private fun parseEnvelope(payload: String): PartyEvent? {
+        val node = runCatching { objectMapper.readTree(payload) }.getOrNull() ?: return null
+        val partyId = runCatching { UUID.fromString(node.path("partyId").asText()) }.getOrNull() ?: return null
+        return PartyEvent(
+            type = node.path("eventType").asText(""),
+            partyId = partyId,
+            partyType = node.path("partyType").asText(""),
+            legalName = node.path("legalName").asText("").trim(),
+            status = node.path("status").asText(""),
+        )
+    }
+
+    private suspend fun dispatch(event: PartyEvent) {
+        when (event.type) {
+            "PARTY_CREATED" -> openPendingAccount(event.partyId, event.partyType, event.legalName)
+            // party-service flips status to ACTIVE (two-key KYC+AML gate) and re-publishes the
+            // party via PARTY_UPDATED / KYC_STATUS_CHANGED, both carrying the new `status`.
+            "PARTY_UPDATED", "KYC_STATUS_CHANGED" -> reconcileToPartyStatus(event.partyId, event.status)
+            "PARTY_ERASED" -> handleErased(event.partyId)
+            else -> Unit // a type we don't project — nothing to do, ack.
+        }
+    }
+
+    /**
+     * Retries [block] a bounded number of times with linear backoff, then rethrows so the message
+     * is nacked to the DLQ. Deliberately retries on ANY exception: from here every failure is a
+     * transient projection failure (poison pills were filtered out before this is called), and the
+     * projections are idempotent (keyed on partyId + account type), so a retry re-runs safely.
+     * The per-attempt log carries the exception type + message, which the service's JSON log format
+     * (`%s`, no `%e`) would otherwise drop — so a failure is diagnosable without the stack trace.
+     */
+    private suspend fun withBoundedRetry(event: PartyEvent, block: suspend () -> Unit) {
+        var attempt = 1
+        while (true) {
+            try {
+                block()
+                return
+            } catch (e: Exception) {
+                if (attempt >= MAX_PROJECTION_ATTEMPTS) {
+                    log.errorf(
+                        e,
+                        "party event %s/%s failed after %d attempts (%s: %s) — dead-lettering",
+                        event.type,
+                        event.partyId,
+                        attempt,
+                        e.javaClass.simpleName,
+                        e.message,
                     )
-                // party-service flips status to ACTIVE (two-key KYC+AML gate) and re-publishes the
-                // party via PARTY_UPDATED / KYC_STATUS_CHANGED, both carrying the new `status`.
-                "PARTY_UPDATED", "KYC_STATUS_CHANGED" ->
-                    reconcileToPartyStatus(partyId, node.path("status").asText(""))
-                "PARTY_ERASED" -> handleErased(partyId)
+                    throw e
+                }
+                log.warnf(
+                    "party event %s/%s projection attempt %d/%d failed (%s: %s) — retrying in %dms",
+                    event.type,
+                    event.partyId,
+                    attempt,
+                    MAX_PROJECTION_ATTEMPTS,
+                    e.javaClass.simpleName,
+                    e.message,
+                    RETRY_BACKOFF_MS * attempt,
+                )
+                delay(RETRY_BACKOFF_MS * attempt)
+                attempt++
             }
-        } catch (e: Exception) {
-            log.errorf(e, "Failed to handle party event: %.300s", payload)
         }
     }
 
@@ -160,15 +243,13 @@ class PartyEventConsumer(
     }
 
     // GDPR Art. 17 right to erasure: null out the stored legalName for every account of the
-    // erased party. Best-effort / poison-pill safe: a DB failure is logged and the message is
-    // acked so a transient error does not wedge the consumer group.
+    // erased party. A transient DB failure here deliberately propagates (to retry then DLQ, via
+    // consume's withBoundedRetry): a swallowed failure would leave the erasure silently
+    // incomplete, a compliance breach. anonymizeByPartyId is idempotent (nulling an already-null
+    // name is a no-op), so a retry or a replay re-runs safely.
     private suspend fun handleErased(partyId: UUID) {
-        try {
-            val count = accountRepository.anonymizeByPartyId(partyId)
-            log.infof("GDPR Art. 17: anonymised legalName for erased party %s (%d account(s))", partyId, count)
-        } catch (e: Exception) {
-            log.errorf(e, "Failed to anonymise account legalName for erased party %s", partyId)
-        }
+        val count = accountRepository.anonymizeByPartyId(partyId)
+        log.infof("GDPR Art. 17: anonymised legalName for erased party %s (%d account(s))", partyId, count)
     }
 
     // Fire the one-time welcome bonus as the account goes live. Best-effort: a failure here must not
@@ -189,5 +270,13 @@ class PartyEventConsumer(
         } catch (e: Exception) {
             log.warnf(e, "Welcome-bonus notification failed for party %s (bonus already granted)", partyId)
         }
+    }
+
+    private companion object {
+        // Small and bounded: enough to ride out a dependency cold start / brief blip (a few
+        // seconds total), not so many that a genuinely-down dependency delays dead-lettering for
+        // long. Linear backoff: RETRY_BACKOFF_MS, then 2x, then 3x (~3s total across 3 attempts).
+        const val MAX_PROJECTION_ATTEMPTS = 4
+        const val RETRY_BACKOFF_MS = 500L
     }
 }

--- a/openbank-account-service/src/main/resources/application.yaml
+++ b/openbank-account-service/src/main/resources/application.yaml
@@ -175,6 +175,16 @@ mp:
         topic: openbank.party.events
         group.id: openbank-account-service
         auto.offset.reset: earliest
+        # A projection failure that survives PartyEventConsumer's bounded retry is nacked here
+        # rather than swallowed. dead-letter-queue routes that record to the DLQ topic and lets
+        # the consumer keep moving — so a transient dependency outage parks the event for replay
+        # instead of destroying it (which a prior catch-all did, dropping a whole cohort's
+        # PARTY_CREATED, 2026-06-24..2026-07-17). The DLQ topic name is left at SmallRye's default
+        # (dead-letter-topic-party-events-in): setting `dead-letter-queue.topic` explicitly here
+        # would be a DOTTED leaf key, which SmallRye Config's YAML source silently quotes so the
+        # connector never reads it (the group.id/dead-letter-queue.topic trap documented in
+        # fraud-service/transaction-service) — the default name avoids that entirely.
+        failure-strategy: dead-letter-queue
         value:
           deserializer: org.apache.kafka.common.serialization.StringDeserializer
         key:

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/PartyEventConsumerTest.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/infrastructure/kafka/PartyEventConsumerTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.util.UUID
@@ -189,14 +190,61 @@ class PartyEventConsumerTest {
     }
 
     @Test
-    fun `PARTY_ERASED anonymisation failure is swallowed and does not wedge the consumer`(): Unit = runBlocking {
+    fun `PARTY_ERASED anonymisation failure propagates after retries so the record is dead-lettered`(): Unit =
+        runBlocking {
+            val partyId = UUID.randomUUID()
+            coEvery { accountRepository.anonymizeByPartyId(partyId) } throws RuntimeException("DB down")
+
+            // A transient DB failure must NOT be swallowed — swallowing left the GDPR erasure
+            // silently incomplete AND (on the account-open path) dropped the customer's account.
+            // It now propagates so SmallRye dead-letters the record for replay.
+            assertThatThrownBy {
+                runBlocking { consumer(bonusEnabled = false).consume(erasedEvent(partyId)) }
+            }.isInstanceOf(RuntimeException::class.java)
+
+            // Retried up to the bound before giving up (idempotent projection, safe to re-run).
+            coVerify(exactly = 4) { accountRepository.anonymizeByPartyId(partyId) }
+        }
+
+    // ── Poison pill vs transient failure ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a malformed event is dropped as a poison pill without touching the projection`(): Unit = runBlocking {
+        // Must NOT throw (that would nack an unprocessable event to the DLQ forever) and must not
+        // attempt any projection.
+        consumer(bonusEnabled = false).consume("}{ not json")
+        consumer(bonusEnabled = false).consume("""{"eventType":"PARTY_CREATED","partyId":"not-a-uuid"}""")
+
+        coVerify(exactly = 0) { accountRepository.findByPartyId(any(), any(), any()) }
+        coVerify(exactly = 0) { accountUseCase.openAccount(any()) }
+    }
+
+    @Test
+    fun `a transient projection failure on PARTY_CREATED retries then propagates for dead-lettering`(): Unit =
+        runBlocking {
+            val partyId = UUID.randomUUID()
+            coEvery { accountRepository.findByPartyId(partyId, any(), any()) } throws
+                RuntimeException("sanctions screening unavailable")
+
+            // A well-formed event we could not project yet must NOT be acked-and-dropped — it
+            // propagates after a bounded retry so the record is dead-lettered, never lost.
+            assertThatThrownBy {
+                runBlocking { consumer(bonusEnabled = false).consume(createdEvent(partyId)) }
+            }.isInstanceOf(RuntimeException::class.java)
+
+            coVerify(exactly = 4) { accountRepository.findByPartyId(partyId, any(), any()) }
+        }
+
+    @Test
+    fun `an unknown event type is a no-op ack, not a poison pill`(): Unit = runBlocking {
         val partyId = UUID.randomUUID()
-        coEvery { accountRepository.anonymizeByPartyId(partyId) } throws RuntimeException("DB down")
+        val unknown = """{"eventType":"PARTY_MERGED","partyId":"$partyId","occurredAt":"2026-06-28T10:00:00Z"}"""
 
-        // Must not throw — poison-pill safe.
-        consumer(bonusEnabled = false).consume(erasedEvent(partyId))
+        // Parses fine, dispatch has no branch for it → nothing happens, no throw.
+        consumer(bonusEnabled = false).consume(unknown)
 
-        coVerify(exactly = 1) { accountRepository.anonymizeByPartyId(partyId) }
+        coVerify(exactly = 0) { accountUseCase.openAccount(any()) }
+        coVerify(exactly = 0) { accountRepository.anonymizeByPartyId(any()) }
     }
 
     private fun erasedEvent(partyId: UUID) =

--- a/openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml
+++ b/openbank-infra/gitops/components/accounts/kafka-account-mtls.yaml
@@ -3,6 +3,7 @@
 # account-service topics:
 #   Produces: openbank.accounts.account.created (two channels: account-events-out + account-outbox-out)
 #             openbank.notification.requests (notification-requests-out)
+#             dead-letter-topic-party-events-in (SmallRye DLQ for party-events-in, failure-strategy)
 #   Consumes: openbank.party.events (group: openbank-account-service, ADR-0073 party lifecycle)
 ---
 apiVersion: kafka.strimzi.io/v1
@@ -37,6 +38,16 @@ spec:
           name: openbank.party.events
           patternType: literal
         operations: [Read, Describe]
+        host: "*"
+      # SmallRye dead-letter topic for the party-events-in channel (failure-strategy:
+      # dead-letter-queue). Without Write here, the DLQ send itself fails and the consumer
+      # wedges on the very failure it was meant to park — the same ANONYMOUS-vs-ACL lockout
+      # class that took party-service down (#1476). Default SmallRye name = dead-letter-topic-<channel>.
+      - resource:
+          type: topic
+          name: dead-letter-topic-party-events-in
+          patternType: literal
+        operations: [Write, Describe]
         host: "*"
       - resource:
           type: group

--- a/openbank-infra/gitops/components/kafka/kafka.yaml
+++ b/openbank-infra/gitops/components/kafka/kafka.yaml
@@ -161,3 +161,26 @@ spec:
   config:
     retention.ms: 604800000
     cleanup.policy: delete
+---
+# Dead-letter topic for account-service's party-events-in channel (SmallRye
+# failure-strategy: dead-letter-queue). A party event whose projection survives the
+# consumer's bounded retry is parked here for inspection/replay instead of being dropped.
+# Name is SmallRye's default (dead-letter-topic-<channel>) — set implicitly, not via a
+# dotted `dead-letter-queue.topic` YAML key (that key is silently mis-quoted by SmallRye
+# Config). Longer retention than the source topic: a DLQ record is a real incident that may
+# outlive a 7-day window before someone replays it. No consumer by design — it is a
+# quarantine, invisible to the event-consumer-liveness gate (that gate reads `outgoing:`
+# channels, and this producer is the connector's implicit DLQ, not a declared channel).
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: dead-letter-topic-party-events-in
+  namespace: messaging
+  labels:
+    strimzi.io/cluster: openbank-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: 2592000000
+    cleanup.policy: delete


### PR DESCRIPTION
## The bug (the data-loss half of #1497)

`PartyEventConsumer` caught **every** exception, logged it, and acked — a `catch (e: Exception)` the comment called "poison-pill safe". It conflated two failures that must be handled oppositely:

- **Poison pill** (malformed event) → ack + drop is correct; retrying forever wedges the group.
- **Transient projection failure** (a valid event a momentarily-down dependency couldn't project) → dropping it **loses the account forever**.

That conflation is what turned this session's sanctions-db and product-catalog outages into a silent, three-week onboarding blackout: every `PARTY_CREATED` in that window was acked-and-dropped and the customers never got an account. Nothing was red.

## The fix

- **Poison pill** (unparseable JSON / missing-or-non-UUID partyId): acked + WARN. An unknown `eventType` is *not* poison — it parses and `dispatch()` no-ops.
- **Transient failure**: a bounded retry (4 attempts, ~3s linear backoff) absorbs a blip — exactly the sanctions cold-start timeout we hit live. If it still fails, the exception **escapes** → SmallRye dead-letters the record (`failure-strategy: dead-letter-queue`) → parked for replay, never destroyed, consumer keeps moving.
- `handleErased`'s swallow removed too: a transient DB failure during GDPR-Art.17 anonymisation now propagates (idempotent) instead of leaving erasure silently incomplete. `grantWelcomeBonus` keeps its swallow — genuinely best-effort (account already ACTIVE, idempotent).
- The per-attempt log carries exception type + message, so these failures are diagnosable despite the service's `%s`-only JSON format dropping stack traces. (The formatter itself is left alone — changing it alters the log shape observability parses.)

## Infra

| file | change |
|---|---|
| `application.yaml` | `failure-strategy: dead-letter-queue` on `party-events-in`. DLQ topic left at SmallRye's default name — an explicit `dead-letter-queue.topic` is a dotted key SmallRye Config mis-quotes (the documented group.id trap). |
| `kafka.yaml` | DLQ `KafkaTopic` (30-day retention). No consumer by design — a quarantine, invisible to the event-consumer-liveness gate (reads `outgoing:` channels; this is the connector's implicit DLQ). |
| `kafka-account-mtls.yaml` | Write+Describe ACL on the DLQ topic. Without it the DLQ send wedges on the very failure it parks — the ACL-lockout class that took party-service down (#1476). |

## Tests

12 green. Added: poison-pill drop, unknown-type no-op, transient-retries-then-propagates, GDPR-failure-propagates. The old "anonymisation failure is swallowed" test is inverted to assert propagation. detekt + ktlint green.

## Scope note

This is the data-loss half of #1497. The remaining half — a fleet alert on DLQ depth / CNPG crash-loops / "zero accounts opened in N days" — is left for a focused observability change and #1497 stays open for it.

## Linked issues

Refs #1497