### PR TITLE
docs(adr): correct ADR-0034 note — money-path OPA enforcement is live, not pending

### DIFF
--- a/docs/adr/0034-unified-opa-authz-mcp-and-rest.md
+++ b/docs/adr/0034-unified-opa-authz-mcp-and-rest.md
@@ -5,13 +5,18 @@ Status: Accepted
 Delivery-Status: Partial
 Author(s): Claude (session: Phase 5b consolidation)
 
-**Delivery note (updated 2026-07-05):**
+**Delivery note (updated 2026-07-17):** the enforcement axis — the part that was materially stale in
+the 2026-07-05 note — is now fully live; the header stays `Partial` only for the D2 bundle-distribution
+mechanism (below).
 - **D1 (single OPA namespace)** — ✅ Shipped: `data.openbank.{agents,rest,shared}` unified; bundle in `openbank-libs/governance/`.
 - **D3 (Kotlin `@Authorize` API)** — ✅ Shipped: interceptor, `OpaSidecarPolicyDecisionPoint`, `AllowAllPolicyDecisionPoint`; fleet sweep complete — all 30 REST services annotated.
-- **Phase 5 (enforcement flip, non-money-path)** — ✅ Shipped: 13 non-money-path services flipped to `authz.enforce: true`; OPA deny→403, unavailable→503. (The PR numbers previously cited here, #1363-#1365, don't resolve in this repo — pre-public-repo-transition references, same pattern as the ADR numbering gap in `README.md`; the shipped state itself is independently verified in gitops config, not just the PR citation.)
-- **Phase 5 (money-path)** — ⬜ Pending: 14 money-path services (account, balance, ledger, transaction, ...) still advisory; each needs 2 approvals + threat-model update. Tracked in issue #266.
-- **D2 (MCP enforcement sidecar)** — ⬜ Pending (advisory mode). The PR previously cited here, #638, doesn't resolve in this repo either (same pre-public-transition pattern). Tracked in issue #266.
-- **D4 (k8s sidecar deployment)** — ⬜ Pending. Tracked in issue #266.
+- **D4 (k8s sidecar deployment)** — ✅ Shipped (was recorded Pending): the OPA sidecar is deployed fleet-wide (19 gitops manifests carry it) — enforcement below depends on it, so it cannot be pending.
+- **Phase 5 (enforcement flip, non-money-path)** — ✅ Shipped: non-money-path services run `AUTHZ_ENFORCE=true`; OPA deny→403, unavailable→503.
+- **Phase 5 (money-path)** — ✅ Shipped (was recorded ⬜ Pending "14 still advisory" as of 2026-07-05; **corrected 2026-07-17**): **all 16 money-path services in `rules.yaml` now run `AUTHZ_ENFORCE=true` in gitops** — account, balance, ledger, transaction, sepa-payment, sepa-instant, domestic-payment, clearing, swift, fx, lending, sca, consent, fraud, billing, settlement (verified per-service in the `payments/*`, `ledger`, `accounts`, `balances`, `consent`, … gitops components). The "14 still advisory" line in the 2026-06-19 amendment below is thereby superseded — kept as the point-in-time record, per this repo's "record, don't overwrite" convention.
+- **D2 / MCP-plane enforcement** — ✅ Enforced (was recorded "Pending, advisory mode"): the agent MCP `/tools/call` gate runs `AGENT_POLICY_ENFORCEMENT=block` in gitops (ADR-0080 P0 in-process charter allow-list). The OPA decision on the MCP path degrades to advisory only on PDP transport error (fail-open by design), not as a standing posture.
+- **D2 / bundle distribution** — ⬜ the reason the header stays `Partial`: the policy bundle currently ships as per-service ConfigMaps (`gen-*-opa-bundle.sh`), not the single Cosign-signed OCI artifact the D2 decision sketched. A deviation, not verified further here.
+- **Break-glass:** `AUTHZ_ENFORCE=false` in a service's gitops env ConfigMap.
+- **Axis caveat:** `AUTHZ_ENFORCE` (OPA authz, deny→403) is a **different axis** from four-eyes (`authz.four-eyes.enforce`, ADR-0155), which remains off fleet-wide — this note does not claim money-path is fully locked down.
 Amends: ADR-0018 (OPA for fine-grained authz, Proposed)
 Extends: ADR-0031 (AI agent governance, Accepted)
 


### PR DESCRIPTION
## What

Corrects ADR-0034's delivery note (dated 2026-07-05), which recorded money-path OPA enforcement, the k8s sidecar, and the MCP plane as pending. All three have shipped.

This **reverses an earlier "not drift" call** I made on this ADR in #1521 — the reversal is recorded in [that issue](https://github.com/JiRaska/open-bank-oss/issues/1521#issuecomment-5004949144). I'd cleared 0034 from a raw `AUTHZ_ENFORCE` count without crossing it against the money-path list; verifying ADR-0126 D5 exposed the error.

## Verified against origin/main gitops

- **Phase 5 money-path — Shipped.** All 16 `money_path_services` (rules.yaml) run `AUTHZ_ENFORCE=true`: account, balance, ledger, transaction, sepa-payment, sepa-instant, domestic-payment, clearing, swift, fx, lending, sca, consent, fraud, billing, settlement. The note's "14 still advisory / #266" was stale.
- **D4 k8s sidecar — Shipped.** OPA sidecar deployed fleet-wide (19 manifests); enforcement depends on it.
- **D2 MCP plane — Enforced.** `AGENT_POLICY_ENFORCEMENT=block` (ADR-0080 P0), not "advisory"; degrades to advisory only on PDP transport error.

## Why the header stays Partial

One genuine gap remains: the policy bundle ships as per-service ConfigMaps (`gen-*-opa-bundle.sh`), not the single Cosign-signed OCI artifact the D2 decision sketched. Not overstated to Shipped.

## Honest scoping

`AUTHZ_ENFORCE` (OPA authz, deny→403) is a **different axis** from four-eyes (`authz.four-eyes.enforce`, ADR-0155), which remains off fleet-wide. This does not claim money-path is fully locked down. The 2026-06-19 in-body amendment's "14 advisory" line is kept as a point-in-time record.

## Scope

Doc-only. Header status unchanged → `README.md` byte-identical. `docs` type does not release.

Refs #1521