### PR TITLE
docs(adr): ADR-0126 Delivery-Status Partial → Shipped (D2 + D3 landed)

### DIFF
--- a/docs/adr/0126-unified-consent-lifecycle.md
+++ b/docs/adr/0126-unified-consent-lifecycle.md
@@ -4,20 +4,17 @@
 |------------------|--------------------------------|
 | Status           | Accepted                       |
 | Decision-Status  | Accepted                       |
-| Delivery-Status  | Partial                        |
+| Delivery-Status  | Shipped                        |
 | Deciders         | Jiri Raska                     |
 | Date             | 2026-06-29                     |
 | Supersedes       | —                              |
 | Superseded by    | —                              |
 
-**Delivery note (updated 2026-07-17):** the header `Partial` is accurate, but two decision points below
-were mismarked "Shipped". D1, D4, D5 shipped — D5 in particular is real: consent-service runs live at
-`AUTHZ_ENFORCE=true` (`openbank-infra/gitops/components/consent/consent-service.yaml`). **D2 is Partial**
-(D3 shipped 2026-07-17 via #1553): D2's `/validate` response omits the promised
-`scope`/`grantedAccounts`/`frequencyPerDay` (returns only `{valid, reason, code}`). D3's revoke/reject
-formerly published via a direct Kafka emitter — a dual-write with no atomic guarantee on a money-path
-revoke; #1553 moved revoke/reject (and grant) onto the transactional outbox, so the lifecycle event is
-now durable with the status change. The header stays `Partial` until D2's DTO is completed. (Aside:
+**Delivery note (updated 2026-07-17):** all five decision points are now Shipped, and the header is
+flipped `Partial → Shipped`. D1/D4/D5 were already live; #1553 moved D3's revoke/reject (and grant)
+onto the transactional outbox — closing a money-path dual-write — and #1609 completed D2's `/validate`
+projection (`scope`/`grantedAccounts`/`frequencyPerDay`). The per-decision *Delivery reality* notes
+below keep the record of what was originally mismarked and how it was fixed. (Aside:
 ADR-0034's "consent still advisory, pending #266" line is itself stale — OPA enforcement is live here.)
 
 ## Context
@@ -71,11 +68,11 @@ The `Consent` aggregate root enforces these caps in its `init` block.
 
 `POST /api/v1/consents` creates a `PENDING_SCA` record. The TPP (or bank agent) then drives SCA via `openbank-sca-service`; `POST /api/v1/consents/{id}/activate` completes the binding after SCA succeeds. SCA session ID is stored on the consent for non-repudiation.
 
-### D2 — Consent validation by resource servers (Partial)
+### D2 — Consent validation by resource servers (✅ Shipped)
 
 `POST /api/v1/consents/{id}/validate` is the machine-to-machine gate called by `account-service`, `balance-service`, `transaction-service` etc. before returning data. Response: `{valid: true/false}` with `scope`, `grantedAccounts`, `frequencyPerDay`. No PII in the response.
 
-> **Delivery reality (2026-07-17):** the endpoint and its checks (grantee match, `isActive`, `hasScope`, `coversAccount`) are live, but the response DTO is `ConsentValidationResponse(valid, reason, code)` — it does **not** yet carry `scope`/`grantedAccounts`/`frequencyPerDay`, so a resource server cannot cache "for the configured `frequencyPerDay` window" as the Consequences section assumes. Partial until the DTO is completed.
+> **Delivery reality (2026-07-17, resolved #1609):** the endpoint and its checks (grantee match, `isActive`, `hasScope`, `coversAccount`) were live, but the response DTO originally carried only `{valid, reason, code}`. #1609 completed the projection: on a valid result the response now returns `scopes`, `grantedAccounts` (covered IBANs; null = all of the party's accounts) and `frequencyPerDay` (PSD2 RTS Art. 10 AISP cap = 4 via `Consent.frequencyPerDay()`; null for non-AISP), so a resource server can cache within that window (openapi `1.2.0`).
 
 ### D3 — Revocation propagation (✅ Shipped)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -134,7 +134,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0123](0123-relicense-to-apache-2.0.md) | Relicense the platform from MPL-2.0 to Apache-2.0 | Accepted | Shipped | — |
 | [0124](0124-oss-readiness-and-public-launch-hardening.md) | OSS-readiness and public-launch hardening | Accepted | Partial | — |
 | [0125](0125-same-account-currency-exchange.md) | Same-account currency exchange (the app's currency swap) | Superseded by ADR-0110 | Superseded | — |
-| [0126](0126-unified-consent-lifecycle.md) | Unified Consent Lifecycle and GDPR Linkage | Accepted | Partial | — |
+| [0126](0126-unified-consent-lifecycle.md) | Unified Consent Lifecycle and GDPR Linkage | Accepted | Shipped | — |
 | [0132](0132-customer-edge-per-party-rate-limiting.md) | Per-party request rate limiting at the customer edge | Accepted | Shipped | — |
 | [0133](0133-tamper-evident-audit-chain.md) | ADR-0133: Tamper-evident audit chain | Accepted | Shipped | — |
 | [0134](0134-business-continuity-and-dora-ictrm.md) | ADR-0134: Business continuity plan and DORA ICT risk management framework | Accepted | Complete | — |


### PR DESCRIPTION
## Summary

With #1553 (D3, merged) and #1609 (D2, merged) now on main, **all five ADR-0126 decision points are delivered**. Flip the header `Delivery-Status: Partial → Shipped`, mark the §D2 section Shipped, and regenerate the ADR index. This is the coordination follow-up flagged in #1606 / #1609.

## Type of change

- [x] docs

## Linked issues

Refs #1521

## Changes

- ADR-0126 header `Delivery-Status`: **Partial → Shipped** (D1/D3/D4/D5 already Shipped; D2 completed by #1609).
- §D2 heading `Partial → ✅ Shipped`; its Delivery-reality note records #1609 (the `/validate` projection: scopes / grantedAccounts / frequencyPerDay, openapi 1.2.0).
- Top delivery note rewritten to the resolved all-Shipped state; the per-decision *Delivery reality* notes keep the record of what was mismarked and how it was fixed (record-don't-overwrite).
- `docs/adr/README.md` regenerated (`gen-index.sh`) → 0126 row now `Shipped`.

## Definition of Done

- [x] `check-adr-registry.sh` + `check-adr-status.sh` pass; README index regenerated & committed.
- [ ] Everything else — N/A (docs-only, no code/API/DB/event change, no release).

## Reviewer notes

- Closes the ADR-0126 delivery-status thread that started this whole line of work (#1521): D3 dual-write + the latent persist-vs-merge 500 (#1553), account-service same class (#1602), then D2 completion (#1609).
