### PR TITLE
ci(ledger): forward Pact broker properties to the koverXmlReport step

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -431,9 +431,36 @@ jobs:
       # Coverage upload (Codecov is free for public repos; tokenless via the OIDC
       # id-token this job already has). Advisory only — never gates the build.
       # koverVerify stays the enforcement mechanism (ratchet-only, rules.yaml).
+      #
+      # The -D flags below MUST mirror "Build + test" verbatim (issue #1009). koverXmlReport
+      # depends on koverGenerateArtifact -> test, so this is a SECOND, independent `./gradlew`
+      # invocation reaching the same `test` task. build.gradle.kts's `tasks.withType<Test> {
+      # System.getProperty(key)?.let { systemProperty(key, it) } }` makes those Pact -D values
+      # part of `test`'s tracked inputs — omitting them here makes the input set differ from the
+      # build step's, which is a guaranteed cache miss: Gradle re-executes `test` from scratch,
+      # this time with pactbroker.url/pact.verifier.publishResults unset, so the pact-jvm
+      # verifier logs "Skipping publishing of verification results ... not 'true'" and the
+      # @PactBroker provider test's @EnabledIfSystemProperty(pactbroker.url) gate skips it
+      # outright. Confirmed live in run 29489275110 job 87613534930 (2026-07-16): the `test` task
+      # ran a second, full time (fresh Testcontainer boot included) right after this step started,
+      # with none of the Pact system properties present. Passing identical values here lets
+      # Gradle recognize `test` as UP-TO-DATE/FROM-CACHE instead of re-running it uncredentialed.
       - name: Generate Kover XML report
         continue-on-error: true
-        run: ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          PUBLISH_RESULTS: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          ./gradlew :${{ inputs.service }}:koverXmlReport --build-cache --console=plain \
+            -Dpactbroker.url="${PACT_BROKER_URL:-}" \
+            -Dpactbroker.auth.username="${PACT_BROKER_USERNAME:-}" \
+            -Dpactbroker.auth.password="${PACT_BROKER_PASSWORD:-}" \
+            -Dpactbroker.enablePending=true \
+            -Dpactbroker.providerBranch="${BRANCH}" \
+            -Dpact.verifier.publishResults="${PUBLISH_RESULTS}" \
+            -Dpact.provider.version="${GITHUB_SHA}" \
+            -Dpact.provider.branch="${BRANCH}" \
+            -Dpact.provider.tag="${BRANCH}"
 
       - name: Upload coverage to Codecov
         continue-on-error: true


### PR DESCRIPTION
## What

`_service-ci.yml`'s "Build + test" step runs `./gradlew :<service>:build ... -Dpactbroker.url=... -Dpact.verifier.publishResults=...` — these `-D` flags flow into every forked `Test` task via `build.gradle.kts`'s `tasks.withType<Test> { System.getProperty(key)?.let { systemProperty(key, it) } }`, which makes them part of `test`'s tracked task inputs.

The very next step, "Generate Kover XML report", runs a **second, independent** `./gradlew :<service>:koverXmlReport --build-cache` invocation with **none** of those `-D` flags. `koverXmlReport` depends on `koverGenerateArtifact` → `test`, so this second invocation reaches the same `test` task — but with a different (missing) system-property input set, which is a guaranteed Gradle cache miss. `test` re-executes from scratch (fresh Testcontainer boot included), this time with `pactbroker.url`/`pact.verifier.publishResults` unset.

## Evidence

Confirmed directly against the ledger-service main-push job for commit `25214dd01` (run `29489275110`, job `87613534930`, 2026-07-16 — the run cited in #1009's own triage comment):

- `test` task header (`> Task :openbank-ledger-service:test`) appears **twice** in the job log, ~1.5 minutes apart, each preceded by a fresh Testcontainer/Ryuk boot.
- First run: `PUBLISH_RESULTS: true` was passed via `-D`, no "Skipping publishing" message.
- Between the two: `> Task :openbank-ledger-service:build` (BUILD SUCCESSFUL) then a **new** `##[group]Run ./gradlew :openbank-ledger-service:koverXmlReport --build-cache --console=plain` group with no `-D` flags in its command line or env dump.
- Second run (inside that koverXmlReport invocation): `koverGenerateArtifactJvm` re-executes (not UP-TO-DATE) because its upstream `test` re-executed, and the pact-jvm verifier repeatedly logs `Skipping publishing of verification results as it has been disabled (pact.verifier.publishResults is not 'true')` — because this invocation never set that property. The `@PactBroker`-gated `LedgerPactBrokerProviderVerificationTest` (`@EnabledIfSystemProperty(named = "pactbroker.url", matches = ".+")`) would also be skipped outright in this second run for the same reason.

## Fix

Forward the identical `-D` flags (same `BRANCH`/`PUBLISH_RESULTS` env, same `PACT_BROKER_URL`/`USERNAME`/`PASSWORD` job-level env already in scope) to the `koverXmlReport` step, so `test`'s inputs match between the two invocations and Gradle can recognize it as UP-TO-DATE/FROM-CACHE instead of re-running it uncredentialed. This also removes a wasted full second test execution (including Testcontainer boot) on every service, every push — a real CI-time/cost win independent of the Pact angle.

## Scope note (why this is `Refs`, not `Closes`)

This closes the concrete, currently-reproducible CI wiring gap: a second, unauthenticated `test` re-run immediately following the correctly-configured one. I could not confirm from outside CI (no Pact Broker UI/API access) whether the *first* invocation's `LedgerPactBrokerProviderVerificationTest` run actually completes a successful publish end-to-end — the job log has no visible "Verifying a pact between..." / broker HTTP trace in either invocation, which is worth a maintainer look with broker access. Recommend re-running `can-i-deploy openbank-ledger-service` after this merges and a fresh main-push build lands, to confirm the broker now shows an up-to-date verification result.

Refs #1009