### PR TITLE
fix(swift): atomic FOR UPDATE SKIP LOCKED outbox claim (#1201)

### DIFF
--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/outbox/SwiftOutboxDispatcher.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/outbox/SwiftOutboxDispatcher.kt
@@ -16,6 +16,17 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker
 import org.eclipse.microprofile.faulttolerance.Retry
 import org.eclipse.microprofile.faulttolerance.Timeout
 
+/**
+ * Drains the swift transactional outbox (ADR-0050 / ADR-0049 D3).
+ *
+ * **N4 — cross-pod row claim (#1201).** `concurrentExecution = SKIP` only prevents in-JVM
+ * overlap; it does not stop two pods from both running this scheduled method. `replicas: 1` is
+ * steady-state only — an Argo Rollouts canary window runs the old and new pod simultaneously
+ * for the whole rollout duration, and both dispatch on their own tick.
+ * `SwiftOutboxRepositoryImpl` therefore implements [OutboxRepository.claimProcessable] as an
+ * atomic `FOR UPDATE SKIP LOCKED` claim, not the unclaimed-peek default, so two concurrently
+ * running pods can never both select and publish the same row.
+ */
 @ApplicationScoped
 class SwiftOutboxDispatcher(
     private val repo: SwiftOutboxRepository,

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/entity/SwiftOutboxEntity.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/entity/SwiftOutboxEntity.kt
@@ -4,9 +4,21 @@
 package com.openbank.swift.infrastructure.persistence.entity
 
 import com.openbank.libs.persistence.outbox.PanacheOutboxEntity
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import java.time.Instant
 
+/**
+ * `claimed_at` is swift-only — added straight on this entity, not the shared
+ * [PanacheOutboxEntity] (mapped by every outbox-bearing service — a shared-entity migration
+ * would need every service migrated in lockstep). Stamped by
+ * `SwiftOutboxRepositoryImpl.claimProcessable`'s atomic claim query on DISPATCHING; read back
+ * by the same query to decide if a DISPATCHING row is stale enough to reclaim.
+ */
 @Entity
 @Table(name = "swift_outbox")
-class SwiftOutboxEntity : PanacheOutboxEntity()
+class SwiftOutboxEntity : PanacheOutboxEntity() {
+    @Column(name = "claimed_at")
+    var claimedAt: Instant? = null
+}

--- a/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/repository/SwiftOutboxRepositoryImpl.kt
+++ b/openbank-swift-service/src/main/kotlin/com/openbank/swift/infrastructure/persistence/repository/SwiftOutboxRepositoryImpl.kt
@@ -14,11 +14,13 @@ import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.Uni
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
+import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.util.UUID
 
 @ApplicationScoped
-class SwiftOutboxRepositoryImpl :
+class SwiftOutboxRepositoryImpl(private val clock: Clock) :
     SwiftOutboxRepository,
     PanacheRepository<SwiftOutboxEntity> {
 
@@ -36,6 +38,37 @@ class SwiftOutboxRepositoryImpl :
             OutboxStatus.FAILED.name,
         ).range(0, limit.coerceAtLeast(1) - 1).list()
     }.awaitSuspending().map { it.toEntry() }
+
+    /**
+     * Reference implementation for the [OutboxRepository.claimProcessable] atomic-claim
+     * override (#1201). One statement: the inner `SELECT ... FOR UPDATE SKIP LOCKED` locks and
+     * skips-past whatever a concurrently running claim has already locked, and the outer `UPDATE`
+     * flips exactly those rows to DISPATCHING and returns them — so two dispatcher instances
+     * racing this at the same instant can never both claim the same row. Also reclaims rows still
+     * DISPATCHING past [staleAfter] (a pod that claimed a row and then crashed or was evicted
+     * before `markSent`/`markFailed`), so a claim can never strand a row forever.
+     *
+     * Plain native SQL rather than a Panache/HQL lock hint: `FOR UPDATE SKIP LOCKED` has no
+     * `jakarta.persistence.LockModeType` equivalent, and the lock only has to be held for the
+     * lifetime of this one statement/transaction — it must not span the network publish call that
+     * follows.
+     */
+    override suspend fun claimProcessable(limit: Int, staleAfter: Duration): List<OutboxEntry> {
+        val now = Instant.now(clock)
+        val staleThreshold = now.minus(staleAfter)
+        return Panache.withTransaction {
+            Panache.getSession().chain { session ->
+                session.createNativeQuery(CLAIM_SQL, SwiftOutboxEntity::class.java)
+                    .setParameter("pending", OutboxStatus.PENDING.name)
+                    .setParameter("failed", OutboxStatus.FAILED.name)
+                    .setParameter("dispatching", OutboxStatus.DISPATCHING.name)
+                    .setParameter("staleThreshold", staleThreshold)
+                    .setParameter("claimLimit", limit.coerceAtLeast(1))
+                    .setParameter("now", now)
+                    .resultList
+            }
+        }.map { entities -> entities.map { it.toEntry() } }.awaitSuspending()
+    }
 
     override suspend fun countProcessable(): Long = Panache.withSession {
         count(
@@ -81,5 +114,22 @@ class SwiftOutboxRepositoryImpl :
         it.attemptCount = 0
         it.createdAt = createdAt
         it.updatedAt = createdAt
+    }
+
+    companion object {
+        @Suppress("MaxLineLength")
+        private const val CLAIM_SQL = """
+            UPDATE swift_outbox
+            SET status = :dispatching, claimed_at = :now, updated_at = :now
+            WHERE id IN (
+                SELECT id FROM swift_outbox
+                WHERE (status IN (:pending, :failed))
+                   OR (status = :dispatching AND claimed_at < :staleThreshold)
+                ORDER BY created_at ASC
+                LIMIT :claimLimit
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING *
+        """
     }
 }

--- a/openbank-swift-service/src/main/resources/db/migration/V7__swift_outbox_claimed_at.sql
+++ b/openbank-swift-service/src/main/resources/db/migration/V7__swift_outbox_claimed_at.sql
@@ -1,0 +1,6 @@
+-- #1201: atomic FOR UPDATE SKIP LOCKED row-claim so two concurrently running dispatcher
+-- instances (e.g. both pods live during an Argo Rollouts canary window) cannot select and
+-- publish the same PENDING/FAILED rows. claimed_at marks when a row moved to DISPATCHING, so a
+-- stale claim (the claiming pod crashed or was evicted before markSent/markFailed) can be
+-- reclaimed on a later tick instead of stranding the row forever.
+ALTER TABLE swift_outbox ADD COLUMN claimed_at TIMESTAMPTZ;

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/integration/SwiftOutboxClaimIT.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/integration/SwiftOutboxClaimIT.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.swift.integration
+
+import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.libs.persistence.outbox.OutboxMessage
+import com.openbank.libs.persistence.outbox.OutboxStatus
+import com.openbank.swift.infrastructure.persistence.repository.SwiftOutboxRepositoryImpl
+import com.openbank.swift.it.PostgresRedisTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Regression coverage for #1201: two dispatcher instances racing [SwiftOutboxRepositoryImpl]'s
+ * `claimProcessable` at the same instant (an Argo Rollouts canary window running old + new pod)
+ * must never both claim the same row, and a claim that never reaches `markSent`/`markFailed`
+ * (the claiming pod crashed or was evicted) must not strand the row forever.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedisTestResource::class)
+class SwiftOutboxClaimIT {
+
+    @Inject
+    lateinit var repository: SwiftOutboxRepositoryImpl
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun clearOutbox() {
+        onEventLoop { Panache.withTransaction { repository.deleteAll() }.awaitSuspending() }
+    }
+
+    // SwiftOutboxRepositoryImpl.persistInTransaction is `override suspend fun
+    // persistInTransaction(message: SwiftOutboxMessage) { persist(...).awaitSuspending() }` -- a
+    // suspend fun with no Uni return, relying on an ambient reactive session/transaction already
+    // open on the current Vert.x duplicated context (unlike most siblings' Uni<Void>-returning
+    // variant, which nests straight inside a Panache.withTransaction { } Java Supplier lambda).
+    // Calling a suspend fun from inside that non-suspend Supplier lambda does not compile, and
+    // calling it with no ambient transaction at all throws "No current Mutiny.Session found" (no
+    // @WithSession/@WithTransaction is active outside a JAX-RS resource method) -- confirmed by
+    // running this empirically. So: bridge the suspend call back into a Uni with `uni(scope) {}`
+    // *inside* the withTransaction Supplier lambda, which both opens the transaction and type
+    // -checks against the Java Supplier<Uni<T>> signature.
+    private fun seedPending(count: Int): List<OutboxMessage> {
+        val messages = (1..count).map {
+            OutboxMessage(
+                aggregateId = Ids.newId(),
+                eventType = "test.event.claim",
+                payload = """{"seq":$it}""",
+                createdAt = Instant.now(),
+            )
+        }
+        messages.forEach { msg ->
+            onEventLoop {
+                Panache.withTransaction {
+                    uni(CoroutineScope(Dispatchers.Unconfined)) { repository.persistInTransaction(msg) }
+                }.awaitSuspending()
+            }
+        }
+        return messages
+    }
+
+    @Test
+    fun `two concurrent claims never return the same row`() {
+        clearOutbox()
+        val seeded = seedPending(50)
+        val seededIds = seeded.map { it.eventId }.toSet()
+
+        val (first, second) = runBlocking {
+            val a = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            val b = async(Dispatchers.IO) { onEventLoop { repository.claimProcessable(30) } }
+            awaitAll(a, b)
+        }
+
+        val firstIds = first.map { it.eventId }.toSet()
+        val secondIds = second.map { it.eventId }.toSet()
+
+        assertThat(firstIds intersect secondIds)
+            .describedAs("no row may be claimed by both concurrent calls")
+            .isEmpty()
+        assertThat(firstIds + secondIds)
+            .describedAs("every claimed row came from this test's own seed")
+            .isSubsetOf(seededIds)
+        assertThat((first + second)).allSatisfy { assertThat(it.status).isEqualTo(OutboxStatus.DISPATCHING) }
+    }
+
+    @Test
+    fun `a stale DISPATCHING row is reclaimed instead of stranded forever`() {
+        clearOutbox()
+        val seeded = seedPending(1).single()
+
+        val firstClaim = onEventLoop { repository.claimProcessable(10, Duration.ofMinutes(5)) }
+        assertThat(firstClaim.map { it.eventId }).containsExactly(seeded.eventId)
+
+        onEventLoop {
+            Panache.withTransaction {
+                repository.update("claimedAt = ?1 where eventId = ?2", Instant.EPOCH, seeded.eventId)
+            }.awaitSuspending()
+        }
+
+        val reclaim = onEventLoop { repository.claimProcessable(10, Duration.ofSeconds(1)) }
+        assertThat(reclaim.map { it.eventId })
+            .describedAs("stale DISPATCHING row must be reclaimable, not stranded")
+            .containsExactly(seeded.eventId)
+    }
+}


### PR DESCRIPTION
## Summary
- Fleet rollout of the ledger-service reference fix (#1201, sub-item 1) to swift-service.
- `SwiftOutboxRepositoryImpl` now overrides `OutboxRepository.claimProcessable` with an atomic native `UPDATE ... WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING *` statement, so two dispatcher pods running simultaneously during an Argo Rollouts canary window can never claim and publish the same PENDING/FAILED row. Stale DISPATCHING rows (claiming pod crashed before markSent/markFailed) are reclaimed too.
- `SwiftOutboxDispatcherTest` already stubbed `claimProcessable` since #1488, but the real atomic-claim implementation didn't exist yet — that PR only fixed the test's mock target against the inherited `listProcessable` default, so the test wasn't actually exercising atomic-claim behavior until now. No test changes needed here, only the real implementation.

## Test plan
- [x] `SwiftOutboxClaimIT` (new): two concurrent claims never overlap; a stale DISPATCHING row is reclaimed.
- [x] Mutation-tested: reverted the atomic claim to a plain `listProcessable` passthrough, confirmed the concurrency test fails, restored it.
- [x] Full non-cached `:openbank-swift-service:test` (all IT + unit tests, including `SwiftOutboxDispatcherTest`) + `ktlintCheck` + `detekt`, green.

Refs #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)