### PR TITLE
test(governance): extract card-issuance OPA REST extension to a testable .rego file

### DIFF
--- a/openbank-infra/gitops/components/payments/card_issuance_rest_ext.rego
+++ b/openbank-infra/gitops/components/payments/card_issuance_rest_ext.rego
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# Card-issuance-service REST extension (ADR-0034 Phase 5 bootstrap, issue #938).
+# Extends openbank.rest with card-domain allow reasons.
+# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
+#
+# Actions gated (CardResource):
+#   card.create    — issueCard
+#   card.list      — listAll, listByAccount (#accountId), listByParty (#partyId)
+#   card.read      — getCard (#id)
+#   card.activate  — activate (#id)
+#   card.block     — block (#id) — ROLE_OPERATOR/ROLE_ADMIN/ROLE_COMPLIANCE (@RolesAllowed is a
+#                    disjunction: ROLE_COMPLIANCE widens the caller set, it does not narrow it)
+#   card.suspend   — suspend (#id) — customer-edge calls this on a customer's OWN card
+#                    (self-service freeze, /customer/v1/cards/{id}/freeze)
+#   card.resume    — resume (#id) — same, customer self-service unfreeze
+#
+# Base rest.rego already grants operator-read-any (ROLE_OPERATOR/ROLE_ADMIN) for card.list/.read
+# — no extension needed for those. The remaining actions have no generic base-rego grant.
+#
+# Verified caller: customer-edge calls card.list/card.suspend/card.resume on the customer's own
+# card via the shared `openbank-services` Keycloak client (service-account-openbank-services,
+# whose realmRoles include ROLE_OPERATOR) — see CustomerEdgeResource.kt cardAction(). Per the
+# documented fleet-wide limitation (rules.yaml authz_policy.principal_type_service_unreachable),
+# AuthorizeInterceptor cannot distinguish this M2M caller from a real human operator holding
+# ROLE_OPERATOR, so granting the role necessarily covers both — same stance as consent-service's
+# service-consent-m2m rule.
+
+package openbank.rest
+
+import rego.v1
+
+# Operators/admins may create, activate, block, suspend, or resume a card — mirroring
+# CardResource's @RolesAllowed on each method. block() is included: its
+# @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE") is a disjunction (any one role
+# admits the caller), so ROLE_COMPLIANCE is an ADDITIONAL grantee, not an extra requirement.
+# Omitting card.block here made the policy strictly narrower than the resource it guards: every
+# card.block by ROLE_OPERATOR/ROLE_ADMIN would 403 the moment AUTHZ_ENFORCE flips to true,
+# disabling the fraud response for a lost/stolen card for the only admin identity in the realm
+# (admin@openbank.local holds OPERATOR/ADMIN/VIEWER, not COMPLIANCE).
+allowed_reasons contains "operator-card-write" if {
+	input.principal.type == "HUMAN"
+	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
+	role in input.principal.roles
+	input.action in {"card.create", "card.activate", "card.block", "card.suspend", "card.resume"}
+}
+
+# Blocking a card (fraud/compliance hold) is also grantable to ROLE_COMPLIANCE alone — a
+# compliance officer who holds neither ROLE_OPERATOR nor ROLE_ADMIN can still block, matching the
+# third role in CardResource's @RolesAllowed on block().
+allowed_reasons contains "compliance-card-block" if {
+	input.principal.type == "HUMAN"
+	"ROLE_COMPLIANCE" in input.principal.roles
+	input.action == "card.block"
+}

--- a/openbank-infra/gitops/components/payments/card_issuance_rest_ext_test.rego
+++ b/openbank-infra/gitops/components/payments/card_issuance_rest_ext_test.rego
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# Unit tests for card_issuance_rest_ext.rego (ADR-0034 Phase 5 bootstrap, issue #938).
+#
+# This is the pattern established by issue #1322: 22 of 27 `gen-*-opa-bundle.sh` generators
+# embed their per-service REST extension as a bash heredoc, so there was nothing on disk for
+# `opa test` to load and no test covered any of them. card-issuance-service was chosen as the
+# first extraction because it is also the generator that shipped the bug #1322 cites as the
+# motivating example: `card.block` was granted to ROLE_COMPLIANCE only, while
+# `CardResource.block()` carries `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")`
+# — a disjunction. The extension was therefore strictly narrower than the resource it guards, and
+# flipping AUTHZ_ENFORCE=true would have 403'd every card.block by an operator (the fraud response
+# for a lost/stolen card). Fixed in #1323, but only because the action list was enumerated by
+# hand — this suite is the mechanical check that would have caught it, and stays in place to
+# catch a future regression the same way (either direction: narrower-than-@RolesAllowed fails
+# closed, wider-than-@RolesAllowed fails open per the resource comparison the base rego docs).
+#
+# Run from repo root: opa test openbank-infra/gitops/components/payments
+# (self-contained — allowed_reasons here is a partial-set rule with no dependency on rules.yaml
+# or agents.yaml, unlike rest.rego's `allow`, so this suite does not need rest.rego or the mocked
+# data those tests stage. See rest_test.rego for the base-policy suite.)
+
+package openbank.rest_test
+
+import data.openbank.rest
+
+# --- card.block: the #1323 regression this suite exists to pin ---
+
+# ROLE_OPERATOR alone must grant card.block (the role #1323 found silently excluded).
+test_card_block_allowed_for_operator if {
+	"operator-card-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "card.block",
+	}
+}
+
+# ROLE_ADMIN alone must also grant card.block.
+test_card_block_allowed_for_admin if {
+	"operator-card-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_ADMIN"]},
+		"action": "card.block",
+	}
+}
+
+# ROLE_COMPLIANCE alone must grant card.block too — @RolesAllowed is a disjunction, so this role
+# is an ADDITIONAL grantee, not a requirement layered on top of ROLE_OPERATOR/ROLE_ADMIN.
+test_card_block_allowed_for_compliance_alone if {
+	"compliance-card-block" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_COMPLIANCE"]},
+		"action": "card.block",
+	}
+}
+
+# A principal with none of the three roles gets no allow reason for card.block.
+test_card_block_denied_for_unrelated_role if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_VIEWER"]},
+		"action": "card.block",
+	}
+}
+
+# --- other CardResource actions covered by the same operator-card-write rule ---
+
+test_card_create_allowed_for_operator if {
+	"operator-card-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "card.create",
+	}
+}
+
+test_card_suspend_allowed_for_operator if {
+	"operator-card-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "card.suspend",
+	}
+}
+
+test_card_resume_allowed_for_operator if {
+	"operator-card-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "card.resume",
+	}
+}
+
+test_card_activate_allowed_for_operator if {
+	"operator-card-write" in rest.allowed_reasons with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "card.activate",
+	}
+}
+
+# ROLE_COMPLIANCE alone does NOT grant card.create/.activate/.suspend/.resume — the third
+# @RolesAllowed role on CardResource applies to block() only, not the fleet-wide "compliance can
+# write cards" grant this extension is careful not to create.
+test_card_create_denied_for_compliance_alone if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "HUMAN", "roles": ["ROLE_COMPLIANCE"]},
+		"action": "card.create",
+	}
+}
+
+# An AI_AGENT principal never matches this extension's HUMAN-only rules (agent access to card
+# actions is mediated by agents.rego/charter_allowed via rest.rego's allow rule, not here).
+test_card_block_denied_for_ai_agent if {
+	count(rest.allowed_reasons) == 0 with input as {
+		"principal": {"type": "AI_AGENT", "roles": ["ROLE_OPERATOR"]},
+		"action": "card.block",
+	}
+}

--- a/openbank-infra/gitops/components/payments/gen-card-issuance-opa-bundle.sh
+++ b/openbank-infra/gitops/components/payments/gen-card-issuance-opa-bundle.sh
@@ -12,67 +12,18 @@ MANIFEST=$REPO/openbank-infra/opa/bundle.manifest
 # infrastructure existed for this service before this bootstrap. card-issuance-service deploys
 # into the shared `payments` namespace/ArgoCD app (payments-services.yaml), not its own — this
 # generator lives alongside that manifest for the same reason the other payments/* bundles do.
-CARD_ISSUANCE_REST_EXT=$(cat << 'REGO'
-# SPDX-License-Identifier: Apache-2.0
-# Card-issuance-service REST extension (ADR-0034 Phase 5 bootstrap, issue #938).
-# Extends openbank.rest with card-domain allow reasons.
-# Mounted alongside rest.rego in the same OPA bundle — OPA merges same-package rules.
 #
-# Actions gated (CardResource):
-#   card.create    — issueCard
-#   card.list      — listAll, listByAccount (#accountId), listByParty (#partyId)
-#   card.read      — getCard (#id)
-#   card.activate  — activate (#id)
-#   card.block     — block (#id) — ROLE_OPERATOR/ROLE_ADMIN/ROLE_COMPLIANCE (@RolesAllowed is a
-#                    disjunction: ROLE_COMPLIANCE widens the caller set, it does not narrow it)
-#   card.suspend   — suspend (#id) — customer-edge calls this on a customer's OWN card
-#                    (self-service freeze, /customer/v1/cards/{id}/freeze)
-#   card.resume    — resume (#id) — same, customer self-service unfreeze
-#
-# Base rest.rego already grants operator-read-any (ROLE_OPERATOR/ROLE_ADMIN) for card.list/.read
-# — no extension needed for those. The remaining actions have no generic base-rego grant.
-#
-# Verified caller: customer-edge calls card.list/card.suspend/card.resume on the customer's own
-# card via the shared `openbank-services` Keycloak client (service-account-openbank-services,
-# whose realmRoles include ROLE_OPERATOR) — see CustomerEdgeResource.kt cardAction(). Per the
-# documented fleet-wide limitation (rules.yaml authz_policy.principal_type_service_unreachable),
-# AuthorizeInterceptor cannot distinguish this M2M caller from a real human operator holding
-# ROLE_OPERATOR, so granting the role necessarily covers both — same stance as consent-service's
-# service-consent-m2m rule.
-
-package openbank.rest
-
-import rego.v1
-
-# Operators/admins may create, activate, block, suspend, or resume a card — mirroring
-# CardResource's @RolesAllowed on each method. block() is included: its
-# @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE") is a disjunction (any one role
-# admits the caller), so ROLE_COMPLIANCE is an ADDITIONAL grantee, not an extra requirement.
-# Omitting card.block here made the policy strictly narrower than the resource it guards: every
-# card.block by ROLE_OPERATOR/ROLE_ADMIN would 403 the moment AUTHZ_ENFORCE flips to true,
-# disabling the fraud response for a lost/stolen card for the only admin identity in the realm
-# (admin@openbank.local holds OPERATOR/ADMIN/VIEWER, not COMPLIANCE).
-allowed_reasons contains "operator-card-write" if {
-	input.principal.type == "HUMAN"
-	some role in {"ROLE_OPERATOR", "ROLE_ADMIN"}
-	role in input.principal.roles
-	input.action in {"card.create", "card.activate", "card.block", "card.suspend", "card.resume"}
-}
-
-# Blocking a card (fraud/compliance hold) is also grantable to ROLE_COMPLIANCE alone — a
-# compliance officer who holds neither ROLE_OPERATOR nor ROLE_ADMIN can still block, matching the
-# third role in CardResource's @RolesAllowed on block().
-allowed_reasons contains "compliance-card-block" if {
-	input.principal.type == "HUMAN"
-	"ROLE_COMPLIANCE" in input.principal.roles
-	input.action == "card.block"
-}
-REGO
-)
+# Extracted to a standalone .rego file (issue #1322) rather than an inline bash heredoc, so
+# `opa test` can load and cover it directly — see card_issuance_rest_ext_test.rego in this same
+# directory, which pins the card.block disjunction that #1323 found broken (a heredoc has nothing
+# on disk for `opa test` to discover; this is the fleet-wide gap issue #1322 tracks, established
+# here as a pattern for the other generators still on heredocs). Read exactly like REST_REGO/
+# AGENTS_REGO above — content is unchanged, only how it reaches this script.
+CARD_ISSUANCE_REST_EXT=$REPO/openbank-infra/gitops/components/payments/card_issuance_rest_ext.rego
 
 CHECKSUM=$(printf '%s\n' \
     "$(cat "$REST_REGO")" \
-    "$(echo "$CARD_ISSUANCE_REST_EXT")" \
+    "$(cat "$CARD_ISSUANCE_REST_EXT")" \
     "$(cat "$AGENTS_REGO")" \
     "$(cat "$AGENTS_YAML")" \
     "$(cat "$RULES_YAML")" \
@@ -98,7 +49,7 @@ OUT=$REPO/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yam
   echo "  rest.rego: |"
   sed 's/^/    /' "$REST_REGO" | sed 's/[[:space:]]*$//'
   echo "  card_issuance_rest_ext.rego: |"
-  echo "$CARD_ISSUANCE_REST_EXT" | sed 's/^/    /' | sed 's/[[:space:]]*$//'
+  sed 's/^/    /' "$CARD_ISSUANCE_REST_EXT" | sed 's/[[:space:]]*$//'
   echo "  agents.rego: |"
   sed 's/^/    /' "$AGENTS_REGO" | sed 's/[[:space:]]*$//'
   echo "  agents-data.yaml: |"


### PR DESCRIPTION
## Summary

Refs #1322 — **partial**, not a close. #1322 documents that 22 of 27 `gen-*-opa-bundle.sh`
generators embed their per-service REST policy extension as an inline bash heredoc, so
`opa test` has nothing on disk to load and none of those extensions carry any unit-test
coverage. That gap is what let the `card.block` bug (issue #1322's motivating example,
fixed in #1323) ship: the extension granted `card.block` to `ROLE_COMPLIANCE` only, while
`CardResource.block()`'s `@RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_COMPLIANCE")`
is a disjunction — the policy was strictly narrower than the resource it guards, and
flipping `AUTHZ_ENFORCE=true` would have 403'd every operator/admin card block (the fraud
response for a lost/stolen card).

This PR extracts **one** generator — `gen-card-issuance-opa-bundle.sh`, chosen because it's
the generator that shipped the motivating bug — to establish the pattern the other 21 can
follow, rather than attempting the full fleet-wide refactor in one change.

- `openbank-infra/gitops/components/payments/card_issuance_rest_ext.rego` — the extension,
  moved out of the heredoc into a standalone file, read from disk exactly the way
  `REST_REGO`/`AGENTS_REGO` already are in the same script. Content is byte-for-byte
  unchanged from the heredoc.
- `openbank-infra/gitops/components/payments/card_issuance_rest_ext_test.rego` — a real
  `opa test` suite (10 cases) that pins the `card.block` disjunction: ROLE_OPERATOR alone,
  ROLE_ADMIN alone, and ROLE_COMPLIANCE alone must each independently grant `card.block`.
  Reverting the fix (dropping `card.block` from the operator/admin grant, reproducing
  #1323's bug) fails 2 of the 10 tests — verified locally before committing.
- `gen-card-issuance-opa-bundle.sh` — swapped the heredoc for a file-path variable read via
  `cat`, matching the existing pattern for the other embedded policy sources.

## Verification

- `opa test` on the new files: 10/10 pass.
- `opa test` with the fix reverted (simulating #1323): 2/10 fail, confirming the suite
  actually catches the regression class it documents.
- `./openbank-infra/opa/build-bundle.sh`: 135/135 unit tests pass, `opa check --strict`
  clean, all decision assertions pass, bundle builds.
- Regenerated `card-issuance-opa-bundle.yaml` and `payments-services.yaml` before and after
  the change and diffed them: **byte-identical**. Also ran every
  `gen-*opa-bundle*.sh` generator fleet-wide (`find openbank-infra/gitops/components -name
  'gen-*opa-bundle*.sh' | sort | xargs -n1 bash`) both before committing and again
  immediately before pushing — zero diff anywhere outside the three files in this PR. This
  change only alters *how* the policy text reaches the generator, not the policy text
  itself or any other service's bundle/checksum.

## Explicitly out of scope

This does **not** close #1322. Two items remain, both flagged as follow-up in a comment on
the issue:
- The other 21 generators still embed rego as heredocs, untested.
- #1322's suggested CI guard (comparing `@Authorize` action principals against
  `@RolesAllowed` on the guarded resource method) is not implemented here — this PR only
  makes the *existing* declared policy testable, it does not add a drift check against the
  Kotlin resource classes.

## Test plan

- [x] `opa test` on the new/changed files (10/10 pass)
- [x] `opa test` with the #1323 fix reverted, confirming the suite fails (2/10 fail)
- [x] `./openbank-infra/opa/build-bundle.sh` full run (135/135 pass)
- [x] Fleet-wide bundle regeneration diffed clean, twice (before commit, before push)
- [ ] CI: OPA policy gate (`opa-policy.yml`) — not yet observed, PR just opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)