### PR TITLE
test(pact): derive ledger-posting pact bodies from the real journal factories

### DIFF
--- a/openbank-billing-service/src/test/kotlin/com/openbank/billing/contract/BillingLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-billing-service/src/test/kotlin/com/openbank/billing/contract/BillingLedgerPostJournalPactConsumerTest.kt
@@ -12,10 +12,18 @@ import au.com.dius.pact.consumer.junit5.PactTestFor
 import au.com.dius.pact.core.model.PactSpecVersion
 import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.billing.domain.FeeJournalCommand
+import com.openbank.billing.infrastructure.client.BillingJournalFactory
+import com.openbank.billing.infrastructure.client.BillingLedgerConfig
 import io.restassured.RestAssured.given
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
 
 /**
  * Consumer-driven contract for the journal posting billing-service makes when charging (or
@@ -43,45 +51,48 @@ import org.junit.jupiter.api.extension.ExtendWith
  *
  * Unlike lending's/transaction's DTOs, billing's `LedgerJournalLineRequest` doesn't declare an
  * `fxRate` field at all (ledger's `PostJournalLineRequest.fxRate` defaults to null, so its
- * absence deserializes fine) — the request body below omits the key entirely to match what
- * billing's real Jackson serializer produces, not `"fxRate": null` like the other contracts.
+ * absence deserializes fine) — the request body omits the key entirely because it is now
+ * SERIALIZED FROM [BillingJournalFactory.buildRequest] itself, not hand-typed.
+ *
+ * Issue #1347: this pact used to hand-write its request body as a JSON literal that happened to
+ * match the factory's output on the day it was written — the contract verified nothing about
+ * [BillingJournalFactory], so a defect in the factory (e.g. #1316's `setScale(4)` bug in the
+ * sibling interest-service posting) would pass provider verification undetected. The body below is
+ * built by calling the real factory with a fixture command and serializing the result with the
+ * same Jackson stack the production REST client uses, so a change to the factory's output shape
+ * changes the recorded pact.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
 class BillingLedgerPostJournalPactConsumerTest {
 
-    private val transactionId = "88888888-8888-8888-8888-888888888888"
     private val accountId = "99999999-9999-9999-9999-999999999999"
 
-    private val requestBody = """
-        {
-          "idempotencyKey": "fee-2026-07-pact-001-maintenance-CZK",
-          "transactionId": "$transactionId",
-          "entryDate": "2026-07-01",
-          "valueDate": "2026-07-01",
-          "description": "Fee charge: Maintenance",
-          "createdBy": "00000000-0000-0000-0000-0000000000bb",
-          "lines": [
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000002",
-              "side": "DEBIT",
-              "amount": 150.00,
-              "currencyCode": "CZK",
-              "baseAmount": 150.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": "$accountId"
-            },
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000004003",
-              "side": "CREDIT",
-              "amount": 150.00,
-              "currencyCode": "CZK",
-              "baseAmount": 150.00,
-              "baseCurrencyCode": "CZK"
-            }
-          ]
-        }
-    """.trimIndent()
+    private val accounts = object : BillingLedgerConfig.Gl {
+        override fun feeReceivable(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000000002")
+        override fun feeIncome(): UUID = UUID.fromString("a0000000-0000-0000-0000-000000004003")
+    }
+    private val systemActorId = UUID.fromString("00000000-0000-0000-0000-0000000000bb")
+    private val entryDate = LocalDate.parse("2026-07-01")
+
+    private val feeCommand = FeeJournalCommand(
+        idempotencyKey = "fee-2026-07-pact-001-maintenance-CZK",
+        cycleId = "2026-07",
+        accountId = accountId,
+        feeId = "maintenance",
+        amount = BigDecimal("150.00"),
+        currency = "CZK",
+        description = "Fee charge: Maintenance",
+    )
+
+    // Same Jackson stack the real REST client (`quarkus-rest-client-reactive-jackson`) serializes
+    // with — this is what makes the pact body a proof about the factory's output, not a
+    // hand-maintained literal that merely happens to agree with it.
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private val requestBody: String = objectMapper.writeValueAsString(
+        BillingJournalFactory.buildRequest(feeCommand, accounts, systemActorId, entryDate),
+    )
 
     @Pact(consumer = "openbank-billing-service", provider = "openbank-ledger-service")
     fun postBillingFeeJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/LendingLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/LendingLedgerPostJournalPactConsumerTest.kt
@@ -12,61 +12,70 @@ import au.com.dius.pact.consumer.junit5.PactTestFor
 import au.com.dius.pact.core.model.PactSpecVersion
 import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.lending.application.port.out.LedgerPosting
+import com.openbank.lending.application.port.out.PostingKind
+import com.openbank.lending.infrastructure.client.LendingGlAccounts
+import com.openbank.lending.infrastructure.client.LendingJournalFactory
+import com.openbank.libs.domain.money.Money
 import io.restassured.RestAssured.given
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
 
 /**
  * Consumer-driven contract for the journal posting lending-service makes when booking a loan
- * disbursement or repayment ([com.openbank.lending.infrastructure.client.LedgerRestClient],
- * ADR-0063 P2 Batch B). Mirrors the transaction-service P1 contract: same endpoint, same
- * stable seeded GL accounts, same response shape. The ledger-service provider verification
- * (LedgerPactProviderVerificationTest) picks this up automatically via @PactBroker — it
- * handles all consumers of openbank-ledger-service.
+ * disbursement or repayment ([LendingJournalFactory.buildRequest], ADR-0063 P2 Batch B). Mirrors
+ * the transaction-service P1 contract: same endpoint, same response shape. The ledger-service
+ * provider verification (LedgerPactProviderVerificationTest) picks this up automatically via
+ * @PactBroker — it handles all consumers of openbank-ledger-service.
  *
- * GL accounts are from ledger V3 migration (stable UUIDs):
- * - a0000000-...-001 = 1100 Customer Cash Clearing (DEBIT / ASSET)
- * - a0000000-...-002 = 2100 Customer Deposit Control (CREDIT / LIABILITY)
+ * Issue #1347: this pact used to hand-write a JSON literal that named `1100 Customer Cash
+ * Clearing` / `2100 Customer Deposit Control` (transaction-service's GL pair) as if it were a
+ * lending disbursement, and included a `"subAccountId": null` field on every line even though
+ * lending's own [com.openbank.lending.infrastructure.client.JournalLineRequest] never declares a
+ * `subAccountId` at all — Jackson would never emit that key. Neither divergence would have been
+ * caught by provider verification, because the recorded body was independent of
+ * [LendingJournalFactory] and [com.openbank.lending.infrastructure.client.LendingLedgerConfig]'s
+ * real defaults. The body below is built from the real factory + real config default GL accounts
+ * (`a0000000-...-001200` loans receivable / `a0000000-...-001100` funding clearing, ADR-0028
+ * D3/D4) for a DISBURSEMENT posting, serialized with the same Jackson stack the production REST
+ * client uses.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
 class LendingLedgerPostJournalPactConsumerTest {
 
-    private val transactionId = "33333333-3333-3333-3333-333333333333"
+    private val accounts = LendingGlAccounts(
+        loansReceivable = UUID.fromString("a0000000-0000-0000-0000-000000001200"),
+        fundingClearing = UUID.fromString("a0000000-0000-0000-0000-000000001100"),
+        interestIncome = UUID.fromString("a0000000-0000-0000-0000-000000004100"),
+        interestReceivable = UUID.fromString("a0000000-0000-0000-0000-000000001300"),
+        loanLossExpense = UUID.fromString("a0000000-0000-0000-0000-000000005100"),
+        loanLossAllowance = UUID.fromString("a0000000-0000-0000-0000-000000001400"),
+    )
+    private val systemActorId = UUID.fromString("00000000-0000-0000-0000-0000000000aa")
+    private val entryDate = LocalDate.parse("2026-01-15")
 
-    private val requestBody = """
-        {
-          "idempotencyKey": "pact-lending-journal-001",
-          "transactionId": "$transactionId",
-          "entryDate": "2026-01-15",
-          "valueDate": "2026-01-15",
-          "description": "pact lending disbursement journal",
-          "lines": [
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000001",
-              "side": "DEBIT",
-              "amount": 200.00,
-              "currencyCode": "CZK",
-              "fxRate": null,
-              "baseAmount": 200.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": null
-            },
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000002",
-              "side": "CREDIT",
-              "amount": 200.00,
-              "currencyCode": "CZK",
-              "fxRate": null,
-              "baseAmount": 200.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": null
-            }
-          ],
-          "createdBy": "44444444-4444-4444-4444-444444444444"
-        }
-    """.trimIndent()
+    private val disbursement = LedgerPosting(
+        reference = "pact-lending-journal-001",
+        partyId = UUID.fromString("22222222-2222-2222-2222-222222222222"),
+        amount = Money.of(BigDecimal("200.00"), "CZK"),
+        kind = PostingKind.DISBURSEMENT,
+    )
+
+    // Same Jackson stack the real REST client (`quarkus-rest-client-reactive-jackson`) serializes
+    // with — this is what makes the pact body a proof about the factory's output, not a
+    // hand-maintained literal that merely happens to agree with it.
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private val requestBody: String = objectMapper.writeValueAsString(
+        LendingJournalFactory.buildRequest(disbursement, accounts, systemActorId, entryDate),
+    )
 
     @Pact(consumer = "openbank-lending-service", provider = "openbank-ledger-service")
     fun postLendingJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/LedgerPostJournalPactConsumerTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/contract/LedgerPostJournalPactConsumerTest.kt
@@ -12,15 +12,27 @@ import au.com.dius.pact.consumer.junit5.PactTestFor
 import au.com.dius.pact.core.model.PactSpecVersion
 import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.libs.domain.money.Money
+import com.openbank.transaction.application.usecase.PaymentJournalFactory
+import com.openbank.transaction.domain.model.Transaction
+import com.openbank.transaction.domain.model.TransactionStatus
+import com.openbank.transaction.domain.model.TransactionType
+import com.openbank.transaction.infrastructure.client.PostJournalRequest
 import io.restassured.RestAssured.given
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
 
 /**
- * Consumer-driven contract for the ledger postJournal call the payment saga makes
- * ([com.openbank.transaction.infrastructure.client.LedgerRestClient.postJournal], ADR-0063 P1).
- * The generated pact is committed to `pacts/` (git-pact) and replayed by
+ * Consumer-driven contract for the ledger postJournal call the payment workflow makes
+ * ([com.openbank.transaction.infrastructure.client.LedgerRestClient.postJournal], ADR-0063 P1,
+ * ADR-0120 P1). The generated pact is committed to `pacts/` (git-pact) and replayed by
  * LedgerPactProviderVerificationTest in openbank-ledger-service.
  *
  * The request posts a balanced two-line CZK journal against the standard chart of accounts that
@@ -30,49 +42,66 @@ import org.junit.jupiter.api.extension.ExtendWith
  * balance check both pass) without any custom state seeding — the empty-DB Testcontainer already
  * carries the chart from the migration.
  *
- * This is the consumer's view of the contract shape (request fields + the {id, transactionId,
- * status} response); it is not a substitute for the saga orchestration tests.
+ * Issue #1347: `lines` used to be a hand-written literal independent of
+ * [PaymentJournalFactory.buildLines] — both lines carried `"subAccountId": null`, a shape that
+ * [PaymentJournalFactory.sameCurrencyLines] never actually produces (an incoming credit sets
+ * `subAccountId` on the deposit-control leg to the target account, ADR-0039 Phase B). Below,
+ * `lines` is built by calling the real factory against a fixture [Transaction] (an incoming CZK
+ * credit — DEBIT cash-clearing / CREDIT deposit-control with `subAccountId = targetAccountId`,
+ * matching this GL pair), so a change to the factory's GL-selection or subAccountId logic changes
+ * the recorded pact instead of leaving it silently agreeing with a stale literal. The envelope
+ * fields (`idempotencyKey`, `createdBy`) mirror the literal formula in
+ * [com.openbank.transaction.application.workflow.PaymentActivitiesImpl.buildJournalRequest] — that
+ * assembly lives inline there, not in a factory, so it is out of scope for this issue.
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
 class LedgerPostJournalPactConsumerTest {
 
-    private val transactionId = "11111111-1111-1111-1111-111111111111"
+    private val transactionId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val targetAccountId = UUID.fromString("55555555-5555-5555-5555-555555555555")
 
-    // Stable seeded GL accounts (ledger V3 migration): 1100 cash-clearing (debit) + 2100
-    // deposit-control (credit), both CZK. Balanced 100.00 / 100.00 → double-entry init passes.
-    private val requestBody = """
-        {
-          "idempotencyKey": "pact-post-journal-001",
-          "transactionId": "$transactionId",
-          "entryDate": "2026-01-15",
-          "valueDate": "2026-01-15",
-          "description": "pact contract journal",
-          "lines": [
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000001",
-              "side": "DEBIT",
-              "amount": 100.00,
-              "currencyCode": "CZK",
-              "fxRate": null,
-              "baseAmount": 100.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": null
-            },
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000002",
-              "side": "CREDIT",
-              "amount": 100.00,
-              "currencyCode": "CZK",
-              "fxRate": null,
-              "baseAmount": 100.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": null
-            }
-          ],
-          "createdBy": "22222222-2222-2222-2222-222222222222"
-        }
-    """.trimIndent()
+    // Mirrors PaymentActivitiesImpl's private `systemActor` constant — the Temporal path's
+    // envelope field, not part of PaymentJournalFactory.
+    private val systemActor = UUID.fromString("00000000-0000-0000-0000-000000000001")
+
+    private val transaction = Transaction(
+        id = transactionId,
+        referenceNumber = "pact-post-journal-001",
+        type = TransactionType.CREDIT,
+        sourceAccountId = null,
+        targetAccountId = targetAccountId,
+        amount = Money.of(BigDecimal("100.00"), "CZK"),
+        fxRate = null,
+        baseAmount = Money.of(BigDecimal("100.00"), "CZK"),
+        status = TransactionStatus.PENDING,
+        description = "pact contract journal",
+        valueDate = LocalDate.parse("2026-01-15"),
+        bookingDate = LocalDate.parse("2026-01-15"),
+        initiatedAt = Instant.parse("2026-01-15T00:00:00Z"),
+        completedAt = null,
+        failedAt = null,
+        failureReason = null,
+        idempotencyKey = "pact-post-journal-001",
+        version = 0,
+    )
+
+    // Same Jackson stack the real REST client (`quarkus-rest-client-reactive-jackson`) serializes
+    // with — this is what makes the pact body a proof about the factory's output, not a
+    // hand-maintained literal that merely happens to agree with it.
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    private val requestBody: String = objectMapper.writeValueAsString(
+        PostJournalRequest(
+            idempotencyKey = "workflow-${transaction.id}-ledger",
+            transactionId = transaction.id,
+            entryDate = transaction.bookingDate.toString(),
+            valueDate = transaction.valueDate.toString(),
+            description = transaction.description,
+            lines = PaymentJournalFactory.buildLines(transaction),
+            createdBy = systemActor,
+        ),
+    )
 
     @Pact(consumer = "openbank-transaction-service", provider = "openbank-ledger-service")
     fun postBalancedJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder

--- a/pacts/openbank-billing-service-openbank-ledger-service.json
+++ b/pacts/openbank-billing-service-openbank-ledger-service.json
@@ -32,10 +32,11 @@
               "baseCurrencyCode": "CZK",
               "currencyCode": "CZK",
               "glAccountId": "a0000000-0000-0000-0000-000000004003",
-              "side": "CREDIT"
+              "side": "CREDIT",
+              "subAccountId": null
             }
           ],
-          "transactionId": "88888888-8888-8888-8888-888888888888",
+          "transactionId": "61032cf1-5aff-3102-93ca-fd8f781d0cac",
           "valueDate": "2026-07-01"
         },
         "headers": {

--- a/pacts/openbank-lending-service-openbank-ledger-service.json
+++ b/pacts/openbank-lending-service-openbank-ledger-service.json
@@ -12,8 +12,8 @@
       ],
       "request": {
         "body": {
-          "createdBy": "44444444-4444-4444-4444-444444444444",
-          "description": "pact lending disbursement journal",
+          "createdBy": "00000000-0000-0000-0000-0000000000aa",
+          "description": "Lending disbursement: pact-lending-journal-001",
           "entryDate": "2026-01-15",
           "idempotencyKey": "pact-lending-journal-001",
           "lines": [
@@ -23,9 +23,8 @@
               "baseCurrencyCode": "CZK",
               "currencyCode": "CZK",
               "fxRate": null,
-              "glAccountId": "a0000000-0000-0000-0000-000000000001",
-              "side": "DEBIT",
-              "subAccountId": null
+              "glAccountId": "a0000000-0000-0000-0000-000000001200",
+              "side": "DEBIT"
             },
             {
               "amount": 200.00,
@@ -33,12 +32,11 @@
               "baseCurrencyCode": "CZK",
               "currencyCode": "CZK",
               "fxRate": null,
-              "glAccountId": "a0000000-0000-0000-0000-000000000002",
-              "side": "CREDIT",
-              "subAccountId": null
+              "glAccountId": "a0000000-0000-0000-0000-000000001100",
+              "side": "CREDIT"
             }
           ],
-          "transactionId": "33333333-3333-3333-3333-333333333333",
+          "transactionId": "2b7840c6-f050-35d5-9d4e-1beefc3cc384",
           "valueDate": "2026-01-15"
         },
         "headers": {

--- a/pacts/openbank-transaction-service-openbank-ledger-service.json
+++ b/pacts/openbank-transaction-service-openbank-ledger-service.json
@@ -12,10 +12,10 @@
       ],
       "request": {
         "body": {
-          "createdBy": "22222222-2222-2222-2222-222222222222",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
           "description": "pact contract journal",
           "entryDate": "2026-01-15",
-          "idempotencyKey": "pact-post-journal-001",
+          "idempotencyKey": "workflow-11111111-1111-1111-1111-111111111111-ledger",
           "lines": [
             {
               "amount": 100.00,
@@ -35,7 +35,7 @@
               "fxRate": null,
               "glAccountId": "a0000000-0000-0000-0000-000000000002",
               "side": "CREDIT",
-              "subAccountId": null
+              "subAccountId": "55555555-5555-5555-5555-555555555555"
             }
           ],
           "transactionId": "11111111-1111-1111-1111-111111111111",


### PR DESCRIPTION
## Summary

Issue #1347: the ledger-posting consumer pacts for billing/lending/transaction hand-wrote their
request JSON as literals independent of the journal factory each test's own KDoc claimed to
cover, so the contract verified nothing about `BillingJournalFactory` / `LendingJournalFactory` /
`PaymentJournalFactory` — a defect in the factory (the shape of #1316's scale bug) would pass
provider verification undetected.

- **billing** (`BillingLedgerPostJournalPactConsumerTest`): body now built via
  `BillingJournalFactory.buildRequest(...)`, serialized with the same Jackson stack the real REST
  client uses.
- **lending** (`LendingLedgerPostJournalPactConsumerTest`): same, via
  `LendingJournalFactory.buildRequest(...)`. Along the way this surfaced that the old literal used
  transaction-service's GL pair (cash-clearing/deposit-control) for a *lending* disbursement — the
  real defaults are loans-receivable/funding-clearing — and included a `subAccountId` field that
  lending's `JournalLineRequest` doesn't even declare. Both are fixed by construction now.
- **transaction** (`LedgerPostJournalPactConsumerTest`): `lines` now built via
  `PaymentJournalFactory.buildLines(...)` against a fixture `Transaction`. This surfaced that the
  old literal had `subAccountId: null` on both legs, a shape the factory never actually produces
  for an incoming credit (the deposit-control leg carries the target account). The envelope
  fields (`idempotencyKey`, `createdBy`) still mirror `PaymentActivitiesImpl`'s inline formula,
  since that assembly isn't part of any factory — out of scope for a test-only change.

**settlement-service left out of scope.** Unlike the other three, settlement has no pure,
side-effect-free journal-building function — the request is assembled inline inside
`LedgerBookAdapter.book()`, which needs a real repository read and isn't callable from a consumer
pact test without a settlement-repository fixture. Extracting a pure `SettlementJournalFactory`
would be a real production refactor (signature/visibility change), which the issue's own
instructions call out as out of scope for a test-only PR. Left for maintainer follow-up.

Test-only changes (`src/test/**` + the corresponding `pacts/*.json` consumer artifacts). No
production code touched. `openbank-lending-service` and `openbank-transaction-service` are
money-path services (`rules.yaml: money_path_services`), but per the issue's own scoping this
stays test-only.

## Test plan

- [x] `:openbank-billing-service:compileTestKotlin` + `ktlintCheck`
- [x] `:openbank-lending-service:compileTestKotlin` + `ktlintCheck`
- [x] `:openbank-transaction-service:compileTestKotlin` + `ktlintCheck`
- [x] Each pact consumer test run individually (`./gradlew :<svc>:test --tests "...PactConsumerTest"`), regenerating `pacts/*.json`
- [ ] Provider verification (`LedgerPactProviderVerificationTest`) — gated on `pactbroker.url`, runs in CI only

Refs #1347 (partial — settlement-service still needs a maintainer decision on extracting a pure
factory before its pact can be fixed the same way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)