### PR TITLE
feat(interest): wire the daily accrual engine (accrueAll was a stub) + seed savings rate

### DIFF
--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/AccountDirectoryPort.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/AccountDirectoryPort.kt
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.application.port.out
+
+import io.smallrye.mutiny.Uni
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * The fleet directory the daily accrual run reads to discover which accounts to accrue and at what
+ * balance. Deliberately narrow: only the fields the accrual formula needs. It is backed by
+ * account-service's staff/service reads (`GET /api/v1/accounts/active` for discovery — the same
+ * fleet-wide cursor list billing-service's cycle scheduler uses, ADR-0143 — and
+ * `GET /api/v1/accounts/{id}/balance` for the booked balance).
+ *
+ * **Fail-open:** an unreachable account-service yields an empty page / a null balance, so a
+ * scheduled tick degrades to "accrue nobody this run" (loud in logs, retried next tick) rather than
+ * crashing the scheduler. Interest that is one day late is a self-healing lag; a crashed scheduler
+ * is a silent multi-day gap.
+ */
+interface AccountDirectoryPort {
+    /** One page of fleet-wide ACTIVE accounts. [cursor] is null for the first page; follow
+     *  [AccountPage.nextCursor] until it is null. */
+    fun listActiveAccounts(cursor: String?, limit: Int): Uni<AccountPage>
+
+    /** The account's booked (cleared) balance — interest accrues on booked, not available, so a
+     *  pending debit does not retroactively shrink the day's accrual. Null when unavailable. */
+    fun bookedBalance(accountId: UUID): Uni<BalanceSnapshot?>
+}
+
+/** An account as the accrual run sees it. [productId] is the catalog product UUID rendered as a
+ *  string — it keys the rate config lookup ([InterestRateConfigRepository.findActiveForProduct]). */
+data class AccountSnapshot(val id: UUID, val productId: String, val accountType: String, val currency: String)
+
+data class AccountPage(val items: List<AccountSnapshot>, val nextCursor: String?)
+
+data class BalanceSnapshot(val booked: BigDecimal, val currency: String)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -12,6 +12,7 @@ import com.openbank.interest.domain.tax.WithholdingTaxPolicy
 import com.openbank.libs.domain.money.CurrencyCode
 import com.openbank.libs.domain.money.Money
 import com.openbank.libs.persistence.outbox.OutboxMessage
+import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
@@ -31,8 +32,11 @@ class InterestService(
     private val capitalizationRepo: InterestCapitalizationRepository,
     private val taxProfilePort: TaxProfilePort,
     private val ledgerPostingPort: LedgerPostingPort,
+    private val accountDirectoryPort: AccountDirectoryPort,
     @ConfigProperty(name = "openbank.interest.day-count-convention", defaultValue = "ACT_365")
     private val defaultDayCount: String,
+    @ConfigProperty(name = "openbank.interest.accruable-account-types", defaultValue = "SAVINGS")
+    private val accruableAccountTypes: String,
     private val clock: Clock,
 ) : AccrueInterestUseCase,
     CapitalizeInterestUseCase,
@@ -46,15 +50,20 @@ class InterestService(
         capitalizationRepo: InterestCapitalizationRepository,
         taxProfilePort: TaxProfilePort,
         ledgerPostingPort: LedgerPostingPort,
+        accountDirectoryPort: AccountDirectoryPort,
         @ConfigProperty(name = "openbank.interest.day-count-convention", defaultValue = "ACT_365")
         defaultDayCount: String,
+        @ConfigProperty(name = "openbank.interest.accruable-account-types", defaultValue = "SAVINGS")
+        accruableAccountTypes: String,
     ) : this(
         configRepo,
         accrualRepo,
         capitalizationRepo,
         taxProfilePort,
         ledgerPostingPort,
+        accountDirectoryPort,
         defaultDayCount,
+        accruableAccountTypes,
         Clock.systemUTC(),
     )
 
@@ -86,10 +95,66 @@ class InterestService(
             }
         }
 
+    /**
+     * The daily accrual run: discover every ACTIVE interest-bearing account fleet-wide (paged via
+     * account-service's ADR-0143 cursor list), read each one's booked balance, and post one accrual
+     * for [date]. Returns the number of accruals actually written.
+     *
+     * Per-account resilience: a missing rate config, an unavailable balance, or a duplicate (the
+     * `UNIQUE(account_id, accrual_date, product_id)` constraint — i.e. this account was already
+     * accrued for [date], so the run is safely **idempotent** and re-runnable) collapses that one
+     * account to a no-op (0), never aborting the batch. Accounts are processed sequentially
+     * (`concatenate`) to keep a bounded, polite load on account-service.
+     */
     override fun accrueAll(date: LocalDate): Uni<Int> {
-        // In production: fetch all active accounts with interest products and accrue
-        return Uni.createFrom().item(0)
+        val accruableTypes = accruableAccountTypes.split(",").map {
+            it.trim().uppercase()
+        }.filter { it.isNotEmpty() }.toSet()
+        return collectAccruableAccounts(cursor = null, acc = emptyList(), accruableTypes = accruableTypes)
+            .flatMap { accounts ->
+                if (accounts.isEmpty()) {
+                    Uni.createFrom().item(0)
+                } else {
+                    Multi.createFrom().iterable(accounts)
+                        .onItem().transformToUniAndConcatenate { account -> accrueOneForDate(account, date) }
+                        .collect().with(java.util.stream.Collectors.summingInt { it })
+                }
+            }
     }
+
+    /** Walk account-service's cursor pages, keeping only the accruable account types, until the
+     *  cursor is exhausted. Page count is small (fleet-wide ACTIVE set); recursion depth == pages. */
+    private fun collectAccruableAccounts(
+        cursor: String?,
+        acc: List<AccountSnapshot>,
+        accruableTypes: Set<String>,
+    ): Uni<List<AccountSnapshot>> = accountDirectoryPort.listActiveAccounts(cursor, ACCRUAL_PAGE_SIZE).flatMap { page ->
+        val kept = acc + page.items.filter { it.accountType.uppercase() in accruableTypes }
+        if (page.nextCursor == null) {
+            Uni.createFrom().item(kept)
+        } else {
+            collectAccruableAccounts(page.nextCursor, kept, accruableTypes)
+        }
+    }
+
+    /** Accrue one account for [date]; 1 if written, 0 if skipped (zero/negative balance, no rate
+     *  config, unavailable balance, or already accrued for [date]). Never fails the caller. */
+    private fun accrueOneForDate(account: AccountSnapshot, date: LocalDate): Uni<Int> =
+        accountDirectoryPort.bookedBalance(account.id).flatMap { balance ->
+            if (balance == null || balance.booked.signum() <= 0) {
+                Uni.createFrom().item(0)
+            } else {
+                accrue(
+                    AccrualRequest(
+                        accountId = account.id,
+                        productId = account.productId,
+                        balance = balance.booked,
+                        currency = balance.currency,
+                        accrualDate = date,
+                    ),
+                ).map { 1 }.onFailure().recoverWithItem(0)
+            }
+        }
 
     /**
      * Capitalizes one `(account, product)` period (ADR-0033 §B/§D): claim → post to the GL → commit.
@@ -406,5 +471,9 @@ class InterestService(
         } else {
             configRepo.update(config.copy(active = false, updatedAt = OffsetDateTime.now(clock)))
         }
+    }
+
+    private companion object {
+        const val ACCRUAL_PAGE_SIZE = 100
     }
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/AccountDirectoryAdapter.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/AccountDirectoryAdapter.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import com.openbank.interest.application.port.out.AccountDirectoryPort
+import com.openbank.interest.application.port.out.AccountPage
+import com.openbank.interest.application.port.out.AccountSnapshot
+import com.openbank.interest.application.port.out.BalanceSnapshot
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import org.jboss.logging.Logger
+import java.util.UUID
+
+/**
+ * **Fail-open** [AccountDirectoryPort] adapter over [AccountServiceClient]. Every upstream failure
+ * degrades (empty page / null balance) and is logged, never thrown — see the port's contract for
+ * why a degraded accrual tick beats a crashed scheduler.
+ */
+@ApplicationScoped
+class AccountDirectoryAdapter : AccountDirectoryPort {
+
+    @Inject
+    @RestClient
+    lateinit var client: AccountServiceClient
+
+    private val log = Logger.getLogger(AccountDirectoryAdapter::class.java)
+
+    override fun listActiveAccounts(cursor: String?, limit: Int): Uni<AccountPage> = client.listActive(limit, cursor)
+        .map { resp ->
+            AccountPage(
+                items = resp.data.map {
+                    AccountSnapshot(
+                        id = it.id,
+                        productId = it.productId.toString(),
+                        accountType = it.accountType,
+                        currency = it.currencyCode,
+                    )
+                },
+                nextCursor = resp.pagination.nextCursor.takeIf { resp.pagination.hasNextPage },
+            )
+        }
+        .onFailure().recoverWithItem { e ->
+            log.warnf(
+                "account-service /active unavailable (cursor=%s); accruing nobody this page: %s",
+                cursor,
+                e.message,
+            )
+            AccountPage(emptyList(), null)
+        }
+
+    override fun bookedBalance(accountId: UUID): Uni<BalanceSnapshot?> = client.getBalance(accountId)
+        .map { resp ->
+            val booked = resp.currentBalance
+            if (booked == null) null else BalanceSnapshot(booked, resp.currencyCode ?: "CZK")
+        }
+        .onFailure().recoverWithItem { e ->
+            log.warnf("account-service balance unavailable for %s; skipping its accrual: %s", accountId, e.message)
+            null
+        }
+}

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/client/AccountServiceClient.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.client
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.DefaultValue
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * REST client for `openbank-account-service`, used by the daily accrual run to discover accounts
+ * and read balances. OIDC service-to-service auth is attached by [OidcClientRequestReactiveFilter]
+ * (the `openbank-services` M2M token, ROLE_SERVICE — the same principal billing-service uses for
+ * these exact endpoints, so no new OPA policy is required).
+ */
+@RegisterRestClient(configKey = "account-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/api/v1/accounts")
+interface AccountServiceClient {
+
+    /** Fleet-wide ACTIVE accounts, cursor-paginated (ADR-0143 discovery read). */
+    @GET
+    @Path("/active")
+    fun listActive(
+        @QueryParam("limit") @DefaultValue("100") limit: Int,
+        @QueryParam("cursor") cursor: String?,
+    ): Uni<ActiveAccountsClientResponse>
+
+    /** Booked/available/reserved balance for one account. */
+    @GET
+    @Path("/{accountId}/balance")
+    fun getBalance(@PathParam("accountId") accountId: UUID): Uni<AccountBalanceClientResponse>
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ActiveAccountsClientResponse(
+    val data: List<AccountClientResponse> = emptyList(),
+    val pagination: PageInfoClientResponse = PageInfoClientResponse(),
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountClientResponse(val id: UUID, val productId: UUID, val accountType: String, val currencyCode: String)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PageInfoClientResponse(val hasNextPage: Boolean = false, val nextCursor: String? = null)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountBalanceClientResponse(
+    val accountId: UUID? = null,
+    val currentBalance: BigDecimal? = null,
+    val currencyCode: String? = null,
+)

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/InterestAccrualScheduler.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/InterestAccrualScheduler.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.scheduler
+
+import com.openbank.interest.application.port.`in`.AccrueInterestUseCase
+import io.quarkus.scheduler.Scheduled
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.LocalDate
+
+/**
+ * Drives the daily interest accrual. One tick per day (cron in `openbank.interest.accrual.cron`)
+ * posts a day's accrual for every ACTIVE interest-bearing account
+ * ([AccrueInterestUseCase.accrueAll]). `SKIP` on concurrent execution means a slow run is never
+ * doubled up, and the accrual itself is idempotent per `(account, date)`, so a retry (or a manual
+ * `POST /accrue/all`) after a partial run only fills the gaps — never double-credits.
+ *
+ * This is the engine that was previously missing: `accrueAll` used to be a stub returning 0, so no
+ * interest was ever accrued despite the rate/accrual/capitalization machinery all existing.
+ */
+@ApplicationScoped
+class InterestAccrualScheduler(private val accrueInterestUseCase: AccrueInterestUseCase, private val clock: Clock) {
+    private val log = Logger.getLogger(InterestAccrualScheduler::class.java)
+
+    @Scheduled(
+        cron = "{openbank.interest.accrual-cron}",
+        identity = "interest-daily-accrual",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    fun runDailyAccrual(): Uni<Void> {
+        val date = LocalDate.now(clock)
+        log.infof("interest accrual tick starting for %s", date)
+        return accrueInterestUseCase.accrueAll(date)
+            .onItem().invoke { count -> log.infof("interest accrual for %s wrote %d accrual(s)", date, count) }
+            .onFailure().invoke { e -> log.errorf(e, "interest accrual for %s failed", date) }
+            .onFailure().recoverWithItem(0)
+            .replaceWithVoid()
+    }
+}

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -69,6 +69,12 @@ quarkus:
     ledger-service:
       url: ${LEDGER_SERVICE_URL:http://localhost:8101}
       scope: jakarta.inject.Singleton
+    # Fleet-directory read for the daily accrual run: discovers ACTIVE accounts
+    # (GET /accounts/active, ADR-0143) and their booked balance (GET /accounts/{id}/balance).
+    # Same openbank-services M2M principal as the ledger/transaction clients above.
+    account-service:
+      url: ${ACCOUNT_SERVICE_URL:http://localhost:8100}
+      scope: jakarta.inject.Singleton
   redis:
     hosts: redis://localhost:6379
   shutdown:
@@ -158,6 +164,10 @@ openbank:
   interest:
     accrual-cron: "0 0 1 * * ?"
     capitalization-cron: "0 0 2 1 * ?"
+    # Account types the daily accrual run posts interest for (comma-separated, matched against
+    # account-service's accountType). Onboarding opens a SAVINGS account per retail customer; the
+    # CURRENT payment account is non-interest-bearing.
+    accruable-account-types: "SAVINGS"
     day-count-convention: ACT_365
     withholding:
       # #999: the bank's own operating/settlement account debited for the §38d odvod to the

--- a/openbank-interest-service/src/main/resources/db/migration/V9__seed_savings_rate_config.sql
+++ b/openbank-interest-service/src/main/resources/db/migration/V9__seed_savings_rate_config.sql
@@ -1,0 +1,26 @@
+-- Seed the interest rate configuration for the retail SAVINGS product (product-catalog
+-- 00000000-0000-0000-0000-0000000000c3, "CZK Savings"). Without an active rate config the accrual
+-- run finds nothing to apply and every SAVINGS account accrues 0 — which is exactly the state the
+-- sandbox was in (0 rate configs, 0 accruals) before the accrual engine was wired.
+--
+-- annual_rate is a DECIMAL FRACTION, not a percentage: the accrual formula is
+--   daily_rate = annual_rate / day_count_divisor ; accrued = balance * daily_rate
+-- so 4.00 % p.a. is stored as 0.040000 (100000 CZK -> ~10.96 CZK/day at ACT_365).
+--
+-- effective_from is backdated so historical accrual backfill for recently-opened accounts resolves
+-- this config. Guarded by NOT EXISTS so a re-run (or a hand-seed on an already-migrated DB) is a
+-- no-op rather than a second overlapping active config for the same product.
+INSERT INTO interest_rate_configs (id, product_id, rate_type, annual_rate, min_balance, day_count, effective_from, active)
+SELECT
+    'a0000000-0000-0000-0000-0000000000c3'::uuid,
+    '00000000-0000-0000-0000-0000000000c3',
+    'FIXED',
+    0.040000,
+    0,
+    'ACT_365',
+    DATE '2025-01-01',
+    TRUE
+WHERE NOT EXISTS (
+    SELECT 1 FROM interest_rate_configs
+    WHERE product_id = '00000000-0000-0000-0000-0000000000c3' AND active = TRUE
+);

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
@@ -4,6 +4,10 @@
 
 package com.openbank.interest.application.usecase
 
+import com.openbank.interest.application.port.out.AccountDirectoryPort
+import com.openbank.interest.application.port.out.AccountPage
+import com.openbank.interest.application.port.out.AccountSnapshot
+import com.openbank.interest.application.port.out.BalanceSnapshot
 import com.openbank.interest.application.port.out.CapitalizationPosting
 import com.openbank.interest.application.port.out.InterestAccrualRepository
 import com.openbank.interest.application.port.out.InterestCapitalizationRepository
@@ -48,13 +52,16 @@ class InterestServiceTest {
     private val capitalizationRepo = mockk<InterestCapitalizationRepository>()
     private val taxProfilePort = mockk<TaxProfilePort>()
     private val ledgerPostingPort = mockk<LedgerPostingPort>()
+    private val accountDirectoryPort = mockk<AccountDirectoryPort>()
     private val service = InterestService(
         configRepo,
         accrualRepo,
         capitalizationRepo,
         taxProfilePort,
         ledgerPostingPort,
+        accountDirectoryPort,
         "ACT_365",
+        "SAVINGS",
         clock,
     )
 
@@ -148,6 +155,85 @@ class InterestServiceTest {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("No active rate config for product SAVINGS")
         verify(exactly = 0) { accrualRepo.save(any()) }
+    }
+
+    @Test
+    fun `accrueAll walks all pages, accrues only accruable types, and returns the written count`() {
+        val date = LocalDate.of(2026, 1, 20)
+        val savingsA = UUID.fromString("aaaa0000-0000-0000-0000-000000000001")
+        val currentB = UUID.fromString("bbbb0000-0000-0000-0000-000000000002")
+        val savingsC = UUID.fromString("cccc0000-0000-0000-0000-000000000003")
+        val config = sampleConfig(annualRate = BigDecimal("0.365"))
+
+        // Two pages; a CURRENT account sits between the two SAVINGS ones and must be filtered out
+        // BEFORE its balance is ever read.
+        every { accountDirectoryPort.listActiveAccounts(null, any()) } returns Uni.createFrom().item(
+            AccountPage(
+                items = listOf(
+                    AccountSnapshot(savingsA, "SAVINGS_PRODUCT", "SAVINGS", "CZK"),
+                    AccountSnapshot(currentB, "CURRENT_PRODUCT", "CURRENT", "CZK"),
+                ),
+                nextCursor = "cursor-1",
+            ),
+        )
+        every { accountDirectoryPort.listActiveAccounts("cursor-1", any()) } returns Uni.createFrom().item(
+            AccountPage(
+                items = listOf(AccountSnapshot(savingsC, "SAVINGS_PRODUCT", "savings", "CZK")),
+                nextCursor = null,
+            ),
+        )
+        every { accountDirectoryPort.bookedBalance(savingsA) } returns
+            Uni.createFrom().item(BalanceSnapshot(BigDecimal("1000.00"), "CZK"))
+        every { accountDirectoryPort.bookedBalance(savingsC) } returns
+            Uni.createFrom().item(BalanceSnapshot(BigDecimal("2000.00"), "CZK"))
+        every { configRepo.findActiveForProduct(any(), date) } returns Uni.createFrom().item(config)
+        every { accrualRepo.save(any()) } answers { Uni.createFrom().item(firstArg<InterestAccrual>()) }
+
+        val count = service.accrueAll(date).await().indefinitely()
+
+        assertThat(count).isEqualTo(2)
+        verify(exactly = 1) { accountDirectoryPort.bookedBalance(savingsA) }
+        verify(exactly = 1) { accountDirectoryPort.bookedBalance(savingsC) }
+        // The CURRENT account is filtered by type — its balance is never even fetched.
+        verify(exactly = 0) { accountDirectoryPort.bookedBalance(currentB) }
+    }
+
+    @Test
+    fun `accrueAll skips zero balance and survives a per-account accrual failure without aborting`() {
+        val date = LocalDate.of(2026, 1, 20)
+        val zero = UUID.fromString("00000000-0000-0000-0000-0000000000a1")
+        val dup = UUID.fromString("00000000-0000-0000-0000-0000000000a2")
+        val ok = UUID.fromString("00000000-0000-0000-0000-0000000000a3")
+        val config = sampleConfig(annualRate = BigDecimal("0.365"))
+
+        every { accountDirectoryPort.listActiveAccounts(null, any()) } returns Uni.createFrom().item(
+            AccountPage(
+                items = listOf(
+                    AccountSnapshot(zero, "SAVINGS_PRODUCT", "SAVINGS", "CZK"),
+                    AccountSnapshot(dup, "SAVINGS_PRODUCT", "SAVINGS", "CZK"),
+                    AccountSnapshot(ok, "SAVINGS_PRODUCT", "SAVINGS", "CZK"),
+                ),
+                nextCursor = null,
+            ),
+        )
+        every { accountDirectoryPort.bookedBalance(zero) } returns
+            Uni.createFrom().item(BalanceSnapshot(BigDecimal.ZERO, "CZK"))
+        every { accountDirectoryPort.bookedBalance(dup) } returns
+            Uni.createFrom().item(BalanceSnapshot(BigDecimal("500.00"), "CZK"))
+        every { accountDirectoryPort.bookedBalance(ok) } returns
+            Uni.createFrom().item(BalanceSnapshot(BigDecimal("1000.00"), "CZK"))
+        every { configRepo.findActiveForProduct(any(), date) } returns Uni.createFrom().item(config)
+        // The duplicate account simulates the UNIQUE(account, date, product) violation on re-run.
+        every { accrualRepo.save(match { it.accountId == dup }) } returns
+            Uni.createFrom().failure(IllegalStateException("duplicate key value violates unique constraint"))
+        every { accrualRepo.save(match { it.accountId == ok }) } answers
+            { Uni.createFrom().item(firstArg<InterestAccrual>()) }
+
+        val count = service.accrueAll(date).await().indefinitely()
+
+        assertThat(count).isEqualTo(1)
+        // Zero-balance account is skipped before any accrual save is attempted.
+        verify(exactly = 0) { accrualRepo.save(match { it.accountId == zero }) }
     }
 
     @Test


### PR DESCRIPTION
## Why

Interest **never accrued** in any environment. `InterestService.accrueAll` was a stub returning `0` (`// In production: fetch all active accounts with interest products and accrue`), there was no scheduler, and no rate config was ever seeded. All the surrounding machinery (rate configs, accrual/capitalization tables, DTOs, REST endpoints, outbox) existed but nothing fed it — sandbox sat at **0 rate configs / 0 accruals / 0 capitalizations**, and the SAVINGS product every retail customer onboards into showed no interest.

Found while auditing which backend features the customer app can't yet surface: interest-service was `0/0` scaled with an empty DB, and the root cause turned out to be a missing engine, not just a dormant pod.

## What

- **`AccountDirectoryPort` + `AccountServiceClient`/`AccountDirectoryAdapter`** — narrow, **fail-open** fleet-directory read over account-service's *existing* service endpoints: `GET /accounts/active` (the same ADR-0143 cursor list billing-service's cycle scheduler uses → **no new endpoint, no new OPA policy**) for discovery, `GET /accounts/{id}/balance` for the booked balance. Upstream failure degrades a tick to "accrue nobody" (logged), never crashes the scheduler.
- **Real `accrueAll(date)`** — pages the fleet, keeps only accruable account types (`openbank.interest.accruable-account-types`, default `SAVINGS`), reads each booked balance, posts one accrual via the existing `accrue()` formula. Per-account resilient; the existing `UNIQUE(account_id, accrual_date, product_id)` makes the whole run **idempotent / re-runnable**.
- **`InterestAccrualScheduler`** — daily `@Scheduled` (`openbank.interest.accrual-cron`, a property that already existed) with `SKIP` concurrent execution. Only accrual is wired; capitalization stays manual (ledger credit path out of scope).
- **`V9`** seeds a **4.00 % p.a.** FIXED / ACT_365 config for the SAVINGS product (`...00c3`), backdated, `NOT EXISTS`-guarded.

## Tests

New unit tests: multi-page discovery + type filtering (a CURRENT account's balance is never fetched) and per-account resilience (zero-balance skip, duplicate-key survival without aborting the batch). Full `:openbank-interest-service:test` green.

## Scope / follow-ups

- Capitalization (monthly credit to the customer) remains manual/out-of-scope — its close path is separately incomplete.
- Edge (`customer-edge`) route + app UI to surface rate + accrued interest ship separately.

Refs ADR-0033, ADR-0143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues

Refs #1618
