### PR TITLE
docs(notification): correct stale APNS_BUNDLE_ID default in ops docs

### DIFF
--- a/openbank-notification-service/src/main/resources/docs/05-operations.cs.md
+++ b/openbank-notification-service/src/main/resources/docs/05-operations.cs.md
@@ -43,7 +43,7 @@ Vyhrazené **management rozhraní** je zapnuté na portu **8085** (`quarkus.mana
 | `FCM_SERVICE_ACCOUNT_JSON` | (nenastaveno) | FCM service-account JSON (Vault) |
 | `FCM_PROJECT_ID` | (nenastaveno) | volitelné, fallback z JSON |
 | `APNS_ENABLED` | `false` | zapnutí APNs push adaptéru |
-| `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_BUNDLE_ID` | / / `cz.openbank.app` | APNs identifikátory |
+| `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_BUNDLE_ID` | / / `tech.openbank.app` | APNs identifikátory |
 | `APNS_PRIVATE_KEY` | (nenastaveno) | .p8 PKCS#8 EC klíč (Vault) |
 | `APNS_SANDBOX` | `false` | true → APNs sandbox host |
 | `BUILD_TIME` / `GIT_COMMIT` | `unknown` | build metadata v `/api/v1/info` |

--- a/openbank-notification-service/src/main/resources/docs/05-operations.en.md
+++ b/openbank-notification-service/src/main/resources/docs/05-operations.en.md
@@ -43,7 +43,7 @@ A dedicated **management interface** is enabled on port **8085** (`quarkus.manag
 | `FCM_SERVICE_ACCOUNT_JSON` | (unset) | FCM service-account JSON (Vault) |
 | `FCM_PROJECT_ID` | (unset) | optional, falls back to JSON |
 | `APNS_ENABLED` | `false` | enable APNs push adapter |
-| `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_BUNDLE_ID` | / / `cz.openbank.app` | APNs identifiers |
+| `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_BUNDLE_ID` | / / `tech.openbank.app` | APNs identifiers |
 | `APNS_PRIVATE_KEY` | (unset) | .p8 PKCS#8 EC key (Vault) |
 | `APNS_SANDBOX` | `false` | true → APNs sandbox host |
 | `BUILD_TIME` / `GIT_COMMIT` | `unknown` | build metadata in `/api/v1/info` |


### PR DESCRIPTION
Closes #1548's follow-up item. The code fix (\`ApnsPushSender.kt\` default,
\`application.yaml\`) already landed in #1528 — these two ops-doc tables
still showed the old \`cz.openbank.app\` default instead of
\`tech.openbank.app\`. Doc-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)