### PR TITLE
chore(deps-ui): ignore tailwindcss v4 major until a deliberate migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,15 @@ updates:
       # compiler API (crashes reading ModuleKind 'Cjs').
       - dependency-name: "typescript"
         versions: ["7.x"]
+      # Tailwind v4 replaces tailwind.config.ts with a CSS-first @theme block,
+      # changes the PostCSS plugin package, and changes the darkMode strategy
+      # syntax. This app's design tokens are deeply wired through
+      # tailwind.config.ts + globals.css, so the bump needs a deliberate,
+      # visually-verified migration PR, not a mechanical Dependabot bump
+      # (#1329 fails typecheck: tailwind.config.ts(8,3) TS2322 on darkMode).
+      # Drop this entry once the migration in #1653 lands.
+      - dependency-name: "tailwindcss"
+        versions: ["4.x"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Adds a `tailwindcss` major-version ignore entry to `.github/dependabot.yml`, mirroring the
  existing `eslint`/`typescript` pattern (#1314), so Dependabot stops reopening a red PR every
  Monday for a bump that cannot pass CI as-is.
- Dependabot PR #1329 (tailwindcss 3.4.7 -> 4.3.3) fails the "Admin UI build" check at typecheck:
  `tailwind.config.ts(8,3): error TS2322: Type '["class"]' is not assignable to type
  'DarkModeStrategy | undefined'` — the first of several v3->v4 breaking changes (CSS-first
  `@theme` config, new PostCSS plugin package, darkMode strategy syntax). `openbank-admin-ui`'s
  design tokens are deeply wired through `tailwind.config.ts` + `globals.css`, so this needs a
  deliberate, visually-verified migration PR, not an auto-bump — tracked in #1653.

## Test plan
- [x] Config-only YAML change; no build/runtime surface to exercise.
- [ ] Confirm `dependabot.yml` still validates on Dependabot's next scheduled run (no immediate
      CI check for this file locally).

Refs #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)