### PR TITLE
chore(gitops): deploy account-service sandbox-10733be2 (party-event DLQ fix, #1533)

### DIFF
--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -48,7 +48,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: account-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-account-service:sandbox-e3a4c19d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-account-service:sandbox-10733be2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Auto deploy run 29594396760 built + pushed + cosign-signed `openbank-account-service:sandbox-10733be2` (`@sha256:07cc8b71…`, cosign v2 + SBOM attest both success), but `can-i-deploy` is stuck in the self-hosted runner backlog. Hand-bumping so #1533's consumer refactor + `failure-strategy: dead-letter-queue` reach the running pod — the DLQ topic + ACL already synced, but the pod still runs the old catch-all-and-ack consumer without this.

## Linked issues

N/A — gitops image bump for an already-merged, already-signed image (#1533).
