### PR TITLE
docs(adr): re-verify fleet ADR Delivery-Status drift (issue #1521)

### DIFF
--- a/docs/adr/0135-push-notification-token-security.md
+++ b/docs/adr/0135-push-notification-token-security.md
@@ -10,6 +10,19 @@ Author(s): Jiri Raska
 - **Security model** — ✅ Complete: token binding to SCA session, 90-day TTL refresh, explicit logout `DELETE` endpoint (PR #2527), payload minimisation (title/template only, no PII), and per-platform registration limit designed.
 - **Token migration** — ⬜ Pending: APNs/FCM feedback loop integration (token revocation callbacks) and migration of existing plain-text tokens to encrypted columns + `registeredAt`/`refreshedAt`/`status` schema not yet done.
 
+**Delivery-Status update (2026-07-17):** the "Token migration" bullet above conflates a
+shipped item with genuinely-pending ones — split for accuracy (issue #1521):
+- **Lifecycle schema** — ✅ Shipped: `status` has existed on `device_tokens` since
+  `V6__create_device_tokens.sql`, and `registered_at`/`refreshed_at` were added by
+  `V7__device_token_lifecycle_columns.sql` and are read/written by `DeviceTokenEntity`,
+  `DeviceTokenRepository`, and `DeviceResource` in `openbank-notification-service`.
+- **Token encryption at rest** — ⬜ still Pending: `device_tokens.token` remains a plain
+  `TEXT` column (no encryption in `DeviceTokenEntity`/the persistence layer).
+- **APNs/FCM feedback-loop revocation callbacks** — ⬜ still Pending: no inbound
+  provider-revocation handler exists; `DeviceTokenRepository`'s "revocation" is
+  outbound-only (explicit logout / admin deactivation), not a feedback-loop callback.
+  Header stays `Delivery-Status: Partial` — this only corrects which sub-items are open.
+
 ## Context
 
 OpenBank's mobile app (iOS + Android, ADR-0064) sends push notifications for payment confirmations,


### PR DESCRIPTION
## Summary

Re-verified every ADR flagged in #1521 as carrying a false Delivery-Status against the current
code on `origin/main`, per the ADR philosophy established after #1522 ("record don't overwrite",
detection is semantic not structural — no automated gate was built or attempted here).

**Result: 21 of the 22 flagged ADRs were already corrected** on `origin/main` before this PR,
via the dated correction notes already landed in #1527, #1530, #1534 and similar prior commits
(most timestamped 2026-07-01 through 2026-07-17). Re-reading each ADR's current text and
independently re-grepping the codebase confirmed those existing notes are accurate — this PR
does not touch them.

**One genuine gap remained: ADR-0135.** Its "Token migration — ⬜ Pending" bullet conflates a
shipped item with two still-open ones:
- `registeredAt`/`refreshedAt`/`status` schema — actually ✅ shipped (`status` since
  `V6__create_device_tokens.sql`; `registered_at`/`refreshed_at` added by
  `V7__device_token_lifecycle_columns.sql`, both wired into `DeviceTokenEntity`,
  `DeviceTokenRepository`, `DeviceResource`).
- Token encryption at rest — still ⬜ pending (`device_tokens.token` remains plain `TEXT`).
- APNs/FCM revocation feedback-loop callback — still ⬜ pending (no inbound provider-revocation
  handler; existing "revocation" plumbing is outbound-only: explicit logout / admin
  deactivation).

Appended a dated correction note (`docs/adr/0135-push-notification-token-security.md`) splitting
the bullet, per the repo's existing correction-note convention (see ADR-0138). Header stays
`Delivery-Status: Partial` — only the sub-item accounting changes. No existing prose was deleted
or rewritten.

## Verification detail (for the issue delta)

Checked all 22 flagged ADRs individually against real code (classes, migrations, gitops
manifests, CI workflows), not against the issue text:

**Already corrected on `origin/main` (no edit needed here):** ADR-0161, 0162, 0169, 0176, 0124,
0126, 0034, 0019, 0020, 0022, 0023, 0024, 0025, 0055, 0059, 0063, 0068, 0094, 0119, 0146, 0017,
0041, 0083.

**Corrected in this PR:** ADR-0135 (stale sub-bullet, see above).

No CI gate or automated detector was built — consistent with #1522's conclusion that this class
of drift is semantic and needs a per-ADR human/agent read, not a structural grep.

Closes #1521