### PR TITLE
fix(observability): right-size holmesgpt memory to stop OOMKills

### DIFF
--- a/openbank-infra/gitops/apps/holmesgpt.yaml
+++ b/openbank-infra/gitops/apps/holmesgpt.yaml
@@ -61,10 +61,14 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            # Steady-state RSS sits at ~448Mi (LLM client + toolset context), so the old
+            # 256Mi request under-declared it by ~2x and the 512Mi limit left no headroom:
+            # OOMKilled (exit 137) on 2026-07-17. Right-size the request to observed usage
+            # and give the limit real slack.
+            memory: 512Mi
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
         nodeSelector:
           workload: observability
         tolerations:


### PR DESCRIPTION
## What
HolmesGPT was **OOMKilled** (exit 137) on 2026-07-17. Its container limit was 512Mi while steady-state RSS sits at **~448Mi** (`kubectl top`), so any transient bump tips it over. The 256Mi request also under-declared real usage by ~2x.

- request `memory: 256Mi → 512Mi` (right-size to observed)
- limit `memory: 512Mi → 1Gi` (real headroom)

## Why it matters
`holmesgpt-holmes` is the RCA engine behind the `holmes-rca` webhook that `severity=critical` alerts route to. An OOM loop degrades incident triage precisely when a critical is firing.

## Evidence
```
lastState.terminated: reason=OOMKilled exitCode=137 finishedAt=2026-07-17T14:43:07Z
kubectl top: holmesgpt-holmes ... 448Mi   (limit 512Mi)
```

## FinOps
+256Mi request on a single pod pinned to the `workload: observability` node pool — far too small to provision a node; limit changes don't bill. Marginal cost ~$0.

## Scope
gitops-only; `holmesgpt` has no `version.txt` so no release is triggered. Found during a monitoring-stack false-positive/real-problem sweep.

## Linked issues
N/A — a standalone bug fixed in full by this PR, found during a monitoring-stack false-positive sweep — no residual work to track.