### PR TITLE
chore(gitops): deploy document-service sandbox-e154349a (RAMCOVA_SMLOUVA data enrichment, #1595)

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-84182a40
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-e154349a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Auto deploy run 29610638256 built + pushed + cosign-signed `openbank-document-service:sandbox-e154349a` (`@sha256:6bf7a179…`, cosign v2 + SBOM attest both success), but `can-i-deploy` is stuck in the self-hosted runner backlog. Hand-bumping so #1595's party/account/product template-data enrichment reaches the running pod.

## Linked issues

N/A — gitops image bump for an already-merged, already-signed image (#1595).
