### PR TITLE
perf(ci): let the PR lane restore a warm Gradle cache (~120s/service build)

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -124,19 +124,36 @@ jobs:
       # stronger control, so the shim is redundant (and unsupported on this host).
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Resolve GRADLE_USER_HOME: prefer the node-local hostPath cache injected by
-      # arc-runners.tf (GRADLE_USER_HOME_NODE_CACHE=/var/cache/gradle-svc) on ARC
-      # ephemeral runners; fall back to workspace-relative path on Mac/Hetzner.
-      # NOTE: env context is NOT available in job-level env: blocks of reusable
-      # workflows (workflow_call) — GitHub rejects the expression at parse time with
-      # "Unrecognized named-value: 'env'" — so we resolve it here in a step where
-      # env IS available. See GitHub docs: contexts available in reusable workflows.
+      # Resolve GRADLE_USER_HOME by runner class:
+      #  - ARC ephemeral (GRADLE_USER_HOME_NODE_CACHE set by arc-runners.tf): node-local
+      #    hostPath cache, per-service.
+      #  - other self-hosted (Mac/Hetzner): workspace-relative, per-service.
+      #    Both keep the home PER-SERVICE so one job's `gradle --stop` post-action can't
+      #    kill a sibling job's daemon on the SHARED persistent registry (the documented
+      #    "1-of-28-fails / daemon disappeared" incident).
+      #  - GitHub-hosted (the PR lane): the DEFAULT ~/.gradle. Each hosted matrix job gets
+      #    its OWN ephemeral runner, so there is no sibling daemon to protect and the
+      #    per-service isolation is not just moot but HARMFUL: a non-standard home defeats
+      #    setup-gradle's cross-job cache restore, so the PR lane was rebuilding build-logic
+      #    and re-resolving dependencies from cold every run ("Gradle User Home cache not
+      #    found"). With the default home it restores the warm cache fleet-lint keeps on
+      #    main. Measured on openbank-domestic-payment: ~82 s restored vs ~204 s cold — the
+      #    restore is read-only (see cache-read-only below), so it adds nothing to the
+      #    Actions cache quota.
+      # NOTE: env context is NOT available in job-level env: blocks of reusable workflows
+      # (workflow_call) — GitHub rejects "Unrecognized named-value: 'env'" at parse time —
+      # so this is resolved in a step where env IS available.
       - name: Resolve GRADLE_USER_HOME
+        env:
+          RUNNER_ENV: ${{ runner.environment }}
         run: |
           if [ -n "${GRADLE_USER_HOME_NODE_CACHE:-}" ]; then
             echo "GRADLE_USER_HOME=${GRADLE_USER_HOME_NODE_CACHE}/${{ inputs.service }}" >> "$GITHUB_ENV"
-          else
+          elif [ "${RUNNER_ENV}" = "self-hosted" ]; then
             echo "GRADLE_USER_HOME=${{ github.workspace }}/../../.gradle-svc/${{ inputs.service }}" >> "$GITHUB_ENV"
+          else
+            # GitHub-hosted PR lane: default home so setup-gradle restores the shared cache.
+            echo "GRADLE_USER_HOME=${HOME}/.gradle" >> "$GITHUB_ENV"
           fi
 
       # Normalize the Testcontainers Docker endpoint across the MIXED runner pool
@@ -370,6 +387,17 @@ jobs:
           # cache to fall back on — so the cache is enabled there and disabled
           # on the self-hosted main lane.
           cache-disabled: ${{ runner.environment == 'self-hosted' }}
+          # On the hosted PR lane: RESTORE the warm cache fleet-lint keeps on main, but
+          # never WRITE. Writing 26 per-service home caches on PR branches would churn the
+          # Actions cache quota (already ~96% full) and re-trigger the "storage quota has
+          # been hit" build failures noted above. Read-only gets the ~120 s speedup (paired
+          # with the default GRADLE_USER_HOME resolved above, which is what lets the restore
+          # actually hit) at zero quota cost. Ignored on self-hosted (cache-disabled there).
+          cache-read-only: ${{ runner.environment != 'self-hosted' }}
+          # Enable the cross-job OS-level fallback restore so a service build can reuse
+          # fleet-lint's / another service's home cache instead of requiring an exact
+          # per-job match (which never exists — the self-hosted main lane writes no cache).
+          gradle-home-cache-strict-match: false
 
       # No --no-daemon (ADR-0043): on a persistent runner the Gradle daemon is kept
       # warm and reused across jobs, so the JVM + 30-module configuration is not paid


### PR DESCRIPTION
## Summary

The hosted PR build starts from a **cold Gradle home every run** (`Gradle User Home cache not found`), recompiling build-logic and re-resolving dependencies each time. This lets it restore the warm cache fleet-lint already keeps on main — **~120 s off every service build, at $0 and zero quota cost**. Validated by two experiments before touching the required path.

## Type of change

- [x] perf
- [ ] feat / fix / refactor / docs / chore / security / breaking change

## Linked issues

Refs #1465

## Root cause

The PR lane set a non-standard per-service `GRADLE_USER_HOME` (`_work/../.gradle-svc/<svc>`). That path stops one job's `gradle --stop` killing a sibling's daemon on the **shared self-hosted** registry (the "1-of-28-fails / daemon disappeared" incident). But a GitHub-hosted matrix job gets its **own** ephemeral runner — no sibling daemon — so there the isolation is not just moot (its own comment said so) but **harmful**: the non-standard home defeats setup-gradle's cross-job cache restore.

## Fix

- Resolve `GRADLE_USER_HOME` by runner class: per-service on ARC and other self-hosted (isolation still needed); **default `~/.gradle` on the hosted PR lane** so the restore hits.
- `cache-read-only` on the hosted lane: **restore** fleet-lint's cache but never **write**. Writing 26 per-service home caches to the ~96 %-full Actions quota would re-trigger the documented "storage quota has been hit" failures.
- `gradle-home-cache-strict-match: false` to enable the OS-level fallback restore (no exact per-job match exists — the self-hosted main lane writes no cache).

## Evidence (two throwaway experiments, #1465)

| experiment | result |
|---|---|
| **1 — ceiling** | warm home cuts `openbank-domestic-payment` from **~211 s → ~22 s**; ~130 s is home-cacheable (build-logic + deps), the rest (JVM boot + config, config-cache off per ADR-0043) is not |
| **2 — cause** | two hosted jobs identical except `GRADLE_USER_HOME`: default home `Cache restored successfully` → **82 s**; per-service home `cache not found` → **204 s**. The path was the entire difference — confirmed from the setup-gradle restore log, not just timing |

## FinOps — quantified

| axis | impact |
|---|---|
| dollars | **$0** — hosted runners (no NAT), public repo (free minutes) |
| Actions cache quota | **0** — `cache-read-only`, no new writes; the 96 %-full quota is untouched |
| NAT | **0** — does not apply to hosted |
| saving | **~120 s / service build** (≈ 5.5 min → 3.5 min on a 1-module PR) |

## Definition of Done

- [x] Hexagonal layering preserved (CI only).
- [ ] Unit/integration/contract tests — N/A (CI YAML; the build logic it runs is unchanged).
- [x] No new lint warnings — `actionlint` finding count identical to `origin/main` (0 = 0); `yamllint` clean; validated against a known-positive first.
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs updated — rationale in the step comments.

## Security checklist

- [x] No secrets, tokens, passwords, or PII.
- [x] No new suppressions.
- [x] No new third-party dependency; no action SHA changed.
- [x] `cache-read-only` on the untrusted PR lane means a PR cannot poison the shared cache — it restores, never writes.

## Compliance impact

- [x] None — build inputs and outputs unchanged; only where the Gradle home lives and whether the cache is restored.

## Rollout / Rollback

- Deployment strategy: takes effect on the next service-touching PR after merge.
- Rollback plan: revert the commit.
- Data migration reversible: N/A.

## Reviewer notes

- **Self-hosted behaviour is byte-for-byte unchanged.** The old `else` (per-service workspace path) is now an `elif [ self-hosted ]` with the identical expression; `cache-disabled` stays `true` on self-hosted, so `cache-read-only` and the default-home branch never apply there. Simulated all three runner classes: ARC → `/var/cache/gradle-svc/<svc>`, self-hosted → `_work/../.gradle-svc/<svc>`, hosted → `~/.gradle`.
- **This PR does NOT self-measure.** Changing only `_service-ci.yml` triggers no service build (not a code-global path), so its own `all-green` passes on an empty matrix. The mechanism is already proven by experiment 2; the live speedup will show on the first service-touching PR after merge — I'll confirm the actual delta there.
- **Why read-only and not read-write:** fleet-lint's cache on main is a superset (whole-fleet build-logic + deps), so a service restore always has a warm base; there is no need for services-ci to write its own, and writing would blow the quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)