### PR TITLE
feat(admin-ui): animate the service map into a data-flow topology

### DIFF
--- a/openbank-admin-ui/scripts/generate-service-graph.mjs
+++ b/openbank-admin-ui/scripts/generate-service-graph.mjs
@@ -181,7 +181,7 @@ for (const name of modules) {
     if (kp.endsWith('datasource.reactive.url') || kp.endsWith('datasource.jdbc.url') || raw.includes('postgresql://')) svcInfra.add('postgres')
     if (kp.endsWith('oidc.auth-server-url') || raw.includes('/realms/')) svcInfra.add('keycloak')
     if (kp === 'opa.url' || kp.endsWith('.opa.url') || /:8181(\/|$)/.test(raw)) svcInfra.add('opa')
-    if (kp.includes('bootstrap-servers')) svcInfra.add('kafka')
+    if (/bootstrap[.-]servers/.test(kp)) svcInfra.add('kafka')
     // External — push/webhook detected by the integration's own enabled flag
     // (the endpoint/creds are injected at runtime, so the URL is usually empty).
     if (kp.endsWith('push.apns.enabled')) addExternal('apple-apns', 'push', envBool(value))

--- a/openbank-admin-ui/scripts/generate-service-graph.mjs
+++ b/openbank-admin-ui/scripts/generate-service-graph.mjs
@@ -116,16 +116,22 @@ const EXTERNAL = {
   'llm-gateway':  { vendor: 'LLM providers', label: 'LLM gateway' },
   s3:             { vendor: 'AWS',           label: 'S3 object store' },
 }
+// Match a host against a registrable domain at a LABEL boundary — the host is
+// exactly the domain or a subdomain of it. A plain substring test would also
+// match a look-alike like `groq.com.attacker.example` or `notcnb.cz`, so we
+// anchor on the dot boundary (CodeQL: incomplete URL substring sanitization).
+const hostIn = (h, domain) => h === domain || h.endsWith('.' + domain)
+
 // Classify a URL host as a known EXTERNAL 3rd party. In-cluster hosts
 // (litellm.ai-platform, ollama, localhost, openbank-*) return null on purpose —
 // they are infra or inter-service edges elsewhere, so counting them here would
 // double up. Unknown public hosts also return null: never fabricate a vendor.
 function classifyHost(host) {
   const h = host.toLowerCase()
-  if (h.includes('cnb.cz')) return { id: 'cnb', type: 'registry' }
-  if (h === 'api.github.com' || h.endsWith('.github.com')) return { id: 'github', type: 'api' }
-  if (h.includes('deepinfra.com') || h.includes('groq.com') || h.includes('nvidia.com')) return { id: 'llm-gateway', type: 'llm' }
-  if (h.includes('amazonaws.com')) return { id: 's3', type: 'api' }
+  if (hostIn(h, 'cnb.cz')) return { id: 'cnb', type: 'registry' }
+  if (hostIn(h, 'github.com')) return { id: 'github', type: 'api' }
+  if (hostIn(h, 'deepinfra.com') || hostIn(h, 'groq.com') || hostIn(h, 'nvidia.com')) return { id: 'llm-gateway', type: 'llm' }
+  if (hostIn(h, 'amazonaws.com')) return { id: 's3', type: 'api' }
   return null
 }
 

--- a/openbank-admin-ui/scripts/generate-service-graph.mjs
+++ b/openbank-admin-ui/scripts/generate-service-graph.mjs
@@ -16,7 +16,18 @@
 //
 // Honest by construction: a config that can't be parsed contributes no edges
 // (never a fabricated dependency). Targets that don't resolve to a known module
-// (OPA, Keycloak, datasources) are dropped — only inter-service edges are kept.
+// stay OUT of the inter-service `edges`/`nodes` (only module→module is kept there).
+//
+// Data-flow map extension (additive, same honesty rule): the animated topology in
+// the admin-ui also wants the *substrate* each service sits on and the *third
+// parties* it reaches, so this generator ALSO emits two extra tiers, parsed from
+// the same application.yaml (base profile only — `%dev`/`%test` overrides ignored):
+//   infraNodes/infraEdges     — Postgres, Kafka, Keycloak, OPA (presence-detected)
+//   externalNodes/externalEdges — Apple APNs, Firebase FCM, Slack, ČNB, GitHub,
+//                                 LLM providers, S3 (host- or enabled-flag-detected)
+// These are strictly additive: the original `nodes`/`edges` are unchanged, so every
+// existing consumer keeps working. A tier node is emitted only if ≥1 edge references
+// it — no orphan/fabricated nodes.
 //
 // Usage: node scripts/generate-service-graph.mjs [--repo <path>] [--out <file>]
 
@@ -63,9 +74,66 @@ function loadConfig(dir) {
   try { return parseYaml(raw) } catch { return null }
 }
 
+// --- Infra + external tier helpers ------------------------------------------
+// Recursively visit every scalar in the parsed YAML, yielding [dottedKeyPath,
+// value]. Profile overrides (`%dev`, `%test`, `%slack-it`) are skipped so the
+// tiers describe the BASE (production-shaped) config, matching the rest/kafka pass.
+function* walkScalars(obj, prefix = '') {
+  if (obj == null || typeof obj !== 'object') return
+  for (const [k, v] of Object.entries(obj)) {
+    if (k.startsWith('%')) continue
+    const keyPath = prefix ? `${prefix}.${k}` : k
+    if (v != null && typeof v === 'object') yield* walkScalars(v, keyPath)
+    else yield [keyPath, v]
+  }
+}
+
+// Resolve a Quarkus `${ENV:default}` wrapper (or a plain scalar) to its effective
+// value/boolean. `${APNS_ENABLED:false}` → 'false'; a bare value passes through.
+function envValue(v) {
+  const s = String(v ?? '').trim()
+  const m = s.match(/^\$\{[^:}]*:([^}]*)\}$/)
+  return (m ? m[1] : s).trim()
+}
+function envBool(v) { return envValue(v).toLowerCase() === 'true' }
+
+// Infra node catalog — id → {tech, label}. Presence-detected from config keys.
+const INFRA = {
+  postgres: { tech: 'postgres', label: 'PostgreSQL' },
+  kafka:    { tech: 'kafka',    label: 'Apache Kafka' },
+  keycloak: { tech: 'keycloak', label: 'Keycloak (OIDC)' },
+  opa:      { tech: 'opa',      label: 'OPA (authz)' },
+}
+const INFRA_EDGE_TYPE = { postgres: 'db', kafka: 'broker', keycloak: 'auth', opa: 'authz' }
+
+// External / 3rd-party catalog — id → {vendor, label}. Host- or flag-detected.
+const EXTERNAL = {
+  'apple-apns':   { vendor: 'Apple',         label: 'APNs (push)' },
+  'firebase-fcm': { vendor: 'Google',        label: 'Firebase FCM (push)' },
+  slack:          { vendor: 'Slack',         label: 'Slack webhook' },
+  cnb:            { vendor: 'ČNB',           label: 'Czech National Bank' },
+  github:         { vendor: 'GitHub',        label: 'GitHub API' },
+  'llm-gateway':  { vendor: 'LLM providers', label: 'LLM gateway' },
+  s3:             { vendor: 'AWS',           label: 'S3 object store' },
+}
+// Classify a URL host as a known EXTERNAL 3rd party. In-cluster hosts
+// (litellm.ai-platform, ollama, localhost, openbank-*) return null on purpose —
+// they are infra or inter-service edges elsewhere, so counting them here would
+// double up. Unknown public hosts also return null: never fabricate a vendor.
+function classifyHost(host) {
+  const h = host.toLowerCase()
+  if (h.includes('cnb.cz')) return { id: 'cnb', type: 'registry' }
+  if (h === 'api.github.com' || h.endsWith('.github.com')) return { id: 'github', type: 'api' }
+  if (h.includes('deepinfra.com') || h.includes('groq.com') || h.includes('nvidia.com')) return { id: 'llm-gateway', type: 'llm' }
+  if (h.includes('amazonaws.com')) return { id: 's3', type: 'api' }
+  return null
+}
+
 const restEdges = []                 // {from, to, via}
 const producers = new Map()          // topic -> Set(service)
 const consumers = new Map()          // topic -> Set(service)
+const infraEdges = []                // {from, to, type}
+const externalEdges = []             // {from, to, type, enabled}
 
 for (const name of modules) {
   const cfg = loadConfig(path.join(REPO, name))
@@ -95,6 +163,40 @@ for (const name of modules) {
       map.get(topic).add(name)
     }
   }
+
+  // --- Infra + external tiers (single walk over the base config) -----------
+  const svcInfra = new Set()                 // infra ids this service touches
+  const svcExternal = new Map()              // `${id}|${type}` -> enabled(bool)
+  const addExternal = (id, type, enabled) => {
+    const k = `${id}|${type}`
+    svcExternal.set(k, (svcExternal.get(k) ?? false) || enabled)
+  }
+  // Any Kafka channel means the service sits on the broker.
+  if (messaging?.outgoing || messaging?.incoming) svcInfra.add('kafka')
+
+  for (const [keyPath, value] of walkScalars(cfg)) {
+    const kp = keyPath.toLowerCase()
+    const raw = envValue(value)
+    // Infra — presence-detected.
+    if (kp.endsWith('datasource.reactive.url') || kp.endsWith('datasource.jdbc.url') || raw.includes('postgresql://')) svcInfra.add('postgres')
+    if (kp.endsWith('oidc.auth-server-url') || raw.includes('/realms/')) svcInfra.add('keycloak')
+    if (kp === 'opa.url' || kp.endsWith('.opa.url') || /:8181(\/|$)/.test(raw)) svcInfra.add('opa')
+    if (kp.includes('bootstrap-servers')) svcInfra.add('kafka')
+    // External — push/webhook detected by the integration's own enabled flag
+    // (the endpoint/creds are injected at runtime, so the URL is usually empty).
+    if (kp.endsWith('push.apns.enabled')) addExternal('apple-apns', 'push', envBool(value))
+    else if (kp.endsWith('push.fcm.enabled')) addExternal('firebase-fcm', 'push', envBool(value))
+    else if (kp.endsWith('webhook.slack.enabled')) addExternal('slack', 'webhook', envBool(value))
+    // External — any http(s) URL whose host is a known 3rd party.
+    const m = raw.match(/^https?:\/\/([^/:\s]+)/)
+    if (m) { const c = classifyHost(m[1]); if (c) addExternal(c.id, c.type, true) }
+  }
+
+  for (const id of svcInfra) infraEdges.push({ from: name, to: `infra:${id}`, type: INFRA_EDGE_TYPE[id] })
+  for (const [k, enabled] of svcExternal) {
+    const [id, type] = k.split('|')
+    externalEdges.push({ from: name, to: `ext:${id}`, type, enabled })
+  }
 }
 
 // Producer → consumer edges, one per (producer, consumer, topic) triple.
@@ -118,6 +220,16 @@ const edges = [
   ...kafkaEdges.map(e => ({ ...e, type: 'kafka' })),
 ]
 
+// Emit an infra/external node only if ≥1 edge references it (no orphan nodes).
+const usedInfra = new Set(infraEdges.map(e => e.to.slice('infra:'.length)))
+const infraNodes = [...usedInfra].sort()
+  .filter(id => INFRA[id])
+  .map(id => ({ id: `infra:${id}`, kind: 'infra', ...INFRA[id] }))
+const usedExternal = new Set(externalEdges.map(e => e.to.slice('ext:'.length)))
+const externalNodes = [...usedExternal].sort()
+  .filter(id => EXTERNAL[id])
+  .map(id => ({ id: `ext:${id}`, kind: 'external', ...EXTERNAL[id] }))
+
 // Per-node fan-in / fan-out, so the UI/agent can rank blast radius directly.
 const degree = {}
 for (const n of modules) degree[n] = { dependsOn: 0, dependedOnBy: 0 }
@@ -129,18 +241,31 @@ for (const e of edges) {
 const graph = {
   schema: 'openbank.service-graph/v1',
   generator: 'generate-service-graph.mjs',
-  source: 'code-derived (application.yaml: quarkus.rest-client + mp.messaging) — ADR-0029 D1',
+  source: 'code-derived (application.yaml: quarkus.rest-client + mp.messaging + infra/3rd-party tiers) — ADR-0029 D1',
   collectedAt: null,
   totals: {
     nodes: modules.length,
     restEdges: restEdges.length,
     kafkaEdges: kafkaEdges.length,
     danglingTopics: danglingTopics.length,
+    infraNodes: infraNodes.length,
+    externalNodes: externalNodes.length,
+    infraEdges: infraEdges.length,
+    externalEdges: externalEdges.length,
   },
   nodes: modules.map(n => ({ name: n, short: n.replace(/^openbank-/, ''), ...degree[n] })),
   edges,
   danglingTopics,
+  // Additive data-flow tiers (see header). Existing consumers ignore these.
+  infraNodes,
+  externalNodes,
+  infraEdges,
+  externalEdges,
 }
 
 writeFileSync(OUT, JSON.stringify(graph, null, 2) + '\n')
-console.log(`[generate-service-graph] ${modules.length} nodes, ${restEdges.length} REST + ${kafkaEdges.length} Kafka edges, ${danglingTopics.length} dangling topics → ${OUT}`)
+console.log(
+  `[generate-service-graph] ${modules.length} nodes, ${restEdges.length} REST + ${kafkaEdges.length} Kafka edges, ` +
+  `${danglingTopics.length} dangling topics · ${infraNodes.length} infra + ${externalNodes.length} external nodes ` +
+  `(${infraEdges.length} infra + ${externalEdges.length} external edges) → ${OUT}`,
+)

--- a/openbank-admin-ui/src/app/api/catalog/graph/route.ts
+++ b/openbank-admin-ui/src/app/api/catalog/graph/route.ts
@@ -16,6 +16,12 @@ export const dynamic = 'force-dynamic'
 
 interface Edge { from: string; to: string; via: string; type: 'rest' | 'kafka' }
 interface Node { name: string; short: string; dependsOn: number; dependedOnBy: number }
+// Additive data-flow tiers (generate-service-graph.mjs). Optional so an older
+// snapshot without them still parses; consumers default each to [].
+interface InfraNode { id: string; kind: 'infra'; tech: string; label: string }
+interface ExternalNode { id: string; kind: 'external'; vendor: string; label: string }
+interface InfraEdge { from: string; to: string; type: 'db' | 'broker' | 'auth' | 'authz' }
+interface ExternalEdge { from: string; to: string; type: 'push' | 'webhook' | 'registry' | 'api' | 'llm'; enabled: boolean }
 interface ServiceGraph {
   schema: string
   source: string
@@ -24,6 +30,10 @@ interface ServiceGraph {
   nodes: Node[]
   edges: Edge[]
   danglingTopics: { topic: string; producedBy: string[]; consumedBy: string[] }[]
+  infraNodes?: InfraNode[]
+  externalNodes?: ExternalNode[]
+  infraEdges?: InfraEdge[]
+  externalEdges?: ExternalEdge[]
   available?: boolean
 }
 
@@ -39,6 +49,10 @@ const UNAVAILABLE: ServiceGraph = {
   nodes: [],
   edges: [],
   danglingTopics: [],
+  infraNodes: [],
+  externalNodes: [],
+  infraEdges: [],
+  externalEdges: [],
   available: false,
 }
 

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -3,8 +3,8 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect } from 'react'
-import { Network, RefreshCw, CheckCircle2, XCircle, HelpCircle, Database, ArrowRight, ArrowLeft, Layers, BookOpen } from 'lucide-react'
+import { useState, useEffect, useMemo } from 'react'
+import { Network, RefreshCw, CheckCircle2, XCircle, HelpCircle, Database, ArrowRight, ArrowLeft, Layers, BookOpen, Play, Pause, KeyRound, ShieldCheck, Boxes, Cloud, Send, Server } from 'lucide-react'
 import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 import { svcUrl } from '@/lib/services/bff'
 import { CatalogDriftBanner } from '@/components/governance/CatalogDriftBanner'
@@ -290,6 +290,111 @@ function LegoBrick({ cx, cy, color, degree, selected }: { cx: number; cy: number
   )
 }
 
+// ---------------------------------------------------------------------------
+// Data-flow tiers (infra substrate + external 3rd parties). Nodes/edges arrive
+// from /api/catalog/graph (generate-service-graph.mjs) — parsed from real
+// application.yaml, never hand-authored. Presentation-only metadata (colour,
+// icon, bilingual copy) lives here; the topology itself is code-derived.
+// ---------------------------------------------------------------------------
+type InfraNodeT = { id: string; kind: 'infra'; tech: string; label: string }
+type ExternalNodeT = { id: string; kind: 'external'; vendor: string; label: string }
+type InfraEdgeT = { from: string; to: string; type: 'db' | 'broker' | 'auth' | 'authz' }
+type ExternalEdgeT = { from: string; to: string; type: 'push' | 'webhook' | 'registry' | 'api' | 'llm'; enabled: boolean }
+type TierMeta = { color: string; Icon: typeof Database; labelCs: string; labelEn: string; descCs: string; descEn: string }
+
+const INFRA_META: Record<string, TierMeta> = {
+  'infra:postgres': { color: '#0ea5e9', Icon: Database, labelCs: 'PostgreSQL', labelEn: 'PostgreSQL', descCs: 'Perzistentní stav služeb (účty, ledger, transakce). Podvojné úložiště, reactive Vert.x klient.', descEn: 'Per-service persistent state (accounts, ledger, transactions). Reactive Vert.x client.' },
+  'infra:kafka': { color: '#6366f1', Icon: Boxes, labelCs: 'Apache Kafka', labelEn: 'Apache Kafka', descCs: 'Asynchronní páteř událostí — produkce/konzumace topiců, outbox dispatch mezi službami.', descEn: 'Async event backbone — topic produce/consume, cross-service outbox dispatch.' },
+  'infra:keycloak': { color: '#0891b2', Icon: KeyRound, labelCs: 'Keycloak (OIDC)', labelEn: 'Keycloak (OIDC)', descCs: 'Vydavatel identit a tokenů (OIDC). Ověřuje operátory i M2M client-credentials tok.', descEn: 'Identity & token issuer (OIDC). Authenticates operators and M2M client-credentials flows.' },
+  'infra:opa': { color: '#16a34a', Icon: ShieldCheck, labelCs: 'OPA (autorizace)', labelEn: 'OPA (authz)', descCs: 'Rozhodovací bod autorizace (ADR-0034). Sidecar vyhodnocuje rest.rego politiky per požadavek.', descEn: 'Authorization decision point (ADR-0034). Sidecar evaluates rest.rego per request.' },
+}
+const EXT_META: Record<string, TierMeta> = {
+  'ext:apple-apns': { color: '#0f172a', Icon: Send, labelCs: 'Apple APNs', labelEn: 'Apple APNs', descCs: 'Push notifikace na iOS zařízení (adapter v notification-service).', descEn: 'Push notifications to iOS devices (notification-service adapter).' },
+  'ext:firebase-fcm': { color: '#f59e0b', Icon: Send, labelCs: 'Firebase FCM', labelEn: 'Firebase FCM', descCs: 'Push notifikace přes Google FCM.', descEn: 'Push notifications via Google FCM.' },
+  'ext:slack': { color: '#7c3aed', Icon: Send, labelCs: 'Slack webhook', labelEn: 'Slack webhook', descCs: 'Odchozí oversight signály (ADR-0059).', descEn: 'Outbound oversight signals (ADR-0059).' },
+  'ext:cnb': { color: '#dc2626', Icon: Cloud, labelCs: 'ČNB', labelEn: 'Czech National Bank', descCs: 'Veřejné feedy ČNB — seznam bank (JERR) a devizové kurzy.', descEn: 'CNB public feeds — bank registry (JERR) and FX rates.' },
+  'ext:github': { color: '#0f172a', Icon: Cloud, labelCs: 'GitHub API', labelEn: 'GitHub API', descCs: 'Rozhraní pro platformní/agentní služby (release, governance).', descEn: 'Interface for platform/agent services (release, governance).' },
+  'ext:llm-gateway': { color: '#0d9488', Icon: Cloud, labelCs: 'LLM brána', labelEn: 'LLM gateway', descCs: 'Externí LLM poskytovatelé (DeepInfra, Groq, NVIDIA) pro AI agenty.', descEn: 'External LLM providers (DeepInfra, Groq, NVIDIA) for AI agents.' },
+  'ext:s3': { color: '#f97316', Icon: Cloud, labelCs: 'AWS S3', labelEn: 'AWS S3', descCs: 'Objektové úložiště (export analytiky, artefakty).', descEn: 'Object store (analytics export, artifacts).' },
+}
+const tierMeta = (id: string): TierMeta | undefined => INFRA_META[id] ?? EXT_META[id]
+
+// Edge-type palette + bilingual label for the legend / detail panel.
+const EDGE_TYPE_COLOR: Record<string, string> = {
+  db: '#38bdf8', broker: '#818cf8', auth: '#22d3ee', authz: '#4ade80',
+  push: '#fb923c', webhook: '#a78bfa', registry: '#f87171', api: '#94a3b8', llm: '#2dd4bf',
+}
+const edgeTypeLabel = (type: string, t: (cs: string, en: string) => string): string => ({
+  db: t('perzistence', 'persistence'), broker: t('události', 'events'), auth: t('identita', 'auth'),
+  authz: t('autorizace', 'authz'), push: t('push', 'push'), webhook: t('webhook', 'webhook'),
+  registry: t('registr', 'registry'), api: 'API', llm: 'LLM',
+}[type] ?? type)
+
+// Tier band geometry — two full-width bands below the service grid.
+const CHIP_H = 32
+const BAND_HEAD = 30
+const BAND_PAD_Y = 14
+const BAND_GAP = 24
+const CHIP_GAP = 16
+const chipWidth = (label: string) => Math.max(96, 30 + label.length * 6.6 + 14)
+
+type TierPos = { cx: number; cy: number; w: number }
+type BandBox = { key: 'infra' | 'external'; x: number; y: number; w: number; h: number }
+// Deterministic flow-layout: centre chips per row, wrapping to the canvas width.
+function layoutBand(nodes: { id: string; label: string }[], availW: number, startY: number) {
+  const rows: { id: string; label: string; w: number }[][] = [[]]
+  let rowW = 0
+  for (const n of nodes) {
+    const w = chipWidth(n.label)
+    const cur = rows[rows.length - 1]
+    if (cur.length && rowW + CHIP_GAP + w > availW) { rows.push([]); rowW = 0 }
+    rows[rows.length - 1].push({ ...n, w })
+    rowW += (cur.length ? CHIP_GAP : 0) + w
+  }
+  const pos: Record<string, TierPos> = {}
+  let y = startY + BAND_HEAD
+  for (const row of rows) {
+    const total = row.reduce((s, r) => s + r.w, 0) + CHIP_GAP * Math.max(0, row.length - 1)
+    let x = CANVAS_PAD + Math.max(0, (availW - total) / 2)
+    for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: y + CHIP_H / 2, w: r.w }; x += r.w + CHIP_GAP }
+    y += CHIP_H + CHIP_GAP
+  }
+  const h = BAND_HEAD + rows.length * (CHIP_H + CHIP_GAP) - CHIP_GAP + BAND_PAD_Y
+  return { pos, height: h }
+}
+
+// A moving particle bound to an edge path (SMIL). Its parent decides whether to
+// mount it at all (flow toggled off / reduced-motion / edge hidden → not rendered).
+function FlowParticle({ pathId, color, dur, begin, r = 2.6 }: { pathId: string; color: string; dur: number; begin: number; r?: number }) {
+  return (
+    <circle r={r} fill={color} stroke="var(--surface)" strokeWidth={0.5}>
+      <animateMotion dur={`${dur}s`} begin={`${begin}s`} repeatCount="indefinite" rotate="auto" calcMode="linear">
+        <mpath href={`#${pathId}`} />
+      </animateMotion>
+    </circle>
+  )
+}
+
+// A rounded "pill" node for an infra/external tier — visually distinct from the
+// LEGO-brick services so the three tiers read apart at a glance.
+function TierChip({ pos, color, label, active, dim, faded, onClick, onEnter, onLeave }: {
+  pos: TierPos; color: string; label: string; active: boolean; dim: boolean; faded: boolean
+  onClick: () => void; onEnter: () => void; onLeave: () => void
+}) {
+  const { cx, cy, w } = pos
+  const x = cx - w / 2, y = cy - CHIP_H / 2
+  return (
+    <g opacity={dim ? 0.25 : 1} style={{ cursor: 'pointer', transition: 'opacity 0.15s' }}
+      onClick={onClick} onMouseEnter={onEnter} onMouseLeave={onLeave}>
+      <rect x={x} y={y} width={w} height={CHIP_H} rx={CHIP_H / 2}
+        fill={active ? color : 'var(--surface)'} stroke={color} strokeWidth={active ? 1.8 : 1.3}
+        strokeDasharray={faded ? '4,3' : undefined} opacity={faded ? 0.75 : 1} filter="url(#node-shadow)" />
+      <circle cx={x + 15} cy={cy} r={4} fill={color} opacity={faded ? 0.5 : 1} />
+      <text x={x + 27} y={cy + 4} fontSize="11" fontWeight="600" fill={active ? '#fff' : 'var(--text-primary)'}>{label}</text>
+    </g>
+  )
+}
+
 // Governance data is code-derived since ADR-0071: it arrives from the
 // /api/services/governance fetch (now backed by governance.json), not a build-time
 // import of the hand-edited manifest. Seed empty; the fetch fills it.
@@ -308,6 +413,22 @@ export default function ServiceMapPage() {
   // Per-service degree (upstream + downstream) from the graph → drives brick size.
   const [degrees, setDegrees] = useState<Record<string, number>>({})
   const [isChecking, setIsChecking] = useState(false)
+  // Data-flow tiers (infra substrate + external 3rd parties), from the same graph fetch.
+  const [infraNodes, setInfraNodes] = useState<InfraNodeT[]>([])
+  const [externalNodes, setExternalNodes] = useState<ExternalNodeT[]>([])
+  const [infraEdges, setInfraEdges] = useState<InfraEdgeT[]>([])
+  const [externalEdges, setExternalEdges] = useState<ExternalEdgeT[]>([])
+  // Animation + tier visibility controls. Infra has ~130 edges → hidden by default
+  // (revealed per-service on hover, or globally via its toggle); external is sparse → shown.
+  const [flow, setFlow] = useState(true)
+  const [showInfra, setShowInfra] = useState(false)
+  const [showExternal, setShowExternal] = useState(true)
+
+  // Respect the OS "reduce motion" setting: start with flow off (static diagram).
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) setFlow(false)
+  }, [])
 
   const checkHealth = async () => {
     setIsChecking(true)
@@ -338,6 +459,10 @@ export default function ServiceMapPage() {
         const graph = await graphRes.json() as {
           edges?: { from: string; to: string; via: string; type: 'rest' | 'kafka' }[]
           nodes?: { name: string; dependsOn?: number; dependedOnBy?: number }[]
+          infraNodes?: InfraNodeT[]
+          externalNodes?: ExternalNodeT[]
+          infraEdges?: InfraEdgeT[]
+          externalEdges?: ExternalEdgeT[]
         }
         setGraphEdges(Array.isArray(graph.edges) ? graph.edges : [])
         const deg: Record<string, number> = {}
@@ -346,6 +471,10 @@ export default function ServiceMapPage() {
           if (id) deg[id] = (n.dependsOn ?? 0) + (n.dependedOnBy ?? 0)
         }
         setDegrees(deg)
+        setInfraNodes(Array.isArray(graph.infraNodes) ? graph.infraNodes : [])
+        setExternalNodes(Array.isArray(graph.externalNodes) ? graph.externalNodes : [])
+        setInfraEdges(Array.isArray(graph.infraEdges) ? graph.infraEdges : [])
+        setExternalEdges(Array.isArray(graph.externalEdges) ? graph.externalEdges : [])
       }
     } catch {
     } finally {
@@ -358,6 +487,7 @@ export default function ServiceMapPage() {
   }, [])
 
   const selectedSvc = SERVICES.find(s => s.id === selected)
+  const selectedTier: InfraNodeT | ExternalNodeT | undefined = [...infraNodes, ...externalNodes].find(n => n.id === selected)
   // Deterministically resolve the manifest service-name from the UI node id
   // This prevents mismatches where the UI human-readable name doesn't match the internal serviceName.
   const govEntry = selectedSvc ? governanceData[SERVICE_ID_TO_NAME[selectedSvc.id]] : null;
@@ -381,6 +511,66 @@ export default function ServiceMapPage() {
 
 
   const svcMap = Object.fromEntries(SERVICES.map(s => [s.id, s]))
+  const activeNode = selected ?? hovered
+  const pathId = (a: string, b: string, i: number) => `fx-${a}-${b}-${i}`.replace(/[^a-zA-Z0-9_-]/g, '_')
+
+  // --- Data-flow tiers: resolve each infra/external edge's source module to a
+  // node on this map. Edges whose source service isn't drawn here are dropped
+  // (honest — never a half-anchored line); that also picks which tier nodes to
+  // render (only those with ≥1 anchored edge → no floating nodes).
+  const moduleToId = (m: string) => SERVICE_NAME_TO_ID[stripPrefix(m)]
+  const resolvedInfra = infraEdges
+    .map(e => ({ ...e, fromId: moduleToId(e.from), kind: 'infra' as const, enabled: true }))
+    .filter((e): e is typeof e & { fromId: string } => !!e.fromId && !!LAYOUT.nodes[e.fromId!])
+  const resolvedExternal = externalEdges
+    .map(e => ({ ...e, fromId: moduleToId(e.from), kind: 'external' as const }))
+    .filter((e): e is typeof e & { fromId: string } => !!e.fromId && !!LAYOUT.nodes[e.fromId!])
+  const infraIdsUsed = new Set(resolvedInfra.map(e => e.to))
+  const externalIdsUsed = new Set(resolvedExternal.map(e => e.to))
+  const renderInfraNodes = infraNodes.filter(n => infraIdsUsed.has(n.id))
+  const renderExternalNodes = externalNodes.filter(n => externalIdsUsed.has(n.id))
+  const hasInfra = renderInfraNodes.length > 0
+  const hasExternal = renderExternalNodes.length > 0
+
+  // Tier band geometry below the service grid (computed each render — a handful
+  // of chips, cheap). When a tier has no nodes, its band is skipped entirely so
+  // the empty-graph page keeps the original height.
+  const availW = LAYOUT.width - CANVAS_PAD * 2
+  const chipLabel = (id: string, fallback: string) => t(tierMeta(id)?.labelCs ?? fallback, tierMeta(id)?.labelEn ?? fallback)
+  const tierPos: Record<string, TierPos> = {}
+  const bandBoxes: (BandBox & { count: number })[] = []
+  {
+    let y = LAYOUT.height
+    const place = (key: 'infra' | 'external', nodes: (InfraNodeT | ExternalNodeT)[]) => {
+      y += BAND_GAP
+      const b = layoutBand(nodes.map(n => ({ id: n.id, label: chipLabel(n.id, n.label) })), availW, y)
+      Object.assign(tierPos, b.pos)
+      bandBoxes.push({ key, x: CANVAS_PAD - 12, y, w: LAYOUT.width - (CANVAS_PAD - 12) * 2, h: b.height, count: nodes.length })
+      y += b.height
+    }
+    if (hasInfra) place('infra', renderInfraNodes)
+    if (hasExternal) place('external', renderExternalNodes)
+  }
+  const svgHeight = bandBoxes.length ? bandBoxes[bandBoxes.length - 1].y + bandBoxes[bandBoxes.length - 1].h + CANVAS_PAD : LAYOUT.height
+
+  // Which tier edges to actually draw: the band toggle, OR always when the edge
+  // touches the active (hovered/selected) node — so hovering a service reveals
+  // exactly the substrate + 3rd parties it uses even with the band toggled off.
+  const tierEdges = [...resolvedInfra, ...resolvedExternal]
+    .filter(e => visibleIds.has(e.fromId) && tierPos[e.to])
+  const tierEdgeShown = (e: { kind: 'infra' | 'external'; fromId: string; to: string }) => {
+    const band = e.kind === 'infra' ? showInfra : showExternal
+    const touchesActive = !!activeNode && (e.fromId === activeNode || e.to === activeNode)
+    return band || touchesActive
+  }
+  // Services (drawn on this map) that connect to the selected tier node.
+  const tierConsumers = selectedTier
+    ? tierEdges.filter(e => e.to === selectedTier.id).map(e => ({
+        svc: svcMap[e.fromId] as (typeof SERVICES)[number] | undefined,
+        type: e.type,
+        enabled: 'enabled' in e ? e.enabled : true,
+      })).filter(c => c.svc)
+    : []
 
   // Render-site translations for strings that live in the module-scope data
   // arrays (GROUP_LABELS, SERVICES.desc) — the hook can't run at module scope.
@@ -443,7 +633,7 @@ export default function ServiceMapPage() {
             <Network size={18} style={{ color: 'var(--accent)' }} />
             {t('Mapa architektury služeb', 'Service Architecture Map')}
           </h1>
-          <p className="page-subtitle">{t(`Interaktivní mapa ${SERVICES.length} mikroslužeb a jejich závislostí · klikněte na službu pro detail`, `Interactive map of ${SERVICES.length} microservices and their dependencies · click a service for detail`)}</p>
+          <p className="page-subtitle">{t(`Animovaná mapa toku dat napříč ${SERVICES.length} službami, infrastrukturou a 3. stranami · sync i async · najeďte myší na uzel pro zvýraznění cesty`, `Animated data-flow map across ${SERVICES.length} services, infrastructure and 3rd parties · sync and async · hover a node to highlight its path`)}</p>
         </div>
       </div>
 
@@ -463,21 +653,40 @@ export default function ServiceMapPage() {
               }}>{label}</button>
           ))}
         </div>
-        <button 
-          onClick={checkHealth}
-          disabled={isChecking}
-          className="btn btn-secondary"
-          style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}
-        >
-          <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
-          {isChecking ? t('Zjišťuji…', 'Checking...') : t('Obnovit stav', 'Refresh Status')}
-        </button>
+        <div style={{ display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap' }}>
+          {([
+            { key: 'flow', on: flow, toggle: () => setFlow(v => !v), icon: flow ? <Pause size={13} /> : <Play size={13} />, label: t('Tok dat', 'Data flow') },
+            { key: 'infra', on: showInfra, toggle: () => setShowInfra(v => !v), icon: <Server size={13} />, label: t('Infra', 'Infra') },
+            { key: 'external', on: showExternal, toggle: () => setShowExternal(v => !v), icon: <Cloud size={13} />, label: t('3. strany', '3rd parties') },
+          ]).map(c => (
+            <button key={c.key} onClick={c.toggle} aria-pressed={c.on}
+              title={t('Přepnout', 'Toggle') + ' ' + c.label}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
+                borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
+                border: `1px solid ${c.on ? 'var(--accent)' : 'var(--border)'}`,
+                background: c.on ? 'var(--accent)' : 'var(--surface)',
+                color: c.on ? '#fff' : 'var(--text-secondary)',
+              }}>
+              {c.icon}{c.label}
+            </button>
+          ))}
+          <button
+            onClick={checkHealth}
+            disabled={isChecking}
+            className="btn btn-secondary"
+            style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}
+          >
+            <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
+            {isChecking ? t('Zjišťuji…', 'Checking...') : t('Obnovit stav', 'Refresh Status')}
+          </button>
+        </div>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: selectedSvc ? '1fr 320px' : '1fr', gap: '16px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: (selectedSvc || selectedTier) ? '1fr 320px' : '1fr', gap: '16px' }}>
         {/* SVG Map */}
         <div className="card" style={{ padding: '0', overflow: 'hidden' }}>
-          <svg viewBox={`0 0 ${LAYOUT.width} ${LAYOUT.height}`} style={{ width: '100%', height: 'auto', display: 'block', background: 'var(--surface)' }}>
+          <svg viewBox={`0 0 ${LAYOUT.width} ${svgHeight}`} style={{ width: '100%', height: 'auto', display: 'block', background: 'var(--surface)' }}>
             <defs>
               <marker id="arrow-sync" markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
                 <path d="M0,0 L0,6 L7,3 z" fill="#94a3b8" />
@@ -510,11 +719,53 @@ export default function ServiceMapPage() {
             {(() => {
               const active = selected ?? hovered
               const isNeighbor = (id: string) =>
-                !!active && (active === id || EDGES.some(e =>
-                  (e.from === active && e.to === id) || (e.to === active && e.from === id)))
+                !!active && (active === id
+                  || EDGES.some(e => (e.from === active && e.to === id) || (e.to === active && e.from === id))
+                  || tierEdges.some(e => (e.to === active && e.fromId === id) || (e.fromId === active && e.to === id)))
 
               return (
                 <>
+                  {/* Tier bands (infra + external) — full-width backgrounds below the grid */}
+                  {bandBoxes.map(band => {
+                    const meta = band.key === 'infra'
+                      ? { color: '#64748b', label: t('Infrastruktura', 'Infrastructure') }
+                      : { color: '#0ea5e9', label: t('Externí / 3. strany', 'External / 3rd parties') }
+                    return (
+                      <g key={band.key}>
+                        <rect x={band.x} y={band.y} width={band.w} height={band.h} rx="16"
+                          fill={`${meta.color}0a`} stroke={`${meta.color}33`} strokeWidth="1" strokeDasharray="4,4" />
+                        <text x={band.x + 18} y={band.y + 20} fontSize="11" fill={meta.color} fontWeight="700" letterSpacing="0.08em">
+                          {meta.label.toUpperCase()}
+                        </text>
+                      </g>
+                    )
+                  })}
+
+                  {/* Tier edges: service → infra/external substrate */}
+                  {tierEdges.map((e, i) => {
+                    if (!tierEdgeShown(e)) return null
+                    const a = LAYOUT.nodes[e.fromId], b = tierPos[e.to]
+                    if (!a || !b) return null
+                    const hhAll = (BRICK_H + STUD_H) / 2
+                    const aHalf = { hw: brickSize(degrees[e.fromId] ?? 0).w / 2, hh: hhAll }
+                    const bHalf = { hw: b.w / 2, hh: CHIP_H / 2 }
+                    const { d } = edgeGeometry(a, b, aHalf, bHalf)
+                    const color = EDGE_TYPE_COLOR[e.type] ?? '#94a3b8'
+                    const dashed = e.type === 'broker' || e.type === 'push' || e.type === 'webhook'
+                    const off = e.kind === 'external' && e.enabled === false
+                    const touches = !!activeNode && (e.fromId === activeNode || e.to === activeNode)
+                    const dim = !!activeNode && !touches
+                    const pid = pathId(e.fromId, e.to, 10000 + i)
+                    return (
+                      <g key={`t${i}`} opacity={off ? 0.3 : dim ? 0.12 : touches ? 1 : 0.55} style={{ transition: 'opacity 0.15s' }}>
+                        <path id={pid} d={d} fill="none" stroke={off ? '#94a3b8' : color}
+                          strokeWidth={touches ? 2 : 1.3}
+                          strokeDasharray={off ? '2,4' : dashed ? '5,4' : undefined} />
+                        {flow && !off && <FlowParticle pathId={pid} color={color} dur={2.6 + (i % 4) * 0.3} begin={(i % 6) * 0.2} r={2.3} />}
+                      </g>
+                    )
+                  })}
+
                   {/* Edges — curved, boundary-trimmed; labels only when active */}
                   {visibleEdges.map((e, i) => {
                     const a = LAYOUT.nodes[e.from], b = LAYOUT.nodes[e.to]
@@ -528,13 +779,15 @@ export default function ServiceMapPage() {
                     const { d, lx, ly } = edgeGeometry(a, b, aHalf, bHalf)
                     const baseColor = isAsync ? '#c4b5fd' : '#cbd5e1'
                     const hiColor = isAsync ? '#8b5cf6' : '#64748b'
+                    const pid = pathId(e.from, e.to, i)
                     return (
                       <g key={i} opacity={dim ? 0.08 : touches ? 1 : 0.5} style={{ transition: 'opacity 0.15s' }}>
-                        <path d={d} fill="none"
+                        <path id={pid} d={d} fill="none"
                           stroke={touches ? hiColor : baseColor}
                           strokeWidth={touches ? 2 : 1.4}
                           strokeDasharray={isAsync ? '5,4' : undefined}
                           markerEnd={`url(#arrow-${e.type}${touches ? '-hi' : ''})`} />
+                        {flow && <FlowParticle pathId={pid} color={hiColor} dur={2.3 + (i % 5) * 0.28} begin={(i % 7) * 0.17} r={isAsync ? 2.8 : 2.4} />}
                         {touches && (() => {
                           const lbl = prettyEdgeLabel(e.label, e.type)
                           if (!lbl) return null
@@ -584,6 +837,28 @@ export default function ServiceMapPage() {
                       </g>
                     )
                   })}
+
+                  {/* Tier chips (on top) — infra substrate + external 3rd parties */}
+                  {[...renderInfraNodes, ...renderExternalNodes].map(n => {
+                    const p = tierPos[n.id]
+                    if (!p) return null
+                    const meta = tierMeta(n.id)
+                    const color = meta?.color ?? '#64748b'
+                    const isSel = selected === n.id
+                    const rel = !!activeNode && (activeNode === n.id
+                      || tierEdges.some(e => e.to === n.id && (e.fromId === activeNode || e.to === activeNode)))
+                    const emphasized = !activeNode || rel
+                    // "faded" when every edge into this external node is disabled (wired but off).
+                    const faded = n.kind === 'external' && externalEdges.filter(e => e.to === n.id).length > 0
+                      && externalEdges.filter(e => e.to === n.id).every(e => e.enabled === false)
+                    return (
+                      <TierChip key={n.id} pos={p} color={color} label={chipLabel(n.id, n.label)}
+                        active={isSel} dim={!emphasized} faded={faded}
+                        onClick={() => setSelected(s => s === n.id ? null : n.id)}
+                        onEnter={() => setHovered(n.id)}
+                        onLeave={() => setHovered(h => h === n.id ? null : h)} />
+                    )
+                  })}
                 </>
               )
             })()}
@@ -598,6 +873,18 @@ export default function ServiceMapPage() {
             <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
               <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#c4b5fd" strokeWidth="1.5" strokeDasharray="5,3" /></svg>
               {t('Async (události Kafka)', 'Async (Kafka events)')}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              <svg width="14" height="14"><rect x="1" y="4" width="12" height="6" rx="3" fill="none" stroke="#64748b" strokeWidth="1.3" /></svg>
+              {t('Infrastruktura (DB · Kafka · OIDC · OPA)', 'Infrastructure (DB · Kafka · OIDC · OPA)')}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              <svg width="14" height="14"><rect x="1" y="4" width="12" height="6" rx="3" fill="none" stroke="#0ea5e9" strokeWidth="1.3" /></svg>
+              {t('Externí 3. strany (push · API)', 'External 3rd parties (push · API)')}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#94a3b8" strokeWidth="1.3" strokeDasharray="2,4" /></svg>
+              {t('Zapojená, ale vypnutá integrace', 'Wired but disabled integration')}
             </div>
           </div>
         </div>
@@ -811,6 +1098,64 @@ export default function ServiceMapPage() {
             </div>
           </div>
         )}
+
+        {/* Detail panel — infra/external tier node */}
+        {selectedTier && !selectedSvc && (() => {
+          const meta = tierMeta(selectedTier.id)
+          const color = meta?.color ?? '#64748b'
+          const isExt = selectedTier.kind === 'external'
+          const anyEnabled = tierConsumers.some(c => c.enabled)
+          const Icon = meta?.Icon ?? Server
+          return (
+            <div className="card" style={{ padding: '20px', alignSelf: 'start' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
+                <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: `${color}1a`, display: 'flex', alignItems: 'center', justifyContent: 'center', color }}>
+                  <Icon size={16} />
+                </div>
+                <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{chipLabel(selectedTier.id, selectedTier.label)}</div>
+                <div style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', padding: '2px 8px', borderRadius: '12px', background: `${color}1a`, color }}>
+                  {isExt ? t('3. strana', '3rd party') : t('Infra', 'Infra')}
+                </div>
+              </div>
+
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                <div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{isExt ? t('DODAVATEL', 'VENDOR') : t('TECHNOLOGIE', 'TECHNOLOGY')}</div>
+                  <div style={{ fontSize: '12px', color: 'var(--text-secondary)' }}>{isExt ? (selectedTier as ExternalNodeT).vendor : (selectedTier as InfraNodeT).tech}</div>
+                </div>
+
+                {meta && (
+                  <div>
+                    <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('POPIS', 'DESCRIPTION')}</div>
+                    <div style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>{t(meta.descCs, meta.descEn)}</div>
+                  </div>
+                )}
+
+                {isExt && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+                    <span style={{ width: '8px', height: '8px', borderRadius: '50%', background: anyEnabled ? 'var(--success)' : 'var(--warning)' }} />
+                    <span style={{ color: 'var(--text-secondary)' }}>{anyEnabled ? t('Integrace zapnutá', 'Integration enabled') : t('Zapojená, ale vypnutá (no-op)', 'Wired but disabled (no-op)')}</span>
+                  </div>
+                )}
+
+                <div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '6px' }}>{t('PŘIPOJENÉ SLUŽBY', 'CONNECTED SERVICES')} ({tierConsumers.length})</div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                    {tierConsumers.map((c, i) => (
+                      <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+                        <span style={{ color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>→</span>
+                        <span style={{ color: c.svc!.color, fontWeight: 600 }}>{c.svc!.name}</span>
+                        <span style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)', background: 'var(--surface-2)', padding: '2px 6px', borderRadius: '4px' }}>
+                          {edgeTypeLabel(c.type, t)}{isExt && !c.enabled ? ' · ' + t('vyp', 'off') : ''}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )
+        })()}
       </div>
     </div>
   )

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -3,7 +3,7 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 'use client'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect } from 'react'
 import { Network, RefreshCw, CheckCircle2, XCircle, HelpCircle, Database, ArrowRight, ArrowLeft, Layers, BookOpen, Play, Pause, KeyRound, ShieldCheck, Boxes, Cloud, Send, Server } from 'lucide-react'
 import type { GovernanceManifestEntry } from '@/lib/governance/manifest'
 import { svcUrl } from '@/lib/services/bff'
@@ -525,8 +525,10 @@ export default function ServiceMapPage() {
   const resolvedExternal = externalEdges
     .map(e => ({ ...e, fromId: moduleToId(e.from), kind: 'external' as const }))
     .filter((e): e is typeof e & { fromId: string } => !!e.fromId && !!LAYOUT.nodes[e.fromId!])
-  const infraIdsUsed = new Set(resolvedInfra.map(e => e.to))
-  const externalIdsUsed = new Set(resolvedExternal.map(e => e.to))
+  // Only count edges from a currently-VISIBLE service, so a group filter hides
+  // tier chips whose sole users are filtered out (no floating "CONNECTED (0)" chip).
+  const infraIdsUsed = new Set(resolvedInfra.filter(e => visibleIds.has(e.fromId)).map(e => e.to))
+  const externalIdsUsed = new Set(resolvedExternal.filter(e => visibleIds.has(e.fromId)).map(e => e.to))
   const renderInfraNodes = infraNodes.filter(n => infraIdsUsed.has(n.id))
   const renderExternalNodes = externalNodes.filter(n => externalIdsUsed.has(n.id))
   const hasInfra = renderInfraNodes.length > 0

--- a/openbank-admin-ui/src/test/service-map-topology.test.tsx
+++ b/openbank-admin-ui/src/test/service-map-topology.test.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Behaviour test for the animated data-flow tiers on /docs/service-map.
+// render-smoke only covers the empty/no-data path (fetch fails); this mounts the
+// page with a code-derived-shaped graph so the infra + external tier rendering,
+// the SMIL flow animation, and the tier detail panel are actually exercised —
+// the parts render-smoke can't reach. The fixture mirrors the shape emitted by
+// scripts/generate-service-graph.mjs (nodes/edges + infra/external tiers), and
+// is hermetic so it runs in CI without the gitignored build artifact.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import ServiceMapPage from '@/app/docs/service-map/page'
+
+// Minimal graph in the /api/catalog/graph shape. Sources are modules that ARE on
+// the service map (account, notification, agent) so their tier edges anchor and
+// their tier nodes render. APNs is wired-but-disabled (enabled:false).
+const GRAPH = {
+  schema: 'openbank.service-graph/v1',
+  nodes: [
+    { name: 'openbank-account-service', short: 'account-service', dependsOn: 1, dependedOnBy: 0 },
+    { name: 'openbank-ledger-service', short: 'ledger-service', dependsOn: 0, dependedOnBy: 1 },
+    { name: 'openbank-notification-service', short: 'notification-service', dependsOn: 0, dependedOnBy: 0 },
+    { name: 'openbank-agent-service', short: 'agent-service', dependsOn: 0, dependedOnBy: 0 },
+  ],
+  edges: [{ from: 'openbank-account-service', to: 'openbank-ledger-service', via: 'ledger-service', type: 'rest' }],
+  danglingTopics: [],
+  infraNodes: [
+    { id: 'infra:postgres', kind: 'infra', tech: 'postgres', label: 'PostgreSQL' },
+    { id: 'infra:kafka', kind: 'infra', tech: 'kafka', label: 'Apache Kafka' },
+  ],
+  externalNodes: [
+    { id: 'ext:apple-apns', kind: 'external', vendor: 'Apple', label: 'APNs (push)' },
+    { id: 'ext:llm-gateway', kind: 'external', vendor: 'LLM providers', label: 'LLM gateway' },
+  ],
+  infraEdges: [
+    { from: 'openbank-account-service', to: 'infra:postgres', type: 'db' },
+    { from: 'openbank-account-service', to: 'infra:kafka', type: 'broker' },
+  ],
+  externalEdges: [
+    { from: 'openbank-notification-service', to: 'ext:apple-apns', type: 'push', enabled: false },
+    { from: 'openbank-agent-service', to: 'ext:llm-gateway', type: 'llm', enabled: true },
+  ],
+  available: true,
+}
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+
+// Answer the page's three mount fetches; everything else is a benign empty payload
+// so unrelated widgets (drift banner) degrade quietly.
+function mockFetch() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const json = (body: unknown) => new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/catalog/graph')) return json(GRAPH)
+    if (url.includes('/api/services/health')) return json({ services: [] })
+    if (url.includes('/api/services/governance')) return json({ byService: {} })
+    return json({})
+  })
+}
+
+describe('service-map data-flow tiers', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', mockFetch()) })
+  afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+  it('renders the infra + external bands with their code-derived nodes', async () => {
+    render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    await waitFor(() => expect(screen.getByText('PostgreSQL')).toBeInTheDocument())
+    expect(screen.getByText('Apache Kafka')).toBeInTheDocument()
+    // Band headers are rendered upper-cased and are unique to the SVG bands.
+    expect(screen.getByText('INFRASTRUCTURE')).toBeInTheDocument()
+    expect(screen.getByText('EXTERNAL / 3RD PARTIES')).toBeInTheDocument()
+    // External 3rd parties whose source service is on the map.
+    expect(screen.getByText('LLM gateway')).toBeInTheDocument()
+    expect(screen.getByText('Apple APNs')).toBeInTheDocument()
+  })
+
+  it('animates flow by default and stops when the flow toggle is turned off', async () => {
+    const { container } = render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    await waitFor(() => expect(screen.getByText('PostgreSQL')).toBeInTheDocument())
+    // Default (no reduce-motion in jsdom) → particles are mounted (service edge at least).
+    expect(container.querySelectorAll('animateMotion').length).toBeGreaterThan(0)
+    // Toggling "Data flow" off removes every particle (static diagram).
+    fireEvent.click(screen.getByRole('button', { name: /Data flow/i }))
+    await waitFor(() => expect(container.querySelectorAll('animateMotion').length).toBe(0))
+  })
+
+  it('opens a tier detail panel listing the connected services on click', async () => {
+    render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    await waitFor(() => expect(screen.getByText('Apache Kafka')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('Apache Kafka'))
+    expect(await screen.findByText(/CONNECTED SERVICES/i)).toBeInTheDocument()
+    // account-service produces to Kafka in the fixture → shown as a consumer of the broker.
+    expect(screen.getByText('Account Service')).toBeInTheDocument()
+  })
+
+  it('draws the wired-but-disabled external integration without a flow particle', async () => {
+    const { container } = render(React.createElement(Providers, null, React.createElement(ServiceMapPage)))
+    await waitFor(() => expect(screen.getByText('Apple APNs')).toBeInTheDocument())
+    // The disabled APNs edge (notification→apns, enabled:false) must never animate,
+    // even with flow on and its 3rd-parties band shown by default.
+    const apnsParticles = [...container.querySelectorAll('animateMotion')]
+      .filter(m => (m.querySelector('mpath')?.getAttribute('href') ?? '').includes('apple-apns'))
+    expect(apnsParticles.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Turn the static `/docs/service-map` into an **animated data-flow map** across three tiers — our k8s services, the infra substrate they sit on, and the external 3rd parties they reach — so an operator can visually follow how data moves (sync and async) across the fleet.

## Type of change

- [x] feat (new functionality)

## Linked issues

None — operator-console UI enhancement.

## Changes

- **`scripts/generate-service-graph.mjs`** — additively derives an **infra tier** (Postgres, Kafka, Keycloak, OPA) and an **external tier** (Apple APNs, Firebase FCM, Slack, ČNB, GitHub, LLM gateway, S3) from each service's `application.yaml`. Honest by construction (ADR-0029): base profile only, presence/host-detected, never hand-authored; a wired-but-disabled integration carries `enabled:false`. The original `nodes`/`edges` are byte-for-byte unchanged; a tier node is emitted only if ≥1 edge references it.
- **`src/app/api/catalog/graph/route.ts`** — passes the four new optional arrays (`infraNodes`/`externalNodes`/`infraEdges`/`externalEdges`) through; availability check unchanged; degrades to `[]`.
- **`src/app/docs/service-map/page.tsx`** — SMIL flow particles ride every visible edge (sync request/response, async pub/sub); two full-width bands render infra + external as distinct pill nodes; per-tier show/hide toggles + a flow play/pause control; `prefers-reduced-motion` starts static; a tier detail panel lists a node's connected services and enabled state. Infra edges are revealed per-service on hover (or via the toggle) to keep the default legible. Every string routes through `t(cs,en)`.
- **`src/test/service-map-topology.test.tsx`** — mounts the page with a code-derived-shaped graph and asserts the tiers render, flow toggles on/off, the detail panel opens, and a disabled external edge never animates.

## Definition of Done

- [x] Hexagonal layering preserved (N/A — admin-ui, no domain layer touched).
- [x] Unit tests added/updated (`service-map-topology.test.tsx`, +4 tests; suite 600→604).
- [ ] Integration tests — N/A (no service boundary).
- [ ] Contract tests — N/A (no public API changed; `/api/catalog/graph` is an internal read-only route, shape extended additively).
- [x] Local gate passes — admin-ui gate: `npm run type-check` · `npm run test` · `npx eslint .` · `npx next build` all green (Gradle gate N/A for admin-ui).
- [x] No new lint **errors** (0 errors; the 2 pre-existing `set-state-in-effect` warnings are unchanged).
- [ ] OpenAPI — N/A (no REST contract change).
- [ ] Flyway — N/A. 
- [ ] Avro — N/A.
- [x] Docs — no ADR needed (presentation feature over existing derived data).

## Security checklist

- [x] No secrets, tokens, passwords, or PII in code, config, tests, logs. Tiers are derived from public `application.yaml` config keys only.
- [x] No new `@Suppress`/`as Any`.
- [x] No new third-party dependency (uses existing React/lucide-react; recharts still unused).
- [x] No auth / crypto / payment code changed.
- [x] No PII path changed.
- [x] No cardholder-data path changed.

## Compliance impact

- [x] None — read-only operator visualization; no data processing, no external egress introduced (the browser makes the same single `/api/catalog/graph` fetch).

## Rollout / Rollback

- Deployment strategy: rolling (standard admin-ui deploy).
- Rollback plan: revert the PR; no state/schema/config migration.
- Data migration reversible: N/A.

## Screenshots / demo (if UI change)

Full render (Infra + 3rd-parties tiers on, flow paused for the still): services grid over an **INFRASTRUCTURE** band (Apache Kafka · Keycloak · OPA · PostgreSQL) and an **EXTERNAL / 3RD PARTIES** band (Apple APNs · ČNB · Firebase FCM · LLM gateway · Slack). Disabled integrations (APNs/FCM/Slack) render **dashed** ("wired but disabled"); enabled ones (ČNB/LLM) solid. Edges fan from each service to its substrate; the legend documents sync/async/infra/external/disabled.

_(Screenshot shared with the author in the working session.)_

## Reviewer notes

- **Scope of the external tier is honest, not exhaustive:** an edge is drawn only when its **source service is on this map**. GitHub/S3 come solely from agent/platform modules that aren't nodes here, so they intentionally don't render — no half-anchored lines, no floating nodes.
- **FinOps:** ~$0 recurring. Representative animation = no metrics/trace queries, no polling; same single `/api/catalog/graph` fetch (payload +few KB); animation is client-side SMIL/CSS. Build-time cost is one extra `application.yaml` parse pass in a generator the admin-ui image build already runs.
- `service-graph.json` stays a gitignored build artifact — not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
