### PR TITLE
chore(gitops): enable interest accrual engine + edge interest route (#1618)

### DIFF
--- a/openbank-infra/gitops/components/accounts/network-policies.yaml
+++ b/openbank-infra/gitops/components/accounts/network-policies.yaml
@@ -50,6 +50,9 @@ spec:
               kubernetes.io/metadata.name: documents
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: interest
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: payments
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-ed34e323
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-5a24a5ea
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -134,6 +134,11 @@ spec:
               value: http://product-catalog.accounts.svc:8104
             - name: BALANCE_SERVICE_URL
               value: http://balance-service.balances.svc:8103
+            # Interest view for the savings account (#1615/#1618): GET /accounts/{id}/interest
+            # projects interest-service's rate + accrued summary. Declared here (not only in
+            # application.yaml) so gen-network-policies.py opens the edge->interest ingress allow.
+            - name: INTEREST_SERVICE_URL
+              value: http://interest-service.interest.svc:8125
             - name: TRANSACTION_SERVICE_URL
               value: http://transaction-service.payments.svc:8102
             - name: DOMESTIC_PAYMENT_SERVICE_URL

--- a/openbank-infra/gitops/components/interest-service/interest-service-http-scaledobject.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service-http-scaledobject.yaml
@@ -26,10 +26,18 @@
 # blocker to skip the service — the existing pilot itself shipped on JVM. Flagging this gap
 # rather than silently assuming native is live.
 #
-# minReplicas: 0 — safe because:
-#   - interest-service is NOT on the money path (rules.yaml money_path_services).
-#   - No resident listener depends on the pod staying warm (no live cron, see above).
-#   - The KEDA HTTP interceptor parks the first request rather than 5xx-ing it.
+# minReplicas: 1 — the premise for min:0 above ("no live cron") no longer holds. The daily
+#   accrual engine (openbank-interest-service #1618/#1614) adds an in-pod @Scheduled
+#   (InterestAccrualScheduler, openbank.interest.accrual-cron) that MUST fire once a day, and at 0
+#   replicas it never would — the pod is not up at cron time and nothing wakes it. interest also
+#   became customer-facing: customer-edge reads GET /accounts/{id}/interest on every savings-account
+#   view (#1615), and a warm pod avoids a KEDA cold-start on that read path. So this service is now a
+#   resident-scheduler + read-serving service, not the on-demand operator tool the T1 sweep assumed.
+#   The manifest above anticipated exactly this ("if/when the described external accrual scheduler is
+#   built…") — we chose the in-pod scheduler + min:1 over an external CronJob POSTing /accrue/all;
+#   either satisfies the daily trigger, and min:1 also fixes the read-path cold start. Reclaiming
+#   scale-to-zero later would mean moving the trigger to a K8s CronJob and accepting cold reads.
+#   Still NOT on the money path (rules.yaml money_path_services); the finops cost is one small JVM pod.
 #
 # maxReplicas: 1 — low-QPS operator/admin-driven traffic; no customer-facing fan-out measured, so a
 #   second replica buys no throughput. It does buy a concurrency hazard: capitalization and
@@ -63,7 +71,7 @@ spec:
     apiVersion: apps/v1
     port: 8125
   replicas:
-    min: 0
+    min: 1
     max: 1
   scaledownPeriod: 300
   targetPendingRequests: 50

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -26,7 +26,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: interest-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-ffa5f44c
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-06e361d9
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8125}
@@ -80,6 +80,10 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # Fleet directory for the daily accrual run (#1618): discovers ACTIVE accounts
+            # (GET /accounts/active) and reads their booked balance (GET /accounts/{id}/balance).
+            - name: ACCOUNT_SERVICE_URL
+              value: "http://account-service.accounts.svc:8100"
             # OPA sidecar bootstrap (ADR-0034 Phase 5, issue #938). Advisory mode first
             # (AUTHZ_ENFORCE=false, @Authorize logs "would DENY" without blocking) — matches
             # every other service's rollout convention. Flip to true only after an observation

--- a/openbank-infra/gitops/components/interest-service/network-policies.yaml
+++ b/openbank-infra/gitops/components/interest-service/network-policies.yaml
@@ -38,6 +38,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: platform
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
Deploys the interest feature — #1614 (accrual engine) + #1615 (edge route).

- **interest-service**: image → `sandbox-06e361d9`; add `ACCOUNT_SERVICE_URL` (accrual discovery + balance reads).
- **interest HTTPScaledObject `min 0 → 1`**: the ADR-0057 T1 scale-to-zero premise ("no live cron") no longer holds — #1614 adds an in-pod `@Scheduled` daily accrual that must fire, and the edge now reads `GET /accounts/{id}/interest` on every savings view. Warm pod fires the cron + drops a KEDA cold-start on the read path; finops cost is one small JVM pod (still off the money path). Rationale in the manifest comment.
- **customer-edge**: image → `sandbox-5a24a5ea`; add `INTEREST_SERVICE_URL`.
- **NetworkPolicies** regenerated: accounts ← interest (discovery/balance), interest ← customer-edge (the read). Nothing else changed.

Images built + signed by Auto Deploy Build+push (runs 29631747622 / 29631749391). Hand-bumping the tags here because Auto Deploy's gitops step is stuck behind the self-hosted runner backlog (both at a queued `can-i-deploy`) — same verified workaround as prior deploys.

Refs #1618, #1614, #1615.

## Linked issues

Refs #1618