### PR TITLE
fix(document-service): fill the RAMCOVA_SMLOUVA template with real party/account/product data

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
@@ -171,4 +171,40 @@ interface ClientSignatureIssuerPort {
  */
 interface ProductCatalogPort {
     suspend fun findDocumentTemplateCode(productId: UUID): String?
+
+    /**
+     * The product's display name + code, for the RAMCOVA_SMLOUVA template's `{{product.name}}`/
+     * `{{product.code}}` clause (Article 2). Same fail-open stance as [findDocumentTemplateCode] —
+     * that clause is itself `{{#if}}`-guarded in the template, so a lookup failure degrades to
+     * omitting the clause, never to blocking the signature.
+     */
+    suspend fun findProduct(productId: UUID): ProductInfo?
 }
+
+data class ProductInfo(val name: String?, val code: String)
+
+/**
+ * Read-only lookup into `openbank-party-service`, scoped to what RAMCOVA_SMLOUVA's `{{party.*}}`
+ * clause needs (the customer's own name + on-file address, ADR-0169 D5). Fails open, matching
+ * [ProductCatalogPort]: `party.name` is the one placeholder the template does NOT `{{#if}}`-guard,
+ * so a lookup failure still renders a legible (if impersonal) contract rather than blocking the
+ * signature over an enrichment dependency — but see [OnboardingDocumentService] for the fallback
+ * used when this returns `null`.
+ */
+interface PartyLookupPort {
+    suspend fun findById(partyId: UUID): PartyInfo?
+}
+
+data class PartyInfo(val legalName: String, val formattedAddress: String?)
+
+/**
+ * Read-only lookup into `openbank-account-service`, scoped to the CURRENT account RAMCOVA_SMLOUVA's
+ * `{{account.iban}}`/`{{product.*}}` clause needs. By the time the framework agreement is signed
+ * the account already exists (ADR-0162 D7 — `account.created` fires before the sign step), so this
+ * is real on-file data. Fails open like [ProductCatalogPort] — the clause is `{{#if}}`-guarded.
+ */
+interface AccountLookupPort {
+    suspend fun findCurrentAccount(partyId: UUID): AccountInfo?
+}
+
+data class AccountInfo(val iban: String, val productId: UUID)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
@@ -12,15 +12,19 @@ import com.openbank.document.application.port.`in`.OnboardingDocumentUseCase
 import com.openbank.document.application.port.`in`.OpenCeremonyCommand
 import com.openbank.document.application.port.`in`.RenderDocumentCommand
 import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
+import com.openbank.document.application.port.out.AccountLookupPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
 import com.openbank.document.application.port.out.DuplicateCeremonyException
 import com.openbank.document.application.port.out.DuplicateDocumentException
+import com.openbank.document.application.port.out.PartyLookupPort
 import com.openbank.document.application.port.out.ProductCatalogPort
 import com.openbank.document.domain.model.Document
 import com.openbank.document.domain.model.DocumentStatus
 import com.openbank.document.domain.model.SignatureLevel
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -43,13 +47,53 @@ import java.util.UUID
 @ApplicationScoped
 class OnboardingDocumentService(
     private val productCatalogPort: ProductCatalogPort,
+    private val partyLookupPort: PartyLookupPort,
+    private val accountLookupPort: AccountLookupPort,
     private val renderUseCase: DocumentRenderUseCase,
     private val documentQueryUseCase: DocumentQueryUseCase,
     private val ceremonyUseCase: SignatureCeremonyUseCase,
     private val documentRepository: DocumentRepositoryPort,
+    private val clock: Clock,
 ) : OnboardingDocumentUseCase {
 
     private val log = Logger.getLogger(OnboardingDocumentService::class.java)
+
+    /**
+     * Assembles the Handlebars data map both render call sites need — the fix for a document that
+     * used to render against `data = emptyMap()` and left a signed legal contract reading
+     * "(the "Customer")" with a blank address (RAMCOVA_SMLOUVA's `{{party.name}}` is the one
+     * placeholder the template does NOT `{{#if}}`-guard). Every lookup here is fail-open (see the
+     * port kdocs) — an unreachable dependency degrades to an omitted clause (the template already
+     * guards account/product/address with `{{#if}}`), never to blocking the signature. `party.name`
+     * is the one exception in practice: party-service is structurally guaranteed to have a
+     * non-blank legalName (a required domain field), so only a live outage — not "the customer has
+     * no name" — would leave it blank, same fail-open trade-off the rest of the fleet accepts for
+     * reference-data dependencies.
+     *
+     * [productIdOverride] lets the eager path (which already knows the exact product from
+     * `account.created`) skip re-deriving it from the looked-up account.
+     *
+     * [partyRef] is typed as a bare `String` everywhere upstream, not a `UUID` — an unparseable
+     * value (malformed data, a non-UUID synthetic reference) is treated the same as an unreachable
+     * lookup: skip enrichment, never throw. A legal-document render must not fail over a party-id
+     * shape issue any more than over a network blip.
+     */
+    private suspend fun buildAgreementData(
+        partyRef: String,
+        caseRef: String,
+        productIdOverride: UUID? = null,
+    ): Map<String, Any?> {
+        val partyId = runCatching { UUID.fromString(partyRef) }.getOrNull()
+        val party = partyId?.let { partyLookupPort.findById(it) }
+        val account = partyId?.let { accountLookupPort.findCurrentAccount(it) }
+        val product = (productIdOverride ?: account?.productId)?.let { productCatalogPort.findProduct(it) }
+        return mapOf(
+            "party" to mapOf("name" to (party?.legalName ?: ""), "address" to party?.formattedAddress),
+            "account" to mapOf("iban" to account?.iban),
+            "product" to mapOf("name" to product?.name, "code" to product?.code),
+            "document" to mapOf("date" to LocalDate.now(clock).toString(), "caseRef" to caseRef),
+        )
+    }
 
     override suspend fun issueOnboardingDocument(cmd: IssueOnboardingDocumentCommand) {
         val idempotencyKey = onboardingKey(cmd.accountId)
@@ -86,7 +130,11 @@ class OnboardingDocumentService(
                 RenderDocumentCommand(
                     templateCode = templateCode,
                     templateVersion = null,
-                    data = emptyMap(),
+                    data = buildAgreementData(
+                        partyRef = cmd.partyRef,
+                        caseRef = cmd.accountId.toString(),
+                        productIdOverride = cmd.productId,
+                    ),
                     contentType = "application/pdf",
                     partyRef = cmd.partyRef,
                     caseRef = cmd.accountId.toString(),
@@ -147,14 +195,15 @@ class OnboardingDocumentService(
         agreements.forEach { documentRepository.save(it.archive()) }
 
         // 4. Render fresh in the requested language + open the ceremony.
+        val caseRef = "$AGREEMENT_KEY_PREFIX$partyRef"
         val document = renderUseCase.render(
             RenderDocumentCommand(
                 templateCode = wantCode,
                 templateVersion = null,
-                data = emptyMap(),
+                data = buildAgreementData(partyRef = partyRef, caseRef = caseRef),
                 contentType = "application/pdf",
                 partyRef = partyRef,
-                caseRef = "$AGREEMENT_KEY_PREFIX$partyRef",
+                caseRef = caseRef,
                 productRef = null,
                 retainUntil = null,
             ),

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/AccountAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/AccountAdapter.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.client
+
+import com.openbank.document.application.port.out.AccountInfo
+import com.openbank.document.application.port.out.AccountLookupPort
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * **Fail-open** [AccountLookupPort] adapter (mirrors [ProductCatalogAdapter]'s stance): an
+ * unreachable account-service must never block signing — the caller degrades to a template
+ * render without the IBAN/product clause rather than failing the ceremony.
+ */
+@ApplicationScoped
+class AccountAdapter : AccountLookupPort {
+
+    @Inject
+    @RestClient
+    lateinit var client: AccountClient
+
+    private val log = Logger.getLogger(AccountAdapter::class.java)
+
+    // CURRENT, not just "first returned": the framework agreement's Article 2 names THE payment
+    // account, and SAVINGS is opened alongside CURRENT for every retail onboarding (#1477 chain)
+    // but is not what "the Customer is provided with a payment account" refers to.
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun findCurrentAccount(partyId: UUID): AccountInfo? = try {
+        client.listByParty(partyId.toString()).awaitSuspending().data
+            .firstOrNull { it.accountType == "CURRENT" }
+            ?.let { AccountInfo(iban = it.accountNumber, productId = UUID.fromString(it.productId)) }
+    } catch (e: Exception) {
+        log.warnf(
+            "account-service unavailable for party %s; contract will omit account details: %s",
+            partyId,
+            e.message,
+        )
+        null
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/AccountClient.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/AccountClient.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * RestClient binding to `openbank-account-service`'s party-scoped account list — narrow, mirroring
+ * [ProductCatalogClient]. Feeds the RAMCOVA_SMLOUVA template's `{{account.iban}}`/`{{product.*}}`
+ * clause (Article 2, "the Customer is provided with a payment account …"): by the time the
+ * framework agreement is signed the account already exists (ADR-0162 D7 — account.created fires
+ * before the sign step), so this is real on-file data, not a placeholder.
+ */
+@RegisterRestClient(configKey = "account-service-api")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Produces(MediaType.APPLICATION_JSON)
+interface AccountClient {
+    @GET
+    @Path("/api/v1/accounts")
+    fun listByParty(@QueryParam("partyId") partyId: String): Uni<AccountPageClientResponse>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountPageClientResponse(val data: List<AccountClientResponse> = emptyList())
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountClientResponse(
+    val id: String,
+    val accountNumber: String,
+    val accountType: String,
+    val productId: String,
+    val status: String,
+)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/PartyAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/PartyAdapter.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.client
+
+import com.openbank.document.application.port.out.PartyInfo
+import com.openbank.document.application.port.out.PartyLookupPort
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * **Fail-open** [PartyLookupPort] adapter (mirrors [ProductCatalogAdapter]'s stance): an
+ * unreachable party-service must never block signing — the caller degrades to a template render
+ * without the customer's name/address rather than failing the ceremony.
+ */
+@ApplicationScoped
+class PartyAdapter : PartyLookupPort {
+
+    @Inject
+    @RestClient
+    lateinit var client: PartyClient
+
+    private val log = Logger.getLogger(PartyAdapter::class.java)
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun findById(partyId: UUID): PartyInfo? = try {
+        val resp = client.getById(partyId.toString()).awaitSuspending()
+        PartyInfo(legalName = resp.legalName, formattedAddress = resp.address?.format())
+    } catch (e: Exception) {
+        log.warnf("party-service unavailable for %s; contract will omit customer details: %s", partyId, e.message)
+        null
+    }
+
+    // Single-line "street, postal code city" — matches the template's plain-string
+    // {{party.address}} placeholder (Article header), not a nested object. Skips whichever
+    // parts a party record doesn't have yet (e.g. self-service onboarding that never collected
+    // a full postal address) rather than emitting "null" or dangling punctuation.
+    private fun PartyAddressClientResponse.format(): String? {
+        val cityLine = listOfNotNull(postalCode?.takeIf { it.isNotBlank() }, city?.takeIf { it.isNotBlank() })
+            .joinToString(" ")
+            .takeIf { it.isNotBlank() }
+        val parts = listOfNotNull(line1?.takeIf { it.isNotBlank() }, line2?.takeIf { it.isNotBlank() }, cityLine)
+        return parts.joinToString(", ").takeIf { it.isNotBlank() }
+    }
+}

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/PartyClient.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/PartyClient.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.document.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+
+/**
+ * RestClient binding to `openbank-party-service`'s party read endpoint — narrow, mirroring
+ * [ProductCatalogClient]. The only fields this service needs are the ones the RAMCOVA_SMLOUVA
+ * template's `{{party.*}}` placeholders reference (name, address): rendering a legal contract
+ * against `data = emptyMap()` left "(the "Customer")" and a blank address on a real signed
+ * document — this is what fills them in with the party's actual (or KYC-synthetic, per
+ * ADR-0069) on-file details.
+ */
+@RegisterRestClient(configKey = "party-service-api")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Produces(MediaType.APPLICATION_JSON)
+interface PartyClient {
+    @GET
+    @Path("/api/v1/parties/{id}")
+    fun getById(@PathParam("id") id: String): Uni<PartyClientResponse>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PartyClientResponse(val id: String, val legalName: String, val address: PartyAddressClientResponse? = null)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PartyAddressClientResponse(
+    val line1: String? = null,
+    val line2: String? = null,
+    val city: String? = null,
+    val postalCode: String? = null,
+    val countryCode: String? = null,
+)

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogAdapter.kt
@@ -5,6 +5,7 @@
 package com.openbank.document.infrastructure.client
 
 import com.openbank.document.application.port.out.ProductCatalogPort
+import com.openbank.document.application.port.out.ProductInfo
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -33,6 +34,14 @@ class ProductCatalogAdapter : ProductCatalogPort {
             .termsAndConditions.firstNotNullOfOrNull { it.documentTemplateCode }
     } catch (e: Exception) {
         log.warnf("product-catalog unavailable for %s; no onboarding document will be issued: %s", productId, e.message)
+        null
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun findProduct(productId: UUID): ProductInfo? = try {
+        client.getById(productId.toString()).awaitSuspending().let { ProductInfo(name = it.name, code = it.code) }
+    } catch (e: Exception) {
+        log.warnf("product-catalog unavailable for %s; contract will omit product details: %s", productId, e.message)
         null
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogClient.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/client/ProductCatalogClient.kt
@@ -17,9 +17,9 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
 
 /**
  * RestClient binding to `openbank-product-catalog`'s product read endpoint — narrow, mirroring
- * `openbank-account-service`'s own `ProductCatalogClient`. The only field this service actually
- * needs is `termsAndConditions[].documentTemplateCode` (ADR-0162 D1), the product's onboarding
- * document reference.
+ * `openbank-account-service`'s own `ProductCatalogClient`. Needs `termsAndConditions[]
+ * .documentTemplateCode` (ADR-0162 D1), the product's onboarding document reference, and `name`
+ * (fills the RAMCOVA_SMLOUVA template's `{{product.name}}` clause once an account exists).
  */
 @RegisterRestClient(configKey = "product-catalog-api")
 @RegisterProvider(OidcClientRequestReactiveFilter::class)
@@ -34,6 +34,7 @@ interface ProductCatalogClient {
 data class ProductClientResponse(
     val id: String,
     val code: String,
+    val name: String? = null,
     val termsAndConditions: List<TermsAndConditionsClientResponse> = emptyList(),
 )
 

--- a/openbank-document-service/src/main/resources/application.yaml
+++ b/openbank-document-service/src/main/resources/application.yaml
@@ -66,6 +66,18 @@ quarkus:
       url: ${PRODUCT_CATALOG_SERVICE_URL:http://localhost:8104}
       connect-timeout: 3000
       read-timeout: 5000
+    # Fill the RAMCOVA_SMLOUVA template's {{party.*}}/{{account.*}}/{{product.*}} clauses at
+    # sign time — was `data = emptyMap()` on every render, so a real signed contract read
+    # "(the "Customer")" with a blank address. Fail-open (PartyAdapter/AccountAdapter): an
+    # outage degrades the render, never blocks the signature.
+    party-service-api:
+      url: ${PARTY_SERVICE_URL:http://localhost:8111}
+      connect-timeout: 3000
+      read-timeout: 5000
+    account-service-api:
+      url: ${ACCOUNT_SERVICE_URL:http://localhost:8100}
+      connect-timeout: 3000
+      read-timeout: 5000
   redis:
     hosts: redis://localhost:6379
   smallrye-reactive-messaging:

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/OnboardingDocumentServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/OnboardingDocumentServiceTest.kt
@@ -8,12 +8,16 @@ import com.openbank.document.application.port.`in`.DocumentQueryUseCase
 import com.openbank.document.application.port.`in`.DocumentRenderUseCase
 import com.openbank.document.application.port.`in`.IssueOnboardingDocumentCommand
 import com.openbank.document.application.port.`in`.OpenCeremonyCommand
-import com.openbank.document.application.port.`in`.RenderDocumentCommand
 import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
+import com.openbank.document.application.port.out.AccountInfo
+import com.openbank.document.application.port.out.AccountLookupPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
 import com.openbank.document.application.port.out.DuplicateCeremonyException
 import com.openbank.document.application.port.out.DuplicateDocumentException
+import com.openbank.document.application.port.out.PartyInfo
+import com.openbank.document.application.port.out.PartyLookupPort
 import com.openbank.document.application.port.out.ProductCatalogPort
+import com.openbank.document.application.port.out.ProductInfo
 import com.openbank.document.domain.model.Document
 import com.openbank.document.domain.model.DocumentStatus
 import com.openbank.document.domain.model.SignatureCeremony
@@ -25,7 +29,9 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 /**
@@ -37,20 +43,30 @@ import java.util.UUID
 class OnboardingDocumentServiceTest {
 
     private val productCatalogPort: ProductCatalogPort = mockk()
+    private val partyLookupPort: PartyLookupPort = mockk()
+    private val accountLookupPort: AccountLookupPort = mockk()
     private val renderUseCase: DocumentRenderUseCase = mockk()
     private val documentQueryUseCase: DocumentQueryUseCase = mockk()
     private val ceremonyUseCase: SignatureCeremonyUseCase = mockk()
     private val documentRepository: DocumentRepositoryPort = mockk()
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-07-17T10:00:00Z"), ZoneOffset.UTC)
     private val service = OnboardingDocumentService(
         productCatalogPort,
+        partyLookupPort,
+        accountLookupPort,
         renderUseCase,
         documentQueryUseCase,
         ceremonyUseCase,
         documentRepository,
+        clock,
     )
 
     private val accountId: UUID = UUID.randomUUID()
     private val productId: UUID = UUID.randomUUID()
+
+    // A non-UUID partyRef here is deliberate — it doubles as coverage for the "unparseable
+    // partyRef" fail-open path (buildAgreementData never throws, just skips enrichment lookups)
+    // instead of needing a separate test to exercise it.
     private val partyRef = "party-1"
     private val idempotencyKey = "onboarding:$accountId"
 
@@ -58,6 +74,10 @@ class OnboardingDocumentServiceTest {
     fun `renders the product's bound template with no pinned version and opens a ceremony`(): Unit = runBlocking {
         coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null
         coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
+        // buildAgreementData still resolves the product from productIdOverride even though
+        // partyRef ("party-1") isn't a parseable UUID — party/account lookups are skipped, but
+        // the product lookup doesn't depend on partyId.
+        coEvery { productCatalogPort.findProduct(productId) } returns null
         val document = document()
         coEvery { renderUseCase.render(any()) } returns document
         coEvery { ceremonyUseCase.findByDocumentId(document.id) } returns null
@@ -65,19 +85,20 @@ class OnboardingDocumentServiceTest {
 
         service.issueOnboardingDocument(IssueOnboardingDocumentCommand(accountId, partyRef, productId))
 
+        // Non-data fields asserted exactly; `data`'s content is covered by the dedicated
+        // enrichment tests below, since it now depends on party/account/product lookups.
         coVerify(exactly = 1) {
             renderUseCase.render(
-                RenderDocumentCommand(
-                    templateCode = "RAMCOVA_SMLOUVA_CS",
-                    templateVersion = null,
-                    data = emptyMap(),
-                    contentType = "application/pdf",
-                    partyRef = partyRef,
-                    caseRef = accountId.toString(),
-                    productRef = productId.toString(),
-                    retainUntil = null,
-                    idempotencyKey = idempotencyKey,
-                ),
+                match {
+                    it.templateCode == "RAMCOVA_SMLOUVA_CS" &&
+                        it.templateVersion == null &&
+                        it.contentType == "application/pdf" &&
+                        it.partyRef == partyRef &&
+                        it.caseRef == accountId.toString() &&
+                        it.productRef == productId.toString() &&
+                        it.retainUntil == null &&
+                        it.idempotencyKey == idempotencyKey
+                },
             )
         }
         coVerify(exactly = 1) {
@@ -136,6 +157,7 @@ class OnboardingDocumentServiceTest {
         // First lookup misses; render loses the unique-key race; the retry lookup finds the winner.
         coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null andThen winner
         coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
+        coEvery { productCatalogPort.findProduct(productId) } returns null
         coEvery { renderUseCase.render(any()) } throws DuplicateDocumentException("lost the race")
         coEvery { ceremonyUseCase.findByDocumentId(winner.id) } returns null
         coEvery { ceremonyUseCase.openCeremony(any()) } returns mockk()
@@ -152,6 +174,7 @@ class OnboardingDocumentServiceTest {
         val document = document()
         coEvery { documentQueryUseCase.findByIdempotencyKey(idempotencyKey) } returns null
         coEvery { productCatalogPort.findDocumentTemplateCode(productId) } returns "RAMCOVA_SMLOUVA_CS"
+        coEvery { productCatalogPort.findProduct(productId) } returns null
         coEvery { renderUseCase.render(any()) } returns document
         coEvery { ceremonyUseCase.findByDocumentId(document.id) } returns null
         coEvery { ceremonyUseCase.openCeremony(any()) } throws DuplicateCeremonyException("lost the race")
@@ -241,6 +264,83 @@ class OnboardingDocumentServiceTest {
 
         coVerify(exactly = 1) { renderUseCase.render(match { it.templateCode == "RAMCOVA_SMLOUVA_CS" }) }
     }
+
+    // ── Template data enrichment — the fix: `data` used to always be emptyMap(), so a real
+    // signed RAMCOVA_SMLOUVA read "(the "Customer")" with a blank address (ADR-0169 D5) ────────
+
+    @Test
+    fun `ensure fills party, account, product and document data into the rendered template`(): Unit = runBlocking {
+        val realPartyRef = UUID.randomUUID()
+        coEvery { documentQueryUseCase.listByParty(realPartyRef.toString()) } returns emptyList()
+        coEvery { partyLookupPort.findById(realPartyRef) } returns
+            PartyInfo(legalName = "Adéla Bartošová", formattedAddress = "Václavské náměstí 1, 110 00 Praha 1")
+        val accountProductId = UUID.randomUUID()
+        coEvery { accountLookupPort.findCurrentAccount(realPartyRef) } returns
+            AccountInfo(iban = "CZ6508000000192000145399", productId = accountProductId)
+        coEvery { productCatalogPort.findProduct(accountProductId) } returns
+            ProductInfo(name = "CZK Current Account", code = "CURRENT_CZK")
+        val rendered = document(code = "RAMCOVA_SMLOUVA_CS")
+        coEvery { renderUseCase.render(any()) } returns rendered
+        coEvery { ceremonyUseCase.findByDocumentId(rendered.id) } returns null
+        coEvery { ceremonyUseCase.openCeremony(any()) } returns ceremony(UUID.randomUUID())
+
+        service.ensureOnboardingAgreement(realPartyRef.toString(), "cs")
+
+        coVerify(exactly = 1) {
+            renderUseCase.render(
+                match {
+                    @Suppress("UNCHECKED_CAST")
+                    val party = it.data["party"] as Map<String, Any?>
+
+                    @Suppress("UNCHECKED_CAST")
+                    val account = it.data["account"] as Map<String, Any?>
+
+                    @Suppress("UNCHECKED_CAST")
+                    val product = it.data["product"] as Map<String, Any?>
+
+                    @Suppress("UNCHECKED_CAST")
+                    val doc = it.data["document"] as Map<String, Any?>
+                    party["name"] == "Adéla Bartošová" &&
+                        party["address"] == "Václavské náměstí 1, 110 00 Praha 1" &&
+                        account["iban"] == "CZ6508000000192000145399" &&
+                        product["name"] == "CZK Current Account" &&
+                        product["code"] == "CURRENT_CZK" &&
+                        doc["date"] == "2026-07-17" &&
+                        doc["caseRef"] == "onboarding-agreement:$realPartyRef"
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `ensure degrades to an unnamed party rather than failing when party-service is unreachable`(): Unit =
+        runBlocking {
+            val realPartyRef = UUID.randomUUID()
+            coEvery { documentQueryUseCase.listByParty(realPartyRef.toString()) } returns emptyList()
+            // PartyLookupPort/AccountLookupPort are themselves fail-open (never throw — see their
+            // adapters), so "unreachable" surfaces here as null, not an exception.
+            coEvery { partyLookupPort.findById(realPartyRef) } returns null
+            coEvery { accountLookupPort.findCurrentAccount(realPartyRef) } returns null
+            val rendered = document(code = "RAMCOVA_SMLOUVA_CS")
+            coEvery { renderUseCase.render(any()) } returns rendered
+            coEvery { ceremonyUseCase.findByDocumentId(rendered.id) } returns null
+            coEvery { ceremonyUseCase.openCeremony(any()) } returns ceremony(UUID.randomUUID())
+
+            // Must not throw — an enrichment-dependency outage degrades the render, never blocks it.
+            service.ensureOnboardingAgreement(realPartyRef.toString(), "cs")
+
+            coVerify(exactly = 1) {
+                renderUseCase.render(
+                    match {
+                        @Suppress("UNCHECKED_CAST")
+                        val party = it.data["party"] as Map<String, Any?>
+                        party["name"] == "" && party["address"] == null
+                    },
+                )
+            }
+            // No account -> no product to look up.
+            coVerify(exactly = 0) { productCatalogPort.findProduct(any()) }
+        }
 
     private fun ceremony(id: UUID): SignatureCeremony = mockk { every { this@mockk.id } returns id }
 

--- a/openbank-infra/gitops/components/accounts/network-policies.yaml
+++ b/openbank-infra/gitops/components/accounts/network-policies.yaml
@@ -47,6 +47,9 @@ spec:
               kubernetes.io/metadata.name: customer-edge
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: documents
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: payments
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -91,6 +91,15 @@ spec:
             # every account.created event. Same in-cluster address billing-service already uses.
             - name: PRODUCT_CATALOG_SERVICE_URL
               value: http://product-catalog.accounts.svc:8104
+            # party-service / account-service REST client base URLs (application.yaml:
+            # quarkus.rest-client.party-service-api / account-service-api) — fill the
+            # RAMCOVA_SMLOUVA template's {{party.*}}/{{account.*}}/{{product.*}} clauses at sign
+            # time (PartyAdapter/AccountAdapter, fail-open). Ports match the live Services
+            # (party-service.party.svc:8111, account-service.accounts.svc:8100).
+            - name: PARTY_SERVICE_URL
+              value: http://party-service.party.svc:8111
+            - name: ACCOUNT_SERVICE_URL
+              value: http://account-service.accounts.svc:8100
             # ADR-0162 D4 (continued): OpenBao pki-document-signing engine address for the client
             # electronic-signature adapter (OpenBaoClientSignatureAdapter). Declaring it here (rather
             # than relying only on the @ConfigProperty code default) is what makes gen-network-policies.py

--- a/openbank-infra/gitops/components/party/network-policies.yaml
+++ b/openbank-infra/gitops/components/party/network-policies.yaml
@@ -41,6 +41,9 @@ spec:
               kubernetes.io/metadata.name: customer-edge
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: documents
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
Every render of the onboarding framework agreement passed `data = emptyMap()` to the Handlebars renderer. The template's `{{party.name}}` placeholder is the one field it does **not** `{{#if}}`-guard, so a real, signed legal contract read `(the "Customer")` with a blank address — confirmed live in the admin template preview and on a real onboarded device.

## Fix

Two new fail-open port/adapter pairs, mirroring `ProductCatalogPort`'s existing stance exactly:

- **PartyLookupPort / PartyAdapter** → `GET party-service /api/v1/parties/{id}` for `legalName` + a formatted address.
- **AccountLookupPort / AccountAdapter** → `GET account-service /api/v1/accounts?partyId=` for the **CURRENT** account's IBAN + productId (Article 2 names *the* payment account; SAVINGS is opened alongside but isn't what that clause means). By sign time the account already exists (ADR-0162 D7), so this is real on-file data.
- `ProductCatalogPort` gains `findProduct(id)` for `{{product.name}}`/`{{product.code}}`.

`OnboardingDocumentService.buildAgreementData()` assembles the nested Handlebars map and is called from both render sites — the live lazy `ensureOnboardingAgreement` (what the app's SIGN screen drives) and the dormant eager path, for consistency. An unparseable `partyRef` degrades the same as an unreachable lookup (skip enrichment, never throw).

## Infra

`party-service-api` / `account-service-api` REST client configs + env vars, mirroring the existing `product-catalog-api` wiring — same shared M2M client, no new Keycloak client or OPA policy (both target endpoints are plain `@RolesAllowed(SERVICE)`). Network policies regenerated: adds `documents` to the ingress allow-list of `party` and `accounts`, nothing else.

## Tests

13 green (2 new: fills all four data namespaces correctly; degrades to an unnamed party without throwing when party-service is unreachable). detekt + ktlint green.

Refs #1497