### PR TITLE
fix(balance): cross-pod exclusion for the daily reconciliation + freshness watchdog (#1201)

### DIFF
--- a/openbank-balance-service/build.gradle.kts
+++ b/openbank-balance-service/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.redpanda)
+    // NoOpClusterLock for scheduler unit tests (#1201 proposed fix 2).
+    testImplementation(project(":openbank-libs-testing"))
 }
 
 kover {

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/BalanceReconciliationScheduler.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/BalanceReconciliationScheduler.kt
@@ -5,6 +5,7 @@
 package com.openbank.balance.infrastructure.schedule
 
 import com.openbank.balance.application.port.`in`.ReconcileBalancesUseCase
+import com.openbank.libs.persistence.lock.ClusterLock
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -16,9 +17,22 @@ import java.time.LocalDate
  * after the business day, persisting the result and logging drift. The use-case mutates no balance;
  * the scheduler only triggers it and must never crash the runtime, so all failures are swallowed
  * after logging.
+ *
+ * **Cross-pod exclusion (#1201).** `concurrentExecution = SKIP` only stops in-JVM overlap; an
+ * Argo Rollouts canary window runs the old and new pod simultaneously for the whole rollout, and
+ * both fire this trigger on their own tick. `reconcile.reconcile()` persists a
+ * [com.openbank.balance.domain.reconciliation.ReconciliationReport] row and records the drift
+ * gauge on every call — two pods both firing at 23:30 would write two report rows for the same
+ * `asOf` and double-record the metric, not corrupt any balance (the use-case itself mutates
+ * nothing), but it is exactly the "no per-row claim to make, only one pod's tick should run at
+ * all" shape [ClusterLock.tryRunExclusively] exists for.
  */
 @ApplicationScoped
-class BalanceReconciliationScheduler(private val reconcile: ReconcileBalancesUseCase, private val clock: Clock) {
+class BalanceReconciliationScheduler(
+    private val reconcile: ReconcileBalancesUseCase,
+    private val clock: Clock,
+    private val clusterLock: ClusterLock,
+) {
     private val log = Logger.getLogger(BalanceReconciliationScheduler::class.java)
 
     @Scheduled(
@@ -27,13 +41,22 @@ class BalanceReconciliationScheduler(private val reconcile: ReconcileBalancesUse
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     suspend fun runDaily() {
-        try {
-            val report = reconcile.reconcile(LocalDate.now(clock))
-            if (report.hasDrift) {
-                log.warnf("Daily balance reconciliation found drift: %s", report.driftedCurrencies)
+        val ran = clusterLock.tryRunExclusively(JOB_NAME) {
+            try {
+                val report = reconcile.reconcile(LocalDate.now(clock))
+                if (report.hasDrift) {
+                    log.warnf("Daily balance reconciliation found drift: %s", report.driftedCurrencies)
+                }
+            } catch (ex: Exception) {
+                log.errorf(ex, "Daily balance reconciliation failed: %s", ex.message)
             }
-        } catch (ex: Exception) {
-            log.errorf(ex, "Daily balance reconciliation failed: %s", ex.message)
         }
+        if (ran == null) {
+            log.infof("Daily balance reconciliation: another pod already holds this tick's lock — skipping")
+        }
+    }
+
+    private companion object {
+        const val JOB_NAME = "balance.reconciliation"
     }
 }

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdog.kt
@@ -5,6 +5,7 @@
 package com.openbank.balance.infrastructure.schedule
 
 import com.openbank.balance.application.port.out.ReconciliationRecordRepository
+import com.openbank.libs.persistence.lock.ClusterLock
 import io.quarkus.scheduler.Scheduled
 import jakarta.enterprise.context.ApplicationScoped
 import org.jboss.logging.Logger
@@ -24,11 +25,17 @@ import java.time.Instant
  * This watchdog runs hourly and escalates the ABSENCE of a fresh tie-out to ERROR, so the log-based
  * alerting stack (Alloy → Loki) pages instead of the gap sitting silent — a missed daily control is
  * now loud. It is read-only and never touches a balance.
+ *
+ * **Cross-pod exclusion (#1201).** Read-only and idempotent, so two pods both checking is not a
+ * correctness bug — but during every canary window it would otherwise double every log line and
+ * double-fire the Loki alert for the same incident. [ClusterLock.tryRunExclusively] wraps the
+ * check so only one pod's tick actually logs.
  */
 @ApplicationScoped
 class ReconciliationFreshnessWatchdog(
     private val recordRepo: ReconciliationRecordRepository,
     private val clock: Clock,
+    private val clusterLock: ClusterLock,
 ) {
     private val log = Logger.getLogger(ReconciliationFreshnessWatchdog::class.java)
 
@@ -42,30 +49,37 @@ class ReconciliationFreshnessWatchdog(
         concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
     )
     suspend fun checkFreshness() {
-        val latest = recordRepo.findLatest()
-        if (latest == null) {
-            log.error(
-                "Balance reconciliation freshness: NO tie-out has ever succeeded — the daily " +
-                    "control-account ⇄ sub-ledger reconciliation (ADR-0039) is absent. Investigate.",
-            )
-            return
-        }
-        val ageHours = Duration.between(latest.generatedAt.toInstant(), Instant.now(clock)).toHours()
-        if (ageHours > staleAfter.toHours()) {
-            log.errorf(
-                "Balance reconciliation freshness: STALE — last successful tie-out was %dh ago " +
-                    "(as-of %s), past the %dh daily SLA; a scheduled run was likely missed.",
-                ageHours,
-                latest.asOf,
-                staleAfter.toHours(),
-            )
-        } else {
-            log.debugf("Balance reconciliation freshness OK: last tie-out %dh ago (as-of %s).", ageHours, latest.asOf)
+        clusterLock.tryRunExclusively(JOB_NAME) {
+            val latest = recordRepo.findLatest()
+            if (latest == null) {
+                log.error(
+                    "Balance reconciliation freshness: NO tie-out has ever succeeded — the daily " +
+                        "control-account ⇄ sub-ledger reconciliation (ADR-0039) is absent. Investigate.",
+                )
+                return@tryRunExclusively
+            }
+            val ageHours = Duration.between(latest.generatedAt.toInstant(), Instant.now(clock)).toHours()
+            if (ageHours > staleAfter.toHours()) {
+                log.errorf(
+                    "Balance reconciliation freshness: STALE — last successful tie-out was %dh ago " +
+                        "(as-of %s), past the %dh daily SLA; a scheduled run was likely missed.",
+                    ageHours,
+                    latest.asOf,
+                    staleAfter.toHours(),
+                )
+            } else {
+                log.debugf(
+                    "Balance reconciliation freshness OK: last tie-out %dh ago (as-of %s).",
+                    ageHours,
+                    latest.asOf,
+                )
+            }
         }
     }
 
     private companion object {
         // 24h daily cadence + 1h grace for run duration / a delayed scheduler.
         const val DAILY_SLA_HOURS = 25L
+        const val JOB_NAME = "balance.reconciliation.freshness"
     }
 }

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/schedule/BalanceReconciliationSchedulerTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/schedule/BalanceReconciliationSchedulerTest.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.balance.infrastructure.schedule
+
+import com.openbank.balance.application.port.`in`.ReconcileBalancesUseCase
+import com.openbank.balance.domain.reconciliation.CurrencyReconciliation
+import com.openbank.balance.domain.reconciliation.ReconciliationReport
+import com.openbank.libs.testing.lock.NoOpClusterLock
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * The scheduler's contract is "never throw, always run the tie-out via the injected clock's
+ * date" — drift and error handling are asserted here without a live Postgres; the atomic
+ * cross-pod exclusion itself is [ClusterLock]/`PostgresClusterLock`'s own concern, proven once
+ * against a real database in `openbank-ledger-service`'s `ClusterLockIT`, not re-proven per
+ * caller.
+ */
+class BalanceReconciliationSchedulerTest {
+
+    private val today = LocalDate.of(2026, 7, 18)
+    private val clock = Clock.fixed(Instant.parse("2026-07-18T22:00:00Z"), ZoneOffset.UTC)
+    private val reconcile = mockk<ReconcileBalancesUseCase>()
+    private val scheduler = BalanceReconciliationScheduler(reconcile, clock, NoOpClusterLock())
+
+    private fun report(hasDrift: Boolean) = ReconciliationReport(
+        asOf = today,
+        generatedAt = OffsetDateTime.now(clock),
+        tolerance = BigDecimal.ZERO,
+        currencies = listOf(
+            CurrencyReconciliation(
+                currency = "CZK",
+                ledgerControlBalance = BigDecimal.TEN,
+                subLedgerBookedSum = if (hasDrift) BigDecimal.ONE else BigDecimal.TEN,
+                difference = if (hasDrift) BigDecimal("-9") else BigDecimal.ZERO,
+                withinTolerance = !hasDrift,
+            ),
+        ),
+    )
+
+    @Test
+    fun `runs the tie-out for today's date from the injected clock`(): Unit = runBlocking {
+        coEvery { reconcile.reconcile(today) } returns report(hasDrift = false)
+        scheduler.runDaily()
+        coVerify(exactly = 1) { reconcile.reconcile(today) }
+    }
+
+    @Test
+    fun `drift is logged without throwing`(): Unit = runBlocking {
+        coEvery { reconcile.reconcile(today) } returns report(hasDrift = true)
+        scheduler.runDaily() // must not throw
+    }
+
+    @Test
+    fun `a use-case failure is swallowed so the scheduler never crashes`(): Unit = runBlocking {
+        coEvery { reconcile.reconcile(today) } throws IllegalStateException("ledger unreachable")
+        scheduler.runDaily() // must not throw
+    }
+}

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdogTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/infrastructure/schedule/ReconciliationFreshnessWatchdogTest.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.balance.infrastructure.schedule
+
+import com.openbank.balance.application.port.out.ReconciliationRecordRepository
+import com.openbank.balance.domain.reconciliation.CurrencyReconciliation
+import com.openbank.balance.domain.reconciliation.ReconciliationReport
+import com.openbank.libs.testing.lock.NoOpClusterLock
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * The watchdog's contract is "never throw, always classify" — the ERROR-log side effects are
+ * asserted operationally via Loki; here we pin that each state (absent, fresh-OK, stale) is
+ * readable without an exception, so a repo glitch can't kill the hourly tick.
+ */
+class ReconciliationFreshnessWatchdogTest {
+
+    private val now = Instant.parse("2026-07-18T10:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val records = mockk<ReconciliationRecordRepository>()
+    private val watchdog = ReconciliationFreshnessWatchdog(records, clock, NoOpClusterLock())
+
+    private fun reportAge(age: Duration) = ReconciliationReport(
+        asOf = LocalDate.of(2026, 7, 17),
+        generatedAt = OffsetDateTime.ofInstant(now.minus(age), ZoneOffset.UTC),
+        tolerance = BigDecimal.ZERO,
+        currencies = listOf(
+            CurrencyReconciliation(
+                currency = "CZK",
+                ledgerControlBalance = BigDecimal.TEN,
+                subLedgerBookedSum = BigDecimal.TEN,
+                difference = BigDecimal.ZERO,
+                withinTolerance = true,
+            ),
+        ),
+    )
+
+    @Test
+    fun `handles absence of any run`(): Unit = runBlocking {
+        coEvery { records.findLatest() } returns null
+        watchdog.checkFreshness() // must not throw; logs ERROR
+    }
+
+    @Test
+    fun `fresh run passes quietly`(): Unit = runBlocking {
+        coEvery { records.findLatest() } returns reportAge(Duration.ofHours(4))
+        watchdog.checkFreshness()
+    }
+
+    @Test
+    fun `stale run is escalated without throwing`(): Unit = runBlocking {
+        coEvery { records.findLatest() } returns reportAge(Duration.ofHours(26))
+        watchdog.checkFreshness()
+    }
+}


### PR DESCRIPTION
## Summary
- Fleet rollout of #1201 proposed fix 2 (`ClusterLock`, PR #1440 on ledger-service) to the exact job the issue names by example: balance-service's 23:30 control-account ⇄ sub-ledger reconciliation.
- `BalanceReconciliationScheduler` and `ReconciliationFreshnessWatchdog` now wrap their bodies in `ClusterLock.tryRunExclusively` (shared port already on `main` since #1440) — identical pattern to `TieOutScheduler`/`TieOutFreshnessWatchdog` in ledger-service, including job-name constants and matching KDoc.
- Without this, an Argo Rollouts canary window (old + new pod running simultaneously for the whole rollout) would let both pods fire the 23:30 tick: two `ReconciliationReport` rows for the same `asOf` and a double-recorded drift gauge. The freshness watchdog is read-only so a double run isn't a correctness bug, but it would double every log line and double-fire the Loki alert for the same incident.

## Test plan
- [x] New unit tests for both schedulers (`NoOpClusterLock`, matching `TieOutSchedulerTest`/`TieOutFreshnessWatchdogTest`'s own pattern): drift, absent-run, stale-run, and exception-swallowing paths.
- [x] Full non-cached `:openbank-balance-service:test` + `ktlintCheck` + `detekt` + `koverVerify` (67% line-coverage gate), all green.

Refs #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)