### PR TITLE
feat(consent): /validate returns scopes, grantedAccounts, frequencyPerDay (ADR-0126 D2)

### DIFF
--- a/docs/threat-models/openbank-consent-service.md
+++ b/docs/threat-models/openbank-consent-service.md
@@ -39,7 +39,7 @@ escalating a consent is a direct path to unauthorized data access or payment ini
 | **S**poofing | TPP impersonates party to create consent | OIDC + SCA binding; party identity verified upstream |
 | **T**ampering | Scope/grantee escalation after creation | Immutable scope post-activation; state machine; audit |
 | **R**epudiation | Party denies granting consent | AuditEvent per transition; SCA evidence retained |
-| **I**nfo disclosure | `validate` leaks consent details to wrong caller | Caller authz; minimal validate response (allow/deny + scope) |
+| **I**nfo disclosure | `validate` leaks consent details to wrong caller | Caller authz (`@Authorize consent.validate` + `@RolesAllowed`); response is a consent-scoped projection (scopes / covered IBANs / frequencyPerDay) to an already-authenticated resource server — no party PII |
 | **D**oS | Consent spam / validate flooding | Rate limit; cache validate decisions briefly |
 | **E**oP | Revoked consent still validates | Revocation is synchronous + event; validate reads live state, deny-by-default |
 
@@ -52,6 +52,15 @@ escalating a consent is a direct path to unauthorized data access or payment ini
 
 ## 6. Change log
 
+- **2026-07-17** — Completed ADR-0126 §D2: `/validate` response now carries `scopes`, `grantedAccounts`
+  (covered IBANs; null = all of the party's accounts) and `frequencyPerDay` (PSD2 RTS Art. 10 AISP cap
+  = 4) so a resource server can cache within that window. Additive optional fields (openapi
+  `1.1.0`→`1.2.0`, non-breaking). **Info-disclosure surface widens** from `{valid, reason, code}` to
+  the consent-scoped projection above — but only to an authenticated, `@Authorize consent.validate` +
+  `@RolesAllowed`-gated resource server that already serves those accounts; no party PII
+  (name / birth number / contact) is exposed and the trust boundary is unchanged. Risk class =
+  **confidentiality** (bounded). No DB/event change. Verified by `ConsentTest` (frequencyPerDay) +
+  `ConsentValidationResponseTest` (projection). Rollback: revert the commit.
 - **2026-07-17** — Consent lifecycle events (grant/revoke/reject) and the expiration sweep now write
   their outbox row in the SAME transaction as the status change (ADR-0126 §D3/§D4). The prior
   direct-Kafka emit was a dual-write that silently dropped the event on a crash between the DB commit

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/application/usecase/ConsentService.kt
@@ -18,7 +18,6 @@ import com.openbank.consent.domain.event.ConsentGranted
 import com.openbank.consent.domain.event.ConsentRejected
 import com.openbank.consent.domain.event.ConsentRevoked
 import com.openbank.consent.domain.model.Consent
-import com.openbank.consent.domain.model.ConsentScope
 import com.openbank.consent.domain.model.ConsentStatus
 import com.openbank.consent.domain.model.ConsentValidationResult
 import jakarta.enterprise.context.ApplicationScoped
@@ -60,13 +59,7 @@ class ConsentService(
 
     override suspend fun createConsent(command: CreateConsentCommand): Consent {
         val now = OffsetDateTime.now(clock)
-        val aispScopes = setOf(
-            ConsentScope.ACCOUNTS_READ,
-            ConsentScope.BALANCES_READ,
-            ConsentScope.TRANSACTIONS_READ,
-            ConsentScope.STATEMENTS_READ,
-        )
-        val maxDays = if (command.scopes.any { s -> s in aispScopes }) 90L else 365L
+        val maxDays = if (command.scopes.any { s -> s in Consent.AISP_SCOPES }) 90L else 365L
         val validTo = if (command.validTo.isAfter(now.plusDays(maxDays))) {
             now.plusDays(maxDays)
         } else {

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/domain/model/Consent.kt
@@ -86,19 +86,7 @@ data class Consent(
         require(scopes.isNotEmpty()) { "Consent must have at least one scope" }
         require(validTo.isAfter(validFrom)) { "validTo must be after validFrom" }
         // PSD2 RTS Art. 10: max 90 days for AISP
-        val maxDays = if (scopes.any {
-                it in setOf(
-                    ConsentScope.ACCOUNTS_READ,
-                    ConsentScope.BALANCES_READ,
-                    ConsentScope.TRANSACTIONS_READ,
-                    ConsentScope.STATEMENTS_READ,
-                )
-            }
-        ) {
-            90L
-        } else {
-            365L
-        }
+        val maxDays = if (scopes.any { it in AISP_SCOPES }) 90L else 365L
         require(!validTo.isAfter(validFrom.plusDays(maxDays))) {
             "Consent validity exceeds maximum allowed $maxDays days"
         }
@@ -128,6 +116,27 @@ data class Consent(
         status = ConsentStatus.REJECTED,
         updatedAt = now,
     )
+
+    /**
+     * PSD2 RTS Art. 10(2)(b) access-frequency cap for this consent's scopes: an AISP may read the
+     * account data at most [AISP_MAX_ACCESSES_PER_DAY] times per day without fresh SCA. Returned by
+     * `/validate` so a resource server can cache within that window. null when no AISP scope applies
+     * (PISP/CBPII/agent/telemetry consents carry no per-day read cap).
+     */
+    fun frequencyPerDay(): Int? = if (scopes.any { it in AISP_SCOPES }) AISP_MAX_ACCESSES_PER_DAY else null
+
+    companion object {
+        /** PSD2 RTS Art. 10 AISP scopes: SCA-gated, 90-day validity cap, ≤4 reads/day without SCA. */
+        val AISP_SCOPES = setOf(
+            ConsentScope.ACCOUNTS_READ,
+            ConsentScope.BALANCES_READ,
+            ConsentScope.TRANSACTIONS_READ,
+            ConsentScope.STATEMENTS_READ,
+        )
+
+        /** PSD2 RTS Art. 10(2)(b): max AISP accesses per day without fresh SCA. */
+        const val AISP_MAX_ACCESSES_PER_DAY = 4
+    }
 }
 
 // ─── Consent Validation Result ───────────────────────────────────────────────

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/ConsentResource.kt
@@ -13,7 +13,6 @@ import com.openbank.consent.application.port.`in`.RevokeConsentCommand
 import com.openbank.consent.application.port.`in`.RevokeConsentUseCase
 import com.openbank.consent.application.port.`in`.ValidateConsentCommand
 import com.openbank.consent.application.port.`in`.ValidateConsentUseCase
-import com.openbank.consent.domain.model.ConsentValidationResult
 import com.openbank.consent.infrastructure.rest.dto.ConsentResponse
 import com.openbank.consent.infrastructure.rest.dto.ConsentValidationResponse
 import com.openbank.consent.infrastructure.rest.dto.CreateConsentRequest
@@ -21,8 +20,6 @@ import com.openbank.consent.infrastructure.rest.dto.RevokeConsentRequest
 import com.openbank.consent.infrastructure.rest.dto.ValidateConsentRequest
 import com.openbank.libs.authz.Authorize
 import com.openbank.libs.idempotency.IdempotencyStore
-import org.eclipse.microprofile.openapi.annotations.Operation
-import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.DELETE
@@ -37,6 +34,8 @@ import jakarta.ws.rs.core.Context
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.core.Response
 import jakarta.ws.rs.core.UriInfo
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
 import java.util.UUID
 
 // @Authorize alone is the fine-grained per-resource check; it must be paired with the coarse
@@ -167,10 +166,7 @@ class ConsentResource(
         val result = validateConsent.validateConsent(
             ValidateConsentCommand(id, request.granteeId, request.requiredScope, request.accountIban),
         )
-        return when (result) {
-            is ConsentValidationResult.Valid -> ConsentValidationResponse(true, null, null)
-            is ConsentValidationResult.Invalid -> ConsentValidationResponse(false, result.reason, result.code)
-        }
+        return ConsentValidationResponse.from(result)
     }
 
     private fun consentCreateKey(granteeId: String, partyId: UUID, requestId: String) =

--- a/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/dto/ConsentDtos.kt
+++ b/openbank-consent-service/src/main/kotlin/com/openbank/consent/infrastructure/rest/dto/ConsentDtos.kt
@@ -54,4 +54,33 @@ data class ConsentResponse(
     }
 }
 
-data class ConsentValidationResponse(val valid: Boolean, val reason: String?, val code: String?)
+/**
+ * `/validate` result for a resource server (ADR-0126 §D2). On [valid] = true the projection fields
+ * describe what the consent grants so the caller can cache within the [frequencyPerDay] window;
+ * on false they are null and [reason]/[code] explain the denial. No PII.
+ */
+data class ConsentValidationResponse(
+    val valid: Boolean,
+    val reason: String?,
+    val code: String?,
+    /** Granted scopes (present when valid). */
+    val scopes: Set<ConsentScope>? = null,
+    /** Accounts the consent covers; null (when valid) = all of the party's accounts. */
+    val grantedAccounts: List<String>? = null,
+    /** PSD2 RTS Art. 10 AISP per-day read cap; null for non-AISP consents. */
+    val frequencyPerDay: Int? = null,
+) {
+    companion object {
+        fun from(result: ConsentValidationResult): ConsentValidationResponse = when (result) {
+            is ConsentValidationResult.Valid -> ConsentValidationResponse(
+                valid = true,
+                reason = null,
+                code = null,
+                scopes = result.consent.scopes,
+                grantedAccounts = result.consent.accountIbans,
+                frequencyPerDay = result.consent.frequencyPerDay(),
+            )
+            is ConsentValidationResult.Invalid -> ConsentValidationResponse(false, result.reason, result.code)
+        }
+    }
+}

--- a/openbank-consent-service/src/main/resources/openapi.yaml
+++ b/openbank-consent-service/src/main/resources/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: Consent Service API
   # major == openbank.api.version == URL /api/v1 (ADR-0048). Minor bump (1.0 -> 1.1): additive
   # endpoint only (PATCH /approvals/{id}, ADR-0155 four-eyes) — no breaking change.
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     Data sharing consent lifecycle — create, activate, reject, revoke, validate. PATCH
     /approvals/{id} decides a four-eyes approval paused by the platform's ADR-0155 maker-checker
@@ -172,6 +172,30 @@ paths:
                 properties:
                   valid:
                     type: boolean
+                  reason:
+                    type: string
+                    nullable: true
+                    description: Human-readable denial reason (present when valid=false).
+                  code:
+                    type: string
+                    nullable: true
+                    description: Machine denial code, e.g. CONSENT_NOT_ACTIVE (present when valid=false).
+                  scopes:
+                    type: array
+                    nullable: true
+                    description: Granted scopes (present when valid=true).
+                    items:
+                      type: string
+                  grantedAccounts:
+                    type: array
+                    nullable: true
+                    description: Covered account IBANs; null (when valid) = all of the party's accounts.
+                    items:
+                      type: string
+                  frequencyPerDay:
+                    type: integer
+                    nullable: true
+                    description: PSD2 RTS Art. 10 AISP per-day read cap (4); null for non-AISP consents.
         '403':
           $ref: '#/components/responses/Forbidden'
 

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/domain/model/ConsentTest.kt
@@ -125,6 +125,25 @@ class ConsentTest {
         }
     }
 
+    @Test
+    fun `frequencyPerDay returns the PSD2 AISP cap for AISP scopes`() {
+        val consent = consent(scopes = setOf(ConsentScope.ACCOUNTS_READ))
+
+        assertThat(consent.frequencyPerDay()).isEqualTo(Consent.AISP_MAX_ACCESSES_PER_DAY)
+    }
+
+    @Test
+    fun `frequencyPerDay is null for non-AISP scopes`() {
+        val consent = consent(
+            scopes = setOf(ConsentScope.TELEMETRY_RUM),
+            accountIbans = null,
+            validFrom = baseValidFrom,
+            validTo = baseValidFrom.plusDays(180),
+        )
+
+        assertThat(consent.frequencyPerDay()).isNull()
+    }
+
     private fun consent(
         scopes: Set<ConsentScope> = setOf(ConsentScope.PAYMENTS_INITIATE),
         accountIbans: List<String>? = listOf("CZ6508000000192000145399"),

--- a/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/rest/dto/ConsentValidationResponseTest.kt
+++ b/openbank-consent-service/src/test/kotlin/com/openbank/consent/infrastructure/rest/dto/ConsentValidationResponseTest.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.consent.infrastructure.rest.dto
+
+import com.openbank.consent.domain.model.Consent
+import com.openbank.consent.domain.model.ConsentScope
+import com.openbank.consent.domain.model.ConsentStatus
+import com.openbank.consent.domain.model.ConsentValidationResult
+import com.openbank.consent.domain.model.GranteeType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class ConsentValidationResponseTest {
+
+    @Test
+    fun `from Valid projects scopes, grantedAccounts and the AISP frequency cap`() {
+        val consent = consent(
+            scopes = setOf(ConsentScope.ACCOUNTS_READ, ConsentScope.BALANCES_READ),
+            accountIbans = listOf("CZ6508000000192000145399"),
+        )
+
+        val response = ConsentValidationResponse.from(ConsentValidationResult.Valid(consent))
+
+        assertThat(response.valid).isTrue()
+        assertThat(response.reason).isNull()
+        assertThat(response.code).isNull()
+        assertThat(response.scopes).isEqualTo(consent.scopes)
+        assertThat(response.grantedAccounts).isEqualTo(consent.accountIbans)
+        assertThat(response.frequencyPerDay).isEqualTo(Consent.AISP_MAX_ACCESSES_PER_DAY)
+    }
+
+    @Test
+    fun `from Valid with an all-accounts non-AISP consent leaves grantedAccounts and frequencyPerDay null`() {
+        val consent = consent(scopes = setOf(ConsentScope.TELEMETRY_RUM), accountIbans = null)
+
+        val response = ConsentValidationResponse.from(ConsentValidationResult.Valid(consent))
+
+        assertThat(response.valid).isTrue()
+        assertThat(response.scopes).isEqualTo(setOf(ConsentScope.TELEMETRY_RUM))
+        assertThat(response.grantedAccounts).isNull()
+        assertThat(response.frequencyPerDay).isNull()
+    }
+
+    @Test
+    fun `from Invalid carries reason and code and no projection fields`() {
+        val response = ConsentValidationResponse.from(
+            ConsentValidationResult.Invalid("Consent is not active (status=REVOKED)", "CONSENT_NOT_ACTIVE"),
+        )
+
+        assertThat(response.valid).isFalse()
+        assertThat(response.reason).isEqualTo("Consent is not active (status=REVOKED)")
+        assertThat(response.code).isEqualTo("CONSENT_NOT_ACTIVE")
+        assertThat(response.scopes).isNull()
+        assertThat(response.grantedAccounts).isNull()
+        assertThat(response.frequencyPerDay).isNull()
+    }
+
+    private fun consent(scopes: Set<ConsentScope>, accountIbans: List<String>?): Consent {
+        val now = OffsetDateTime.now()
+        return Consent(
+            id = UUID.randomUUID(),
+            partyId = UUID.randomUUID(),
+            granteeId = "tpp-123",
+            granteeType = GranteeType.TPP,
+            granteeName = "Test TPP",
+            scopes = scopes,
+            accountIbans = accountIbans,
+            status = ConsentStatus.ACTIVE,
+            validFrom = now,
+            validTo = now.plusDays(30),
+            scaSessionId = null,
+            redirectUri = null,
+            tppTransactionId = null,
+            ipAddress = null,
+            userAgent = null,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Completes **ADR-0126 §D2** — the last Partial decision point. The consent `/validate` response promised `scope`/`grantedAccounts`/`frequencyPerDay` but shipped only `{valid, reason, code}`, so a resource server could not cache "for the configured `frequencyPerDay` window" the ADR assumes. On a valid result the response now projects the granted scopes, covered IBANs, and the PSD2 AISP per-day cap.

## Type of change

- [x] feat (new functionality)

## Linked issues

Refs #1521

## Changes

- **Domain**: `Consent.frequencyPerDay()` → `4` (PSD2 RTS Art. 10(2)(b) AISP cap) for AISP scopes, else `null`. New companion `Consent.AISP_SCOPES` / `AISP_MAX_ACCESSES_PER_DAY` — the AISP scope set was duplicated inline in the `init` block and `ConsentService.createConsent`; both now reference the companion (DRY).
- **DTO**: `ConsentValidationResponse` gains optional `scopes` / `grantedAccounts` (null = all party accounts) / `frequencyPerDay`, plus a testable `from(result)` factory; the resource delegates to it.
- **OpenAPI**: `/validate` 200 schema completed; `info.version` **1.1.0 → 1.2.0** (additive optional response fields = non-breaking = minor, ADR-0048).
- **Threat model**: change-log entry — the `/validate` info-disclosure surface widens to a consent-scoped projection, but only for an authenticated `@Authorize consent.validate`-gated resource server; no party PII.

## Definition of Done

- [x] Hexagonal layering preserved (the PSD2 cap lives in the domain; DTO factory in infra).
- [x] Unit tests added (`ConsentTest.frequencyPerDay`, `ConsentValidationResponseTest`).
- [ ] Integration tests — N/A (pure projection; no DB/tx behavior to exercise).
- [x] Contract: `openapi.yaml` updated + `info.version` bumped; response-shape asserted by `ConsentValidationResponseTest`. No Pact consumer of consent `/validate` exists.
- [x] `./gradlew ktlintCheck detekt koverVerify test` passes (module).
- [x] No new lint warnings.
- [x] OpenAPI updated (hand-maintained spec; +minor bump).
- [ ] Flyway / event schema — N/A (no DB or event change).
- [x] Docs — threat model updated.

## Security checklist

- [x] No secrets/PII in code/config/tests/logs.
- [x] No new `@Suppress` / `as Any`.
- [x] No new third-party dependency.
- [x] **PII/consent path** — response now carries covered IBANs; gated by `@Authorize consent.validate` + `@RolesAllowed` to resource servers that already serve those accounts. No name/birth-number/contact.

## Compliance impact

- [x] PSD2 / SCA / RTS — realizes the RTS Art. 10 access-frequency signal the resource servers need.
- [x] GDPR — data-minimization preserved (consent-scoped projection, no extra PII).

## Rollout / Rollback

- Deployment strategy: rolling (money-path canary).
- Rollback plan: revert the commit — additive fields, no schema/state change.
- Data migration reversible: N/A.

## Reviewer notes

- **Money-path → 2 approvals + threat-model review (ADR-0030).** Threat model updated.
- **Design call (flag for veto):** `frequencyPerDay` is the PSD2 regulatory constant **4** for AISP, not a per-consent stored value — consent-service never modelled it and psd2-service (Berlin Group layer) already defaults it to 4. Returning a stored value would need a domain field + migration + creation input; that's deliberately out of scope.
- **ADR doc:** this PR completes D2 in *code*. The ADR-0126 §D2 section text + header `Partial → Shipped` flip are intentionally **not** here — #1606 owns the ADR-0126 delivery-status doc (§D3), and editing the same ADR top-note in two open PRs would conflict. Once this and #1606 both land, the header flips to Shipped in one follow-up.
