### PR TITLE
fix(account): make account authorizations persist; merge + session on the repo

### DIFF
--- a/docs/threat-models/openbank-account-service.md
+++ b/docs/threat-models/openbank-account-service.md
@@ -230,3 +230,15 @@ not change any existing request's outcome until explicitly flipped.
   active book — acceptable because the roles are staff/M2M only and the same information is
   already reachable via repeated `/search` paging; gateway rate limits apply. No DB change, no
   new index (status + PK keyset uses the existing primary key). Rollback: revert the commit.
+- **2026-07-17** — Fixed `AccountAuthorizationRepositoryImpl`: every method ran without a reactive
+  session/transaction, and `save` mapped the domain to a fresh entity and `persist`ed it. Against a
+  real DB the whole authorization feature was non-functional — grant returned 422 (`No current
+  Mutiny.Session found`) and revoke/suspend/reinstate would have hit `account_authorizations_pkey`
+  on the application-assigned `@Id` (INSERT scheduled for an existing row). Masked because
+  `AuthorizationServiceTest` mocks the repository and no IT exercised the flow. Reads now wrap
+  `Panache.withSession`; `save` wraps `Panache.withTransaction` + `session.merge` (upsert). This is
+  an **integrity/availability** fix — access-grant/revocation on an account is a security control
+  (an un-revocable authorization is a real EoP risk); it must actually persist. No API/DB change.
+  Verified by `AccountAuthorizationLifecycleIT` (real Postgres: grant→revoke→REVOKED; fails-first on
+  the old code with 422). Same `persist`-vs-`merge` class as consent-service #1553; tracked in #1600.
+  Rollback: revert the commit.

--- a/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountAuthorizationRepositoryImpl.kt
+++ b/openbank-account-service/src/main/kotlin/com/openbank/account/infrastructure/persistence/repository/AccountAuthorizationRepositoryImpl.kt
@@ -7,6 +7,7 @@ package com.openbank.account.infrastructure.persistence.repository
 import com.openbank.account.application.port.out.AccountAuthorizationRepository
 import com.openbank.account.domain.model.AccountAuthorization
 import com.openbank.account.infrastructure.persistence.entity.AccountAuthorizationEntity
+import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
@@ -21,20 +22,29 @@ class AccountAuthorizationRepositoryImpl(private val clock: Clock) :
 
     override suspend fun save(auth: AccountAuthorization): AccountAuthorization {
         val entity = AccountAuthorizationEntity.fromDomain(auth)
-        persistAndFlush(entity).awaitSuspending()
-        return entity.toDomain()
+        // merge, not persist: AccountAuthorization has an application-assigned @Id, so persist()
+        // schedules an INSERT for every write and every revoke/suspend/reinstate (re-saving the same
+        // id) fails on the PK. withTransaction also supplies the reactive session the bare persist
+        // lacked (grant returned 422 "No current Mutiny.Session found"). See #1600.
+        return Panache.withTransaction {
+            Panache.getSession().flatMap { session -> session.merge(entity) }
+        }.awaitSuspending().toDomain()
     }
 
     override suspend fun findById(id: UUID): AccountAuthorization? =
-        find("id", id).firstResult().awaitSuspending()?.toDomain()
+        Panache.withSession { find("id", id).firstResult() }.awaitSuspending()?.toDomain()
 
     override suspend fun findByAccountId(accountId: UUID): List<AccountAuthorization> =
-        find("accountId", accountId).list().awaitSuspending().map { it.toDomain() }
+        Panache.withSession { find("accountId", accountId).list() }.awaitSuspending().map { it.toDomain() }
 
-    override suspend fun findActiveByAccountAndParty(accountId: UUID, partyId: UUID): List<AccountAuthorization> = find(
-        "accountId = ?1 and partyId = ?2 and status = 'ACTIVE' and validFrom <= ?3 and (validTo is null or validTo >= ?3)",
-        accountId,
-        partyId,
-        LocalDate.now(clock),
-    ).list().awaitSuspending().map { it.toDomain() }
+    override suspend fun findActiveByAccountAndParty(accountId: UUID, partyId: UUID): List<AccountAuthorization> =
+        Panache.withSession {
+            find(
+                "accountId = ?1 and partyId = ?2 and status = 'ACTIVE' and validFrom <= ?3 " +
+                    "and (validTo is null or validTo >= ?3)",
+                accountId,
+                partyId,
+                LocalDate.now(clock),
+            ).list()
+        }.awaitSuspending().map { it.toDomain() }
 }

--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountAuthorizationLifecycleIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountAuthorizationLifecycleIT.kt
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.account.integration
+
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.security.TestSecurity
+import io.restassured.module.kotlin.extensions.Extract
+import io.restassured.module.kotlin.extensions.Given
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import jakarta.inject.Inject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.UUID
+import javax.sql.DataSource
+
+/**
+ * A granted account authorization must be revocable. `AccountAuthorization` has an application-assigned
+ * @Id, so `AccountAuthorizationRepositoryImpl.save` mapping the domain to a fresh entity and
+ * `persist`ing it schedules an INSERT for every write — grant works, but revoke/suspend/reinstate
+ * (which re-save the same id) fail on the primary key. Invisible to `AuthorizationServiceTest` (mocks
+ * the repository); only a real DB shows it.
+ *
+ * Drives create-account -> grant -> revoke through the real REST endpoints (a bare-thread reactive
+ * repository call throws "No current Vertx context found"; only an HTTP request carries one) and
+ * asserts the row transitioned via a plain JDBC read.
+ */
+@QuarkusTest
+@QuarkusTestResource(com.openbank.account.it.PostgresRedpandaRedisTestResource::class)
+class AccountAuthorizationLifecycleIT {
+
+    @Inject
+    lateinit var dataSource: DataSource
+
+    private val operator = "00000000-0000-0000-0000-0000000000aa"
+
+    private fun openAccount(): UUID {
+        val payload = """
+            {"partyId":"${UUID.randomUUID()}","productId":"${UUID.randomUUID()}",
+            "accountType":"CURRENT","currencyCode":"CZK","legalName":"Auth IT Customer"}
+        """.trimIndent()
+        val id = Given {
+            contentType("application/json")
+            header("Idempotency-Key", UUID.randomUUID().toString())
+            body(payload)
+        } When {
+            post("/api/v1/accounts")
+        } Then {
+            statusCode(201)
+        } Extract {
+            jsonPath().getString("id")
+        }
+        return UUID.fromString(id)
+    }
+
+    private fun grant(accountId: UUID): UUID {
+        val payload = """
+            {"partyId":"${UUID.randomUUID()}","role":"FULL_ACCESS","dailyLimit":null,"transactionLimit":null,
+            "validFrom":"${LocalDate.now()}","validTo":null,"grantedBy":"$operator"}
+        """.trimIndent()
+        val response = Given {
+            contentType("application/json")
+            body(payload)
+        } When {
+            post("/api/v1/accounts/$accountId/authorizations")
+        } Then {
+            statusCode(201)
+        } Extract {
+            this
+        }
+        assertThat(response.jsonPath().getString("status")).isEqualTo("ACTIVE")
+        return UUID.fromString(response.jsonPath().getString("id"))
+    }
+
+    private fun authStatus(id: UUID): String? = dataSource.connection.use { conn ->
+        val ps = conn.prepareStatement("SELECT status FROM account_authorizations WHERE id = ?")
+        ps.setObject(1, id)
+        val rs = ps.executeQuery()
+        if (rs.next()) rs.getString("status") else null
+    }
+
+    @Test
+    @TestSecurity(user = "00000000-0000-0000-0000-0000000000aa", roles = ["ROLE_OPERATOR"])
+    fun `a granted authorization can be revoked and the row transitions to REVOKED`() {
+        val accountId = openAccount()
+        val authId = grant(accountId)
+
+        Given {
+            contentType("application/json")
+            body("""{"revokedBy":"$operator","reason":"customer request"}""")
+        } When {
+            delete("/api/v1/accounts/$accountId/authorizations/$authId")
+        } Then {
+            statusCode(200)
+            body("status", org.hamcrest.Matchers.equalTo("REVOKED"))
+        }
+
+        assertThat(authStatus(authId)).describedAs("account_authorizations.status after revoke").isEqualTo("REVOKED")
+    }
+}


### PR DESCRIPTION
## Summary

`AccountAuthorizationRepositoryImpl` ran **every** method without a reactive session/transaction, and `save` mapped the domain to a **fresh** entity and `persist`ed it. Against a real DB the whole account-authorization feature was non-functional — grant returned **HTTP 422** (`No current Mutiny.Session found`) and revoke/suspend/reinstate would have hit `account_authorizations_pkey` on the application-assigned `@Id`. This wraps the reads in `Panache.withSession` and `save` in `Panache.withTransaction` + `session.merge`.

## Type of change

- [x] fix (bug fix)

## Linked issues

Refs #1600

## Changes

- `AccountAuthorizationRepositoryImpl.save` → `Panache.withTransaction { getSession().flatMap { it.merge(entity) } }`. `merge` (not `persist`) because the aggregate has an application-assigned `@Id`: `persist` schedules an INSERT for every write, so grant (INSERT) needed the session and revoke/suspend/reinstate (re-save of the same id) would violate the PK.
- `findById` / `findByAccountId` / `findActiveByAccountAndParty` wrapped in `Panache.withSession` (they had no session either).
- New `AccountAuthorizationLifecycleIT` — create-account → grant → revoke through the real REST endpoints, asserts `account_authorizations.status = REVOKED` via JDBC. **Fails-first on the current code with 422.**
- Threat model change-log entry (money-path, ADR-0030).

## Definition of Done

- [x] Hexagonal layering preserved.
- [ ] Unit tests added/updated — existing `AuthorizationServiceTest` unaffected (mocks the port).
- [x] Integration tests added/updated.
- [ ] Contract tests — N/A, no API change.
- [x] `./gradlew ktlintCheck detekt koverVerify test` passes (module).
- [x] No new lint warnings.
- [ ] OpenAPI — N/A, no REST API change.
- [ ] Flyway migration — N/A, table unchanged.
- [ ] Event schema — N/A, account authorizations emit no event.
- [x] Docs updated (threat model).

## Security checklist

- [x] No secrets/PII in code, config, tests, logs.
- [x] No new `@Suppress` / `as Any`.
- [x] No new third-party dependency.
- [x] **Auth code changed** → account authorization is an access-control record; an un-revocable authorization is an EoP risk. `security-review-required`.
- [ ] PII path changed? → no.
- [ ] Cardholder data path? → no.

## Compliance impact

- [x] None directly, but authorization = access control (integrity of a security control).

## Rollout / Rollback

- Deployment strategy: rolling (money-path canary).
- Rollback plan: revert the commit — no schema/state change.
- Data migration reversible: N/A.

## Reviewer notes

- **Money-path service → 2 approvals + threat-model review (ADR-0030).** Threat model updated here.
- Part of the fleet audit in #1600 (`persist` vs `merge` on assigned-`@Id` aggregates). consent-service was the first (#1553); `pid-service` `Party.update` is the other confirmed instance, still open in #1600.
- This is the first real-DB exercise of the account authorization flow — it had zero IT coverage, which is exactly why the sessionless repo shipped.
