### PR TITLE
fix(observability): heartbeat money-path SLOs to stop false SLOMetricAbsent pages

### DIFF
--- a/openbank-infra/gitops/components/observability/probes-synthetic.yaml
+++ b/openbank-infra/gitops/components/observability/probes-synthetic.yaml
@@ -114,3 +114,75 @@ spec:
         - https://kc.open-bank.tech/realms/openbank-customers/.well-known/openid-configuration
       labels:
         tier: iam
+---
+# Money-path SLO heartbeat (issue #669, rules.yaml: money_path_services).
+#
+# WHY THIS EXISTS
+# The per-money-path availability/latency SLOs (pyrra-slo-money-path.yaml) use
+# `traces_spanmetrics_calls_total{service=...}` as their indicator. That series
+# is produced by the Tempo metrics-generator span_metrics processor, whose
+# registry drops any service's series after `stale_duration` (default 15m) of
+# no spans. On this cluster there is no continuous money-path load yet (#669's
+# load benchmark is still open), so a money-path service that goes quiet for
+# >15m loses its series and Pyrra's built-in `SLOMetricAbsent` alert fires at
+# `severity: critical` — a pager page for a service that is perfectly healthy,
+# just idle. On 2026-07-18 that was 12 of the 17 firing criticals (fraud / vop /
+# billing / settlement), and the set rotates to whichever service is quietest.
+#
+# WHAT THIS DOES
+# Blackbox GETs each money-path service's in-cluster root every 60s. The service
+# handles the request (returns 404 at "/", an application URI that is NOT the
+# span-suppressed /q/* management path), so it emits ONE server span per probe.
+# That span keeps `traces_spanmetrics_calls_total{service=...}` warm, so the SLI
+# never goes absent while the service is up. Validated 2026-07-18: a single
+# in-cluster GET to fraud-service made `openbank-fraud-service` reappear in
+# spanmetrics within ~5s of being absent.
+#
+# WHY IT DOES NOT MASK A REAL OUTAGE
+# A genuinely-down service refuses the connection -> no span -> the series still
+# drops and `SLOMetricAbsent` still fires. It also shows here as
+# `probe_success{job="synthetic-money-path"}==0` (http_app treats a 404/401/403
+# as up, only a connection/transport failure as down), which is a cleaner direct
+# up/down signal than trace-absence. The 404 heartbeats are client errors
+# (span status UNSET, not STATUS_CODE_ERROR) and complete in <1s, so they do not
+# inflate the availability error-ratio or the latency SLO. Once #669 drives real
+# traffic, that traffic dominates and these heartbeats become negligible.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: synthetic-money-path
+  namespace: observability
+  labels:
+    app.kubernetes.io/part-of: observability
+spec:
+  jobName: synthetic-money-path
+  interval: 60s
+  scrapeTimeout: 10s
+  # Lenient: a 404/401/403 at "/" is expected and proves the service is up and
+  # emitting spans; only a connection failure (service down) yields probe_success=0.
+  module: http_app
+  prober:
+    url: blackbox-exporter:9115
+  targets:
+    staticConfig:
+      labels:
+        tier: money-path
+      static:
+        - http://ledger-service.ledger.svc.cluster.local:8101/
+        - http://transaction-service.payments.svc.cluster.local:8102/
+        - http://account-service.accounts.svc.cluster.local:8100/
+        - http://balance-service.balances.svc.cluster.local:8103/
+        - http://sepa-payment.payments.svc.cluster.local:8115/
+        - http://sepa-instant.payments.svc.cluster.local:8127/
+        - http://domestic-payment.payments.svc.cluster.local:8116/
+        - http://clearing-service.payments.svc.cluster.local:8124/
+        - http://swift-service.payments.svc.cluster.local:8122/
+        - http://fx-service.fx.svc.cluster.local:8119/
+        - http://lending-service.lending.svc.cluster.local:8126/
+        - http://sca-service.sca.svc.cluster.local:8110/
+        - http://consent-service.consent.svc.cluster.local:8106/
+        - http://fraud-service.fraud.svc.cluster.local:8133/
+        - http://billing-service.billing.svc.cluster.local:8132/
+        - http://settlement-service.payments.svc.cluster.local:8138/
+        - http://sanctions-service.sanctions.svc.cluster.local:8123/
+        - http://vop-service.payments.svc.cluster.local:8149/


### PR DESCRIPTION
## Problem
`SLOMetricAbsent` was **12 of the 17 firing criticals** on 2026-07-18 (fraud / vop / billing / settlement) — all four pods `2/2 Running`, healthy. It pages because the money-path SLO indicator `traces_spanmetrics_calls_total{service=...}` comes from the **Tempo metrics-generator**, whose registry drops a service's series after **15m** of no spans. With no continuous money-path load yet (**#669**), any idle service loses its series and Pyrra's built-in absent-alert fires `critical`. The set rotates to whichever service is quietest — so this is structural, not a per-service bug.

## Fix
A blackbox `Probe` (`synthetic-money-path`) GETs each of the 18 `money_path_services` in-cluster root every 60s. The service returns 404 at `/` — an application URI, **not** the span-suppressed `/q/*` path — so it emits one server span per probe, keeping the SLI series warm.

**Validated 2026-07-18:** a single in-cluster GET to fraud-service made `openbank-fraud-service` reappear in spanmetrics within ~5s of being `absent`.

## Why it does not mask a real outage
- Down service → connection refused → no span → `SLOMetricAbsent` **still fires**, and `probe_success{job="synthetic-money-path"}==0` (http_app counts 404/401/403 as up, only transport failure as down) — a cleaner direct up/down signal than trace-absence.
- 404 heartbeats are client errors → span status `UNSET` (not `STATUS_CODE_ERROR`), <1s → they do **not** inflate the availability error-ratio or the latency SLO.
- Once #669 drives real traffic, that dominates and the heartbeats are negligible.

## FinOps
18 in-cluster GETs/60s (~0.3 req/s, all 404, no NAT egress) on the already-running blackbox-exporter. Marginal cost **~$0**.

## Scope
gitops-only (a `Probe` CR); no released module, no release triggered. Reuses the existing `http_app` blackbox module. Found during a monitoring-stack sweep.

Refs #669