### PR TITLE
feat(interest): per-account rate override; CURRENT defaults to zero interest (#1618)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -252,7 +252,7 @@ class CustomerEdgeResource(
             return forbidden("Account does not belong to caller")
         }
         val productId = extractTextField(objectMapper, accountJson, "productId")
-        val annualRate = productId?.let { fetchActiveAnnualRate(it, customer.partyId) }
+        val annualRate = productId?.let { fetchEffectiveAnnualRate(accountId, it, customer.partyId) }
         val out = objectMapper.createObjectNode()
         if (annualRate == null) {
             // No active rate config for this product — not interest-bearing (or interest-service is
@@ -286,17 +286,21 @@ class CustomerEdgeResource(
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
     }
 
-    /** The active annual rate (decimal fraction) for [productId], or null if the product has no
-     *  active interest config or interest-service is unavailable (fail-soft — the caller reports
-     *  ineligible rather than failing the whole request). */
-    private fun fetchActiveAnnualRate(productId: String, partyId: UUID): java.math.BigDecimal? {
-        val resp = upstream.get("$interestServiceUrl/api/v1/interest/rates?productId=$productId", partyId.toString())
+    /** The annual rate (decimal fraction) EFFECTIVE for this account — an account-specific override
+     *  if one is set, else the product default — or null when the account earns no interest (a plain
+     *  CURRENT account, whose product default is deactivated) or interest-service is unavailable
+     *  (fail-soft: the caller reports ineligible rather than failing the whole request). 204 = no
+     *  effective rate. */
+    private fun fetchEffectiveAnnualRate(accountId: UUID, productId: String, partyId: UUID): java.math.BigDecimal? {
+        val resp = upstream.get(
+            "$interestServiceUrl/api/v1/interest/accounts/$accountId/effective-rate?productId=$productId",
+            partyId.toString(),
+        )
         if (resp.status != 200) return null
-        val arr =
-            runCatching { objectMapper.readTree(resp.entity?.toString() ?: return null) }.getOrNull() ?: return null
-        if (!arr.isArray) return null
-        val active = arr.firstOrNull { it.get("active")?.asBoolean(false) == true } ?: return null
-        return active.get("annualRate")?.decimalValue()
+        val node = runCatching {
+            objectMapper.readTree(resp.entity?.toString() ?: return null)
+        }.getOrNull() ?: return null
+        return node.get("annualRate")?.decimalValue()
     }
 
     // --- Currency pockets (ADR-0109) ---

--- a/openbank-interest-service/ktlint-baseline.xml
+++ b/openbank-interest-service/ktlint-baseline.xml
@@ -7,66 +7,19 @@
     <file name="src/main/kotlin/com/openbank/interest/application/port/in/RemitWithholdingUseCase.kt">
         <error line="5" column="9" source="standard:package-name" />
     </file>
-    <file name="src/main/kotlin/com/openbank/interest/application/port/out/InterestOutboxPort.kt">
-        <error line="28" column="43" source="standard:trailing-comma-on-declaration-site" />
-        <error line="42" column="27" source="standard:trailing-comma-on-declaration-site" />
-    </file>
     <file name="src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt">
         <error line="7" column="1" source="standard:no-wildcard-imports" />
         <error line="8" column="1" source="standard:no-wildcard-imports" />
         <error line="9" column="1" source="standard:no-wildcard-imports" />
-        <error line="30" column="40" source="standard:trailing-comma-on-declaration-site" />
-        <error line="31" column="28" source="standard:class-signature" />
-        <error line="31" column="55" source="standard:class-signature" />
-        <error line="31" column="75" source="standard:class-signature" />
-        <error line="33" column="72" source="standard:function-expression-body" />
-        <error line="35" column="26" source="standard:binary-expression-wrapping" />
-        <error line="35" column="33" source="standard:multiline-if-else" />
-        <error line="35" column="58" source="standard:argument-list-wrapping" />
-        <error line="35" column="80" source="standard:argument-list-wrapping" />
-        <error line="35" column="121" source="standard:max-line-length" />
-        <error line="35" column="136" source="standard:argument-list-wrapping" />
-        <error line="35" column="137" source="standard:argument-list-wrapping" />
-        <error line="51" column="48" source="standard:trailing-comma-on-call-site" />
-        <error line="63" column="113" source="standard:function-expression-body" />
-        <error line="65" column="37" source="standard:multiline-if-else" />
-        <error line="79" column="88" source="standard:trailing-comma-on-call-site" />
-        <error line="86" column="104" source="standard:trailing-comma-on-call-site" />
-        <error line="103" column="36" source="standard:trailing-comma-on-declaration-site" />
-        <error line="117" column="30" source="standard:trailing-comma-on-call-site" />
-        <error line="134" column="34" source="standard:argument-list-wrapping" />
-        <error line="134" column="47" source="standard:argument-list-wrapping" />
-        <error line="134" column="75" source="standard:trailing-comma-on-call-site" />
-        <error line="145" column="71" source="standard:function-signature" />
-        <error line="147" column="33" source="standard:multiline-if-else" />
-        <error line="148" column="18" source="standard:multiline-if-else" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceService.kt">
-        <error line="28" column="49" source="standard:trailing-comma-on-declaration-site" />
-        <error line="65" column="30" source="standard:trailing-comma-on-call-site" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/domain/model/InterestModels.kt">
-        <error line="28" column="57" source="standard:trailing-comma-on-declaration-site" />
-        <error line="43" column="57" source="standard:trailing-comma-on-declaration-site" />
-        <error line="66" column="57" source="standard:trailing-comma-on-declaration-site" />
-        <error line="74" column="49" source="standard:trailing-comma-on-declaration-site" />
-        <error line="83" column="26" source="standard:trailing-comma-on-declaration-site" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/domain/tax/WithholdingRemittance.kt">
         <error line="23" column="12" source="standard:trailing-comma-on-declaration-site" />
-        <error line="46" column="57" source="standard:trailing-comma-on-declaration-site" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/domain/tax/WithholdingRemittancePolicy.kt">
-        <error line="9" column="1" source="standard:no-unused-imports" />
-        <error line="43" column="62" source="standard:function-signature" />
-        <error line="60" column="54" source="standard:trailing-comma-on-call-site" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/domain/tax/WithholdingTaxModels.kt">
         <error line="31" column="16" source="standard:trailing-comma-on-declaration-site" />
         <error line="55" column="35" source="standard:trailing-comma-on-declaration-site" />
         <error line="76" column="35" source="standard:trailing-comma-on-declaration-site" />
         <error line="91" column="13" source="standard:trailing-comma-on-declaration-site" />
-        <error line="118" column="57" source="standard:trailing-comma-on-declaration-site" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/domain/tax/WithholdingTaxPolicy.kt">
         <error line="48" column="54" source="standard:trailing-comma-on-declaration-site" />
@@ -83,13 +36,6 @@
         <error line="35" column="5" source="standard:class-signature" />
         <error line="35" column="80" source="standard:class-signature" />
     </file>
-    <file name="src/main/kotlin/com/openbank/interest/infrastructure/outbox/InterestOutboxBacklogGauge.kt">
-        <error line="44" column="31" source="standard:function-signature" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/infrastructure/outbox/InterestOutboxDispatcher.kt">
-        <error line="38" column="65" source="standard:trailing-comma-on-call-site" />
-        <error line="40" column="46" source="standard:function-signature" />
-    </file>
     <file name="src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt">
         <error line="7" column="1" source="standard:no-wildcard-imports" />
         <error line="12" column="1" source="standard:no-wildcard-imports" />
@@ -99,466 +45,164 @@
         <error line="21" column="1" source="standard:spacing-between-declarations-with-annotations" />
         <error line="21" column="33" source="standard:annotation" />
         <error line="22" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="22" column="32" source="standard:annotation" />
-        <error line="22" column="61" source="standard:annotation" />
-        <error line="23" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="23" column="61" source="standard:annotation" />
+        <error line="22" column="5" source="standard:spacing-between-declarations-with-comments" />
+        <error line="23" column="60" source="standard:annotation" />
         <error line="24" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="24" column="32" source="standard:annotation" />
         <error line="24" column="61" source="standard:annotation" />
         <error line="25" column="1" source="standard:spacing-between-declarations-with-annotations" />
         <error line="25" column="61" source="standard:annotation" />
         <error line="26" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="26" column="32" source="standard:annotation" />
         <error line="26" column="61" source="standard:annotation" />
         <error line="27" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="27" column="37" source="standard:annotation" />
+        <error line="27" column="61" source="standard:annotation" />
         <error line="28" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="28" column="35" source="standard:annotation" />
+        <error line="28" column="32" source="standard:annotation" />
+        <error line="28" column="61" source="standard:annotation" />
         <error line="29" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="29" column="29" source="standard:annotation" />
+        <error line="29" column="37" source="standard:annotation" />
         <error line="30" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="30" column="33" source="standard:annotation" />
+        <error line="30" column="35" source="standard:annotation" />
         <error line="31" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="31" column="33" source="standard:annotation" />
-        <error line="34" column="8" source="standard:annotation" />
+        <error line="31" column="29" source="standard:annotation" />
+        <error line="32" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="32" column="33" source="standard:annotation" />
+        <error line="33" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="33" column="33" source="standard:annotation" />
         <error line="36" column="8" source="standard:annotation" />
-        <error line="36" column="43" source="standard:annotation" />
-        <error line="37" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="37" column="60" source="standard:annotation" />
-        <error line="38" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="38" column="33" source="standard:annotation" />
+        <error line="38" column="8" source="standard:annotation" />
+        <error line="38" column="43" source="standard:annotation" />
         <error line="39" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="39" column="59" source="standard:annotation" />
+        <error line="39" column="60" source="standard:annotation" />
         <error line="40" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="40" column="35" source="standard:annotation" />
+        <error line="40" column="33" source="standard:annotation" />
         <error line="41" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="41" column="57" source="standard:annotation" />
+        <error line="41" column="59" source="standard:annotation" />
         <error line="42" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="42" column="61" source="standard:annotation" />
+        <error line="42" column="35" source="standard:annotation" />
         <error line="43" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="43" column="64" source="standard:annotation" />
+        <error line="43" column="57" source="standard:annotation" />
         <error line="44" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="44" column="43" source="standard:annotation" />
+        <error line="44" column="61" source="standard:annotation" />
         <error line="45" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="45" column="29" source="standard:annotation" />
-        <error line="45" column="58" source="standard:annotation" />
+        <error line="45" column="64" source="standard:annotation" />
         <error line="46" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="46" column="40" source="standard:annotation" />
+        <error line="46" column="43" source="standard:annotation" />
         <error line="47" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="47" column="37" source="standard:annotation" />
+        <error line="47" column="29" source="standard:annotation" />
+        <error line="47" column="58" source="standard:annotation" />
         <error line="48" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="48" column="33" source="standard:annotation" />
-        <error line="51" column="8" source="standard:annotation" />
+        <error line="48" column="40" source="standard:annotation" />
+        <error line="49" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="49" column="37" source="standard:annotation" />
+        <error line="50" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="50" column="33" source="standard:annotation" />
         <error line="53" column="8" source="standard:annotation" />
-        <error line="53" column="43" source="standard:annotation" />
-        <error line="54" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="54" column="60" source="standard:annotation" />
-        <error line="55" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="55" column="33" source="standard:annotation" />
+        <error line="55" column="8" source="standard:annotation" />
+        <error line="55" column="43" source="standard:annotation" />
         <error line="56" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="56" column="34" source="standard:annotation" />
+        <error line="56" column="60" source="standard:annotation" />
         <error line="57" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="57" column="32" source="standard:annotation" />
+        <error line="57" column="33" source="standard:annotation" />
         <error line="58" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="58" column="63" source="standard:annotation" />
+        <error line="58" column="34" source="standard:annotation" />
         <error line="59" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="59" column="68" source="standard:annotation" />
+        <error line="59" column="32" source="standard:annotation" />
         <error line="60" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="60" column="62" source="standard:annotation" />
+        <error line="60" column="63" source="standard:annotation" />
         <error line="61" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="61" column="60" source="standard:annotation" />
+        <error line="61" column="68" source="standard:annotation" />
         <error line="62" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="62" column="60" source="standard:annotation" />
+        <error line="62" column="62" source="standard:annotation" />
         <error line="63" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="63" column="43" source="standard:annotation" />
+        <error line="63" column="60" source="standard:annotation" />
         <error line="64" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="64" column="65" source="standard:annotation" />
+        <error line="64" column="60" source="standard:annotation" />
         <error line="65" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="65" column="33" source="standard:annotation" />
-        <error line="68" column="8" source="standard:annotation" />
+        <error line="65" column="43" source="standard:annotation" />
+        <error line="66" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="66" column="65" source="standard:annotation" />
+        <error line="67" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="67" column="33" source="standard:annotation" />
         <error line="70" column="8" source="standard:annotation" />
-        <error line="70" column="43" source="standard:annotation" />
-        <error line="71" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="71" column="67" source="standard:annotation" />
-        <error line="72" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="72" column="60" source="standard:annotation" />
+        <error line="72" column="8" source="standard:annotation" />
+        <error line="72" column="43" source="standard:annotation" />
         <error line="73" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="73" column="32" source="standard:annotation" />
+        <error line="73" column="67" source="standard:annotation" />
         <error line="74" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="74" column="34" source="standard:annotation" />
+        <error line="74" column="60" source="standard:annotation" />
         <error line="75" column="1" source="standard:spacing-between-declarations-with-annotations" />
         <error line="75" column="32" source="standard:annotation" />
         <error line="76" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="76" column="62" source="standard:annotation" />
+        <error line="76" column="34" source="standard:annotation" />
         <error line="77" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="77" column="53" source="standard:annotation" />
+        <error line="77" column="32" source="standard:annotation" />
         <error line="78" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="78" column="60" source="standard:annotation" />
+        <error line="78" column="62" source="standard:annotation" />
         <error line="79" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="79" column="43" source="standard:annotation" />
+        <error line="79" column="53" source="standard:annotation" />
         <error line="80" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="80" column="13" source="standard:argument-list-wrapping" />
-        <error line="80" column="31" source="standard:argument-list-wrapping" />
-        <error line="80" column="32" source="standard:annotation" />
-        <error line="80" column="45" source="standard:argument-list-wrapping" />
-        <error line="80" column="60" source="standard:argument-list-wrapping" />
-        <error line="80" column="61" source="standard:annotation" />
-        <error line="80" column="121" source="standard:max-line-length" />
+        <error line="80" column="60" source="standard:annotation" />
         <error line="81" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="81" column="34" source="standard:annotation" />
+        <error line="81" column="43" source="standard:annotation" />
         <error line="82" column="1" source="standard:spacing-between-declarations-with-annotations" />
         <error line="82" column="13" source="standard:argument-list-wrapping" />
-        <error line="82" column="28" source="standard:argument-list-wrapping" />
-        <error line="82" column="29" source="standard:annotation" />
-        <error line="82" column="42" source="standard:argument-list-wrapping" />
-        <error line="82" column="57" source="standard:argument-list-wrapping" />
-        <error line="82" column="58" source="standard:annotation" />
+        <error line="82" column="31" source="standard:argument-list-wrapping" />
+        <error line="82" column="32" source="standard:annotation" />
+        <error line="82" column="45" source="standard:argument-list-wrapping" />
+        <error line="82" column="60" source="standard:argument-list-wrapping" />
+        <error line="82" column="61" source="standard:annotation" />
         <error line="82" column="121" source="standard:max-line-length" />
         <error line="83" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="83" column="63" source="standard:annotation" />
+        <error line="83" column="34" source="standard:annotation" />
         <error line="84" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="84" column="33" source="standard:annotation" />
-        <error line="87" column="8" source="standard:annotation" />
+        <error line="84" column="13" source="standard:argument-list-wrapping" />
+        <error line="84" column="28" source="standard:argument-list-wrapping" />
+        <error line="84" column="29" source="standard:annotation" />
+        <error line="84" column="42" source="standard:argument-list-wrapping" />
+        <error line="84" column="57" source="standard:argument-list-wrapping" />
+        <error line="84" column="58" source="standard:annotation" />
+        <error line="84" column="121" source="standard:max-line-length" />
+        <error line="85" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="85" column="63" source="standard:annotation" />
+        <error line="86" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="86" column="33" source="standard:annotation" />
         <error line="89" column="8" source="standard:annotation" />
-        <error line="89" column="43" source="standard:annotation" />
-        <error line="90" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="90" column="34" source="standard:annotation" />
-        <error line="91" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="91" column="35" source="standard:annotation" />
+        <error line="91" column="8" source="standard:annotation" />
+        <error line="91" column="43" source="standard:annotation" />
         <error line="92" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="92" column="32" source="standard:annotation" />
+        <error line="92" column="34" source="standard:annotation" />
         <error line="93" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="93" column="43" source="standard:annotation" />
+        <error line="93" column="35" source="standard:annotation" />
         <error line="94" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="94" column="66" source="standard:annotation" />
+        <error line="94" column="32" source="standard:annotation" />
         <error line="95" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="95" column="33" source="standard:annotation" />
+        <error line="95" column="43" source="standard:annotation" />
         <error line="96" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="96" column="31" source="standard:annotation" />
+        <error line="96" column="66" source="standard:annotation" />
         <error line="97" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="97" column="13" source="standard:argument-list-wrapping" />
-        <error line="97" column="28" source="standard:argument-list-wrapping" />
-        <error line="97" column="29" source="standard:annotation" />
-        <error line="97" column="42" source="standard:argument-list-wrapping" />
-        <error line="97" column="57" source="standard:argument-list-wrapping" />
-        <error line="97" column="58" source="standard:annotation" />
-        <error line="97" column="121" source="standard:max-line-length" />
+        <error line="97" column="33" source="standard:annotation" />
         <error line="98" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="98" column="33" source="standard:annotation" />
+        <error line="98" column="31" source="standard:annotation" />
+        <error line="99" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="99" column="13" source="standard:argument-list-wrapping" />
+        <error line="99" column="28" source="standard:argument-list-wrapping" />
+        <error line="99" column="29" source="standard:annotation" />
+        <error line="99" column="42" source="standard:argument-list-wrapping" />
+        <error line="99" column="57" source="standard:argument-list-wrapping" />
+        <error line="99" column="58" source="standard:annotation" />
+        <error line="99" column="121" source="standard:max-line-length" />
+        <error line="100" column="1" source="standard:spacing-between-declarations-with-annotations" />
+        <error line="100" column="33" source="standard:annotation" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/infrastructure/persistence/mapper/InterestMapper.kt">
         <error line="7" column="1" source="standard:no-wildcard-imports" />
         <error line="10" column="1" source="standard:no-wildcard-imports" />
-        <error line="16" column="22" source="standard:statement-wrapping" />
-        <error line="16" column="50" source="standard:statement-wrapping" />
-        <error line="17" column="38" source="standard:statement-wrapping" />
-        <error line="17" column="68" source="standard:statement-wrapping" />
-        <error line="18" column="34" source="standard:statement-wrapping" />
-        <error line="18" column="70" source="standard:statement-wrapping" />
-        <error line="19" column="30" source="standard:statement-wrapping" />
-        <error line="19" column="58" source="standard:statement-wrapping" />
-        <error line="25" column="76" source="standard:trailing-comma-on-call-site" />
-        <error line="28" column="22" source="standard:statement-wrapping" />
-        <error line="28" column="50" source="standard:statement-wrapping" />
-        <error line="29" column="34" source="standard:statement-wrapping" />
-        <error line="29" column="66" source="standard:statement-wrapping" />
-        <error line="30" column="36" source="standard:statement-wrapping" />
-        <error line="30" column="72" source="standard:statement-wrapping" />
-        <error line="31" column="30" source="standard:statement-wrapping" />
-        <error line="31" column="66" source="standard:statement-wrapping" />
-        <error line="37" column="84" source="standard:trailing-comma-on-call-site" />
-        <error line="40" column="22" source="standard:statement-wrapping" />
-        <error line="40" column="50" source="standard:statement-wrapping" />
-        <error line="41" column="38" source="standard:statement-wrapping" />
-        <error line="41" column="64" source="standard:statement-wrapping" />
-        <error line="42" column="52" source="standard:statement-wrapping" />
-        <error line="43" column="36" source="standard:statement-wrapping" />
-        <error line="43" column="64" source="standard:statement-wrapping" />
-        <error line="44" column="44" source="standard:statement-wrapping" />
-        <error line="51" column="65" source="standard:trailing-comma-on-call-site" />
-        <error line="54" column="22" source="standard:statement-wrapping" />
-        <error line="54" column="64" source="standard:statement-wrapping" />
-        <error line="55" column="34" source="standard:statement-wrapping" />
-        <error line="55" column="64" source="standard:statement-wrapping" />
-        <error line="56" column="40" source="standard:statement-wrapping" />
-        <error line="56" column="58" source="standard:statement-wrapping" />
-        <error line="57" column="34" source="standard:statement-wrapping" />
-        <error line="57" column="62" source="standard:statement-wrapping" />
-        <error line="58" column="30" source="standard:statement-wrapping" />
-        <error line="58" column="64" source="standard:statement-wrapping" />
-        <error line="65" column="82" source="standard:trailing-comma-on-call-site" />
-        <error line="68" column="22" source="standard:statement-wrapping" />
-        <error line="68" column="52" source="standard:statement-wrapping" />
-        <error line="69" column="36" source="standard:statement-wrapping" />
-        <error line="69" column="62" source="standard:statement-wrapping" />
-        <error line="70" column="36" source="standard:statement-wrapping" />
-        <error line="70" column="60" source="standard:statement-wrapping" />
-        <error line="77" column="62" source="standard:trailing-comma-on-call-site" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestOutboxRepositoryImpl.kt">
-        <error line="6" column="1" source="standard:import-ordering" />
-        <error line="21" column="38" source="standard:class-signature" />
-        <error line="21" column="64" source="standard:class-signature" />
-        <error line="23" column="63" source="standard:function-signature" />
-        <error line="26" column="82" source="standard:function-signature" />
-        <error line="31" column="49" source="standard:trailing-comma-on-call-site" />
-        <error line="35" column="52" source="standard:function-signature" />
-        <error line="83" column="30" source="standard:trailing-comma-on-call-site" />
-        <error line="86" column="73" source="standard:function-signature" />
-        <error line="91" column="49" source="standard:trailing-comma-on-call-site" />
-        <error line="100" column="43" source="standard:function-signature" />
-        <error line="105" column="49" source="standard:trailing-comma-on-call-site" />
-        <error line="109" column="48" source="standard:function-signature" />
-        <error line="122" column="65" source="standard:function-signature" />
-        <error line="146" column="28" source="standard:argument-list-wrapping" />
-        <error line="146" column="43" source="standard:argument-list-wrapping" />
-        <error line="146" column="56" source="standard:argument-list-wrapping" />
-        <error line="146" column="72" source="standard:argument-list-wrapping" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt">
         <error line="7" column="1" source="standard:no-wildcard-imports" />
         <error line="8" column="1" source="standard:no-wildcard-imports" />
         <error line="10" column="1" source="standard:no-wildcard-imports" />
-        <error line="28" column="44" source="standard:parameter-list-wrapping" />
-        <error line="28" column="44" source="standard:class-signature" />
-        <error line="28" column="78" source="standard:trailing-comma-on-declaration-site" />
-        <error line="34" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="36" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="37" column="29" source="standard:function-literal" />
-        <error line="37" column="45" source="standard:argument-list-wrapping" />
-        <error line="37" column="121" source="standard:max-line-length" />
-        <error line="37" column="127" source="standard:argument-list-wrapping" />
-        <error line="37" column="163" source="standard:argument-list-wrapping" />
-        <error line="37" column="178" source="standard:argument-list-wrapping" />
-        <error line="37" column="183" source="standard:argument-list-wrapping" />
-        <error line="37" column="192" source="standard:argument-list-wrapping" />
-        <error line="37" column="205" source="standard:function-literal" />
-        <error line="37" column="211" source="standard:function-literal" />
-        <error line="37" column="212" source="standard:wrapping" />
-        <error line="37" column="220" source="standard:argument-list-wrapping" />
-        <error line="37" column="236" source="standard:argument-list-wrapping" />
-        <error line="37" column="238" source="standard:function-literal" />
-        <error line="38" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="39" column="29" source="standard:function-literal" />
-        <error line="39" column="45" source="standard:argument-list-wrapping" />
-        <error line="39" column="117" source="standard:argument-list-wrapping" />
-        <error line="39" column="121" source="standard:max-line-length" />
-        <error line="39" column="153" source="standard:argument-list-wrapping" />
-        <error line="39" column="166" source="standard:function-literal" />
-        <error line="39" column="172" source="standard:function-literal" />
-        <error line="39" column="173" source="standard:wrapping" />
-        <error line="39" column="181" source="standard:argument-list-wrapping" />
-        <error line="39" column="197" source="standard:argument-list-wrapping" />
-        <error line="39" column="199" source="standard:function-literal" />
-        <error line="40" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="41" column="29" source="standard:function-literal" />
-        <error line="41" column="45" source="standard:argument-list-wrapping" />
-        <error line="41" column="121" source="standard:max-line-length" />
-        <error line="41" column="216" source="standard:argument-list-wrapping" />
-        <error line="41" column="252" source="standard:argument-list-wrapping" />
-        <error line="41" column="267" source="standard:argument-list-wrapping" />
-        <error line="41" column="272" source="standard:argument-list-wrapping" />
-        <error line="41" column="281" source="standard:argument-list-wrapping" />
-        <error line="41" column="296" source="standard:argument-list-wrapping" />
-        <error line="41" column="301" source="standard:argument-list-wrapping" />
-        <error line="41" column="305" source="standard:argument-list-wrapping" />
-        <error line="41" column="321" source="standard:argument-list-wrapping" />
-        <error line="41" column="322" source="standard:argument-list-wrapping" />
-        <error line="41" column="343" source="standard:function-literal" />
-        <error line="41" column="349" source="standard:function-literal" />
-        <error line="41" column="350" source="standard:wrapping" />
-        <error line="41" column="359" source="standard:argument-list-wrapping" />
-        <error line="41" column="375" source="standard:argument-list-wrapping" />
-        <error line="41" column="377" source="standard:function-literal" />
-        <error line="42" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="43" column="33" source="standard:function-literal" />
-        <error line="43" column="42" source="standard:argument-list-wrapping" />
-        <error line="43" column="80" source="standard:argument-list-wrapping" />
-        <error line="43" column="89" source="standard:argument-list-wrapping" />
-        <error line="43" column="104" source="standard:function-literal" />
-        <error line="43" column="106" source="standard:statement-wrapping" />
-        <error line="43" column="118" source="standard:binary-expression-wrapping" />
-        <error line="43" column="121" source="standard:max-line-length" />
-        <error line="43" column="133" source="standard:statement-wrapping" />
-        <error line="43" column="147" source="standard:binary-expression-wrapping" />
-        <error line="43" column="165" source="standard:statement-wrapping" />
-        <error line="43" column="176" source="standard:argument-list-wrapping" />
-        <error line="43" column="177" source="standard:argument-list-wrapping" />
-        <error line="43" column="183" source="standard:function-literal" />
-        <error line="43" column="184" source="standard:wrapping" />
-        <error line="43" column="201" source="standard:argument-list-wrapping" />
-        <error line="43" column="202" source="standard:argument-list-wrapping" />
-        <error line="43" column="204" source="standard:function-literal" />
-        <error line="43" column="206" source="standard:statement-wrapping" />
-        <error line="43" column="206" source="standard:function-literal" />
-        <error line="43" column="208" source="standard:function-literal" />
-        <error line="48" column="44" source="standard:parameter-list-wrapping" />
-        <error line="48" column="44" source="standard:class-signature" />
-        <error line="48" column="78" source="standard:trailing-comma-on-declaration-site" />
-        <error line="54" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="54" column="70" source="standard:function-signature" />
-        <error line="56" column="27" source="standard:argument-list-wrapping" />
-        <error line="56" column="99" source="standard:argument-list-wrapping" />
-        <error line="56" column="121" source="standard:max-line-length" />
-        <error line="56" column="132" source="standard:argument-list-wrapping" />
-        <error line="58" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="58" column="47" source="standard:parameter-list-wrapping" />
-        <error line="58" column="64" source="standard:parameter-list-wrapping" />
-        <error line="58" column="82" source="standard:parameter-list-wrapping" />
-        <error line="58" column="96" source="standard:parameter-list-wrapping" />
-        <error line="58" column="121" source="standard:max-line-length" />
-        <error line="60" column="13" source="standard:multiline-if-else" />
-        <error line="60" column="33" source="standard:function-literal" />
-        <error line="60" column="49" source="standard:argument-list-wrapping" />
-        <error line="60" column="121" source="standard:max-line-length" />
-        <error line="60" column="170" source="standard:argument-list-wrapping" />
-        <error line="60" column="203" source="standard:argument-list-wrapping" />
-        <error line="60" column="218" source="standard:argument-list-wrapping" />
-        <error line="60" column="223" source="standard:argument-list-wrapping" />
-        <error line="60" column="232" source="standard:argument-list-wrapping" />
-        <error line="60" column="247" source="standard:argument-list-wrapping" />
-        <error line="60" column="252" source="standard:argument-list-wrapping" />
-        <error line="60" column="256" source="standard:argument-list-wrapping" />
-        <error line="60" column="271" source="standard:argument-list-wrapping" />
-        <error line="60" column="276" source="standard:argument-list-wrapping" />
-        <error line="60" column="278" source="standard:argument-list-wrapping" />
-        <error line="60" column="291" source="standard:function-literal" />
-        <error line="62" column="13" source="standard:multiline-if-else" />
-        <error line="62" column="33" source="standard:function-literal" />
-        <error line="62" column="49" source="standard:argument-list-wrapping" />
-        <error line="62" column="121" source="standard:max-line-length" />
-        <error line="62" column="126" source="standard:argument-list-wrapping" />
-        <error line="62" column="159" source="standard:argument-list-wrapping" />
-        <error line="62" column="174" source="standard:argument-list-wrapping" />
-        <error line="62" column="179" source="standard:argument-list-wrapping" />
-        <error line="62" column="188" source="standard:argument-list-wrapping" />
-        <error line="62" column="201" source="standard:function-literal" />
-        <error line="65" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="65" column="57" source="standard:parameter-list-wrapping" />
-        <error line="65" column="57" source="standard:function-signature" />
-        <error line="65" column="74" source="standard:parameter-list-wrapping" />
-        <error line="65" column="74" source="standard:function-signature" />
-        <error line="65" column="93" source="standard:parameter-list-wrapping" />
-        <error line="65" column="93" source="standard:function-signature" />
-        <error line="65" column="110" source="standard:parameter-list-wrapping" />
-        <error line="65" column="110" source="standard:function-signature" />
-        <error line="65" column="121" source="standard:max-line-length" />
-        <error line="66" column="29" source="standard:function-literal" />
-        <error line="66" column="45" source="standard:argument-list-wrapping" />
-        <error line="66" column="121" source="standard:max-line-length" />
-        <error line="66" column="186" source="standard:argument-list-wrapping" />
-        <error line="66" column="219" source="standard:argument-list-wrapping" />
-        <error line="66" column="234" source="standard:argument-list-wrapping" />
-        <error line="66" column="239" source="standard:argument-list-wrapping" />
-        <error line="66" column="248" source="standard:argument-list-wrapping" />
-        <error line="66" column="263" source="standard:argument-list-wrapping" />
-        <error line="66" column="268" source="standard:argument-list-wrapping" />
-        <error line="66" column="277" source="standard:argument-list-wrapping" />
-        <error line="66" column="292" source="standard:argument-list-wrapping" />
-        <error line="66" column="297" source="standard:argument-list-wrapping" />
-        <error line="66" column="303" source="standard:argument-list-wrapping" />
-        <error line="66" column="316" source="standard:function-literal" />
-        <error line="66" column="322" source="standard:function-literal" />
-        <error line="66" column="323" source="standard:wrapping" />
-        <error line="66" column="331" source="standard:argument-list-wrapping" />
-        <error line="66" column="347" source="standard:argument-list-wrapping" />
-        <error line="66" column="349" source="standard:function-literal" />
-        <error line="67" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="68" column="29" source="standard:function-literal" />
-        <error line="68" column="45" source="standard:argument-list-wrapping" />
-        <error line="68" column="121" source="standard:max-line-length" />
-        <error line="68" column="203" source="standard:argument-list-wrapping" />
-        <error line="68" column="225" source="standard:argument-list-wrapping" />
-        <error line="68" column="240" source="standard:argument-list-wrapping" />
-        <error line="68" column="245" source="standard:argument-list-wrapping" />
-        <error line="68" column="254" source="standard:argument-list-wrapping" />
-        <error line="68" column="269" source="standard:argument-list-wrapping" />
-        <error line="68" column="274" source="standard:argument-list-wrapping" />
-        <error line="68" column="278" source="standard:argument-list-wrapping" />
-        <error line="68" column="293" source="standard:argument-list-wrapping" />
-        <error line="68" column="298" source="standard:argument-list-wrapping" />
-        <error line="68" column="300" source="standard:argument-list-wrapping" />
-        <error line="68" column="315" source="standard:function-literal" />
-        <error line="73" column="44" source="standard:parameter-list-wrapping" />
-        <error line="73" column="44" source="standard:class-signature" />
-        <error line="73" column="80" source="standard:parameter-list-wrapping" />
-        <error line="73" column="80" source="standard:class-signature" />
-        <error line="73" column="104" source="standard:trailing-comma-on-declaration-site" />
-        <error line="79" column="1" source="standard:spacing-between-declarations-with-annotations" />
-        <error line="80" column="29" source="standard:function-literal" />
-        <error line="80" column="45" source="standard:argument-list-wrapping" />
-        <error line="80" column="121" source="standard:max-line-length" />
-        <error line="80" column="127" source="standard:argument-list-wrapping" />
-        <error line="80" column="167" source="standard:argument-list-wrapping" />
-        <error line="80" column="182" source="standard:argument-list-wrapping" />
-        <error line="80" column="187" source="standard:argument-list-wrapping" />
-        <error line="80" column="196" source="standard:argument-list-wrapping" />
-        <error line="80" column="209" source="standard:function-literal" />
-        <error line="80" column="215" source="standard:function-literal" />
-        <error line="80" column="216" source="standard:wrapping" />
-        <error line="80" column="224" source="standard:argument-list-wrapping" />
-        <error line="80" column="240" source="standard:argument-list-wrapping" />
-        <error line="80" column="242" source="standard:function-literal" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/WithholdingTaxRepositoryImpl.kt">
-        <error line="31" column="44" source="standard:parameter-list-wrapping" />
-        <error line="31" column="44" source="standard:class-signature" />
-        <error line="31" column="78" source="standard:trailing-comma-on-declaration-site" />
-        <error line="39" column="92" source="standard:function-signature" />
-        <error line="43" column="49" source="standard:trailing-comma-on-call-site" />
-        <error line="47" column="101" source="standard:function-signature" />
-        <error line="51" column="49" source="standard:trailing-comma-on-call-site" />
-        <error line="59" column="49" source="standard:trailing-comma-on-call-site" />
-        <error line="68" column="99" source="standard:trailing-comma-on-call-site" />
-        <error line="77" column="44" source="standard:parameter-list-wrapping" />
-        <error line="77" column="44" source="standard:class-signature" />
-        <error line="77" column="78" source="standard:trailing-comma-on-declaration-site" />
-        <error line="85" column="97" source="standard:function-signature" />
-        <error line="89" column="56" source="standard:trailing-comma-on-call-site" />
-        <error line="93" column="76" source="standard:function-signature" />
-        <error line="97" column="56" source="standard:trailing-comma-on-call-site" />
-        <error line="104" column="5" source="standard:class-signature" />
-        <error line="104" column="42" source="standard:class-signature" />
-        <error line="104" column="42" source="standard:trailing-comma-on-declaration-site" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt">
-        <error line="7" column="1" source="standard:no-wildcard-imports" />
-        <error line="8" column="1" source="standard:no-wildcard-imports" />
-        <error line="12" column="1" source="standard:no-wildcard-imports" />
-        <error line="29" column="59" source="standard:trailing-comma-on-declaration-site" />
-        <error line="31" column="9" source="standard:annotation" />
-        <error line="33" column="28" source="standard:function-signature" />
-        <error line="43" column="10" source="standard:annotation" />
-        <error line="46" column="57" source="standard:function-signature" />
-        <error line="51" column="10" source="standard:annotation" />
-        <error line="58" column="10" source="standard:annotation" />
-        <error line="64" column="46" source="standard:trailing-comma-on-declaration-site" />
-        <error line="70" column="9" source="standard:annotation" />
-        <error line="75" column="38" source="standard:trailing-comma-on-declaration-site" />
-        <error line="79" column="9" source="standard:annotation" />
-        <error line="84" column="55" source="standard:trailing-comma-on-declaration-site" />
-        <error line="91" column="9" source="standard:annotation" />
-        <error line="96" column="10" source="standard:annotation" />
-        <error line="99" column="70" source="standard:function-signature" />
-        <error line="103" column="9" source="standard:annotation" />
-        <error line="108" column="9" source="standard:annotation" />
-        <error line="110" column="66" source="standard:function-signature" />
-        <error line="114" column="12" source="standard:annotation" />
-        <error line="117" column="73" source="standard:function-signature" />
-    </file>
-    <file name="src/main/kotlin/com/openbank/interest/infrastructure/rest/WithholdingRemittanceResource.kt">
-        <error line="30" column="5" source="standard:class-signature" />
-        <error line="30" column="54" source="standard:class-signature" />
-        <error line="30" column="54" source="standard:trailing-comma-on-declaration-site" />
-        <error line="36" column="9" source="standard:function-signature" />
-        <error line="37" column="9" source="standard:function-signature" />
-        <error line="37" column="40" source="standard:function-signature" />
-        <error line="37" column="40" source="standard:trailing-comma-on-declaration-site" />
-        <error line="47" column="9" source="standard:annotation" />
-        <error line="50" column="9" source="standard:function-signature" />
-        <error line="51" column="9" source="standard:function-signature" />
-        <error line="51" column="39" source="standard:function-signature" />
-        <error line="51" column="39" source="standard:trailing-comma-on-declaration-site" />
     </file>
     <file name="src/main/kotlin/com/openbank/interest/infrastructure/rest/dto/InterestDtos.kt">
         <error line="22" column="30" source="standard:trailing-comma-on-declaration-site" />
@@ -570,135 +214,6 @@
     <file name="src/test/kotlin/com/openbank/governance/HibernateSequenceGuardTest.kt">
         <error line="54" column="33" source="standard:trailing-comma-on-call-site" />
         <error line="68" column="36" source="standard:trailing-comma-on-call-site" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt">
-        <error line="47" column="21" source="standard:argument-list-wrapping" />
-        <error line="47" column="34" source="standard:argument-list-wrapping" />
-        <error line="48" column="25" source="standard:argument-list-wrapping" />
-        <error line="48" column="45" source="standard:argument-list-wrapping" />
-        <error line="48" column="58" source="standard:argument-list-wrapping" />
-        <error line="48" column="67" source="standard:trailing-comma-on-call-site" />
-        <error line="65" column="52" source="standard:trailing-comma-on-call-site" />
-        <error line="70" column="15" source="standard:function-literal" />
-        <error line="70" column="49" source="standard:argument-list-wrapping" />
-        <error line="70" column="68" source="standard:argument-list-wrapping" />
-        <error line="70" column="87" source="standard:argument-list-wrapping" />
-        <error line="70" column="89" source="standard:function-literal" />
-        <error line="70" column="98" source="standard:binary-expression-wrapping" />
-        <error line="70" column="120" source="standard:max-line-length" />
-        <error line="70" column="121" source="standard:argument-list-wrapping" />
-        <error line="70" column="127" source="standard:argument-list-wrapping" />
-        <error line="89" column="52" source="standard:trailing-comma-on-call-site" />
-        <error line="92" column="15" source="standard:function-literal" />
-        <error line="92" column="49" source="standard:argument-list-wrapping" />
-        <error line="92" column="68" source="standard:argument-list-wrapping" />
-        <error line="92" column="87" source="standard:argument-list-wrapping" />
-        <error line="92" column="89" source="standard:function-literal" />
-        <error line="92" column="98" source="standard:binary-expression-wrapping" />
-        <error line="92" column="120" source="standard:max-line-length" />
-        <error line="108" column="95" source="standard:trailing-comma-on-call-site" />
-        <error line="115" column="15" source="standard:function-literal" />
-        <error line="115" column="16" source="standard:wrapping" />
-        <error line="115" column="41" source="standard:argument-list-wrapping" />
-        <error line="115" column="49" source="standard:argument-list-wrapping" />
-        <error line="115" column="56" source="standard:argument-list-wrapping" />
-        <error line="115" column="57" source="standard:argument-list-wrapping" />
-        <error line="115" column="59" source="standard:function-literal" />
-        <error line="115" column="68" source="standard:binary-expression-wrapping" />
-        <error line="115" column="69" source="standard:function-literal" />
-        <error line="115" column="70" source="standard:wrapping" />
-        <error line="115" column="93" source="standard:argument-list-wrapping" />
-        <error line="115" column="121" source="standard:max-line-length" />
-        <error line="115" column="127" source="standard:argument-list-wrapping" />
-        <error line="115" column="129" source="standard:function-literal" />
-        <error line="116" column="15" source="standard:function-literal" />
-        <error line="116" column="41" source="standard:argument-list-wrapping" />
-        <error line="116" column="49" source="standard:argument-list-wrapping" />
-        <error line="116" column="56" source="standard:argument-list-wrapping" />
-        <error line="116" column="57" source="standard:argument-list-wrapping" />
-        <error line="116" column="59" source="standard:function-literal" />
-        <error line="116" column="68" source="standard:binary-expression-wrapping" />
-        <error line="116" column="69" source="standard:function-literal" />
-        <error line="116" column="93" source="standard:argument-list-wrapping" />
-        <error line="116" column="119" source="standard:argument-list-wrapping" />
-        <error line="116" column="121" source="standard:function-literal" />
-        <error line="116" column="121" source="standard:max-line-length" />
-        <error line="144" column="114" source="standard:trailing-comma-on-call-site" />
-        <error line="151" column="15" source="standard:function-literal" />
-        <error line="151" column="16" source="standard:wrapping" />
-        <error line="151" column="41" source="standard:argument-list-wrapping" />
-        <error line="151" column="49" source="standard:argument-list-wrapping" />
-        <error line="151" column="56" source="standard:argument-list-wrapping" />
-        <error line="151" column="57" source="standard:argument-list-wrapping" />
-        <error line="151" column="59" source="standard:function-literal" />
-        <error line="151" column="68" source="standard:binary-expression-wrapping" />
-        <error line="151" column="69" source="standard:function-literal" />
-        <error line="151" column="70" source="standard:wrapping" />
-        <error line="151" column="93" source="standard:argument-list-wrapping" />
-        <error line="151" column="121" source="standard:max-line-length" />
-        <error line="151" column="127" source="standard:argument-list-wrapping" />
-        <error line="151" column="129" source="standard:function-literal" />
-        <error line="152" column="15" source="standard:function-literal" />
-        <error line="152" column="41" source="standard:argument-list-wrapping" />
-        <error line="152" column="49" source="standard:argument-list-wrapping" />
-        <error line="152" column="56" source="standard:argument-list-wrapping" />
-        <error line="152" column="57" source="standard:argument-list-wrapping" />
-        <error line="152" column="59" source="standard:function-literal" />
-        <error line="152" column="68" source="standard:binary-expression-wrapping" />
-        <error line="152" column="69" source="standard:function-literal" />
-        <error line="152" column="93" source="standard:argument-list-wrapping" />
-        <error line="152" column="119" source="standard:argument-list-wrapping" />
-        <error line="152" column="121" source="standard:function-literal" />
-        <error line="152" column="121" source="standard:max-line-length" />
-        <error line="194" column="95" source="standard:trailing-comma-on-call-site" />
-        <error line="208" column="33" source="standard:trailing-comma-on-call-site" />
-        <error line="209" column="14" source="standard:trailing-comma-on-call-site" />
-        <error line="242" column="9" source="standard:function-signature" />
-        <error line="243" column="9" source="standard:function-signature" />
-        <error line="243" column="46" source="standard:function-signature" />
-        <error line="243" column="46" source="standard:trailing-comma-on-declaration-site" />
-        <error line="256" column="65" source="standard:trailing-comma-on-call-site" />
-        <error line="271" column="65" source="standard:trailing-comma-on-call-site" />
-        <error line="279" column="33" source="standard:trailing-comma-on-declaration-site" />
-        <error line="292" column="65" source="standard:trailing-comma-on-call-site" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/interest/application/usecase/WithholdingRemittanceServiceTest.kt">
-        <error line="34" column="99" source="standard:function-signature" />
-        <error line="39" column="112" source="standard:trailing-comma-on-call-site" />
-        <error line="52" column="15" source="standard:function-literal" />
-        <error line="52" column="37" source="standard:argument-list-wrapping" />
-        <error line="52" column="45" source="standard:argument-list-wrapping" />
-        <error line="52" column="54" source="standard:argument-list-wrapping" />
-        <error line="52" column="55" source="standard:argument-list-wrapping" />
-        <error line="52" column="57" source="standard:function-literal" />
-        <error line="52" column="66" source="standard:binary-expression-wrapping" />
-        <error line="52" column="67" source="standard:function-literal" />
-        <error line="52" column="91" source="standard:argument-list-wrapping" />
-        <error line="52" column="121" source="standard:max-line-length" />
-        <error line="52" column="124" source="standard:argument-list-wrapping" />
-        <error line="52" column="126" source="standard:function-literal" />
-        <error line="72" column="32" source="standard:argument-list-wrapping" />
-        <error line="72" column="49" source="standard:argument-list-wrapping" />
-        <error line="73" column="28" source="standard:argument-list-wrapping" />
-        <error line="73" column="63" source="standard:trailing-comma-on-call-site" />
-        <error line="92" column="15" source="standard:function-literal" />
-        <error line="92" column="37" source="standard:argument-list-wrapping" />
-        <error line="92" column="45" source="standard:argument-list-wrapping" />
-        <error line="92" column="54" source="standard:argument-list-wrapping" />
-        <error line="92" column="55" source="standard:argument-list-wrapping" />
-        <error line="92" column="57" source="standard:function-literal" />
-        <error line="92" column="66" source="standard:binary-expression-wrapping" />
-        <error line="92" column="67" source="standard:function-literal" />
-        <error line="92" column="91" source="standard:argument-list-wrapping" />
-        <error line="92" column="121" source="standard:max-line-length" />
-        <error line="92" column="124" source="standard:argument-list-wrapping" />
-        <error line="92" column="126" source="standard:function-literal" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/interest/domain/tax/WithholdingRemittancePolicyTest.kt">
-        <error line="25" column="56" source="standard:trailing-comma-on-declaration-site" />
-        <error line="37" column="24" source="standard:trailing-comma-on-call-site" />
-        <error line="45" column="37" source="standard:trailing-comma-on-call-site" />
-        <error line="76" column="75" source="standard:trailing-comma-on-call-site" />
     </file>
     <file name="src/test/kotlin/com/openbank/interest/domain/tax/WithholdingTaxPolicyTest.kt">
         <error line="17" column="9" source="standard:function-signature" />
@@ -716,28 +231,5 @@
         <error line="117" column="49" source="standard:trailing-comma-on-call-site" />
         <error line="118" column="14" source="standard:trailing-comma-on-call-site" />
         <error line="132" column="84" source="standard:trailing-comma-on-call-site" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/interest/infrastructure/outbox/InterestOutboxBacklogGaugeTest.kt">
-        <error line="6" column="1" source="standard:import-ordering" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/interest/infrastructure/outbox/InterestOutboxDispatchTest.kt">
-        <error line="61" column="35" source="standard:function-signature" />
-    </file>
-    <file name="src/test/kotlin/com/openbank/interest/integration/InterestOutboxDispatchIT.kt">
-        <error line="69" column="32" source="standard:parameter-list-wrapping" />
-        <error line="69" column="32" source="standard:function-signature" />
-        <error line="69" column="47" source="standard:parameter-list-wrapping" />
-        <error line="69" column="47" source="standard:function-signature" />
-        <error line="69" column="66" source="standard:parameter-list-wrapping" />
-        <error line="69" column="66" source="standard:function-signature" />
-        <error line="69" column="85" source="standard:parameter-list-wrapping" />
-        <error line="69" column="85" source="standard:function-signature" />
-        <error line="69" column="102" source="standard:parameter-list-wrapping" />
-        <error line="69" column="102" source="standard:function-signature" />
-        <error line="69" column="120" source="standard:parameter-list-wrapping" />
-        <error line="69" column="120" source="standard:function-signature" />
-        <error line="69" column="121" source="standard:max-line-length" />
-        <error line="87" column="66" source="standard:function-signature" />
-        <error line="114" column="1" source="standard:spacing-between-declarations-with-annotations" />
     </file>
 </baseline>

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/in/InterestPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/in/InterestPorts.kt
@@ -30,5 +30,9 @@ interface ManageRateConfigUseCase {
     fun createConfig(config: InterestRateConfig): Uni<InterestRateConfig>
     fun getConfig(id: UUID): Uni<InterestRateConfig?>
     fun listConfigs(productId: String?): Uni<List<InterestRateConfig>>
+
+    /** The rate that actually applies to [accountId] (account override, else product default), or
+     *  null if the account earns no interest. Drives the app's per-account rate view. */
+    fun effectiveRate(accountId: UUID, productId: String, date: LocalDate): Uni<InterestRateConfig?>
     fun deactivateConfig(id: UUID): Uni<InterestRateConfig>
 }

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/InterestPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/InterestPorts.kt
@@ -22,6 +22,14 @@ interface InterestRateConfigRepository {
     fun findByProductId(productId: String): Uni<List<InterestRateConfig>>
     fun findAll(): Uni<List<InterestRateConfig>>
     fun findActiveForProduct(productId: String, date: LocalDate): Uni<InterestRateConfig?>
+
+    /**
+     * The rate that actually applies to [accountId] on [date]: an active account-specific override
+     * (accountId set) wins over the product-level default (accountId null, productId matches). Null
+     * when neither exists — the account earns no interest (e.g. a plain CURRENT account, whose
+     * product default is deactivated). This is what the accrual run and the app's rate view use.
+     */
+    fun findEffectiveRate(accountId: UUID, productId: String, date: LocalDate): Uni<InterestRateConfig?>
     fun update(config: InterestRateConfig): Uni<InterestRateConfig>
 }
 

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -68,7 +68,7 @@ class InterestService(
     )
 
     override fun accrue(request: AccrualRequest): Uni<InterestAccrual> =
-        configRepo.findActiveForProduct(request.productId, request.accrualDate).flatMap { config ->
+        configRepo.findEffectiveRate(request.accountId, request.productId, request.accrualDate).flatMap { config ->
             if (config == null) {
                 Uni.createFrom().failure(
                     IllegalStateException("No active rate config for product ${request.productId}"),
@@ -465,6 +465,10 @@ class InterestService(
     override fun getConfig(id: UUID): Uni<InterestRateConfig?> = configRepo.findById(id)
     override fun listConfigs(productId: String?): Uni<List<InterestRateConfig>> =
         if (productId != null) configRepo.findByProductId(productId) else configRepo.findAll()
+
+    override fun effectiveRate(accountId: UUID, productId: String, date: LocalDate): Uni<InterestRateConfig?> =
+        configRepo.findEffectiveRate(accountId, productId, date)
+
     override fun deactivateConfig(id: UUID): Uni<InterestRateConfig> = configRepo.findById(id).flatMap { config ->
         if (config == null) {
             Uni.createFrom().failure(IllegalArgumentException("Config not found"))

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/domain/model/InterestModels.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/domain/model/InterestModels.kt
@@ -27,6 +27,10 @@ enum class DayCount { ACT_365, ACT_360, ACT_ACT, THIRTY_360 }
 data class InterestRateConfig(
     val id: UUID = UUID.randomUUID(),
     val productId: String,
+    /** When set, this rate is an override for that single account, taking precedence over the
+     *  product-level default (accountId == null). Lets a specific customer be granted interest on an
+     *  otherwise non-interest-bearing account (e.g. a CURRENT account, which defaults to 0). */
+    val accountId: UUID? = null,
     val rateType: InterestRateType = InterestRateType.FIXED,
     val annualRate: BigDecimal,
     val minBalance: BigDecimal = BigDecimal.ZERO,

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/entity/InterestEntities.kt
@@ -19,6 +19,8 @@ import java.util.UUID
 class InterestRateConfigEntity : PanacheEntityBase() {
     @Id @Column(columnDefinition = "uuid") var id: UUID = UUID.randomUUID()
     @Column(name = "product_id") var productId: String = ""
+    // Non-null => an account-specific override that wins over the product-level default (null).
+    @Column(name = "account_id", columnDefinition = "uuid") var accountId: UUID? = null
     @Column(name = "rate_type") @Enumerated(EnumType.STRING) var rateType: InterestRateType = InterestRateType.FIXED
     @Column(name = "annual_rate", precision = 10, scale = 6) var annualRate: BigDecimal = BigDecimal.ZERO
     @Column(name = "min_balance", precision = 20, scale = 4) var minBalance: BigDecimal = BigDecimal.ZERO

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/mapper/InterestMapper.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/mapper/InterestMapper.kt
@@ -15,6 +15,7 @@ class InterestMapper {
     fun toEntity(c: InterestRateConfig) = InterestRateConfigEntity().also {
         it.id = c.id
         it.productId = c.productId
+        it.accountId = c.accountId
         it.rateType = c.rateType
         it.annualRate = c.annualRate
         it.minBalance = c.minBalance
@@ -27,7 +28,7 @@ class InterestMapper {
         it.updatedAt = c.updatedAt
     }
     fun toDomain(e: InterestRateConfigEntity) = InterestRateConfig(
-        id = e.id, productId = e.productId, rateType = e.rateType,
+        id = e.id, productId = e.productId, accountId = e.accountId, rateType = e.rateType,
         annualRate = e.annualRate, minBalance = e.minBalance, maxBalance = e.maxBalance,
         dayCount = e.dayCount, effectiveFrom = e.effectiveFrom, effectiveTo = e.effectiveTo,
         active = e.active, createdAt = e.createdAt, updatedAt = e.updatedAt,

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt
@@ -58,6 +58,21 @@ class InterestRateConfigRepositoryImpl @Inject constructor(
             ).setParameter("p", productId).setParameter("d", date).setMaxResults(1).singleResultOrNull
         }.map { it?.let(mapper::toDomain) }
 
+    @WithSession
+    override fun findEffectiveRate(accountId: UUID, productId: String, date: LocalDate): Uni<InterestRateConfig?> =
+        sf.withSession { s ->
+            // account-specific override (accountId set) OR the product-wide default (accountId null);
+            // the CASE orders overrides (0) before defaults (1) so setMaxResults(1) picks the override.
+            s.createQuery(
+                "FROM InterestRateConfigEntity WHERE active = true AND effectiveFrom <= :d " +
+                    "AND (effectiveTo IS NULL OR effectiveTo >= :d) " +
+                    "AND (accountId = :a OR (accountId IS NULL AND productId = :p)) " +
+                    "ORDER BY CASE WHEN accountId IS NULL THEN 1 ELSE 0 END, effectiveFrom DESC",
+                InterestRateConfigEntity::class.java,
+            ).setParameter("a", accountId).setParameter("p", productId).setParameter("d", date)
+                .setMaxResults(1).singleResultOrNull
+        }.map { it?.let(mapper::toDomain) }
+
     @WithTransaction
     override fun update(config: InterestRateConfig): Uni<InterestRateConfig> = sf.withTransaction { s ->
         s.find(InterestRateConfigEntity::class.java, config.id).flatMap { e ->

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/rest/InterestResource.kt
@@ -140,6 +140,20 @@ class InterestResource(
         rateConfigUseCase.listConfigs(productId)
 
     @GET
+    @Path("/accounts/{accountId}/effective-rate")
+    @Operation(summary = "The interest rate effective for an account (override, else product default)")
+    @Authorize(action = "interest.read", resource = "#accountId")
+    fun effectiveRate(
+        @PathParam("accountId") accountId: UUID,
+        @QueryParam("productId") productId: String,
+        @QueryParam("date") @DefaultValue("") date: String,
+    ): Uni<Response> {
+        val on = if (date.isNotEmpty()) LocalDate.parse(date) else LocalDate.now(clock)
+        return rateConfigUseCase.effectiveRate(accountId, productId, on)
+            .map { it?.let { c -> Response.ok(c).build() } ?: Response.noContent().build() }
+    }
+
+    @GET
     @Path("/rates/{id}")
     @Operation(summary = "Get interest rate configuration by ID")
     @Authorize(action = "interest.read", resource = "#id")

--- a/openbank-interest-service/src/main/resources/db/migration/V11__per_account_rate_override.sql
+++ b/openbank-interest-service/src/main/resources/db/migration/V11__per_account_rate_override.sql
@@ -1,0 +1,24 @@
+-- Per-account interest rate override + CURRENT defaults to ZERO interest.
+--
+-- Product decision: the everyday CURRENT account earns NO interest by default — the bank keeps the
+-- float on the settled balance ("sedlina"). That's the reversal of V10 (which had seeded CURRENT at
+-- 2.5%): here the CURRENT product config is deactivated, so a plain current account accrues nothing.
+--
+-- But interest must be *configurable per account*: a specific customer can be granted a rate on
+-- their current account. So interest_rate_configs gains a nullable account_id — a row with
+-- account_id set is an account-specific override that wins over the product-level default; NULL is
+-- the product-wide default (SAVINGS 4%, and now no active CURRENT default). The accrual lookup
+-- prefers the account-specific row (findEffectiveRate).
+
+ALTER TABLE interest_rate_configs ADD COLUMN account_id UUID NULL;
+
+-- One active override per (account) and one active default per (product) — a partial unique index
+-- for each, so a second overlapping active config can't silently shadow the first.
+CREATE UNIQUE INDEX ux_rate_active_account ON interest_rate_configs (account_id)
+    WHERE active AND account_id IS NOT NULL;
+
+-- CURRENT (…00c2) defaults to zero interest: deactivate V10's product-level config. Savings (…00c3)
+-- stays active at 4%. A current account only accrues if it is given an explicit account_id override.
+UPDATE interest_rate_configs
+SET active = FALSE, updated_at = NOW()
+WHERE product_id = '00000000-0000-0000-0000-0000000000c2' AND account_id IS NULL;

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
@@ -123,7 +123,7 @@ class InterestServiceTest {
         val accrualSlot: CapturingSlot<InterestAccrual> = slot()
 
         every {
-            configRepo.findActiveForProduct(request.productId, request.accrualDate)
+            configRepo.findEffectiveRate(request.accountId, request.productId, request.accrualDate)
         } returns Uni.createFrom().item(config)
         every { accrualRepo.save(capture(accrualSlot)) } returns
             Uni.createFrom().item(expectedAccrual(request, config))
@@ -133,7 +133,7 @@ class InterestServiceTest {
         assertThat(accrualSlot.captured.dailyRate).isEqualByComparingTo(BigDecimal("0.0010000000"))
         assertThat(accrualSlot.captured.accruedAmount).isEqualByComparingTo(BigDecimal("1.000000"))
         assertThat(result).isEqualTo(expectedAccrual(request, config))
-        verify(exactly = 1) { configRepo.findActiveForProduct(request.productId, request.accrualDate) }
+        verify(exactly = 1) { configRepo.findEffectiveRate(request.accountId, request.productId, request.accrualDate) }
         verify(exactly = 1) { accrualRepo.save(any()) }
     }
 
@@ -148,7 +148,7 @@ class InterestServiceTest {
         )
 
         every {
-            configRepo.findActiveForProduct(request.productId, request.accrualDate)
+            configRepo.findEffectiveRate(request.accountId, request.productId, request.accrualDate)
         } returns Uni.createFrom().nullItem()
 
         assertThatThrownBy { service.accrue(request).await().indefinitely() }
@@ -186,7 +186,7 @@ class InterestServiceTest {
             Uni.createFrom().item(BalanceSnapshot(BigDecimal("1000.00"), "CZK"))
         every { accountDirectoryPort.bookedBalance(savingsC) } returns
             Uni.createFrom().item(BalanceSnapshot(BigDecimal("2000.00"), "CZK"))
-        every { configRepo.findActiveForProduct(any(), date) } returns Uni.createFrom().item(config)
+        every { configRepo.findEffectiveRate(any(), any(), date) } returns Uni.createFrom().item(config)
         every { accrualRepo.save(any()) } answers { Uni.createFrom().item(firstArg<InterestAccrual>()) }
 
         val count = service.accrueAll(date).await().indefinitely()
@@ -222,7 +222,7 @@ class InterestServiceTest {
             Uni.createFrom().item(BalanceSnapshot(BigDecimal("500.00"), "CZK"))
         every { accountDirectoryPort.bookedBalance(ok) } returns
             Uni.createFrom().item(BalanceSnapshot(BigDecimal("1000.00"), "CZK"))
-        every { configRepo.findActiveForProduct(any(), date) } returns Uni.createFrom().item(config)
+        every { configRepo.findEffectiveRate(any(), any(), date) } returns Uni.createFrom().item(config)
         // The duplicate account simulates the UNIQUE(account, date, product) violation on re-run.
         every { accrualRepo.save(match { it.accountId == dup }) } returns
             Uni.createFrom().failure(IllegalStateException("duplicate key value violates unique constraint"))


### PR DESCRIPTION
**Product model:** the everyday **CURRENT** account earns **no interest by default** — the bank keeps the float on the settled balance ("sedlina"). But interest must be **configurable per account**, so a specific customer can be granted a rate on their current account.

- `interest_rate_configs` gains a nullable **`account_id`** (V11). A row with `account_id` set is an **account-specific override** that wins over the product-level default (`account_id` null). New `findEffectiveRate(accountId, productId, date)` picks the override first, else the product default — one query (`ORDER BY (accountId IS NULL)` sorts overrides ahead). `accrue()` uses it.
- **V11 deactivates the CURRENT product default** (the 2.5% from #1642/V10) → a plain current account accrues nothing; SAVINGS stays 4%. `accruable-account-types` stays `CURRENT,SAVINGS` so a current account **with** an override is still scanned + accrued.
- Setting an override needs **no new endpoint**: `POST /rates` already persists `InterestRateConfig`, which now carries `accountId`. New `GET /accounts/{id}/effective-rate?productId=` resolves the effective rate for the app.
- **customer-edge**: the interest route now reads the account's **effective** rate (override or product default) via the new endpoint instead of the product-only `/rates` list — an overridden current account shows interest, a plain one shows none (`eligible=false`).

**ktlint-baseline** regenerated for interest-service: adding a column to the first entity shifts every line-keyed baseline entry in `InterestEntities.kt`. The regenerated baseline is accurate and drops ~476 stale entries for violations fixed since it was last written; `ktlintCheck` green.

## Linked issues

Refs #1618