### PR TITLE
fix(settlement): emit audit events on every settlement state transition

### DIFF
--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/usecase/SettlementService.kt
@@ -4,6 +4,9 @@
 
 package com.openbank.settlement.application.usecase
 
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.`in`.OriginateSettlementCommand
 import com.openbank.settlement.application.port.`in`.SettlementUseCase
 import com.openbank.settlement.application.port.out.CreditPort
@@ -33,6 +36,7 @@ class SettlementService(
     private val ledgerPort: LedgerPort,
     private val temporalConfig: TemporalConfig,
     private val workflowClient: WorkflowClient,
+    private val auditPublisher: AuditEventPublisher,
     private val clock: Clock,
 ) : SettlementUseCase {
 
@@ -44,7 +48,17 @@ class SettlementService(
         ledgerPort: LedgerPort,
         temporalConfig: TemporalConfig,
         workflowClient: WorkflowClient,
-    ) : this(settlementRepository, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient, Clock.systemUTC())
+        auditPublisher: AuditEventPublisher,
+    ) : this(
+        settlementRepository,
+        debitPort,
+        creditPort,
+        ledgerPort,
+        temporalConfig,
+        workflowClient,
+        auditPublisher,
+        Clock.systemUTC(),
+    )
 
     private val log = Logger.getLogger(SettlementService::class.java)
 
@@ -154,19 +168,52 @@ class SettlementService(
     private suspend fun runLegacySettle(settlementId: UUID): SettlementStatus = try {
         log.infof("Legacy settle: debiting payer for settlement %s (claimed → DEBITED)", settlementId)
         debitPort.debit(settlementId)
+        // claimForProcessing already flipped the row to DEBITED (atomic PENDING -> DEBITED CAS)
+        // before this method was ever called, so the audited row already carries that status.
+        settlementRepository.findById(settlementId)?.let { audit("settlement.debit", it) }
 
         log.infof("Legacy settle: crediting payee for settlement %s", settlementId)
         creditPort.credit(settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED)
+        val credited = settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED)
+        audit("settlement.credit", credited)
 
         log.infof("Legacy settle: booking settlement %s to ledger", settlementId)
         ledgerPort.book(settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.BOOKED)
+        val booked = settlementRepository.updateStatus(settlementId, SettlementStatus.BOOKED)
+        audit("settlement.ledger-book", booked)
 
         SettlementStatus.BOOKED
     } catch (ex: Exception) {
         log.errorf(ex, "Legacy settle failed for settlement %s; rejecting", settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.REJECTED)
+        val rejected = settlementRepository.updateStatus(settlementId, SettlementStatus.REJECTED)
+        audit("settlement.reject", rejected, result = AuditResult.FAILURE)
         SettlementStatus.REJECTED
+    }
+
+    /**
+     * Publishes an [AuditEvent] for a legacy-path settlement state transition (issue #1502).
+     * `actorId`/`actorType` are `settlement-service`/`SERVICE`: the legacy settle path is itself
+     * server-driven (originated by an authenticated REST call, but the debit/credit/book sequence
+     * that follows carries no per-step caller identity), same convention as the Temporal-activities
+     * audit trail in [com.openbank.settlement.application.workflow.SettlementActivitiesImpl].
+     */
+    private suspend fun audit(operation: String, settlement: Settlement, result: AuditResult = AuditResult.SUCCESS) {
+        auditPublisher.publish(
+            AuditEvent(
+                actorId = "settlement-service",
+                actorType = "SERVICE",
+                operation = operation,
+                resourceType = "settlement",
+                resourceId = settlement.id.toString(),
+                result = result,
+                payload = mapOf(
+                    "status" to settlement.status.name,
+                    "payerAccountId" to settlement.payerAccountId.toString(),
+                    "payeeAccountId" to settlement.payeeAccountId.toString(),
+                    "amount" to settlement.amount.toString(),
+                    "currency" to settlement.currency,
+                ),
+            ),
+        )
     }
 }

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImpl.kt
@@ -4,10 +4,14 @@
 
 package com.openbank.settlement.application.workflow
 
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.asUni
@@ -18,12 +22,23 @@ import kotlinx.coroutines.async
 import org.jboss.logging.Logger
 import java.util.UUID
 
+/**
+ * ADR-0101 P3 settlement saga activities. Each state transition below also emits an [AuditEvent]
+ * onto the shared libs audit pipeline (issue #1502 — settlement-service previously emitted zero
+ * audit events despite governance.yaml claiming a `topic` edge to audit-service, a DORA Art. 17
+ * reconstructability gap for a debit→credit→ledger-booking money-path saga). Mirrors the pattern
+ * `PartyResource` uses in openbank-party-service: inject the libs [AuditEventPublisher] directly
+ * (the `@Default` [com.openbank.libs.audit.LoggingAuditEventPublisher] bean satisfies it — no
+ * Kafka topic/config/gitops wiring required), publish *after* the mutation + status update
+ * succeed so a thrown activity exception (Temporal will retry) never records a false SUCCESS.
+ */
 @ApplicationScoped
 open class SettlementActivitiesImpl(
     private val settlementRepository: SettlementRepository,
     private val debitPort: DebitPort,
     private val creditPort: CreditPort,
     private val ledgerPort: LedgerPort,
+    private val auditPublisher: AuditEventPublisher,
 ) : SettlementActivities {
 
     private val log = Logger.getLogger(SettlementActivitiesImpl::class.java)
@@ -31,21 +46,24 @@ open class SettlementActivitiesImpl(
     override fun debitPayer(settlementId: UUID): Unit = runOnVertxContext {
         log.infof("Debiting payer for settlement %s", settlementId)
         debitPort.debit(settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.DEBITED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.DEBITED)
+        audit("settlement.debit", settlement)
         Unit
     }
 
     override fun creditPayee(settlementId: UUID): Unit = runOnVertxContext {
         log.infof("Crediting payee for settlement %s", settlementId)
         creditPort.credit(settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED)
+        audit("settlement.credit", settlement)
         Unit
     }
 
     override fun bookToLedger(settlementId: UUID): Unit = runOnVertxContext {
         log.infof("Booking settlement %s to ledger", settlementId)
         ledgerPort.book(settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.BOOKED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.BOOKED)
+        audit("settlement.ledger-book", settlement)
         Unit
     }
 
@@ -54,7 +72,8 @@ open class SettlementActivitiesImpl(
             "Reversing debit for settlement %s (compensation — stub: wire reversal to balance-service)",
             settlementId,
         )
-        settlementRepository.updateStatus(settlementId, SettlementStatus.REVERSED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.REVERSED)
+        audit("settlement.reverse-debit", settlement)
         Unit
     }
 
@@ -63,7 +82,8 @@ open class SettlementActivitiesImpl(
             "Reversing credit for settlement %s (compensation — stub: wire reversal to balance-service)",
             settlementId,
         )
-        settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED_REVERSED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.CREDITED_REVERSED)
+        audit("settlement.reverse-credit", settlement)
         Unit
     }
 
@@ -72,14 +92,43 @@ open class SettlementActivitiesImpl(
             "Reversing ledger booking for settlement %s (compensation — stub: wire reversal to ledger-service)",
             settlementId,
         )
-        settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_REVERSED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.LEDGER_REVERSED)
+        audit("settlement.reverse-ledger-book", settlement)
         Unit
     }
 
     override fun rejectSettlement(settlementId: UUID): Unit = runOnVertxContext {
         log.warnf("Rejecting settlement %s after compensation", settlementId)
-        settlementRepository.updateStatus(settlementId, SettlementStatus.REJECTED)
+        val settlement = settlementRepository.updateStatus(settlementId, SettlementStatus.REJECTED)
+        audit("settlement.reject", settlement, result = AuditResult.FAILURE)
         Unit
+    }
+
+    /**
+     * Publishes an [AuditEvent] for a settlement-saga state transition. `actorId`/`actorType` are
+     * `settlement-service`/`SERVICE` (not a JWT subject): Temporal activities run on a worker
+     * thread with no caller identity — the saga itself is the actor, same convention as
+     * party-service's M2M-caller audit entries. Payload carries amount/currency/payer/payee so the
+     * event is reconstructable on its own (Art. 17), without a join back to the settlements table.
+     */
+    private suspend fun audit(operation: String, settlement: Settlement, result: AuditResult = AuditResult.SUCCESS) {
+        auditPublisher.publish(
+            AuditEvent(
+                actorId = "settlement-service",
+                actorType = "SERVICE",
+                operation = operation,
+                resourceType = "settlement",
+                resourceId = settlement.id.toString(),
+                result = result,
+                payload = mapOf(
+                    "status" to settlement.status.name,
+                    "payerAccountId" to settlement.payerAccountId.toString(),
+                    "payeeAccountId" to settlement.payeeAccountId.toString(),
+                    "amount" to settlement.amount.toString(),
+                    "currency" to settlement.currency,
+                ),
+            ),
+        )
     }
 
     /**

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceOriginateTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.settlement.application.usecase
 
+import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.settlement.application.port.`in`.OriginateSettlementCommand
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
@@ -33,8 +34,17 @@ class SettlementServiceOriginateTest {
     private val ledgerPort: LedgerPort = mockk(relaxed = true)
     private val temporalConfig: TemporalConfig = mockk(relaxed = true)
     private val workflowClient: WorkflowClient = mockk(relaxed = true)
+    private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
 
-    private val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+    private val service = SettlementService(
+        repo,
+        debitPort,
+        creditPort,
+        ledgerPort,
+        temporalConfig,
+        workflowClient,
+        auditPublisher,
+    )
 
     @Test
     fun `originate persists a PENDING settlement from the command and starts settlement`() {

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceSettleTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.settlement.application.usecase
 
+import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
@@ -38,6 +39,7 @@ class SettlementServiceSettleTest {
     private val creditPort: CreditPort = mockk(relaxed = true)
     private val ledgerPort: LedgerPort = mockk(relaxed = true)
     private val temporalConfig: TemporalConfig = mockk(relaxed = true)
+    private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
 
     private fun pendingSettlement(id: UUID = UUID.randomUUID()) = Settlement(
         id = id,
@@ -53,7 +55,15 @@ class SettlementServiceSettleTest {
     @Test
     fun `settle throws when the settlement does not exist`() {
         val workflowClient: WorkflowClient = mockk(relaxed = true)
-        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val service = SettlementService(
+            repo,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            temporalConfig,
+            workflowClient,
+            auditPublisher,
+        )
         val id = UUID.randomUUID()
         coEvery { repo.findById(id) } returns null
 
@@ -65,7 +75,15 @@ class SettlementServiceSettleTest {
     @Test
     fun `settle runs the legacy saga and reaches BOOKED when Temporal is disabled`() {
         val workflowClient: WorkflowClient = mockk(relaxed = true)
-        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val service = SettlementService(
+            repo,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            temporalConfig,
+            workflowClient,
+            auditPublisher,
+        )
         val settlement = pendingSettlement()
         coEvery { repo.findById(settlement.id) } returns settlement
         every { temporalConfig.enabled() } returns false
@@ -83,7 +101,15 @@ class SettlementServiceSettleTest {
     @Test
     fun `settle loses the legacy claim race and returns the current status without re-processing`() {
         val workflowClient: WorkflowClient = mockk(relaxed = true)
-        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val service = SettlementService(
+            repo,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            temporalConfig,
+            workflowClient,
+            auditPublisher,
+        )
         val settlement = pendingSettlement().copy(status = SettlementStatus.DEBITED)
         coEvery { repo.findById(settlement.id) } returnsMany listOf(
             settlement.copy(status = SettlementStatus.PENDING),
@@ -101,7 +127,15 @@ class SettlementServiceSettleTest {
     @Test
     fun `settle rejects when the legacy saga throws mid-flight`() {
         val workflowClient: WorkflowClient = mockk(relaxed = true)
-        val service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, workflowClient)
+        val service = SettlementService(
+            repo,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            temporalConfig,
+            workflowClient,
+            auditPublisher,
+        )
         val settlement = pendingSettlement()
         coEvery { repo.findById(settlement.id) } returns settlement
         every { temporalConfig.enabled() } returns false

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/usecase/SettlementServiceTemporalSettleTest.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.settlement.application.usecase
 
+import com.openbank.libs.audit.AuditEventPublisher
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
@@ -40,6 +41,7 @@ class SettlementServiceTemporalSettleTest {
     private val creditPort: CreditPort = mockk(relaxed = true)
     private val ledgerPort: LedgerPort = mockk(relaxed = true)
     private val temporalConfig: TemporalConfig = mockk(relaxed = true)
+    private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
 
     private lateinit var env: TestWorkflowEnvironment
     private lateinit var worker: Worker
@@ -58,7 +60,15 @@ class SettlementServiceTemporalSettleTest {
         env.start()
         every { temporalConfig.enabled() } returns true
         every { temporalConfig.taskQueue() } returns TASK_QUEUE
-        service = SettlementService(repo, debitPort, creditPort, ledgerPort, temporalConfig, env.workflowClient)
+        service = SettlementService(
+            repo,
+            debitPort,
+            creditPort,
+            ledgerPort,
+            temporalConfig,
+            env.workflowClient,
+            auditPublisher,
+        )
     }
 
     @AfterEach

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/application/workflow/SettlementActivitiesImplTest.kt
@@ -4,34 +4,59 @@
 
 package com.openbank.settlement.application.workflow
 
+import com.openbank.libs.audit.AuditEvent
+import com.openbank.libs.audit.AuditEventPublisher
+import com.openbank.libs.audit.AuditResult
 import com.openbank.settlement.application.port.out.CreditPort
 import com.openbank.settlement.application.port.out.DebitPort
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.SettlementRepository
+import com.openbank.settlement.domain.model.Settlement
 import com.openbank.settlement.domain.model.SettlementStatus
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
 import java.util.UUID
 
+/**
+ * Also covers issue #1502: each state transition below must emit an [AuditEvent] onto the shared
+ * libs audit pipeline so settlement-service has a DORA Art. 17 reconstructable audit trail.
+ */
 class SettlementActivitiesImplTest {
 
     private val settlementRepository: SettlementRepository = mockk(relaxed = true)
     private val debitPort: DebitPort = mockk(relaxed = true)
     private val creditPort: CreditPort = mockk(relaxed = true)
     private val ledgerPort: LedgerPort = mockk(relaxed = true)
+    private val auditPublisher: AuditEventPublisher = mockk(relaxed = true)
 
     private lateinit var activities: SettlementActivitiesImpl
+
+    private fun settlement(id: UUID, status: SettlementStatus) = Settlement(
+        id = id,
+        payerAccountId = UUID.randomUUID(),
+        payeeAccountId = UUID.randomUUID(),
+        amount = BigDecimal("10.00"),
+        currency = "CZK",
+        status = status,
+        createdAt = Instant.now(),
+        updatedAt = Instant.now(),
+    )
 
     @BeforeEach
     fun setUp() {
         // TestableActivities overrides runOnVertxContext to run synchronously — the production impl
         // needs a real Vert.x context (VertxContextSupport), which a plain unit test does not have.
-        activities = TestableActivities(settlementRepository, debitPort, creditPort, ledgerPort)
-        coEvery { settlementRepository.updateStatus(any(), any()) } returns mockk()
+        activities = TestableActivities(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher)
+        coEvery { settlementRepository.updateStatus(any(), any()) } answers {
+            settlement(firstArg(), secondArg())
+        }
     }
 
     @Test
@@ -40,6 +65,25 @@ class SettlementActivitiesImplTest {
         activities.debitPayer(id)
         coVerify { debitPort.debit(id) }
         coVerify { settlementRepository.updateStatus(id, SettlementStatus.DEBITED) }
+    }
+
+    @Test
+    fun `debitPayer publishes a settlement_debit audit event`() {
+        val id = UUID.randomUUID()
+        val events = mutableListOf<AuditEvent>()
+        coEvery { auditPublisher.publish(capture(events)) } returns Unit
+
+        activities.debitPayer(id)
+
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.operation).isEqualTo("settlement.debit")
+            assertThat(e.actorId).isEqualTo("settlement-service")
+            assertThat(e.actorType).isEqualTo("SERVICE")
+            assertThat(e.resourceType).isEqualTo("settlement")
+            assertThat(e.resourceId).isEqualTo(id.toString())
+            assertThat(e.result).isEqualTo(AuditResult.SUCCESS)
+            assertThat(e.payload["status"]).isEqualTo("DEBITED")
+        })
     }
 
     @Test
@@ -90,6 +134,21 @@ class SettlementActivitiesImplTest {
         coVerify(exactly = 0) { creditPort.credit(any()) }
         coVerify { settlementRepository.updateStatus(id, SettlementStatus.REJECTED) }
     }
+
+    @Test
+    fun `rejectSettlement publishes a FAILURE settlement_reject audit event`() {
+        val id = UUID.randomUUID()
+        val events = mutableListOf<AuditEvent>()
+        coEvery { auditPublisher.publish(capture(events)) } returns Unit
+
+        activities.rejectSettlement(id)
+
+        assertThat(events).singleElement().satisfies({ e ->
+            assertThat(e.operation).isEqualTo("settlement.reject")
+            assertThat(e.result).isEqualTo(AuditResult.FAILURE)
+            assertThat(e.resourceId).isEqualTo(id.toString())
+        })
+    }
 }
 
 /** Runs the activity bodies synchronously, bypassing the real Vert.x-context bridge. */
@@ -98,6 +157,7 @@ private class TestableActivities(
     debitPort: DebitPort,
     creditPort: CreditPort,
     ledgerPort: LedgerPort,
-) : SettlementActivitiesImpl(settlementRepository, debitPort, creditPort, ledgerPort) {
+    auditPublisher: AuditEventPublisher,
+) : SettlementActivitiesImpl(settlementRepository, debitPort, creditPort, ledgerPort, auditPublisher) {
     override fun <T> runOnVertxContext(block: suspend () -> T): T = runBlocking { block() }
 }


### PR DESCRIPTION
## Summary

`settlement-service`'s `governance.yaml` claims a downstream `topic` edge to
`audit-service` ("emits settlement audit events") that was false: the
service used no `AuditEventPublisher` at all, so its debit→credit→ledger
-booking money-path saga (ADR-0101) produced zero audit trail — a DORA
Art. 17 reconstructability gap (#1502).

Wires the shared `com.openbank.libs.audit.AuditEventPublisher` into both
reachable settlement paths, following the same minimal-diff pattern
`openbank-party-service`'s `PartyResource` already uses: inject the libs
port directly, and the `@Default` `LoggingAuditEventPublisher` bean
satisfies it — no Kafka topic, config key, or gitops change required.

- `SettlementActivitiesImpl` (the Temporal saga activities): `debitPayer`,
  `creditPayee`, `bookToLedger`, `reverseDebit`, `reverseCredit`,
  `reverseBookToLedger`, `rejectSettlement`.
- `SettlementService.runLegacySettle` (the non-Temporal path — still the
  *default* today, since `openbank.temporal.enabled` defaults to `false`):
  the same debit/credit/book/reject transitions.

Each event carries `resourceType=settlement`, `resourceId=<settlementId>`,
and a payload of status/payer/payee/amount/currency, so it's
reconstructable on its own without a join back to the `settlements` table.
Rejections are recorded with `AuditResult.FAILURE`.

## Type of change

- [x] fix
- [ ] feat / perf / refactor / docs / test / chore / build / ci / security / breaking

## Linked issues

Closes #1502

## Money-path review

`settlement-service` is `money_path_services` — this needs 2 approvals.
A threat model already exists at `docs/threat-models/openbank-settlement-service.md`
(T2 already cites "audit trail in `openbank-libs/audit`" as a mitigation —
this PR is what makes that claim true).

## Test plan

- [x] `./gradlew :openbank-settlement-service:ktlintCheck :openbank-settlement-service:detekt :openbank-settlement-service:compileKotlin :openbank-settlement-service:compileTestKotlin` — pass
- [x] `./gradlew :openbank-settlement-service:quarkusBuild -x test` — pass (CDI/ArC wiring of the new `AuditEventPublisher` injection resolves cleanly)
- [x] `./gradlew :openbank-settlement-service:test --tests "...SettlementActivitiesImplTest" --tests "...SettlementServiceSettleTest" --tests "...SettlementServiceOriginateTest" --tests "...SettlementServiceTemporalSettleTest"` — 17 tests, 0 failures
- [x] New tests: `debitPayer publishes a settlement_debit audit event` and `rejectSettlement publishes a FAILURE settlement_reject audit event` (mirrors `PartyResourceAuditTest`'s capture-and-assert pattern)