### PR TITLE
fix(gitops): provision interest-service OIDC client secret (#1618)

### DIFF
--- a/openbank-infra/gitops/components/interest-service/oidc-externalsecret.yaml
+++ b/openbank-infra/gitops/components/interest-service/oidc-externalsecret.yaml
@@ -1,0 +1,35 @@
+# OIDC client secret for interest-service (Keycloak client openbank-services).
+# Same shared service-account secret used by the other app-plane services, stored in Vault
+# under key `account-service`. Mirrors document-service/billing's oidc-externalsecret.yaml exactly.
+#
+# Why this was missing until #1618: interest-service never made an OUTBOUND M2M call before — the
+# accrual engine (accrueAll) was a stub, and capitalization (its only other outbound path) never ran
+# against real data. So the empty `interest-service-oidc` reference in the Deployment (optional:true)
+# went unnoticed. Now the accrual run calls account-service (GET /accounts/active + /balance) via the
+# OidcClientRequestReactiveFilter, which mints an openbank-services token from THIS secret — without
+# it every accrual tick 401s at account-service and (fail-open) accrues nobody.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: interest-service-oidc
+  namespace: interest
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv
+  target:
+    name: interest-service-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      metadata:
+        annotations:
+          argocd.argoproj.io/compare-options: IgnoreExtraneous
+  data:
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: account-service
+        property: OIDC_CLIENT_SECRET


### PR DESCRIPTION
interest-service's `interest-service-oidc` secret was never populated — no ExternalSecret created it and the Deployment reference is `optional: true`, so `OIDC_CLIENT_SECRET` resolved **empty**. Invisible while interest-service made no outbound M2M call (accrueAll was a stub, capitalization never ran on real data).

The accrual engine (#1614) now calls account-service (`GET /accounts/active` + `/balance`) via `OidcClientRequestReactiveFilter`, which mints an `openbank-services` token from this secret. Without it, every accrual tick 401s at account-service and fail-opens to "accrue nobody".

Adds the ExternalSecret mirroring document-service/billing exactly: shared `openbank-services` service-account secret from Vault key `account-service`, ClusterSecretStore `vault-kv`.

## Linked issues

Refs #1618