### PR TITLE
security(notification): escape HTML variables in rendered notification bodies

### DIFF
--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -11,6 +11,7 @@ import com.openbank.libs.audit.AuditResult
 import com.openbank.notification.application.port.out.OversightWebhookPublisher
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
+import com.openbank.notification.domain.HtmlEscape
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationStatus
@@ -438,13 +439,20 @@ class NotificationConsumer {
 }
 
 /**
- * Reads a declared template variable, or "" when the caller omitted it.
+ * Reads a declared template variable, HTML-escaped, or "" when the caller omitted it.
  *
  * The schema is closed against **undeclared** keys, not against missing ones (see
  * [NotificationTemplate.variables]): rejecting a partial request would silently drop a real
  * message, since poison payloads are acked. An omitted variable renders empty, as it always has.
  *
+ * Escaping happens HERE, not per call site (issue #1382): every one of [renderTemplate]'s ~16
+ * reads interpolates straight into an HTML body (or, for `PASSWORD_RESET`'s `resetLink`, an
+ * `href="..."` attribute) with zero escaping between a domain-event-supplied variable and the
+ * mail actually sent — a `reason`, `documentType`, or `scope` containing markup rendered verbatim
+ * in the customer's mail client. Escaping the shared accessor closes every call site in one place
+ * instead of relying on each of the 16 to remember it.
+ *
  * Top-level rather than a member so `renderTemplate` reads as copy instead of null-handling — the
  * 16 inline `?: ""` reads it replaces were most of that function's cyclomatic complexity.
  */
-private fun Map<String, String>.v(key: String): String = this[key] ?: ""
+private fun Map<String, String>.v(key: String): String = HtmlEscape.escape(this[key] ?: "")

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/OperatorMessageService.kt
@@ -5,6 +5,7 @@
 package com.openbank.notification.application
 
 import com.openbank.libs.domain.identifiers.Ids
+import com.openbank.notification.domain.HtmlEscape
 import com.openbank.notification.domain.model.OperatorMessageTemplate
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
@@ -158,16 +159,25 @@ class OperatorMessageService {
      * `vars.getValue(key)` is safe: [compose] already rejected any request whose `variables`
      * don't exactly match `template.variables` (extra AND missing), so every declared key is
      * guaranteed present by the time render() runs — no fallback-to-"" indirection needed.
+     *
+     * Every value interpolated into the HTML *body* is [HtmlEscape.escape]d (issue #1382): this
+     * is the operator-reachable half of that issue — `note` (`GENERIC_NOTICE`) and
+     * `ticketReference` (`SUPPORT_FOLLOWUP`) previously reached `Mail.withHtml` completely
+     * unescaped, so `ROLE_OPERATOR` free text like `<img src=x onerror=...>` rendered live in the
+     * customer's mail client. `subject` is deliberately NOT escaped: it becomes the mail
+     * `Subject:` header, not HTML, so HTML-entity-encoding it would corrupt the visible subject
+     * line rather than protect anything (header injection there is already closed by
+     * [validateRequest]'s recipient pattern; `subject` itself carries no address/header syntax).
      */
     private fun render(template: OperatorMessageTemplate, vars: Map<String, String>): Pair<String, String> =
         when (template) {
             OperatorMessageTemplate.GENERIC_NOTICE ->
                 (vars.getValue("subject").ifBlank { "A message from OpenBank" }) to
-                    "<p>${vars.getValue("note")}</p>"
+                    "<p>${HtmlEscape.escape(vars.getValue("note"))}</p>"
             OperatorMessageTemplate.SUPPORT_FOLLOWUP ->
                 "Following up on your support request" to
                     "<p>We are following up on your support request " +
-                    "(reference <b>${vars.getValue("ticketReference")}</b>). " +
+                    "(reference <b>${HtmlEscape.escape(vars.getValue("ticketReference"))}</b>). " +
                     "Please reply to this message if you have further questions.</p>"
         }
 

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/HtmlEscape.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/HtmlEscape.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain
+
+/**
+ * Minimal HTML-context escaper for template variables interpolated into rendered notification
+ * bodies (issue #1382).
+ *
+ * Neither [com.openbank.notification.application.NotificationConsumer.renderTemplate] nor
+ * [com.openbank.notification.application.OperatorMessageService.render] ran any escaping between
+ * a caller-supplied variable and the HTML body handed to `Mail.withHtml` — an operator (or, for
+ * the system templates, an upstream domain event) could inject arbitrary markup that a customer's
+ * mail client would render, including `<img onerror=...>`/`<script>`-style payloads and, for
+ * `PASSWORD_RESET`'s `resetLink` (interpolated into an `href="..."` attribute), an attribute
+ * breakout via an embedded `"`.
+ *
+ * Deliberately not a general-purpose sanitizer: every call site here treats its variables as
+ * plain text that must render literally, never as markup the caller is allowed to inject, so
+ * escaping the five reserved characters is sufficient and correct for both the element-body and
+ * attribute-value contexts these templates use.
+ */
+object HtmlEscape {
+    fun escape(value: String): String = value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&#39;")
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplateSensitivity.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplateSensitivity.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+/**
+ * [TemplateSensitivity]'s counterpart for [OperatorMessageTemplate] (issue #1386).
+ *
+ * `OperatorMessageTemplate` and `NotificationTemplate` are deliberately disjoint enums (see
+ * `OperatorMessageTemplate`'s own KDoc, ADR-0176 D1/D2) — but that split reintroduced, for
+ * `OperatorMessageTemplate`, the exact secret-leak gap that [TemplateSensitivity] closed for
+ * `NotificationTemplate` after issue #1325: `NotificationResource.bodyForRead` looked up the
+ * stored `template` column string against `NotificationTemplate.entries` only, so any row
+ * written by [com.openbank.notification.application.OperatorMessageService] (whose `template`
+ * column holds an `OperatorMessageTemplate` name) failed the `firstOrNull` lookup and fell
+ * through to the unconditional fail-open branch — serving the raw stored body to any
+ * `ROLE_OPERATOR` reader with **no** redaction check performed at all, secret or not.
+ *
+ * Both current constants (`GENERIC_NOTICE`, `SUPPORT_FOLLOWUP`) are non-secret today, so this is
+ * currently latent, not exploitable — but the guard now exists, mirroring
+ * [TemplateSensitivity.SECRET_TEMPLATES]'s allow-list shape, so the moment a future
+ * `OperatorMessageTemplate` constant embeds something sensitive (a support PIN, a magic link, a
+ * one-time code an operator relays), classifying it here is the only change needed to redact it
+ * on read — the same one-question test as [TemplateSensitivity]: *if a bank operator read this
+ * body, could they use it to act as the customer?*
+ */
+object OperatorMessageTemplateSensitivity {
+
+    /**
+     * Templates whose rendered body would contain a secret that authenticates the customer.
+     * Empty today — neither current constant carries one — but kept as a real allow-list
+     * (not a placeholder) so [NotificationResource.bodyForRead][com.openbank.notification
+     * .infrastructure.rest.NotificationResource.bodyForRead] has something to check instead of
+     * failing open for this enum, exactly as it already does for [NotificationTemplate].
+     */
+    val SECRET_TEMPLATES: Set<OperatorMessageTemplate> = emptySet()
+
+    /** True when [template]'s rendered body would embed an authentication secret. */
+    fun isSecret(template: OperatorMessageTemplate): Boolean = template in SECRET_TEMPLATES
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationResource.kt
@@ -6,6 +6,8 @@ package com.openbank.notification.infrastructure.rest
 
 import com.openbank.libs.authz.Authorize
 import com.openbank.notification.domain.model.NotificationTemplate
+import com.openbank.notification.domain.model.OperatorMessageTemplate
+import com.openbank.notification.domain.model.OperatorMessageTemplateSensitivity
 import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
 import jakarta.annotation.security.RolesAllowed
@@ -135,14 +137,37 @@ class NotificationResource {
      * way out, so two controls must both fail to leak an OTP to an operator. Same
      * defense-in-depth shape as the ADR-0059 D3 scrubber.
      *
-     * An unrecognised template returns [stored] verbatim rather than redacting. That is safe
-     * because the write path only ever persists a value that parsed into [NotificationTemplate]
-     * (a payload with any other template is rejected as poison), so an unknown value here means
-     * the enum shrank after the row was written — and any such row was already redacted by the
-     * write path or by V9. Fail-open keeps a legacy row readable instead of 500-ing on it.
+     * Checks BOTH template enums that can legitimately own this column (issue #1386): the
+     * `template` string here is not exclusively [NotificationTemplate] — since ADR-0176,
+     * [com.openbank.notification.application.OperatorMessageService] persists an
+     * [OperatorMessageTemplate] name into the same column. The original single-enum lookup
+     * failed open (returned [stored] unredacted with no check at all) for every
+     * `OperatorMessageTemplate` row, silently reintroducing the exact secret-leak shape issue
+     * #1325 closed for `NotificationTemplate`. Both current `OperatorMessageTemplate` constants
+     * are non-secret, so this was latent, not exploitable — but a future one that embeds
+     * something sensitive now has a real classifier to extend
+     * ([OperatorMessageTemplateSensitivity]) instead of silently inheriting the fail-open path.
+     *
+     * A template string matching NEITHER enum returns [stored] verbatim rather than redacting.
+     * That remains safe for the same reason as before: the write paths only ever persist a value
+     * that parsed into one of these two enums (any other template is rejected as poison), so an
+     * unmatched value here means an enum shrank after the row was written — and any such row was
+     * already redacted by its write path or by V9. Fail-open keeps a legacy row readable instead
+     * of 500-ing on it.
      */
     private fun bodyForRead(template: String, stored: String): String {
-        val known = NotificationTemplate.entries.firstOrNull { it.name == template } ?: return stored
-        return if (TemplateSensitivity.isSecret(known)) TemplateSensitivity.REDACTED_BODY else stored
+        val known = NotificationTemplate.entries.firstOrNull { it.name == template }
+        if (known != null) {
+            return if (TemplateSensitivity.isSecret(known)) TemplateSensitivity.REDACTED_BODY else stored
+        }
+        val operatorKnown = OperatorMessageTemplate.entries.firstOrNull { it.name == template }
+        if (operatorKnown != null) {
+            return if (OperatorMessageTemplateSensitivity.isSecret(operatorKnown)) {
+                TemplateSensitivity.REDACTED_BODY
+            } else {
+                stored
+            }
+        }
+        return stored
     }
 }

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/HtmlEscapeTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/HtmlEscapeTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Executable form of the escaping guarantee behind issue #1382: a template variable rendered
+ * into an HTML notification body can never smuggle live markup into a customer's mail client.
+ */
+class HtmlEscapeTest {
+
+    @Test
+    fun `escapes the five HTML-significant characters`() {
+        assertThat(HtmlEscape.escape("<img src=x onerror=alert(1)>"))
+            .isEqualTo("&lt;img src=x onerror=alert(1)&gt;")
+        assertThat(HtmlEscape.escape("Tom & Jerry")).isEqualTo("Tom &amp; Jerry")
+        assertThat(HtmlEscape.escape("\"quoted\" & 'single'"))
+            .isEqualTo("&quot;quoted&quot; &amp; &#39;single&#39;")
+    }
+
+    @Test
+    fun `an attribute-breakout payload can no longer close the surrounding quote`() {
+        // The PASSWORD_RESET template interpolates resetLink into href="...". A raw double quote
+        // in the value would close the attribute early and let the rest of the string inject a
+        // new attribute or element; escaped, the quote is inert text.
+        val payload = "https://example.com/reset?t=abc\" onmouseover=\"alert(1)"
+        val escaped = HtmlEscape.escape(payload)
+        assertThat(escaped).doesNotContain("\"")
+        assertThat(escaped).contains("&quot;")
+    }
+
+    @Test
+    fun `plain text is unaffected`() {
+        assertThat(HtmlEscape.escape("TCK-42")).isEqualTo("TCK-42")
+        assertThat(HtmlEscape.escape("")).isEqualTo("")
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplateSensitivityTest.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/domain/model/OperatorMessageTemplateSensitivityTest.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.domain.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Executable form of the guarantee behind issue #1386: [OperatorMessageTemplate] has its own
+ * secret classifier, the same shape as [TemplateSensitivity] for [NotificationTemplate], so a
+ * future secret-bearing operator-message template has somewhere real to be classified instead of
+ * silently inheriting `NotificationResource.bodyForRead`'s fail-open path.
+ */
+class OperatorMessageTemplateSensitivityTest {
+
+    @Test
+    fun `no current OperatorMessageTemplate is classified secret`() {
+        for (t in OperatorMessageTemplate.entries) {
+            assertThat(OperatorMessageTemplateSensitivity.isSecret(t)).isFalse()
+        }
+    }
+
+    @Test
+    fun `the classification set is pinned, so widening it is deliberate`() {
+        assertThat(OperatorMessageTemplateSensitivity.SECRET_TEMPLATES).isEmpty()
+    }
+}

--- a/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/OperatorMessageServiceIT.kt
+++ b/openbank-notification-service/src/test/kotlin/com/openbank/notification/integration/OperatorMessageServiceIT.kt
@@ -180,4 +180,38 @@ class OperatorMessageServiceIT {
 
         assertThat(bodyFor(partyId)).isNull()
     }
+
+    /**
+     * Issue #1382: an operator's free-text `note` reached `Mail.withHtml` completely unescaped,
+     * so a payload like `<img src=x onerror=...>` rendered live markup in the customer's mail
+     * client instead of literal text. `render()` now runs every body variable through
+     * [com.openbank.notification.domain.HtmlEscape] before interpolation.
+     */
+    @Test
+    fun `an operator-supplied note cannot inject HTML into the delivered or stored body`() {
+        val partyId = UUID.randomUUID()
+        mailbox.clear()
+        val payload = "<img src=x onerror=alert(document.cookie)>"
+
+        onVertxContext {
+            service.compose(
+                OperatorMessageRequest(
+                    partyId = partyId,
+                    template = OperatorMessageTemplate.GENERIC_NOTICE,
+                    recipient = "notice@example.com",
+                    variables = mapOf("subject" to "Heads up", "note" to payload),
+                ),
+            )
+        }
+
+        val sent = mailbox.getMailMessagesSentTo("notice@example.com")
+        assertThat(sent).hasSize(1)
+        assertThat(sent.first().html).doesNotContain(payload)
+        assertThat(sent.first().html).contains("&lt;img")
+
+        val stored = bodyFor(partyId)
+        assertThat(stored).isNotNull()
+        assertThat(stored).doesNotContain(payload)
+        assertThat(stored).contains("&lt;img")
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #1382: `OperatorMessageService.render()` (`GENERIC_NOTICE`/`SUPPORT_FOLLOWUP`) and `NotificationConsumer.renderTemplate` (all system templates) interpolated caller/domain-event-supplied variables straight into an HTML body with no escaping — an operator's `note` (reachable via `ROLE_OPERATOR` `opsmessage.compose`) or a domain-event `reason`/`scope`/`documentType` could inject live markup into a customer's mail client, and `PASSWORD_RESET`'s `resetLink` allowed attribute breakout via an embedded `"`. Adds a shared `HtmlEscape` object and applies it at every interpolation site (the shared `Map<String,String>.v()` accessor now escapes once for all ~16 `NotificationConsumer` call sites; `OperatorMessageService.render()` escapes `note`/`ticketReference` but deliberately leaves `subject` unescaped since it becomes a mail header, not HTML).
- Fixes #1386: `NotificationResource.bodyForRead` only recognised `NotificationTemplate` names. Since ADR-0176, `OperatorMessageService` persists rows under a disjoint `OperatorMessageTemplate` name — those rows silently skipped the secret-redaction check entirely (fail-open with no check performed), rather than failing open onto "not secret" the way the original design intended. Adds `OperatorMessageTemplateSensitivity`, the same allow-list shape as the existing `TemplateSensitivity`, and checks both enums. Both current `OperatorMessageTemplate` constants are non-secret today, so this closes a latent gap, not a live leak — but a future secret-bearing constant now has a real classifier to extend.

Note: #1182 (rendered push-payload content violating ADR-0135 §3) was triaged separately and left comment-only — it needs a cross-repo fetch-on-tap handler in `openbank-app` before the payload can be safely changed (see the issue's own triage comment), so it isn't part of this PR.

## Governance
`openbank-notification-service` is **not** on `money_path_services` (confirmed against `openbank-libs/governance/rules.yaml`), so the 2-approval + threat-model gate does not apply here. Standard review applies. Labels on both issues include `security-review-required` — flagging that for whoever reviews, even though it isn't a hard merge gate in `rules.yaml`.

## Test plan
- [x] `./gradlew :openbank-notification-service:ktlintCheck`
- [x] `./gradlew :openbank-notification-service:detekt`
- [x] `./gradlew :openbank-notification-service:compileKotlin :openbank-notification-service:compileTestKotlin`
- [x] New unit tests pass: `HtmlEscapeTest`, `OperatorMessageTemplateSensitivityTest`, existing `TemplateSensitivityTest`
- [x] New `OperatorMessageServiceIT` case asserts an `<img onerror=...>` payload in `note` is escaped in both the delivered mail and the stored row body
- [ ] Full `OperatorMessageServiceIT`/`NotificationConsumerIT` Postgres-backed suite — not run locally in this pass (Testcontainers); relying on CI

Closes #1382
Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)