### PR TITLE
ci(auto-deploy): surface the services can-i-deploy leaves behind (#1420)

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -734,6 +734,38 @@ jobs:
           deployable_json="$(printf '%s\n' "${deployable_list[@]:-}" | jq -R . | jq -sc 'map(select(length > 0))')"
           echo "deployable=${deployable_json}" >> "$GITHUB_OUTPUT"
           echo "Deployable this run: ${deployable_json}"
+          # ── #1420: name the services left behind (changed − deployable), loudly ──────────
+          # The gate keeps the deployable SUBSET moving and only fails its own status "for
+          # visibility"; the complement is silently starved. Four money-path services sat 5+
+          # days behind main before anyone diffed image tags by hand (issue #1420). The gate
+          # already knows the complement — emit it so a green-looking run cannot hide a stuck
+          # money-path deploy. This changes NO deploy behaviour: rc/deployable/exit are
+          # untouched; it only adds a summary + annotations, escalating to ::error:: when a
+          # money-path service is the one left behind.
+          BLOCKED_JSON="$(jq -cn --argjson all "$SERVICES" --argjson ok "$deployable_json" '$all - $ok' 2>/dev/null || echo '[]')"
+          echo "blocked=${BLOCKED_JSON}" >> "$GITHUB_OUTPUT"
+          BLOCKED_N="$(echo "$BLOCKED_JSON" | jq 'length')"
+          if [ "$BLOCKED_N" -gt 0 ]; then
+            # money-path service names come from the governance source of truth, so this can't
+            # rot as the fleet's money-path set changes.
+            MP="$(awk '/^money_path_services:/{f=1;next} f&&/^  - /{print $2} f&&/^[a-zA-Z]/{exit}' openbank-libs/governance/rules.yaml)"
+            {
+              echo "### can-i-deploy: ${BLOCKED_N} changed service(s) left behind"
+              echo "Rebuilt this run but blocked by the contract gate — they stay on their current (older) image while \`main\` advances:"
+            } >> "$GITHUB_STEP_SUMMARY"
+            mp_blocked=0
+            for svc in $(echo "$BLOCKED_JSON" | jq -r '.[]'); do
+              if echo "$MP" | grep -qx "$svc"; then
+                echo "::error::[${svc}] MONEY-PATH service blocked by can-i-deploy — not deploying; it stays behind main (issue #1420)"
+                echo "- \`${svc}\` — **money-path**, blocked" >> "$GITHUB_STEP_SUMMARY"
+                mp_blocked=1
+              else
+                echo "::warning::[${svc}] blocked by can-i-deploy — not deploying (issue #1420)"
+                echo "- \`${svc}\` — blocked" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            done
+            [ "$mp_blocked" = "1" ] && echo "::error::can-i-deploy left one or more MONEY-PATH services behind this run — see the job summary (issue #1420)"
+          fi
           # Enforce: non-zero rc still fails this job's own status for visibility (ADR-0092) —
           # it no longer blocks gitops-pr/record-deployment for the deployable subset above.
           exit $rc


### PR DESCRIPTION
## What

`can-i-deploy` (ADR-0092) keeps the deployable **subset** moving and only fails its own status "for visibility". The **complement** — services rebuilt this run but blocked by the contract gate — is emitted nowhere. So a fleet-wide change that invalidates the pact matrix silently strands services, and every affected run still reads green.

This emits the blocked set (`changed − deployable`) as a job summary + annotations, escalating to `::error::` when a **money-path** service is the one left behind. Money-path membership is read from `rules.yaml` (governance source of truth) so it can't rot.

## Verified live (2026-07-17, not from the issue's snapshot)

The condition is active and worsening:
- **consent, lending, sepa-payment, transaction** (all money-path) are still pinned to `sandbox-e3a4c19d` — a commit from **2026-07-11**, now **~5.8 days** behind `main`.
- Recent `auto-deploy` runs are the intermittent success/failure mix the issue describes; a failing run's `can-i-deploy` step shows the pact verdict.

## Scope — deliberately the zero-risk piece

Purely additive (+32 lines, 0 deletions). **`rc`, the `deployable` output, and the final `exit` are untouched** — no deploy behaviour changes; it only removes the "green-looking deploy" illusion. Verified: blocked-set + money-path classification logic tested in isolation; no new actionlint findings vs `origin/main`.

This is issue #1420 **item 3**. It does **not**:
- fix the pact-matrix convergence root cause (item 1) — that's a larger, money-path-sensitive change;
- add a runtime "deployed image age > N days" alert (item 2) — deliberately held back given current alert-fatigue.

Refs #1420