### PR TITLE
perf(ci): close openbank-libs-domain/runtime/testing gap in code-global rebuild trigger

### DIFF
--- a/.github/workflows/services-ci.yml
+++ b/.github/workflows/services-ci.yml
@@ -131,7 +131,7 @@ jobs:
             echo "Changed files:"; echo "$FILES" | sed 's/^/  /'
 
             # Code-global inputs every module compiles/tests against -> rebuild all.
-            # (openbank-libs, version catalog, root build, gradle.properties,
+            # (openbank-libs*, version catalog, root build, gradle.properties,
             # build-logic.) A change here can alter any service's compile or test
             # inputs, so the whole fleet must rebuild.
             # NB: feed grep via a here-string, NOT `echo "$FILES" | grep -q`.
@@ -145,8 +145,26 @@ jobs:
             # Governance catalogs (openbank-libs/governance/) are data for CI
             # checks + admin-ui, not a compile/test input of any module — an
             # ADR/control-catalog edit must not cost a 28-module fleet run.
+            #
+            # `openbank-libs/` alone is stale since ADR-0122 split the module in two
+            # (#33/#34): openbank-libs-domain and openbank-libs-runtime are compiled
+            # into EVERY service exactly like openbank-libs was, and
+            # openbank-libs-testing supplies the shared Pact/authz/outbox conformance
+            # kits every service's test source set depends on (testImplementation) —
+            # i.e. it can change *how* a provider's Pact verification test runs
+            # without touching that provider's own src/ or any pacts/*.json, and
+            # without a `pacts/` diff to catch it downstream (issue #1208 triage,
+            # gap #2). A literal `^openbank-libs/` prefix does not match any of the
+            # three split module names, so before this fix a change to any of them
+            # fell through to the per-module fan-out below and rebuilt only that
+            # module itself — a silent under-build of every other service's compile
+            # and Pact-provider-test inputs. auto-deploy.yml's analogous SHARED_CHANGED
+            # check already lists openbank-libs-domain/openbank-libs-runtime
+            # explicitly (#376); this brings services-ci.yml's PR-path trigger in
+            # line with it, plus openbank-libs-testing (auto-deploy correctly omits
+            # it — it's test-only, never shipped in a runtime image).
             FILES_CODE=$(grep -vE '^openbank-libs/governance/' <<< "$FILES" || true)
-            if grep -qE '^(openbank-libs/|gradle/|settings\.gradle\.kts|build\.gradle\.kts|gradle\.properties|build-logic/)' <<< "$FILES_CODE"; then
+            if grep -qE '^(openbank-libs/|openbank-libs-domain/|openbank-libs-runtime/|openbank-libs-testing/|gradle/|settings\.gradle\.kts|build\.gradle\.kts|gradle\.properties|build-logic/)' <<< "$FILES_CODE"; then
               echo "Decision: code-global change -> build all modules."
               CHANGED="$ALL"
             else


### PR DESCRIPTION
## Summary
- `services-ci.yml`'s PR-path "code-global change -> rebuild all" regex still matched only the literal `openbank-libs/` prefix, predating the ADR-0122 domain/runtime split (#33/#34).
- `openbank-libs-domain` and `openbank-libs-runtime` compile into every service exactly like `openbank-libs` did pre-split, and `openbank-libs-testing` supplies the shared conformance kits every service's test source set depends on — including the Pact provider verification tests #1208 is about.
- Before this fix, a change to any of the three fell through to the per-module fan-out and rebuilt **only that module itself**, silently under-building every other service's compile and Pact-test inputs. `auto-deploy.yml`'s analogous `SHARED_CHANGED` check already lists `openbank-libs-domain`/`openbank-libs-runtime` explicitly (#376); this brings `services-ci.yml`'s PR-path trigger in line with it, and adds `openbank-libs-testing` (which `auto-deploy.yml` correctly omits, since it's test-only and never ships in a runtime image).
- This is a **safety-only** change — it only *adds* full-fleet triggering for three module paths that previously fan-out'd to just themselves. It never causes an under-build; worst case is a few extra full-fleet PR runs on `openbank-libs-testing` changes.

## Why this, not the broader #1208 proposal
#1208 proposes narrowing the **push-to-main** full-fleet rule to a scoped (changed-modules + `pacts/`-diff-driven) rebuild. The repo owner's own prior triage on that issue flagged this exact gap as a prerequisite to check ("what about a change to `openbank-libs-testing` or `build-logic` that alters *how* Pact tests execute without a `pacts/*.json` diff and without matching the shared-path list?") and recommended the narrowing land as its own deliberate, reviewed PR with a canary period — not something to fix opportunistically.

This PR closes that specific prerequisite gap on the **PR path** (which already does scoped fan-out and was directly exposed to it), independent of whether/when the push-path narrowing itself ships. It is intentionally the minimal, risk-asymmetric slice: I'm leaving the push-path narrowing itself as comment-only on #1208, per the owner's explicit ask for a canary/observation period before that lands.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- [x] `actionlint` on the modified file — zero new findings (the two pre-existing shellcheck notes, SC2001/SC2086, are present at the same relative positions on `origin/main` too).
- [x] Verified the new regex against sample paths: `openbank-libs-domain/...`, `openbank-libs-runtime/...`, `openbank-libs-testing/...` now match code-global (full-fleet); an ordinary service path (`openbank-ledger-service/...`) still correctly falls through to per-module fan-out.
- [ ] CI itself will exercise the changed logic on this PR's own push (workflow-file-only change, so per the existing per-module fan-out fallback it should build just the `openbank-libs` canary — or full-fleet if the reviewer wants to `workflow_dispatch` the modified logic directly to sanity-check the new match).

Refs #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)