### PR TITLE
chore(gitops): interest-service -> sandbox-9ea756c6 (CURRENT accounts interest, #1618)

### DIFF
--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -26,7 +26,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: interest-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-06e361d9
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-interest-service:sandbox-9ea756c6
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8125}


### PR DESCRIPTION
Rolls out #1642 — V10 CURRENT product rate (2.5% p.a.) + accruable-account-types CURRENT,SAVINGS. Image built + signed by Auto Deploy Build+push; hand-bump (Auto Deploy gitops step behind runner backlog).

## Linked issues

Refs #1618