### PR TITLE
docs(governance): correct stale merge_group note in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,15 +167,17 @@ fire from *outside* it, so they stay here:
   `GIT_SEQUENCE_EDITOR=true git rebase -i --exec 'git commit --amend --no-edit -S' origin/main`,
   then verify via the API (`gh api .../pulls/<N>/commits --jq '.[].commit.verification'`) — not
   `gh pr view`.
-- **The `merge_group:` triggers in the required-check workflows are DEAD CODE — there is no merge
-  queue and there cannot be one.** GitHub merge queue requires an **organization-owned** repo; this
-  one is owned by a personal account, so adding a `merge_queue` rule to the ruleset returns
-  `422 Invalid rule 'merge_queue'` (issue #1465 has the isolation proof). The support was built
-  before that was checked; it is kept because it is correct and inert (the trigger simply never
-  fires) and would be needed the day the repo moves under an org — but do not read it as a working
-  gate, and do not "fix" a queue that isn't there. Consequence: the frozen-`base.sha` race
-  (#481 × #524) stays open, and `strict_required_status_checks_policy` (require branches up to
-  date) is the only remaining lever that works on a personal account.
+- **There is no `merge_group:` trigger anywhere in the required-check workflows — and there cannot
+  be one.** GitHub merge queue requires an **organization-owned** repo; this one is owned by a
+  personal account, so adding a `merge_queue` rule to the ruleset returns `422 Invalid rule
+  'merge_queue'` (issue #1465 has the isolation proof). Support for it was built (#1467), then
+  deliberately **reverted** (#1504): an unreachable trigger is not a harmless spare part — nothing
+  exercises `services-ci`'s `merge_group` base-selection logic, so it would silently drift from the
+  PR-path logic it must mirror, and the day someone enabled a queue it would report stale-but-green,
+  the exact vacuous-green failure class this codebase works hard to avoid elsewhere. Don't re-add it
+  without re-checking the 422 first. Consequence: the frozen-`base.sha` race (#481 × #524) stays
+  open, and `strict_required_status_checks_policy` (require branches up to date) is the only
+  remaining lever that works on a personal account.
 
 ### Dependency graph & PR-time CVE gating
 Rationale + what does *not* cover it: `rules.yaml: dependencies.pr_time_cve_gate` (authoritative).


### PR DESCRIPTION
## Summary
- CLAUDE.md's CI/bot-signing section described the `merge_group:` trigger support as currently present ("kept because it is correct and inert"). PR #1504 reverted #1467's merge_group support entirely on 2026-07-17, reasoning that unreachable trigger logic is a drift risk (services-ci's merge_group base-selection would silently rot with nothing exercising it), not a harmless inert asset.
- Verified against `origin/main`: no `merge_group` reference remains in any workflow.
- Updated the bullet to describe the code as removed, pointing to #1467 (built it) and #1504 (reverted it, with reasoning), keeping the still-true consequence (#481 × #524 frozen-base.sha race stays open).

## Type of change
- [x] docs

## Linked issues
Refs #1465

## Test plan
- [x] `git show origin/main:.github/workflows/*.yml | grep merge_group` → no hits
- [x] Docs-only change, no CI-relevant path touched