### PR TITLE
feat(interest): make the CURRENT account interest-bearing too, not just SAVINGS (#1618)

### DIFF
--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -35,7 +35,7 @@ class InterestService(
     private val accountDirectoryPort: AccountDirectoryPort,
     @ConfigProperty(name = "openbank.interest.day-count-convention", defaultValue = "ACT_365")
     private val defaultDayCount: String,
-    @ConfigProperty(name = "openbank.interest.accruable-account-types", defaultValue = "SAVINGS")
+    @ConfigProperty(name = "openbank.interest.accruable-account-types", defaultValue = "CURRENT,SAVINGS")
     private val accruableAccountTypes: String,
     private val clock: Clock,
 ) : AccrueInterestUseCase,
@@ -53,7 +53,7 @@ class InterestService(
         accountDirectoryPort: AccountDirectoryPort,
         @ConfigProperty(name = "openbank.interest.day-count-convention", defaultValue = "ACT_365")
         defaultDayCount: String,
-        @ConfigProperty(name = "openbank.interest.accruable-account-types", defaultValue = "SAVINGS")
+        @ConfigProperty(name = "openbank.interest.accruable-account-types", defaultValue = "CURRENT,SAVINGS")
         accruableAccountTypes: String,
     ) : this(
         configRepo,

--- a/openbank-interest-service/src/main/resources/application.yaml
+++ b/openbank-interest-service/src/main/resources/application.yaml
@@ -165,9 +165,11 @@ openbank:
     accrual-cron: "0 0 1 * * ?"
     capitalization-cron: "0 0 2 1 * ?"
     # Account types the daily accrual run posts interest for (comma-separated, matched against
-    # account-service's accountType). Onboarding opens a SAVINGS account per retail customer; the
-    # CURRENT payment account is non-interest-bearing.
-    accruable-account-types: "SAVINGS"
+    # account-service's accountType). BOTH the everyday CURRENT account and SAVINGS earn interest —
+    # the onboarding balance lands on CURRENT, so interest must apply there or nearly every customer
+    # earns nothing. Each type accrues at its own product's rate (CURRENT 2.5% V10, SAVINGS 4% V9);
+    # an account whose product has no active rate config is simply skipped.
+    accruable-account-types: "CURRENT,SAVINGS"
     day-count-convention: ACT_365
     withholding:
       # #999: the bank's own operating/settlement account debited for the §38d odvod to the

--- a/openbank-interest-service/src/main/resources/db/migration/V10__seed_current_rate_config.sql
+++ b/openbank-interest-service/src/main/resources/db/migration/V10__seed_current_rate_config.sql
@@ -1,0 +1,26 @@
+-- Make the CURRENT (everyday payment) account interest-bearing too, not just SAVINGS.
+--
+-- Why: the onboarding bonus (and every retail customer's working balance) lands on the CURRENT
+-- account (product 00000000-0000-0000-0000-0000000000c2), NOT savings — savings accounts are
+-- opened but sit empty unless the customer moves money there by hand. With interest seeded only on
+-- SAVINGS (V9), virtually every customer earned nothing because their money is on CURRENT. Seeding a
+-- rate for the CURRENT product makes interest apply to the account the customer actually holds a
+-- balance on — systematically, for every current and future account, no per-account backfill.
+--
+-- Two-tier by product, as a real bank would: CURRENT 2.50 % p.a. (an interest-bearing everyday
+-- account), SAVINGS 4.00 % p.a. (the premium product, V9). annual_rate is a DECIMAL FRACTION.
+-- Backdated + NOT EXISTS-guarded, same shape as V9.
+INSERT INTO interest_rate_configs (id, product_id, rate_type, annual_rate, min_balance, day_count, effective_from, active)
+SELECT
+    'a0000000-0000-0000-0000-0000000000c2'::uuid,
+    '00000000-0000-0000-0000-0000000000c2',
+    'FIXED',
+    0.025000,
+    0,
+    'ACT_365',
+    DATE '2025-01-01',
+    TRUE
+WHERE NOT EXISTS (
+    SELECT 1 FROM interest_rate_configs
+    WHERE product_id = '00000000-0000-0000-0000-0000000000c2' AND active = TRUE
+);


### PR DESCRIPTION
**Conceptual fix, not a per-account patch.**

The onboarding balance — and every retail customer's working money — lands on the **CURRENT** account, not SAVINGS. Savings accounts are opened but sit empty unless the customer moves money there by hand. Live data: ~every party has a CURRENT with 100k CZK; only 2 of 9 savings accounts have any balance. So with interest seeded only on SAVINGS (V9), virtually every customer earned **nothing** — their money is on CURRENT.

- **V10** seeds a rate config for the CURRENT product (`…00c2`) at **2.50% p.a.** — a real two-tier structure: CURRENT 2.5% (interest-bearing everyday account), SAVINGS 4% (premium).
- `accruable-account-types` `"SAVINGS"` → `"CURRENT,SAVINGS"` (yaml + code default). Each type accrues at its own product's rate; an account whose product has no active rate is skipped.

Now **every account with a balance — existing and future — accrues automatically** on the account the customer actually holds money on. No backfill, no per-account intervention. The edge route + app card need no change (edge reports `eligible=true` once the product has a rate), so the interest line now shows on the CURRENT/home account too.

## Linked issues

Refs #1618