### PR TITLE
revert(product-catalog): unbind the account-contract template from the CZK onboarding products

### DIFF
--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/ProductSeed.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/domain/ProductSeed.kt
@@ -791,13 +791,12 @@ object ProductSeed {
                     url = "https://openbank.example/tac/savings-czk/v1.1",
                     effectiveFrom = LocalDate.of(2024, 12, 1),
                     language = "cs",
-                    // ADR-0162 D1: bind the account contract by CODE (current PUBLISHED version
-                    // resolved at render time), mirroring CURRENT_PERSONAL. Without this,
-                    // OnboardingDocumentService.issueOnboardingDocument finds no template for the
-                    // onboarding product and issues no account-contract document — the eager
-                    // account.created path no-ops. This is the retail CZK onboarding product
-                    // (id ...c3), so the omission meant every onboarding skipped it.
-                    documentTemplateCode = "UCET_SMLOUVA_CS",
+                    // No documentTemplateCode by design (ADR-0170 D5): at onboarding the customer
+                    // signs ONLY the framework agreement (RAMCOVA_SMLOUVA), which incorporates the
+                    // account-contract terms by reference — a separate account-contract signing
+                    // ceremony is an explicitly-deferred phase-2 refinement. Binding a template here
+                    // (as #1524 mistakenly did) makes the eager issueOnboardingDocument path open a
+                    // UCET_SMLOUVA ceremony that nothing ever signs — a dangling PENDING artifact.
                 ),
             ),
             versionHistory = listOf(
@@ -1106,13 +1105,12 @@ object ProductSeed {
                     effectiveFrom = LocalDate.of(2025, 1, 1),
                     language = "cs",
                     summary = "Korunový běžný účet — obchodní podmínky v1.0",
-                    // ADR-0162 D1: bind the account contract by CODE (current PUBLISHED version
-                    // resolved at render time), mirroring CURRENT_PERSONAL. Without this,
-                    // OnboardingDocumentService.issueOnboardingDocument finds no template for the
-                    // onboarding product and issues no account-contract document. This is THE
-                    // retail CZK onboarding current account (id ...c2), so the omission meant the
-                    // eager account.created path no-op'd for every new customer.
-                    documentTemplateCode = "UCET_SMLOUVA_CS",
+                    // No documentTemplateCode by design (ADR-0170 D5): at onboarding the customer
+                    // signs ONLY the framework agreement (RAMCOVA_SMLOUVA), which incorporates the
+                    // account-contract terms by reference — a separate account-contract signing
+                    // ceremony is an explicitly-deferred phase-2 refinement. Binding a template here
+                    // (as #1524 mistakenly did) makes the eager issueOnboardingDocument path open a
+                    // UCET_SMLOUVA ceremony that nothing ever signs — a dangling PENDING artifact.
                 ),
             ),
             versionHistory = listOf(

--- a/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/domain/OnboardingProductTemplateBindingTest.kt
+++ b/openbank-product-catalog/src/test/kotlin/com/openbank/productcatalog/domain/OnboardingProductTemplateBindingTest.kt
@@ -8,24 +8,30 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 /**
- * Pins the onboarding products' account-contract binding. CURRENT_CZK (id ...c2) and SAVINGS_CZK
- * (id ...c3) are what account-service opens for every self-service onboarding
- * (openbank.account.onboarding.default-product-id / savings-product-id). document-service's
- * eager OnboardingDocumentService.issueOnboardingDocument resolves the account-contract template
- * off the product's documentTemplateCode; when it was absent the whole eager path silently
- * no-op'd for every new customer (no account-contract document, only an INFO log). This test
- * makes that omission a failing build, not a live discovery.
+ * Pins the phase-1 onboarding-signature invariant (ADR-0170 D5): the CZK onboarding products
+ * CURRENT_CZK (id ...c2) and SAVINGS_CZK (id ...c3) must NOT bind a documentTemplateCode.
+ *
+ * At onboarding the customer signs only the framework agreement (RAMCOVA_SMLOUVA), which
+ * incorporates the account-contract terms by reference; a separate account-contract signing
+ * ceremony is an explicitly-deferred phase-2 refinement. Binding a template here makes the eager
+ * OnboardingDocumentService.issueOnboardingDocument path open a UCET_SMLOUVA ceremony that nothing
+ * ever signs — a dangling PENDING artifact (this happened in #1524 and is reverted here). This
+ * test fails the build if that binding is re-introduced.
  */
 class OnboardingProductTemplateBindingTest {
 
     @Test
-    fun `the CZK onboarding products bind an account-contract document template`() {
+    fun `the CZK onboarding products bind no account-contract template (phase-1, ADR-0170 D5)`() {
         for (code in listOf("CURRENT_CZK", "SAVINGS_CZK")) {
             val product = ProductSeed.products.single { it.code == code }
             val bound = product.termsAndConditions.mapNotNull { it.documentTemplateCode }
             assertThat(bound)
-                .describedAs("%s must bind a documentTemplateCode so onboarding can issue its contract", code)
-                .contains("UCET_SMLOUVA_CS")
+                .describedAs(
+                    "%s must NOT bind a documentTemplateCode — onboarding signs only RAMCOVA_SMLOUVA; " +
+                        "a per-account-contract ceremony is deferred (ADR-0170 D5)",
+                    code,
+                )
+                .isEmpty()
         }
     }
 }


### PR DESCRIPTION
Reverts #1524.

## Why

#1524 bound `UCET_SMLOUVA_CS` to `CURRENT_CZK` / `SAVINGS_CZK` so the eager `issueOnboardingDocument` path would render an account-contract document off `account.created`. Per **ADR-0170 D5** that is wrong for phase 1: at onboarding the customer signs **only the framework agreement (`RAMCOVA_SMLOUVA`)**, which incorporates the account-contract terms *by reference* — a separate per-account-contract signing ceremony is an explicitly-deferred phase-2 refinement.

The binding made the eager path open a `UCET_SMLOUVA` ceremony per account that **nothing ever signs** — the app signs `RAMCOVA` via the lazy, per-language `ensureOnboardingAgreement` path, which this does not touch. Result: dangling `PENDING_SIGNATURE` ceremonies, two per onboarded customer.

Seen live on a real device onboarding (party `5f74b80a`): two `UCET_SMLOUVA_CS` PENDING ceremonies and **no framework agreement**.

#1524 was chasing a log line (`Product ...c2 has no documentTemplateCode bound`) that looked like a bug but was the **correct phase-1 state** — the eager path is dormant infrastructure for the deferred phase-2 multi-doc ceremony.

## Change

- Remove the `documentTemplateCode` binding from both CZK onboarding products.
- Invert `OnboardingProductTemplateBindingTest` to pin the phase-1 invariant (onboarding products bind **no** template) so the binding can't be re-introduced silently.
- `CURRENT_PERSONAL`'s pre-existing binding is untouched — it is not an onboarding product.

Live product-catalog rows + the dangling ceremonies are corrected separately (the seeder only seeds an empty store). The framework-agreement sign flow is fixed app-side in a companion change (HOME-entry gate on actual signed status).

## Linked issues

Refs #1497