### PR TITLE
fix(notification): keep the PUSH status update on the Vert.x context after the async APNs send

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -24,6 +24,7 @@ import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.mailer.Mail
 import io.quarkus.mailer.reactive.ReactiveMailer
 import io.smallrye.mutiny.Uni
+import io.vertx.core.Vertx
 import jakarta.annotation.PostConstruct
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -33,6 +34,7 @@ import org.jboss.logging.Logger
 import java.time.Clock
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.Executor
 
 @ApplicationScoped
 class NotificationConsumer {
@@ -300,6 +302,12 @@ class NotificationConsumer {
         entity: NotificationEntity,
     ): Uni<Void> {
         val pushText = htmlToPlain(body)
+        // Capture the Vert.x (duplicated) context now, while we are demonstrably on it — the
+        // opening findActiveByParty transaction below only works because we are. The push adapter's
+        // send completes on the JDK HttpClient's own thread pool, off the event loop
+        // (ApnsPushSender), so without hopping back, the trailing status/invalidate transaction
+        // runs with "No current Vertx context found" and is silently swallowed (issue #1548).
+        val vertxContext = Vertx.currentContext()
         return Panache.withTransaction { deviceTokenRepo.findActiveByParty(req.partyId) }
             .chain { tokens ->
                 if (tokens.isEmpty()) {
@@ -315,6 +323,9 @@ class NotificationConsumer {
                     ).map { result -> deviceId to result }
                 }
                 Uni.join().all(sends).andCollectFailures()
+                    // The sends completed off the Vert.x event loop; hop back onto the captured
+                    // context so the Panache.withTransaction below has a context (issue #1548).
+                    .emitOn(Executor { command -> vertxContext?.runOnContext { command.run() } ?: command.run() })
                     .chain { results ->
                         val delivered = results.count { it.second.success }
                         val invalidIds = results.filter { it.second.invalidToken }.map { it.first }

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/push/ApnsPushSender.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/push/ApnsPushSender.kt
@@ -47,8 +47,11 @@ class ApnsPushSender {
     @ConfigProperty(name = "openbank.notification.push.apns.team-id")
     var teamId: Optional<String> = Optional.empty()
 
-    @ConfigProperty(name = "openbank.notification.push.apns.bundle-id", defaultValue = "cz.openbank.app")
-    var bundleId: String = "cz.openbank.app"
+    // Default must match the app's PRODUCT_BUNDLE_IDENTIFIER (openbank-app iosApp/project.yml),
+    // since it becomes the apns-topic header — a mismatch is rejected BadTopic. Overridable per
+    // env; the default exists so an unconfigured deploy fails the right way, not silently wrong.
+    @ConfigProperty(name = "openbank.notification.push.apns.bundle-id", defaultValue = "tech.openbank.app")
+    var bundleId: String = "tech.openbank.app"
 
     // .p8 PEM contents (PKCS#8 EC private key), raw or Base64-encoded. Via env/Vault.
     @ConfigProperty(name = "openbank.notification.push.apns.private-key")

--- a/openbank-notification-service/src/main/resources/application.yaml
+++ b/openbank-notification-service/src/main/resources/application.yaml
@@ -224,7 +224,7 @@ openbank:
         enabled: ${APNS_ENABLED:false}
         key-id: ${APNS_KEY_ID:}
         team-id: ${APNS_TEAM_ID:}
-        bundle-id: ${APNS_BUNDLE_ID:cz.openbank.app}
+        bundle-id: ${APNS_BUNDLE_ID:tech.openbank.app}
         # .p8 PKCS#8 EC private key (raw PEM or Base64).
         private-key: ${APNS_PRIVATE_KEY:}
         # true → APNs sandbox host (debug builds); false → production.

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/NotificationConsumerIT.kt
@@ -4,10 +4,15 @@
 package com.openbank.notification.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.notification.application.port.out.PushMessage
+import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.PushResult
 import com.openbank.notification.domain.model.TemplateSensitivity
+import com.openbank.notification.infrastructure.persistence.entity.DeviceTokenEntity
+import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.mailer.MockMailbox
@@ -15,16 +20,22 @@ import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.Uni
 import io.smallrye.reactive.messaging.memory.InMemoryConnector
 import io.smallrye.reactive.messaging.memory.InMemorySource
+import jakarta.annotation.Priority
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Alternative
 import jakarta.inject.Inject
 import org.assertj.core.api.Assertions.assertThat
 import org.eclipse.microprofile.reactive.messaging.Message
 import org.eclipse.microprofile.reactive.messaging.spi.Connector
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.function.Supplier
 
@@ -239,5 +250,95 @@ class NotificationConsumerIT {
 
         assertThat(bodyFor(partyId)).contains("Alice")
         assertThat(bodyFor(partyId)).isNotEqualTo(TemplateSensitivity.REDACTED_BODY)
+    }
+
+    // ── PUSH channel end-to-end (issue #1548 hardening) ──
+
+    @Inject
+    lateinit var deviceTokenRepo: DeviceTokenRepository
+
+    private fun seedActiveDevice(partyId: UUID, token: String) {
+        VertxContextSupport.subscribeAndAwait {
+            Panache.withTransaction {
+                val now = Instant.now()
+                val entity = DeviceTokenEntity().also {
+                    it.deviceId = UUID.randomUUID()
+                    it.partyId = partyId
+                    it.appInstance = "it-instance-$token"
+                    it.platform = "APNS"
+                    it.token = token
+                    it.status = "ACTIVE"
+                    it.registeredAt = now
+                    it.createdAt = now
+                    it.updatedAt = now
+                }
+                deviceTokenRepo.persist(entity)
+            }
+        }
+    }
+
+    private fun deviceStatusFor(token: String): String? = VertxContextSupport.subscribeAndAwait {
+        Panache.withSession { deviceTokenRepo.find("token", token).firstResult() }
+    }?.status
+
+    /**
+     * End-to-end PUSH coverage (there was none before #1548): one device the adapter accepts, one
+     * it rejects as invalid. Asserts the fan-out result is persisted — row flips to SENT (≥1
+     * delivered) and the rejected token is retired. [OffContextPushSender] completes its send on a
+     * worker thread to mirror ApnsPushSender's JDK HttpClient.
+     *
+     * NOTE: this exercises the post-send transaction but does NOT deterministically reproduce the
+     * production "No current Vertx context found" failure — Quarkus' Mutiny context propagation
+     * restores the context inside this Testcontainers harness, so the pre-fix code also passes here.
+     * The fix (capture the Vert.x context, hop back onto it after the off-loop send) is verified
+     * against the real APNs path in the sandbox: with the adapter enabled the row now commits SENT.
+     */
+    @Test
+    fun `PUSH delivery persists SENT and retires provider-rejected tokens`() {
+        val partyId = UUID.randomUUID()
+        seedActiveDevice(partyId, OffContextPushSender.GOOD_TOKEN)
+        seedActiveDevice(partyId, OffContextPushSender.BAD_TOKEN)
+
+        consumeAndAwait(
+            NotificationRequest(
+                partyId = partyId,
+                channel = NotificationChannel.PUSH,
+                template = NotificationTemplate.WELCOME,
+                recipient = "push-recipient@example.com",
+                variables = mapOf("name" to "Push"),
+            ),
+        )
+
+        // At least one device accepted → row committed SENT (pre-fix: stuck PENDING).
+        assertThat(statusFor(partyId)).isEqualTo("SENT")
+        // The provider-rejected token was retired in the same transaction (pre-fix: stayed ACTIVE).
+        assertThat(deviceStatusFor(OffContextPushSender.BAD_TOKEN)).isEqualTo("INVALID")
+        assertThat(deviceStatusFor(OffContextPushSender.GOOD_TOKEN)).isEqualTo("ACTIVE")
+    }
+}
+
+/**
+ * Test push adapter that completes its send on a worker thread — off the Vert.x event loop —
+ * mirroring ApnsPushSender's JDK HttpClient completion. `@Alternative` at `@Priority(1)` replaces
+ * the real PushSenderRouter for this test module; the non-PUSH tests never invoke it. The good
+ * token is accepted, any other token is rejected as invalid.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+class OffContextPushSender : PushSender {
+    override fun send(message: PushMessage): Uni<PushResult> {
+        val result = if (message.token == GOOD_TOKEN) {
+            PushResult.ok("apns-id-it")
+        } else {
+            PushResult.failed("BadDeviceToken", "invalid token", invalidToken = true)
+        }
+        return Uni.createFrom().completionStage(CompletableFuture.supplyAsync({ result }, EXECUTOR))
+    }
+
+    companion object {
+        const val GOOD_TOKEN = "apns-good-token-it"
+        const val BAD_TOKEN = "apns-bad-token-it"
+        private val EXECUTOR = Executors.newSingleThreadExecutor()
     }
 }


### PR DESCRIPTION
## What

Fixes the bug that surfaced the moment APNs push delivery went live (#1528, #1548).

`NotificationConsumer.sendPush` fans the message out to `ApnsPushSender`, whose JDK `HttpClient` completes on its **own thread pool — off the Vert.x event loop**. The trailing `Panache.withTransaction { invalidate + update status }` then ran with no Vert.x context and threw `IllegalStateException: No current Vertx context found`, which `consume()` swallowed.

Observed in the sandbox after the first real push:
```
PUSH fan-out … devices=2 delivered=1 invalidated=1
ERROR Failed to process notification … IllegalStateException: No current Vertx context found
```
The push **was** delivered, but the row stayed `PENDING` (never `SENT`) and the `BadDeviceToken` token was **not** retired → every later push re-fans-out to the dead token. Dormant until APNs was enabled — while the adapter was disabled its `skipped()` result completed on-context.

## Fix

- Capture the Vert.x context up front (we're demonstrably on it — the opening `findActiveByParty` transaction only works because we are) and `emitOn` back onto it before the post-send transaction, so the status flip and token retirement run on-context.
- Default `APNS_BUNDLE_ID` `cz.openbank.app` → `tech.openbank.app` (the app's `PRODUCT_BUNDLE_IDENTIFIER`) — it becomes the `apns-topic`, so the wrong default is a silent `BadTopic` on an unconfigured deploy.

## Test

Adds end-to-end PUSH coverage to `NotificationConsumerIT` (there was none): one accepted + one rejected device → asserts the row commits `SENT` and the rejected token is retired.

**Honest caveat:** Quarkus' Mutiny context propagation restores the context inside the Testcontainers harness, so this test does **not** deterministically reproduce the production off-context failure (the pre-fix code also passes it). It is happy-path coverage. The fix itself is verified against the real APNs path in the sandbox — with the adapter enabled the row now commits `SENT` — which I'll re-confirm after this deploys.

## Linked issues
Refs #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)