### PR TITLE
fix(admin-ui): reconcile operator-messaging UI with shipped notification-service contract

### DIFF
--- a/openbank-admin-ui/src/app/notifications/page.tsx
+++ b/openbank-admin-ui/src/app/notifications/page.tsx
@@ -11,7 +11,7 @@ import { useAuth } from '@/lib/auth/useAuth'
 import { hasPermission } from '@/lib/auth/roles'
 import { classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { opsMessageApi, type OperatorMessage } from '@/lib/api'
+import { opsMessageApi } from '@/lib/api'
 
 const NOTIFICATION_SERVICE = '/api/svc/notification-service'
 
@@ -99,7 +99,7 @@ export default function NotificationsPage() {
         ))}
       </div>
 
-      {canApprove && <PendingOperatorMessages />}
+      {canApprove && <OperatorMessageApprovals />}
 
       {unavailable && (
         <div className="card" style={{ padding: 0, marginBottom: '16px' }}>
@@ -167,117 +167,87 @@ export default function NotificationsPage() {
 }
 
 /**
- * Operator-initiated customer messages awaiting a second approver (ADR-0176 D5). Backed by
- * OperatorMessageResource.listPending — reuses the opsmessage.approve grant, since
- * ApprovalStore itself has no query to list pending approvals (see that endpoint's KDoc).
+ * Four-eyes checker surface for operator-initiated messages (ADR-0176 D5). A maker's compose
+ * call (`POST /api/v1/notifications/messages`) is paused with 202 + a pending-approval id when
+ * `AUTHZ_FOUR_EYES_ENFORCE=true`; a DIFFERENT operator decides it here via the single
+ * `PATCH /api/v1/notifications/approvals/{id}` endpoint. SelfApprovalNotAllowedException refuses
+ * a maker deciding their own request server-side (403).
  *
- * A DIFFERENT operator than the one who composed the message must decide it —
- * SelfApprovalNotAllowedException refuses it server-side if the same operator tries. This
- * component doesn't try to hide the "compose" button from the maker (there's no reliable
- * client-side way to know in advance who composed which row before deciding), it just
- * surfaces the server's rejection as a plain error if it happens.
+ * Deliberately NOT an auto-loaded queue: the shipped backend (ApprovalStore) exposes no query to
+ * enumerate pending approvals — there is no list endpoint — so the checker acts on the approval
+ * id the maker relays out of band (shown on the maker's party-page banner). A backend list
+ * endpoint would let this become a real queue; that is remaining ADR-0176 work.
  */
-function PendingOperatorMessages() {
+function OperatorMessageApprovals() {
   const { t } = useLanguage()
-  const [rows, setRows] = useState<OperatorMessage[]>([])
-  const [loading, setLoading] = useState(true)
-  const [busyId, setBusyId] = useState<string | null>(null)
-  const [rowError, setRowError] = useState<Record<string, string>>({})
+  const [approvalId, setApprovalId] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean; text: string } | null>(null)
 
-  const load = useCallback(async () => {
-    setLoading(true)
+  const decide = async (approve: boolean) => {
+    const id = approvalId.trim()
+    if (!id) return
+    setBusy(true); setResult(null)
     try {
-      const { items } = await opsMessageApi.listPending()
-      setRows(items)
+      const decision = await opsMessageApi.decide(id, approve)
+      setResult({ ok: true, text: `${t('Rozhodnutí uloženo', 'Decision recorded')}: ${decision.status}` })
+      setApprovalId('')
     } catch {
-      setRows([])
+      // Most often SelfApprovalNotAllowedException / already-decided — never surface the raw
+      // backend message for a user-initiated write (graceful-state rule).
+      setResult({ ok: false, text: t(
+        'Rozhodnutí se nezdařilo. Zkontrolujte ID schválení — jiný operátor už možná rozhodl, nebo jste zprávu vytvořili vy.',
+        'The decision failed. Check the approval id — another operator may have already decided it, or you composed this message yourself.',
+      ) })
     } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => { load() }, [load])
-
-  const decide = async (row: OperatorMessage, approve: boolean) => {
-    setBusyId(row.id)
-    setRowError(prev => { const next = { ...prev }; delete next[row.id]; return next })
-    try {
-      if (approve) await opsMessageApi.approve(row.id)
-      else await opsMessageApi.reject(row.id)
-      await load()
-    } catch {
-      // Most often SelfApprovalNotAllowedException (the maker tried to decide their own
-      // message) — never surface the raw backend message for a user-initiated write.
-      setRowError(prev => ({
-        ...prev,
-        [row.id]: t(
-          'Rozhodnutí se nezdařilo. Jiný operátor už možná rozhodl, nebo jste zprávu sami vytvořili.',
-          'The decision failed. Another operator may have already decided it, or you composed this message yourself.',
-        ),
-      }))
-    } finally {
-      setBusyId(null)
+      setBusy(false)
     }
   }
-
-  if (!loading && rows.length === 0) return null
 
   return (
     <div className="card" style={{ overflow: 'hidden', marginBottom: '16px' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '16px 20px', borderBottom: '1px solid var(--border)' }}>
         <Clock size={15} style={{ color: 'var(--yellow)' }} />
         <span style={{ fontWeight: 600, fontSize: '13px' }}>
-          {t('Zprávy čekající na schválení', 'Messages awaiting approval')}
+          {t('Schválení zpráv (princip čtyř očí)', 'Message approvals (four-eyes)')}
         </span>
-        {!loading && <span className="tag" style={{ marginLeft: 'auto' }}>{rows.length}</span>}
       </div>
-      <table className="data-table">
-        <thead>
-          <tr>
-            <th>{t('Šablona', 'Template')}</th>
-            <th>{t('Reference', 'Reference')}</th>
-            <th>{t('Účel', 'Purpose')}</th>
-            <th>{t('Akce', 'Actions')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading && Array.from({ length: 2 }).map((_, i) => (
-            <tr key={i}>{Array.from({ length: 4 }).map((_, j) => (
-              <td key={j}><div className="skeleton" style={{ height: '14px', width: '80px' }} /></td>
-            ))}</tr>
-          ))}
-          {!loading && rows.map(row => (
-            <tr key={row.id}>
-              <td><span className="tag">{row.template}</span></td>
-              <td style={{ fontSize: '12px', fontFamily: 'var(--font-mono)' }}>{row.referenceId}</td>
-              <td><span className="tag">{row.purpose}</span></td>
-              <td>
-                <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
-                  <button
-                    className="btn btn-secondary"
-                    style={{ color: 'var(--green)' }}
-                    onClick={() => decide(row, true)}
-                    disabled={busyId === row.id}
-                  >
-                    <Check size={13} /> {t('Schválit', 'Approve')}
-                  </button>
-                  <button
-                    className="btn btn-secondary"
-                    style={{ color: 'var(--red)' }}
-                    onClick={() => decide(row, false)}
-                    disabled={busyId === row.id}
-                  >
-                    <X size={13} /> {t('Zamítnout', 'Reject')}
-                  </button>
-                  {rowError[row.id] && (
-                    <span style={{ fontSize: '11px', color: 'var(--red)' }}>{rowError[row.id]}</span>
-                  )}
-                </div>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div style={{ padding: '16px 20px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        <span style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+          {t(
+            'Zadejte ID schválení, které vám předal operátor odesílající zprávu, a rozhodněte. Vlastní zprávu schválit nelze.',
+            'Enter the approval id the composing operator gave you, then decide. You cannot approve your own message.',
+          )}
+        </span>
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+          <input
+            className="input"
+            style={{ flex: 1, minWidth: '240px', fontFamily: 'var(--font-mono)' }}
+            value={approvalId}
+            onChange={e => setApprovalId(e.target.value)}
+            placeholder={t('ID schválení', 'Approval id')}
+          />
+          <button
+            className="btn btn-secondary"
+            style={{ color: 'var(--green)' }}
+            onClick={() => decide(true)}
+            disabled={busy || !approvalId.trim()}
+          >
+            <Check size={13} /> {t('Schválit', 'Approve')}
+          </button>
+          <button
+            className="btn btn-secondary"
+            style={{ color: 'var(--red)' }}
+            onClick={() => decide(false)}
+            disabled={busy || !approvalId.trim()}
+          >
+            <X size={13} /> {t('Zamítnout', 'Reject')}
+          </button>
+        </div>
+        {result && (
+          <span style={{ fontSize: '12px', color: result.ok ? 'var(--green)' : 'var(--red)' }}>{result.text}</span>
+        )}
+      </div>
     </div>
   )
 }

--- a/openbank-admin-ui/src/app/parties/[id]/page.tsx
+++ b/openbank-admin-ui/src/app/parties/[id]/page.tsx
@@ -14,7 +14,7 @@ import { hasPermission } from '@/lib/auth/roles'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 import { svcUrl, classifyBffFailure } from '@/lib/services/bff'
 import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
-import { opsMessageApi } from '@/lib/api'
+import { opsMessageApi, OPERATOR_MESSAGE_TEMPLATE_VARS, type OperatorMessageTemplate, type ComposeMessageRequest } from '@/lib/api'
 
 const PAGE_SIZE = 25
 
@@ -232,7 +232,7 @@ function PartyDetailPage() {
         </div>
       )}
 
-      {tab === 'messages' && <MessagesTab partyId={party.id} roles={roles} />}
+      {tab === 'messages' && <MessagesTab partyId={party.id} partyEmail={party.email} roles={roles} />}
     </div>
   )
 }
@@ -248,7 +248,7 @@ function PartyDetailPage() {
  * `notifications:view` permission gating this tab is UX only — it decides what we render,
  * not what an operator can fetch. Showing bodies here needs the policy fix first.
  */
-function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
+function MessagesTab({ partyId, partyEmail, roles }: { partyId: string; partyEmail: string; roles: string[] }) {
   // A helper component outside the page needs its own language context (all admin-ui pages
   // are 'use client') — never reference the page's `t` out of scope (CLAUDE.md rule #4).
   const { t, language } = useLanguage()
@@ -262,11 +262,16 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
   const canCompose = hasPermission(roles, 'opsmessage:compose')
   const [sending, setSending] = useState(false)
   const [composeError, setComposeError] = useState<string | null>(null)
-  // Set once the maker's first submit call returns 202 — nothing here polls automatically
-  // (ADR-0176 introduces the fleet's first 202/X-Approval-Id UI flow; a real approval
-  // notification channel is a separate, larger piece of work). The maker clicks "Retry send"
-  // themselves once a colleague has approved it.
-  const [pendingSubmit, setPendingSubmit] = useState<{ id: string; approvalId?: string } | null>(null)
+  const [template, setTemplate] = useState<OperatorMessageTemplate>('GENERIC_NOTICE')
+  const [recipient, setRecipient] = useState(partyEmail)
+  const [vars, setVars] = useState<Record<string, string>>({})
+  // Set once compose returns 202 — nothing here polls automatically (ADR-0176 introduces the
+  // fleet's first 202/X-Approval-Id UI flow; a real approval notification channel is a separate,
+  // larger piece of work). We hold the EXACT request that was paused: the retry must resend the
+  // byte-identical body (the interceptor binds the approval to the request's content), and the
+  // maker relays `approvalId` to a colleague, who decides it on the Notifications page. The maker
+  // then clicks "Retry send".
+  const [pendingSubmit, setPendingSubmit] = useState<{ request: ComposeMessageRequest; approvalId: string } | null>(null)
   const [retrying, setRetrying] = useState(false)
 
   const load = useCallback(async (nextPage: number) => {
@@ -302,33 +307,37 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
   // The endpoint is offset-paged (page/size/total), not cursor-paged like party search.
   const hasNextPage = (page + 1) * PAGE_SIZE < total
 
-  const REFERENCE_ID_PATTERN = /^[A-Za-z0-9-]{1,40}$/
+  // Mirror the backend recipient guard (OperatorMessageService.EMAIL_PATTERN): reject blanks and
+  // CR/LF header-injection before the BFF call, so a malformed address never leaves the browser.
+  const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  const templateVars = OPERATOR_MESSAGE_TEMPLATE_VARS[template]
 
-  // ADR-0176 D2: OPERATOR_ACCOUNT_NOTICE is the only composable template today, so the operator
-  // supplies just a reference code — never free text. Two calls, mirroring
-  // OperatorMessageResource's own KDoc: draft persists the content, submit is the four-eyes
-  // -gated one and pauses (202) until a different operator approves it.
+  // ADR-0176 D2: a single four-eyes-gated compose call (POST /notifications/messages). The
+  // operator picks a closed-catalogue template, a recipient, and the template's exact variables;
+  // no free-text template. When four-eyes enforcement is on the call pauses (202) until a
+  // different operator decides it on the Notifications page.
   async function sendMessage() {
-    const referenceId = window.prompt(
-      t('Referenční kód (např. TICKET-123):', 'Reference (e.g. TICKET-123):'),
-    )
-    if (referenceId === null) return
-    if (!REFERENCE_ID_PATTERN.test(referenceId)) {
-      setComposeError(t(
-        'Referenční kód musí obsahovat 1–40 alfanumerických znaků nebo pomlček.',
-        'Reference must be 1-40 alphanumeric characters or hyphens.',
-      ))
+    const trimmedRecipient = recipient.trim()
+    if (!EMAIL_PATTERN.test(trimmedRecipient)) {
+      setComposeError(t('Zadejte platnou e-mailovou adresu příjemce.', 'Enter a valid recipient email address.'))
       return
     }
+    // The request must carry EXACTLY the template's declared keys — extra or missing are both 400.
+    const variables: Record<string, string> = {}
+    for (const key of templateVars) variables[key] = (vars[key] ?? '').trim()
+    if (templateVars.some(key => !variables[key])) {
+      setComposeError(t('Vyplňte prosím všechna pole šablony.', 'Please fill in every template field.'))
+      return
+    }
+    const request: ComposeMessageRequest = { partyId, template, recipient: trimmedRecipient, variables }
     setSending(true); setComposeError(null)
     try {
-      const drafted = await opsMessageApi.draft({ partyId, template: 'OPERATOR_ACCOUNT_NOTICE', referenceId, purpose: 'SERVICE' })
-      const result = await opsMessageApi.submit(drafted.id)
+      const result = await opsMessageApi.compose(request)
       if (result.status === 'PENDING_APPROVAL') {
-        setPendingSubmit({ id: drafted.id, approvalId: result.approvalId })
+        setPendingSubmit({ request, approvalId: result.approvalId })
       } else {
-        // Only reached if four-eyes enforcement is off in this environment — still a real
-        // send, so refresh the history to show it.
+        // four-eyes enforcement off in this environment — a real send, so refresh the history.
+        setVars({})
         load(0)
       }
     } catch {
@@ -344,17 +353,28 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
     if (!pendingSubmit) return
     setRetrying(true)
     try {
-      const result = await opsMessageApi.submit(pendingSubmit.id, pendingSubmit.approvalId)
+      // Byte-identical replay of the paused request, now carrying the approval id.
+      const result = await opsMessageApi.compose(pendingSubmit.request, pendingSubmit.approvalId)
       if (result.status !== 'PENDING_APPROVAL') {
         setPendingSubmit(null)
+        setVars({})
         load(0)
       }
       // Still PENDING_APPROVAL: nobody has decided it yet — leave the banner up.
     } catch {
       // A 409 (already resolved) or 403 (rejected/self-approval) most often means someone
-      // already decided it — leave the banner up rather than guessing; the Pending approvals
-      // queue on the Notifications page has the authoritative status.
+      // already decided it — leave the banner up rather than guessing; the approvals panel
+      // on the Notifications page has the authoritative status.
     } finally { setRetrying(false) }
+  }
+
+  function varLabel(key: string): string {
+    switch (key) {
+      case 'subject': return t('Předmět', 'Subject')
+      case 'note': return t('Text zprávy', 'Message body')
+      case 'ticketReference': return t('Číslo tiketu', 'Ticket reference')
+      default: return key
+    }
   }
 
   return (
@@ -362,21 +382,74 @@ function MessagesTab({ partyId, roles }: { partyId: string; roles: string[] }) {
       {canCompose && (
         <div className="card" style={{ padding: '14px 20px', marginBottom: '16px' }}>
           {pendingSubmit ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <Clock size={15} style={{ color: 'var(--yellow)' }} />
-              <span style={{ fontSize: '13px' }}>
-                {t('Zpráva čeká na schválení druhým operátorem.', 'Message is awaiting a second operator’s approval.')}
-              </span>
-              <button className="btn btn-secondary" style={{ marginLeft: 'auto' }} onClick={retrySubmit} disabled={retrying}>
-                <RefreshCw size={13} /> {retrying ? t('Zkouším…', 'Retrying…') : t('Zkusit znovu odeslat', 'Retry send')}
-              </button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <Clock size={15} style={{ color: 'var(--yellow)' }} />
+                <span style={{ fontSize: '13px' }}>
+                  {t('Zpráva čeká na schválení druhým operátorem.', 'Message is awaiting a second operator’s approval.')}
+                </span>
+                <button className="btn btn-secondary" style={{ marginLeft: 'auto' }} onClick={retrySubmit} disabled={retrying}>
+                  <RefreshCw size={13} /> {retrying ? t('Zkouším…', 'Retrying…') : t('Zkusit znovu odeslat', 'Retry send')}
+                </button>
+              </div>
+              {/* No backend endpoint lists pending approvals (ApprovalStore has no query), so the
+                  checker cannot discover this from a queue — the maker relays the id out of band. */}
+              <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
+                {t('Předejte toto ID schválení druhému operátorovi:', 'Give this approval id to a second operator:')}{' '}
+                <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)' }}>{pendingSubmit.approvalId}</span>
+              </div>
             </div>
           ) : (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <button className="btn btn-secondary" onClick={sendMessage} disabled={sending}>
-                <Send size={13} /> {sending ? t('Odesílám…', 'Sending…') : t('Poslat zprávu', 'Send message')}
-              </button>
-              {composeError && <span style={{ fontSize: '12px', color: 'var(--red)' }}>{composeError}</span>}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+              <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '12px', color: 'var(--text-muted)' }}>
+                  {t('Šablona', 'Template')}
+                  <select
+                    className="input"
+                    value={template}
+                    onChange={e => { setTemplate(e.target.value as OperatorMessageTemplate); setVars({}); setComposeError(null) }}
+                  >
+                    <option value="GENERIC_NOTICE">{t('Obecné oznámení', 'Generic notice')}</option>
+                    <option value="SUPPORT_FOLLOWUP">{t('Reakce na požadavek podpory', 'Support follow-up')}</option>
+                  </select>
+                </label>
+                <label style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '12px', color: 'var(--text-muted)', flex: 1, minWidth: '220px' }}>
+                  {t('Příjemce (e-mail)', 'Recipient (email)')}
+                  <input
+                    className="input"
+                    type="email"
+                    value={recipient}
+                    onChange={e => setRecipient(e.target.value)}
+                    placeholder={t('jmeno@priklad.cz', 'name@example.com')}
+                  />
+                </label>
+              </div>
+              {templateVars.map(key => (
+                <label key={key} style={{ display: 'flex', flexDirection: 'column', gap: '4px', fontSize: '12px', color: 'var(--text-muted)' }}>
+                  {varLabel(key)}
+                  {key === 'note' ? (
+                    <textarea
+                      className="input"
+                      rows={3}
+                      value={vars[key] ?? ''}
+                      onChange={e => setVars(prev => ({ ...prev, [key]: e.target.value }))}
+                    />
+                  ) : (
+                    <input
+                      className="input"
+                      type="text"
+                      value={vars[key] ?? ''}
+                      onChange={e => setVars(prev => ({ ...prev, [key]: e.target.value }))}
+                    />
+                  )}
+                </label>
+              ))}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <button className="btn btn-secondary" onClick={sendMessage} disabled={sending}>
+                  <Send size={13} /> {sending ? t('Odesílám…', 'Sending…') : t('Poslat zprávu', 'Send message')}
+                </button>
+                {composeError && <span style={{ fontSize: '12px', color: 'var(--red)' }}>{composeError}</span>}
+              </div>
             </div>
           )}
         </div>

--- a/openbank-admin-ui/src/lib/api.ts
+++ b/openbank-admin-ui/src/lib/api.ts
@@ -99,47 +99,72 @@ export const accountApi = {
     apiFetchSimple<Account>(`${ACCOUNT_SERVICE}/api/v1/accounts/${id}/unfreeze`, { method: 'POST', body: JSON.stringify({ reason }) }),
 }
 
-// Operator-initiated customer messaging (ADR-0176). draft/submit is a two-call maker
-// step — see openbank-notification-service's OperatorMessageResource KDoc for why a single
-// annotated endpoint cannot both create the row and be the four-eyes-gated one.
-export interface OperatorMessage {
-  id: string; partyId: string; template: string; referenceId: string; purpose: string; status: string
+// Operator-initiated customer messaging (ADR-0176 D2/D5). Mirrors the SHIPPED
+// notification-service contract exactly (OperatorMessageResource + ApprovalResource +
+// openapi.yaml), not the draft/submit two-call sketch the ADR record used:
+//   - compose is a SINGLE call — POST /api/v1/notifications/messages — that both persists
+//     and sends. It is itself the four-eyes-gated action (`@Authorize("opsmessage.compose",
+//     resource="#request")`); AuthorizeInterceptor pauses it with 202 when four-eyes
+//     enforcement is on and lets the maker replay the byte-identical body once approved.
+//   - the checker decides via a SINGLE PATCH /api/v1/notifications/approvals/{id} {approve},
+//     not separate approve/reject verbs.
+export type OperatorMessageTemplate = 'GENERIC_NOTICE' | 'SUPPORT_FOLLOWUP'
+
+// Each template's EXACT required variable keys (notification-service OperatorMessageTemplate).
+// The compose request must carry exactly these keys — extra AND missing are both rejected 400.
+export const OPERATOR_MESSAGE_TEMPLATE_VARS: Record<OperatorMessageTemplate, readonly string[]> = {
+  GENERIC_NOTICE: ['subject', 'note'],
+  SUPPORT_FOLLOWUP: ['ticketReference'],
 }
-// The 202-pending shape AuthorizeInterceptor returns on submit's first (un-approved) call.
-// Shares `status` with OperatorMessage so callers can branch on one field regardless of which
-// shape actually came back.
-export interface OpsMessageSubmitResult {
-  status: string; approvalId?: string; id?: string
+
+export interface ComposeMessageRequest {
+  partyId: string
+  template: OperatorMessageTemplate
+  recipient: string
+  variables: Record<string, string>
+}
+
+// compose resolves to one of two backend shapes: 201 ComposeMessageResponse ({id}) when the
+// message was sent, or the AuthorizeInterceptor 202 body ({status, approvalId}) when four-eyes
+// enforcement paused it pending a second operator. Callers branch on `status`.
+export type ComposeResult =
+  | { status: 'SENT'; id: string }
+  | { status: 'PENDING_APPROVAL'; approvalId: string }
+
+// PATCH /approvals/{id} -> ApprovalResponse.
+export interface ApprovalDecision {
+  id: string; action: string; resourceId: string | null; status: string; decidedBy: string | null
 }
 
 export const opsMessageApi = {
-  draft: (data: { partyId: string; template: string; referenceId: string; purpose: string }) =>
-    apiFetchSimple<OperatorMessage>(`${NOTIFICATION_SERVICE}/api/v1/opsmessages`, {
+  // 201 -> {status:'SENT', id}. 202 (four-eyes on) -> {status:'PENDING_APPROVAL', approvalId}:
+  // relay that id to a DIFFERENT operator to decide, then replay this exact request (same body)
+  // with `approvalId` set — the interceptor binds the approval to the request's content, so the
+  // retry must be byte-identical or it mints a fresh pending approval.
+  compose: async (req: ComposeMessageRequest, approvalId?: string): Promise<ComposeResult> => {
+    const res = await fetch(`${NOTIFICATION_SERVICE}/api/v1/notifications/messages`, {
       method: 'POST',
-      body: JSON.stringify(data),
+      headers: { 'Content-Type': 'application/json', ...(approvalId ? { 'X-Approval-Id': approvalId } : {}) },
+      body: JSON.stringify(req),
+    })
+    if (res.status === 202) {
+      const body = await res.json().catch(() => ({}))
+      return { status: 'PENDING_APPROVAL', approvalId: body.approvalId }
+    }
+    if (!res.ok) {
+      const error = await res.json().catch(() => ({ message: res.statusText }))
+      throw new Error(error.message || `HTTP ${res.status}`)
+    }
+    const body = await res.json()
+    return { status: 'SENT', id: body.id }
+  },
+  // Checker decision (ApprovalResource.decide): one PATCH with an approve boolean. Self-approval
+  // is refused server-side (403); an unknown/already-decided id is 404/409 — all thrown here.
+  decide: (id: string, approve: boolean) =>
+    apiFetchSimple<ApprovalDecision>(`${NOTIFICATION_SERVICE}/api/v1/notifications/approvals/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ approve }),
     }),
-  // No approvalId yet -> first call, expect back {status:"PENDING_APPROVAL", approvalId}.
-  // With approvalId (the maker's retry, once a different operator has approved) -> expect back
-  // the sent OperatorMessage, status "SENT".
-  submit: (id: string, approvalId?: string) =>
-    apiFetchSimple<OpsMessageSubmitResult>(`${NOTIFICATION_SERVICE}/api/v1/opsmessages/${id}/submit`, {
-      method: 'POST',
-      headers: approvalId ? { 'X-Approval-Id': approvalId } : undefined,
-    }),
-  listPending: (page = 0, size = 20) =>
-    apiFetchSimple<{ items: OperatorMessage[]; total: number }>(
-      `${NOTIFICATION_SERVICE}/api/v1/opsmessages?page=${page}&size=${size}`,
-    ),
-  approve: (id: string) =>
-    apiFetchSimple<{ id: string; status: string }>(
-      `${NOTIFICATION_SERVICE}/api/v1/opsmessages/approvals/${id}/approve`,
-      { method: 'POST' },
-    ),
-  reject: (id: string) =>
-    apiFetchSimple<{ id: string; status: string }>(
-      `${NOTIFICATION_SERVICE}/api/v1/opsmessages/approvals/${id}/reject`,
-      { method: 'POST' },
-    ),
 }
 
 const LEDGER_SERVICE = '/api/svc/ledger-service'

--- a/openbank-admin-ui/src/test/opsmessage-api.contract.test.ts
+++ b/openbank-admin-ui/src/test/opsmessage-api.contract.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { opsMessageApi, OPERATOR_MESSAGE_TEMPLATE_VARS, type ComposeMessageRequest } from '@/lib/api'
+
+// Pins the admin-ui client to the SHIPPED notification-service contract (ADR-0176):
+// OperatorMessageResource (POST /api/v1/notifications/messages) + ApprovalResource
+// (PATCH /api/v1/notifications/approvals/{id}) + openapi.yaml. Regression guard for the gap where
+// the client called an invented /opsmessages draft/submit/approve surface that 404s through the BFF.
+
+function jsonRes(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+}
+
+function lastCall() {
+  const mock = fetch as unknown as ReturnType<typeof vi.fn>
+  const [url, init] = mock.mock.calls[mock.mock.calls.length - 1] as [string, RequestInit]
+  const headers = (init.headers ?? {}) as Record<string, string>
+  const body = init.body ? JSON.parse(init.body as string) : undefined
+  return { url, method: init.method, headers, body }
+}
+
+const REQ: ComposeMessageRequest = {
+  partyId: '11111111-1111-1111-1111-111111111111',
+  template: 'GENERIC_NOTICE',
+  recipient: 'customer@example.com',
+  variables: { subject: 'Hello', note: 'A note' },
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('opsMessageApi — shipped notification-service contract', () => {
+  it('compose POSTs to /api/v1/notifications/messages and maps 201 -> SENT', async () => {
+    const notificationId = '22222222-2222-2222-2222-222222222222'
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(201, { id: notificationId })))
+
+    const result = await opsMessageApi.compose(REQ)
+
+    const call = lastCall()
+    expect(call.url).toBe('/api/svc/notification-service/api/v1/notifications/messages')
+    expect(call.method).toBe('POST')
+    expect(call.headers['Content-Type']).toBe('application/json')
+    // First (un-approved) call carries no approval header.
+    expect(call.headers['X-Approval-Id']).toBeUndefined()
+    expect(call.body).toEqual(REQ)
+    expect(result).toEqual({ status: 'SENT', id: notificationId })
+  })
+
+  it('compose maps the AuthorizeInterceptor 202 body -> PENDING_APPROVAL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(202, { status: 'PENDING_APPROVAL', approvalId: 'appr-1' })))
+
+    const result = await opsMessageApi.compose(REQ)
+
+    expect(result).toEqual({ status: 'PENDING_APPROVAL', approvalId: 'appr-1' })
+  })
+
+  it('compose retry sends the byte-identical body plus the X-Approval-Id header', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(201, { id: 'sent-after-approval' })))
+
+    const result = await opsMessageApi.compose(REQ, 'appr-1')
+
+    const call = lastCall()
+    expect(call.headers['X-Approval-Id']).toBe('appr-1')
+    expect(call.body).toEqual(REQ) // resource binding is content-derived — must not mutate on retry
+    expect(result).toEqual({ status: 'SENT', id: 'sent-after-approval' })
+  })
+
+  it('compose surfaces a 400 (bad template variables / recipient) as a thrown error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(400, { message: 'recipient is not a well-formed email address' })))
+
+    await expect(opsMessageApi.compose(REQ)).rejects.toThrow(/well-formed email/)
+  })
+
+  it('decide PATCHes /api/v1/notifications/approvals/{id} with an approve boolean', async () => {
+    const approvalResponse = {
+      id: 'appr-1', action: 'opsmessage.compose', resourceId: 'r', status: 'APPROVED', decidedBy: 'op-2',
+    }
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(200, approvalResponse)))
+
+    const decision = await opsMessageApi.decide('appr-1', true)
+
+    const call = lastCall()
+    expect(call.url).toBe('/api/svc/notification-service/api/v1/notifications/approvals/appr-1')
+    expect(call.method).toBe('PATCH')
+    expect(call.body).toEqual({ approve: true })
+    expect(decision).toEqual(approvalResponse)
+  })
+
+  it('decide sends approve:false on a reject', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonRes(200, {
+      id: 'appr-1', action: 'opsmessage.compose', resourceId: null, status: 'REJECTED', decidedBy: 'op-2',
+    })))
+
+    await opsMessageApi.decide('appr-1', false)
+
+    expect(lastCall().body).toEqual({ approve: false })
+  })
+
+  it('exposes exactly the shipped OperatorMessageTemplate variable sets — no OPERATOR_ACCOUNT_NOTICE', () => {
+    expect(OPERATOR_MESSAGE_TEMPLATE_VARS).toEqual({
+      GENERIC_NOTICE: ['subject', 'note'],
+      SUPPORT_FOLLOWUP: ['ticketReference'],
+    })
+    expect(Object.keys(OPERATOR_MESSAGE_TEMPLATE_VARS)).not.toContain('OPERATOR_ACCOUNT_NOTICE')
+  })
+})


### PR DESCRIPTION
## Summary

The operator compose/approve UI for customer messaging (ADR-0176 D2) was wired to a non-existent backend surface and 404'd through the pass-through BFF, so an operator could not actually compose or approve a message from the console. This realigns the admin-ui client to the shipped `notification-service` contract and adds a regression test.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #1521

## Changes

- `opsMessageApi` (`src/lib/api.ts`) rewritten to the shipped contract (`OperatorMessageResource`, `ApprovalResource`, `openapi.yaml` 1.6.0):
  - two-call draft+submit → **single** `POST /api/v1/notifications/messages` (compose is itself the four-eyes-gated call; `201` sent / `202` pending — the maker replays the byte-identical body with `X-Approval-Id` once approved).
  - template `OPERATOR_ACCOUNT_NOTICE` → `GENERIC_NOTICE` / `SUPPORT_FOLLOWUP`.
  - `referenceId` + `purpose` → `recipient` (email) + template `variables` map.
  - separate approve/reject verbs → single `PATCH /api/v1/notifications/approvals/{id}` `{approve}`.
  - **dropped `listPending`**: the backend (`ApprovalStore`) exposes no query to enumerate pending approvals — no list endpoint exists — so the auto-loaded checker queue was unbuildable. Replaced with a decide-by-approval-id form; the maker relays the id out of band (a real queue needs a backend list endpoint — remaining ADR-0176 work).
- Party detail (`src/app/parties/[id]/page.tsx`): compose card is now a real form — template select, recipient prefilled from the party, dynamic template-variable inputs — with client-side validation mirroring the backend recipient/variable guards. The pending banner surfaces the `approvalId` for relay; retry resends the exact request.
- Notifications (`src/app/notifications/page.tsx`): the fiction-backed pending-approvals queue becomes the decide-by-approval-id form (`PATCH` decide).
- New `src/test/opsmessage-api.contract.test.ts` pins the paths, the 201/202 branch, the `PATCH` decide call, and the template-variable set so the surface cannot silently re-drift.

## Definition of Done

- [x] Hexagonal layering preserved (admin-ui client only; no backend change).
- [x] Unit tests added/updated (`opsmessage-api.contract.test.ts`, 7 cases).
- [ ] Integration tests added/updated (if service boundary involved).
- [x] Contract tests updated (client-side contract test added; backend contract unchanged).
- [x] No new lint warnings (`eslint` 0 errors; pre-existing `set-state-in-effect` warnings only, on untouched lines).
- [x] `type-check` clean, all admin-ui guard tests pass (i18n / graceful-state / layout-shell / agent-insights).
- [x] OpenAPI spec: no change (this fixes the client to match the *existing* spec).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs.
- [x] No new `@SuppressWarnings` / `as Any` / `@Suppress`.
- [x] No new third-party dependency.
- [x] Auth / crypto / payment code: unchanged. The four-eyes segregation-of-duties is enforced server-side (`SelfApprovalNotAllowedException`); the UI only surfaces the id and relays the decision.

## Compliance impact

- [x] None (client wiring fix; no data path, authz, or contract change).

## Rollout / Rollback

- Deployment strategy: rolling (admin-ui, not a money-path service).
- Rollback plan: revert the PR; the prior behavior is a non-functional (404'ing) compose/approve UI, so revert only returns to the broken state.
- Data migration reversible: N/A.

## Reviewer notes

- Verified against `origin/main`: `notification-service` `OperatorMessageResource` / `ApprovalResource` / `openapi.yaml` are the source of truth; the client now matches them exactly.
- Both contract halves tested: admin-ui client-contract test (7/7) + the backend's own suites (`OperatorMessageResourceTest` 3/3, `ApprovalResourceTest` 3/3, `AuthorizeInterceptorTest` 23/23, incl. 201-compose / 400-bad-var / 202-pending / approved-id-consumed / different-maker-re-pends / self-approval).
- **Not** exercised: a full live click-through (needs the deployed sandbox — Quarkus + Postgres + Kafka + Keycloak + mailer + an authed Next session). Four-eyes enforcement defaults `false` in sandbox, so compose returns `201` directly there and no pending approvals exist.
- Design call worth a look: dropping the checker *queue* for a decide-by-id form, because the backend genuinely cannot list pending approvals today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
