### PR TITLE
docs: refresh README and ROADMAP against deployed sandbox state

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 
 ## Project Status
 
-**Beta — M1 complete, M2/M3/M5 in progress.** 33 backend microservices in the repo (32 deployed to the AWS sandbox, 1 code-only/deploy-gated — FINREP; manifests exist but no ArgoCD Application wires them in yet); customer-edge + admin-UI + developer portal deployed. The intra-bank money path is end-to-end; the ISO 20022 pipeline and clearing simulator are wired; live interbank network connections and multi-region are later milestones. See [docs/ROADMAP.md](docs/ROADMAP.md) for the full M1–M7 plan.
+**Beta — M1 complete, M2/M3/M5 in progress.** ~37 backend microservices in the repo, all now deployed to the AWS sandbox — FINREP (previously the lone code-only service) deploys via its own ArgoCD Application (#547), and the new Verification-of-Payee (VoP) service is live (ADR-0171); customer-edge + admin-UI + developer portal deployed. The intra-bank money path is end-to-end; the ISO 20022 pipeline and clearing simulator are wired; live interbank network connections and multi-region are later milestones. See [docs/ROADMAP.md](docs/ROADMAP.md) for the full M1–M7 plan.
 
 | Area | Status |
 |---|---|
@@ -42,8 +42,9 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 | Cards, disputes, interest, standing orders, statements, onboarding | 🟢 Implemented + deployed; standing-order daily scheduler live |
 | Lending | 🟢 Deployed to sandbox (four-eyes KYC gate, ADR-0028); no live credit bureau integration |
 | SWIFT messaging | 🟡 Deployed (ISO 20022 MT/MX pipeline wired); no live SWIFT network connection |
+| Verification of Payee (VoP) | 🟢 Deployed to sandbox; name-match on outbound credit transfers, UI gate on SCT/SCT Inst (ADR-0171) |
 | AnaCredit, SDD, TPP registry | 🟢 Implemented, deployed to sandbox |
-| FINREP | 🟡 Implemented, code-only (manifests exist; not yet wired into an ArgoCD Application) |
+| FINREP | 🟢 Implemented, deployed to sandbox (ArgoCD Application registered, #547) |
 | Product catalog | 🟢 Implemented, deployed |
 | Customer edge (BFF) + mobile app | 🟡 BFF deployed (OPA enforce mode on); KMP/Compose app in active dev (separate repo) |
 | AI agent service (MCP, policy-gated) | 🟡 Fleet read tools + audit (ADR-0031); **copilot-service with LLM deployed in sandbox** |
@@ -54,7 +55,7 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 | Supply-chain security (SBOM, signing, SAST, pen-test P0–P2) | 🟢 CI-enforced (ADR-0030); external pen-test P0–P2 findings remediated |
 | CI/CD | 🟢 Self-hosted runners + path-scoped gates + GitOps auto-deploy (ADR-0040) |
 | Observability (OTel, Grafana, Prometheus, Loki, Tempo, Pyroscope) | 🟢 Live; GoAlert on-call, Pyrra SLO-as-code, GlitchTip errors, DomainMetrics fleet-wide |
-| Cloud substrate (AWS, OpenTofu, ArgoCD GitOps) | 🟢 Sandbox live (EKS + ArgoCD) — 33 backend microservices in repo, 32 deployed (FINREP code-only/deploy-gated) |
+| Cloud substrate (AWS, OpenTofu, ArgoCD GitOps) | 🟢 Sandbox live (EKS + ArgoCD) — full in-repo backend fleet deployed (no service code-only any longer) |
 
 ### What works right now (sandbox at open-bank.tech)
 
@@ -140,8 +141,8 @@ diagram, container diagram, key decisions, deployment topology, and security arc
 
 | Layer | Technology |
 |---|---|
-| Backend | Kotlin 2.3 + Quarkus 3.33 |
-| Database | PostgreSQL 16 (Flyway migrations); upgrading to 18 via CNPG (runbook 0003, in progress) |
+| Backend | Kotlin 2.3.20 + Quarkus 3.37 |
+| Database | PostgreSQL 18 via CNPG (Flyway migrations) — cluster fleet migrated 16 → 18 (runbook 0003); local Docker dev still on 16 |
 | Messaging | Apache Kafka (transactional outbox); Redpanda for per-JVM integration tests |
 | Schema registry | Apicurio 2.6 |
 | Cache | Valkey 7.2 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,8 +27,9 @@ milestone completion in releases, not by inferred dates.
   is live (ADR-0101, FX + statement flows); idempotency coverage and integration-test depth are the
   remaining gaps.
 - **M3 (Compliance)** — PSD2 XS2A developer portal live, GDPR Art. 17 erasure pipeline wired fleet-wide,
-  EUDI/PID digital identity (OpenID4VP + OpenID4VCI) live. AnaCredit/FINREP reporting and full AML vendor
-  feed integration are pending.
+  EUDI/PID digital identity (OpenID4VP + OpenID4VCI) live, Verification of Payee (VoP) on outbound
+  credit transfers live (ADR-0171). AnaCredit and FINREP regulatory-reporting services are deployed;
+  live regulator submission and full AML vendor-feed integration are the remaining gaps.
 - **M4 (Observability)** — OTel fleet-wide, DomainMetrics on every service, GoAlert on-call,
   Pyrra SLO-as-code, GlitchTip error tracking, Grafana dashboards. Chaos engineering is deferred to M6.
 - **M5 (Security)** — external pen-test P0–P2 findings remediated, SBOM + cosign signing in CI,
@@ -58,7 +59,7 @@ schemes directly — operators do. AI-driven account-opening / payment decisions
 
 ## Known gaps (honest list)
 
-Current limitations as of the Beta (June 2026). Updated as milestones ship:
+Current limitations as of the Beta (July 2026). Updated as milestones ship:
 
 - **Interbank rails do not connect to live networks.** ISO 20022 pipeline and clearing simulator are
   wired and flags are on (ADR-0104/0108); money moves end-to-end with a simulated counterparty. Real
@@ -68,24 +69,25 @@ Current limitations as of the Beta (June 2026). Updated as milestones ship:
   deployed with OPA enforce mode on, but app stores releases are not yet public.
 - **KYC/AML vendors are stubs** — screening logic is real (sanctions uses pg_trgm fuzzy matching) but
   runs against in-memory/seed lists, not real providers (Refinitiv, ComplyAdvantage, EBA feed).
-- **One service is code-only, not deployed** — `finrep` is implemented and its gitops manifests
-  exist, but no ArgoCD Application wires it into the sandbox cluster yet. `anacredit`, `sdd`, and
-  `tpp-registry` were in this same state until 2026-07-01 and are now deployed. (`lending` and
-  `psd2` are deployed; `swift-service` is deployed with ISO 20022 MT/MX but without a live SWIFT
-  network connection.)
+- **Regulatory-reporting services generate reports but do not submit to a live regulator.** The full
+  in-repo backend fleet is now deployed — `finrep`, the last code-only service, deploys via its own
+  ArgoCD Application (#547, 2026-07-08), joining `anacredit`, `sdd`, and `tpp-registry` (deployed since
+  2026-07-01). `finrep`/`anacredit` build the CNB/EBA reports but do not yet transmit them to a live
+  supervisory endpoint. (`lending` and `psd2` are deployed; `swift-service` is deployed with ISO 20022
+  MT/MX but without a live SWIFT network connection.)
 - **SCA is maturing, not complete** — passkey RP, settlement gate and non-repudiation hash chain are
   in (ADR-0086), but full FIDO2 attestation / real OTP delivery are not finished.
-- **AI copilot is sandbox-only** — a real LLM (meta/llama-3.1-70b-instruct) runs in the sandbox
-  copilot-service; production model gateway, rate-limiting, and abuse guardrails are not hardened for
-  public traffic.
+- **AI copilot is sandbox-only** — a real LLM (deepseek-ai/DeepSeek-V3.2, via DeepInfra) runs in the
+  sandbox copilot-service; the backend is model-agnostic (swap by env). Production model gateway,
+  rate-limiting, and abuse guardrails are not hardened for public traffic.
 - **Contract tests are thin** — Pact Broker is live (pact.open-bank.tech) but published pact coverage
   across the fleet is a known gap.
 - **HA on money-path DBs only; DR still unproven** — all 17 money-path CNPG clusters run
   `instances: 2` with live-verified switchover ([ADR-0159](adr/0159-cnpg-ha-money-path.md), shipped
   2026-07-12); non-money-path databases remain `instances: 1`. Single region, single cluster: the
   automated DR restore-verify workflow exists but is dispatch-only and not yet on its quarterly
-  schedule, so RTO/RPO targets (M6) are stated, not demonstrated. PostgreSQL is upgrading to 18
-  (CNPG, runbook in progress).
+  schedule, so RTO/RPO targets (M6) are stated, not demonstrated. The CNPG fleet now runs
+  PostgreSQL 18 (migrated from 16; runbook 0003); local Docker dev still ships 16.
 - **Not licensed to operate as a bank.** See the disclaimer in the README.
 
 ---


### PR DESCRIPTION
## Summary

README/ROADMAP had drifted from the actual deployed sandbox state. FINREP (last code-only service) has been deployed since #547 and was still listed as code-only; the Verification-of-Payee service (ADR-0171) shipped and was never mentioned; framework/runtime versions and the copilot LLM model were stale.

## Type of change

- [x] docs
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] chore
- [ ] security
- [ ] breaking change

## Linked issues

None — direct doc correction, verified against `origin/main` and live gitops manifests.

## Changes

- README: FINREP marked deployed (was "code-only"); added VoP status row; corrected service-count framing (no service is code-only anymore); Kotlin 2.3.20 / Quarkus 3.37 (was 2.3 / 3.33); PostgreSQL 18 via CNPG (was "16, upgrading")
- ROADMAP: M3 now credits VoP + notes AnaCredit/FINREP are deployed (gap is live regulator submission, not deployment); "known gaps" code-only-service bullet replaced with a regulator-submission gap; copilot model corrected to deepseek-ai/DeepSeek-V3.2 via DeepInfra (was meta/llama-3.1-70b-instruct, not what's actually configured); date bumped June → July 2026; Postgres 18 migration marked done for the CNPG fleet

## Definition of Done

- [x] Docs updated (README, ROADMAP)
- [ ] N/A: no code/API/DB/schema change

## Security checklist

- [x] No secrets, tokens, passwords, or PII in this change
- [x] No new dependency
- [x] Not an auth/crypto/payment/PII/cardholder-data path

## Compliance impact

- [x] None

## Rollout / Rollback

- Deployment strategy: N/A (docs only)
- Rollback plan: revert commit
- Data migration reversible: N/A

## Reviewer notes

All factual claims re-verified against `origin/main` (gitops manifests, `libs.versions.toml`, ArgoCD Application/component definitions), not from memory or a stale local checkout.