### PR TITLE
feat(fees): surface account fee schedule to the app + heal stale catalogue (#1618-style)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -303,6 +303,34 @@ class CustomerEdgeResource(
         return node.get("annualRate")?.decimalValue()
     }
 
+    // --- Fees (ADR-0138 fee schedule transparency) ---
+
+    /**
+     * The fee schedule for one of the caller's OWN accounts: the fees the account's product can
+     * charge (monthly maintenance, transaction fees, card fees…), each with its amount, frequency and
+     * any waiver condition. Read-only transparency — product-catalog is the authority (the same
+     * `/products/{id}/fees` read billing-service uses). Ownership is enforced HERE (product-catalog is
+     * not party-scoped); an unavailable catalogue or a product with no schedule fail-soft to `[]` so
+     * the app draws an empty state rather than an error.
+     */
+    @GET
+    @Path("/accounts/{accountId}/fees")
+    @Authorize(action = "customer.accounts.read", resource = "#accountId")
+    @Blocking
+    fun getAccountFees(@PathParam("accountId") accountId: UUID): Response {
+        val customer = customer()
+        val accountJson = fetchAccount(accountId, customer.partyId)
+            ?: return forbidden("Account does not belong to caller")
+        if (extractOwnerPartyId(accountJson) != customer.partyId.toString()) {
+            return forbidden("Account does not belong to caller")
+        }
+        val productId = extractTextField(objectMapper, accountJson, "productId")
+            ?: return Response.ok("[]").type(MediaType.APPLICATION_JSON).build()
+        val resp = upstream.get("$productCatalogUrl/api/v1/products/$productId/fees", customer.partyId.toString())
+        val body = if (resp.status == 200) resp.entity?.toString()?.takeIf { it.isNotBlank() } ?: "[]" else "[]"
+        return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
+    }
+
     // --- Currency pockets (ADR-0109) ---
     // Customer self-service over the account-service pocket lifecycle. All routes are
     // ownership-checked here (account-service also re-checks via the X-Customer-Party-Id

--- a/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/ProductCatalogSeeder.kt
+++ b/openbank-product-catalog/src/main/kotlin/com/openbank/productcatalog/infrastructure/persistence/ProductCatalogSeeder.kt
@@ -4,7 +4,10 @@
 
 package com.openbank.productcatalog.infrastructure.persistence
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.openbank.productcatalog.domain.Product
 import com.openbank.productcatalog.domain.ProductIds
 import com.openbank.productcatalog.domain.ProductSeed
 import io.quarkus.runtime.StartupEvent
@@ -14,6 +17,7 @@ import jakarta.enterprise.context.ApplicationScoped
 import jakarta.enterprise.event.Observes
 import org.hibernate.reactive.mutiny.Mutiny
 import org.jboss.logging.Logger
+import java.util.UUID
 
 /**
  * Idempotent first-boot seed of the canonical catalogue (ADR-0105 P1). Flyway (V1) owns the schema;
@@ -49,6 +53,46 @@ class ProductCatalogSeeder(private val sf: Mutiny.SessionFactory, private val ma
             }
         }
         if (inserted > 0) log.info("Seeded $inserted canonical products (ADR-0105 P1).")
+        // Heal rows seeded before a fee schedule was added to ProductSeed (the fee-schedule addition
+        // never reached an already-seeded catalogue, since seed() only runs on an empty table).
+        val patched = try {
+            backfillFees()
+        } catch (e: RuntimeException) {
+            if (isUniqueViolation(e)) 0 else throw e
+        }
+        if (patched > 0) log.info("Backfilled fee schedules for $patched catalogue product(s) from the seed.")
+    }
+
+    /**
+     * Heals stale catalogue rows that predate a fee-schedule addition to [ProductSeed]: for each seed
+     * product that exists in the DB but whose persisted doc has an empty `fees` array, backfill the
+     * fees from the seed. Deliberately narrow — it ONLY touches products with no fees, so an operator
+     * who curated a product's fees (via the PUT endpoint) is never overwritten, keeping the seeder's
+     * "never clobber operator edits" contract while leaving [ProductSeed] the single source of truth.
+     */
+    private fun backfillFees(): Int = VertxContextSupport.subscribeAndAwait {
+        sf.withTransaction { s ->
+            val seedById = ProductSeed.products
+                .filter { it.fees.isNotEmpty() }
+                .associateBy { ProductIds.canonicalId(it.id) }
+            s.createQuery("FROM ProductEntity", ProductEntity::class.java).resultList.map { entities ->
+                entities.count { e -> backfillFeesFor(e, seedById) }
+            }
+        }
+    } ?: 0
+
+    /**
+     * Backfill [e]'s doc fees from the seed if — and only if — the seed has fees for it and its
+     * persisted doc has none. Returns true iff it patched (a managed entity, flushed on commit).
+     */
+    private fun backfillFeesFor(e: ProductEntity, seedById: Map<UUID, Product>): Boolean {
+        val seedP = seedById[e.id] ?: return false
+        val doc = mapper.readTree(e.doc) as? ObjectNode ?: return false
+        val fees = doc.get("fees")
+        if (fees != null && fees.isArray && fees.size() > 0) return false // already has fees — leave it
+        doc.set<JsonNode>("fees", mapper.valueToTree(seedP.fees))
+        e.doc = mapper.writeValueAsString(doc)
+        return true
     }
 
     private fun seed(): Int = VertxContextSupport.subscribeAndAwait {


### PR DESCRIPTION
The customer app had no way to see what its account is charged. The fee schedules **already exist in `ProductSeed`** (CURRENT_CZK: 99 CZK/mo waivable + free SEPA/CERTIS; SAVINGS_CZK: free), but the live catalogue was seeded **before** those fees were added, and the seeder only runs on an empty table — so every product's persisted `doc` had an empty `fees` array and the schedule was invisible.

- **product-catalog**: `ProductCatalogSeeder` now backfills fees on boot for any seeded product whose persisted doc has no fees, from `ProductSeed` (the single source of truth — no duplication). **Narrow by design**: it only touches empty-fee products, so an operator who curated a product's fees via the PUT endpoint is never overwritten — preserving the seeder's "never clobber operator edits" contract.
- **customer-edge**: `GET /customer/v1/accounts/{id}/fees` — ownership-checked, resolves the account's `productId`, returns product-catalog's `/products/{id}/fees` schedule. **Fail-soft** to `[]` when the catalogue is unavailable or the product has no schedule → the app draws an empty state, not an error. Same `catalog.read` the edge already uses for pockets — no new OPA policy.

Pairs with the app's Fees screen (openbank-app). Refs ADR-0138.

## Linked issues

N/A — customer-facing fee-schedule transparency (no tracking issue; sibling of the interest feature #1618).