### PR TITLE
chore(governance): resolve #1503's 7-edge lineage-code-audit triage

### DIFF
--- a/openbank-authz-policy-auditor/governance.yaml
+++ b/openbank-authz-policy-auditor/governance.yaml
@@ -16,10 +16,6 @@ lineage:
       description: reads openbank-infra/opa/policies/*.rego, openbank-libs/governance/policies/*.rego,
         openbank-libs-runtime AuthorizeInterceptor.kt, and openbank-libs/governance/agents.yaml via a
         repo checkout
-  downstream:
-    - serviceName: admin-ui
-      relationType: api
-      description: exposes OPA/Rego and agents.yaml static-policy-drift findings and HITL approval queue
 schemaLineage:
   ownedSchemas:
     - authzaudit_schema

--- a/openbank-docs-truth-agent/governance.yaml
+++ b/openbank-docs-truth-agent/governance.yaml
@@ -15,10 +15,6 @@ lineage:
       relationType: api
       description: reads docs/adr/*.md Delivery-Status lines and rules.yaml enforced flags via a
         repo checkout, and greps the repo for the artifacts each ADR names
-  downstream:
-    - serviceName: admin-ui
-      relationType: api
-      description: exposes ADR-status-vs-code drift findings and HITL approval queue
 schemaLineage:
   ownedSchemas: [docstruth_schema]
   dependentSchemas: []

--- a/openbank-document-service/governance.yaml
+++ b/openbank-document-service/governance.yaml
@@ -20,13 +20,6 @@ lineage:
     - serviceName: account-service
       relationType: topic
       description: consumes account.created for onboarding document issuance (ADR-0162 D7)
-  downstream:
-    - serviceName: lending-service
-      relationType: api
-      description: consumes rendered loan agreements
-    - serviceName: account-service
-      relationType: api
-      description: consumes rendered account statements/agreements
 schemaLineage:
   ownedSchemas:
     - documents_schema

--- a/openbank-flaky-test-hunter/governance.yaml
+++ b/openbank-flaky-test-hunter/governance.yaml
@@ -15,11 +15,6 @@ lineage:
       relationType: api
       description: reads fleet-wide */src/test/kotlin/**/*.kt test sources, .github/scripts/*.sh CI
         guard scripts, and JUnit/Gradle test-result reports via a repo checkout
-  downstream:
-    - serviceName: admin-ui
-      relationType: api
-      description: exposes silent-test-failure findings (runBlocking-Unit drift, Pact provider
-        gating blind spots, provider-class collisions, test-count drift) and the HITL approval queue
 schemaLineage:
   ownedSchemas:
     - flakytest_schema

--- a/openbank-governance-auditor/governance.yaml
+++ b/openbank-governance-auditor/governance.yaml
@@ -14,10 +14,6 @@ lineage:
     - serviceName: github
       relationType: api
       description: reads merged-PR metadata (reviews, merge-commit verification, labels, body) via the GitHub API
-  downstream:
-    - serviceName: admin-ui
-      relationType: api
-      description: exposes governance-audit findings and HITL approval queue
 schemaLineage:
   ownedSchemas:
     - govaudit_schema

--- a/openbank-release-steward/governance.yaml
+++ b/openbank-release-steward/governance.yaml
@@ -15,10 +15,6 @@ lineage:
       relationType: api
       description: reads release-please-config.json/.release-please-manifest.json/application.yaml
         via a repo checkout, and open-PR openapi.yaml diffs via the GitHub API
-  downstream:
-    - serviceName: admin-ui
-      relationType: api
-      description: exposes release/version-invariant findings and HITL approval queue
 schemaLineage:
   ownedSchemas: [releasesteward_schema]
   dependentSchemas: []


### PR DESCRIPTION
## Summary

Triages the 7 `lineage-code-audit` edges #1503 flagged — the ones `check-governance-lineage.py` surfaced outside #1021's original 34-edge scan (resolved in #1499).

All 7 are confirmed stale, zero backing code in either direction:

- **`authz-policy-auditor`/`docs-truth-agent`/`flaky-test-hunter`/`governance-auditor`/`release-steward` -> `admin-ui:api`**: each agent exposes its own findings REST resource, but grepping `openbank-admin-ui/src` for any of the five service names turns up nothing — no BFF route, no `fetch()`, nothing. This does **not** match the `devops-agent`/`finops-agent` reversed-direction shape from #1021 (those have a dedicated `/api/devops` and `/api/finops` BFF route calling directly into the agent, confirmed by reading `route.ts`); it matches the *other* #1021 bucket instead — the #889 failure class, an aspirational claim with no code on either side. Deleted the same way #1499 deleted its 19 stale edges: removed from the agent's own `governance.yaml`, no converse edge added to `admin-ui`'s (which has no `lineage:` section at all).

- **`document-service -> account-service:api`** and **`-> lending-service:api`**: investigated fresh per the issue's instruction, not pattern-matched onto the admin-ui shape. `document-service` has no `@RegisterRestClient` toward either service, and neither `account-service` nor `lending-service` has a REST client or Kafka consumer pointed at `document-service` — zero api-level or topic-level connection in either direction. (The service that actually calls `document-service`'s `/api/v1/documents` endpoints is `customer-edge`, via `DocumentServiceClient` — a real dependency, but a different edge pair than the one declared here, and neither side's `governance.yaml` claims it. Out of scope for this issue — flagging for awareness only.) Both edges deleted as stale claims.

No `rules.yaml` change was needed — none of the 7 warranted an allowlist entry (no heuristic-invisible-but-real dependency found), so **no OPA bundle regeneration** was required this time.

## Verification

`check-governance-lineage.py --root .`, run fresh against `origin/main` before and after:

- **Before**: 37 downstream edges checked, **11 unallowlisted violations**, 6 allowlisted
- **After**: 30 downstream edges checked, **4 unallowlisted violations**, 6 allowlisted

The remaining 4 are the pre-existing gaps #1499 already flagged and deliberately left as warnings, each needing its own issue (not folded into this one, per #1021's own classification): `onboarding-service->account-service:api`, `psd2-service->consent-service:api`, `psd2-service->sca-service:api`, `settlement-service->audit-service:topic`.

Closes #1503.