### PR TITLE
feat(admin-ui): add an infrastructure topology page

### DIFF
--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -1,0 +1,538 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+import { useState, useEffect } from 'react'
+import {
+  Network, RefreshCw, Play, Pause, CheckCircle2, XCircle, HelpCircle,
+  Cloud, GitBranch, Database, Eye, Server,
+} from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+
+// ---------------------------------------------------------------------------
+// Infrastructure topology (ADR-0027/0029). A companion to the code-derived
+// service map (/docs/service-map): the SAME animated engine, but here the NODES
+// are the real platform components (with LIVE status from /api/infra/status) and
+// the EDGES are the *documented platform architecture* — how the pieces wire
+// together (ArgoCD deploys, CNPG backs Postgres up to S3, External Secrets pulls
+// from OpenBao, Karpenter provisions nodes, observability scrapes, Istio mesh,
+// ingress routes). That backbone is not machine-declared anywhere (operators live
+// in Terraform helm_release, gitops only has app→namespace + operator→workload),
+// so — like the existing cloud-architecture / observability-stack pages — the
+// edges are hand-authored but true & verifiable, NOT a derived-data claim.
+// ---------------------------------------------------------------------------
+
+type Status = 'UP' | 'DOWN' | 'UNKNOWN'
+type GroupKey = 'aws' | 'platform' | 'data' | 'observability'
+type EdgeType =
+  | 'deploys' | 'provisions' | 'admits' | 'issues'
+  | 'manages' | 'uses' | 'backs-up' | 'secrets' | 'pulls' | 'routes' | 'auth'
+  | 'scales' | 'scrapes' | 'queries' | 'alerts' | 'mesh'
+
+type NodeDef = { id: string; group: GroupKey; label: string; descCs: string; descEn: string; live: boolean }
+type EdgeDef = { from: string; to: string; type: EdgeType }
+
+// Group metadata — colour + bilingual label. Icons render in the detail panel (HTML).
+const GROUPS: Record<GroupKey, { color: string; cs: string; en: string; Icon: typeof Cloud }> = {
+  aws:           { color: '#f97316', cs: 'AWS substrát',            en: 'AWS substrate',        Icon: Cloud },
+  platform:      { color: '#7c3aed', cs: 'Platforma / control plane', en: 'Platform / control plane', Icon: GitBranch },
+  data:          { color: '#2563eb', cs: 'Data / backing služby',   en: 'Data / backing services', Icon: Database },
+  observability: { color: '#0d9488', cs: 'Observabilita',           en: 'Observability',         Icon: Eye },
+}
+const GROUP_ORDER: GroupKey[] = ['aws', 'platform', 'data', 'observability']
+
+// Nodes. `live` ids match the /api/infra/status contract (badge overlays); the
+// rest are architectural-only (AWS substrate, operators, mesh) shown without a badge.
+const NODES: NodeDef[] = [
+  // AWS substrate
+  { id: 'vpc',   group: 'aws', label: 'VPC',            descCs: 'Privátní síť, subnety, routing (ADR-0058).', descEn: 'Private network, subnets, routing (ADR-0058).', live: false },
+  { id: 'eks',   group: 'aws', label: 'EKS',            descCs: 'Řízený Kubernetes cluster.', descEn: 'Managed Kubernetes cluster.', live: false },
+  { id: 'nodes', group: 'aws', label: 'EC2 uzly',       descCs: 'Spot/arm64 uzly provisionované Karpenterem.', descEn: 'Spot/arm64 nodes provisioned by Karpenter.', live: false },
+  { id: 'ecr',   group: 'aws', label: 'ECR',            descCs: 'Registr kontejnerů + pull-through cache.', descEn: 'Container registry + pull-through cache.', live: false },
+  { id: 's3',    group: 'aws', label: 'S3',             descCs: 'Objektové úložiště — zálohy WAL, artefakty.', descEn: 'Object store — WAL backups, artifacts.', live: false },
+  { id: 'nat',   group: 'aws', label: 'NAT (fck-nat)',  descCs: 'Odchozí egress (fck-nat instance, ADR-0058).', descEn: 'Outbound egress (fck-nat instance, ADR-0058).', live: false },
+  // Platform / control plane
+  { id: 'argocd',          group: 'platform', label: 'ArgoCD',          descCs: 'GitOps engine (app-of-apps) — nasazuje celou platformu.', descEn: 'GitOps engine (app-of-apps) — deploys the whole platform.', live: true },
+  { id: 'argo-rollouts',   group: 'platform', label: 'Argo Rollouts',   descCs: 'Progresivní doručení (canary/blue-green).', descEn: 'Progressive delivery (canary/blue-green).', live: false },
+  { id: 'karpenter',       group: 'platform', label: 'Karpenter',       descCs: 'Autoscaler uzlů (Spot/arm64), bin-packing.', descEn: 'Node autoscaler (Spot/arm64), bin-packing.', live: true },
+  { id: 'keda',            group: 'platform', label: 'KEDA',            descCs: 'Event-driven scaling / scale-to-zero.', descEn: 'Event-driven scaling / scale-to-zero.', live: true },
+  { id: 'kyverno',         group: 'platform', label: 'Kyverno',        descCs: 'Admission policy — ověřuje image attestace.', descEn: 'Admission policy — verifies image attestations.', live: true },
+  { id: 'cert-manager',    group: 'platform', label: 'cert-manager',   descCs: 'Životní cyklus TLS certifikátů.', descEn: 'TLS certificate lifecycle.', live: true },
+  { id: 'external-secrets',group: 'platform', label: 'External Secrets', descCs: 'Synchronizuje Secrety z OpenBao (ESO).', descEn: 'Syncs Secrets from OpenBao (ESO).', live: false },
+  { id: 'ingress-nginx',   group: 'platform', label: 'ingress-nginx',  descCs: 'Vstupní routing HTTP(S) do clusteru.', descEn: 'HTTP(S) ingress routing into the cluster.', live: false },
+  { id: 'istio',           group: 'platform', label: 'Istio',          descCs: 'Service mesh — mTLS STRICT mezi službami.', descEn: 'Service mesh — STRICT mTLS between services.', live: false },
+  // Data / backing services
+  { id: 'cnpg',            group: 'data', label: 'CloudNativePG',      descCs: 'Postgres operátor — spravuje DB clustery.', descEn: 'Postgres operator — manages DB clusters.', live: false },
+  { id: 'postgres',        group: 'data', label: 'PostgreSQL',         descCs: 'Perzistentní stav služeb (per-service DB).', descEn: 'Per-service persistent state.', live: true },
+  { id: 'strimzi',         group: 'data', label: 'Strimzi',           descCs: 'Kafka operátor (KRaft).', descEn: 'Kafka operator (KRaft).', live: false },
+  { id: 'kafka',           group: 'data', label: 'Apache Kafka',      descCs: 'Asynchronní páteř událostí.', descEn: 'Async event backbone.', live: true },
+  { id: 'schema-registry', group: 'data', label: 'Schema Registry',   descCs: 'Schémata událostí (Avro), kompatibilita.', descEn: 'Event schemas (Avro), compatibility.', live: true },
+  { id: 'openbao',         group: 'data', label: 'OpenBao',           descCs: 'Trezor tajemství (Vault-kompatibilní).', descEn: 'Secrets vault (Vault-compatible).', live: true },
+  { id: 'valkey',          group: 'data', label: 'Valkey',            descCs: 'In-memory cache (Redis-kompatibilní).', descEn: 'In-memory cache (Redis-compatible).', live: true },
+  { id: 'keycloak',        group: 'data', label: 'Keycloak',          descCs: 'Vydavatel identit a tokenů (OIDC).', descEn: 'Identity & token issuer (OIDC).', live: true },
+  { id: 'temporal',        group: 'data', label: 'Temporal',          descCs: 'Orchestrace workflow (durable).', descEn: 'Durable workflow orchestration.', live: true },
+  { id: 'opa',             group: 'data', label: 'OPA',               descCs: 'Rozhodovací bod autorizace (rego).', descEn: 'Authorization decision point (rego).', live: false },
+  // Observability
+  { id: 'prometheus',   group: 'observability', label: 'Prometheus',    descCs: 'Metriky (time-series), pravidla, alerty.', descEn: 'Metrics (time-series), rules, alerts.', live: true },
+  { id: 'grafana',      group: 'observability', label: 'Grafana',       descCs: 'Dashboardy nad metrikami/logy/trace.', descEn: 'Dashboards over metrics/logs/traces.', live: true },
+  { id: 'loki',         group: 'observability', label: 'Loki',          descCs: 'Agregace logů.', descEn: 'Log aggregation.', live: true },
+  { id: 'tempo',        group: 'observability', label: 'Tempo',         descCs: 'Distribuované trasování.', descEn: 'Distributed tracing.', live: true },
+  { id: 'pyroscope',    group: 'observability', label: 'Pyroscope',     descCs: 'Kontinuální profilování.', descEn: 'Continuous profiling.', live: true },
+  { id: 'alloy',        group: 'observability', label: 'Grafana Alloy',  descCs: 'Sběrný agent (metriky/logy) → backend.', descEn: 'Collector agent (metrics/logs) → backend.', live: true },
+  { id: 'otel-collector', group: 'observability', label: 'OTel Collector', descCs: 'OTLP ingest — trace/metriky.', descEn: 'OTLP ingest — traces/metrics.', live: true },
+  { id: 'alertmanager', group: 'observability', label: 'Alertmanager',  descCs: 'Směrování a deduplikace alertů.', descEn: 'Alert routing and dedup.', live: true },
+  { id: 'pyrra',        group: 'observability', label: 'Pyrra (SLO)',   descCs: 'SLO / error budgety nad Prometheem.', descEn: 'SLO / error budgets over Prometheus.', live: true },
+  { id: 'glitchtip',    group: 'observability', label: 'GlitchTip',     descCs: 'Sledování chyb (Sentry API).', descEn: 'Error tracking (Sentry API).', live: true },
+  { id: 'goalert',      group: 'observability', label: 'GoAlert',       descCs: 'On-call eskalace.', descEn: 'On-call escalation.', live: true },
+  { id: 'ntfy',         group: 'observability', label: 'ntfy',          descCs: 'Push notifikace alertů.', descEn: 'Alert push notifications.', live: true },
+  { id: 'kafka-ui',     group: 'observability', label: 'Kafka UI',      descCs: 'Inspekce Kafka topiců.', descEn: 'Kafka topic inspection.', live: true },
+]
+
+// Curated architectural backbone — every edge is real & verifiable in gitops/TF.
+const EDGES: EdgeDef[] = [
+  // AWS substrate wiring
+  { from: 'vpc', to: 'eks', type: 'uses' },
+  { from: 'karpenter', to: 'nodes', type: 'provisions' },
+  { from: 'nodes', to: 'eks', type: 'uses' },
+  { from: 'eks', to: 'ecr', type: 'pulls' },
+  { from: 'nat', to: 'vpc', type: 'routes' },
+  // ArgoCD deploys the platform (representative set)
+  { from: 'argocd', to: 'cnpg', type: 'deploys' },
+  { from: 'argocd', to: 'strimzi', type: 'deploys' },
+  { from: 'argocd', to: 'keda', type: 'deploys' },
+  { from: 'argocd', to: 'kyverno', type: 'deploys' },
+  { from: 'argocd', to: 'cert-manager', type: 'deploys' },
+  { from: 'argocd', to: 'external-secrets', type: 'deploys' },
+  { from: 'argocd', to: 'argo-rollouts', type: 'deploys' },
+  { from: 'argocd', to: 'ingress-nginx', type: 'deploys' },
+  { from: 'argocd', to: 'prometheus', type: 'deploys' },
+  { from: 'argocd', to: 'grafana', type: 'deploys' },
+  // Operators → managed workloads
+  { from: 'cnpg', to: 'postgres', type: 'manages' },
+  { from: 'strimzi', to: 'kafka', type: 'manages' },
+  { from: 'postgres', to: 's3', type: 'backs-up' },
+  { from: 'external-secrets', to: 'openbao', type: 'secrets' },
+  { from: 'keda', to: 'kafka', type: 'scales' },
+  { from: 'kyverno', to: 'eks', type: 'admits' },
+  { from: 'cert-manager', to: 'ingress-nginx', type: 'issues' },
+  { from: 'cert-manager', to: 'istio', type: 'issues' },
+  { from: 'ingress-nginx', to: 'keycloak', type: 'routes' },
+  { from: 'ingress-nginx', to: 'grafana', type: 'routes' },
+  { from: 'istio', to: 'kafka', type: 'mesh' },
+  // Backing-service usage
+  { from: 'keycloak', to: 'postgres', type: 'uses' },
+  { from: 'temporal', to: 'postgres', type: 'uses' },
+  { from: 'schema-registry', to: 'kafka', type: 'uses' },
+  { from: 'keycloak', to: 'opa', type: 'auth' },
+  // Observability pipeline
+  { from: 'alloy', to: 'prometheus', type: 'scrapes' },
+  { from: 'alloy', to: 'loki', type: 'scrapes' },
+  { from: 'otel-collector', to: 'tempo', type: 'scrapes' },
+  { from: 'otel-collector', to: 'prometheus', type: 'scrapes' },
+  { from: 'grafana', to: 'prometheus', type: 'queries' },
+  { from: 'grafana', to: 'loki', type: 'queries' },
+  { from: 'grafana', to: 'tempo', type: 'queries' },
+  { from: 'grafana', to: 'pyroscope', type: 'queries' },
+  { from: 'pyrra', to: 'prometheus', type: 'queries' },
+  { from: 'prometheus', to: 'alertmanager', type: 'alerts' },
+  { from: 'alertmanager', to: 'goalert', type: 'alerts' },
+  { from: 'alertmanager', to: 'ntfy', type: 'alerts' },
+]
+
+// Edge visual category (3 buckets keep the legend legible) + per-type label.
+type EdgeCat = 'control' | 'data' | 'flow'
+const EDGE_CAT: Record<EdgeType, EdgeCat> = {
+  deploys: 'control', provisions: 'control', admits: 'control', issues: 'control',
+  manages: 'data', uses: 'data', 'backs-up': 'data', secrets: 'data', pulls: 'data', routes: 'data', auth: 'data',
+  scales: 'flow', scrapes: 'flow', queries: 'flow', alerts: 'flow', mesh: 'flow',
+}
+const CAT_COLOR: Record<EdgeCat, string> = { control: '#7c3aed', data: '#2563eb', flow: '#0d9488' }
+const CAT_DASHED: Record<EdgeCat, boolean> = { control: false, data: false, flow: true }
+const edgeTypeLabel = (type: EdgeType, t: (cs: string, en: string) => string): string => ({
+  deploys: t('nasazuje', 'deploys'), provisions: t('provisiony', 'provisions'), admits: t('admission', 'admits'),
+  issues: t('vydává cert', 'issues cert'), manages: t('spravuje', 'manages'), uses: t('používá', 'uses'),
+  'backs-up': t('zálohuje', 'backs up'), secrets: t('tajemství', 'secrets'), pulls: t('stahuje', 'pulls'),
+  routes: t('routuje', 'routes'), auth: t('autorizace', 'auth'), scales: t('škáluje', 'scales'),
+  scrapes: t('sběr', 'scrapes'), queries: t('dotazuje', 'queries'), alerts: t('alerty', 'alerts'), mesh: t('mesh mTLS', 'mesh mTLS'),
+}[type])
+
+// ---------------------------------------------------------------------------
+// Layout — full-width bands stacked top→bottom, each a centred wrapped grid of
+// pills. Deterministic (NODES is static), so adding a node never overlaps.
+// ---------------------------------------------------------------------------
+const WIDTH = 1240
+const CANVAS_PAD = 40
+const PILL_H = 34
+const BAND_HEAD = 30
+const BAND_PAD_Y = 16
+const BAND_GAP = 26
+const PILL_GAP = 16
+const pillWidth = (label: string) => Math.max(112, 34 + label.length * 7 + 20)
+
+type Pt = { cx: number; cy: number; w: number }
+type Band = { key: GroupKey; y: number; h: number }
+
+const LAYOUT: { pos: Record<string, Pt>; bands: Band[]; height: number } = (() => {
+  const availW = WIDTH - CANVAS_PAD * 2
+  const pos: Record<string, Pt> = {}
+  const bands: Band[] = []
+  let y = CANVAS_PAD
+  for (const g of GROUP_ORDER) {
+    const list = NODES.filter(n => n.group === g)
+    const rows: { id: string; w: number }[][] = [[]]
+    let rowW = 0
+    for (const n of list) {
+      const w = pillWidth(n.label)
+      const cur = rows[rows.length - 1]
+      if (cur.length && rowW + PILL_GAP + w > availW) { rows.push([]); rowW = 0 }
+      rows[rows.length - 1].push({ id: n.id, w })
+      rowW += (cur.length ? PILL_GAP : 0) + w
+    }
+    let ry = y + BAND_HEAD
+    for (const row of rows) {
+      const total = row.reduce((s, r) => s + r.w, 0) + PILL_GAP * Math.max(0, row.length - 1)
+      let x = CANVAS_PAD + Math.max(0, (availW - total) / 2)
+      for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: ry + PILL_H / 2, w: r.w }; x += r.w + PILL_GAP }
+      ry += PILL_H + PILL_GAP
+    }
+    const h = BAND_HEAD + rows.length * (PILL_H + PILL_GAP) - PILL_GAP + BAND_PAD_Y
+    bands.push({ key: g, y, h })
+    y += h + BAND_GAP
+  }
+  return { pos, bands, height: y - BAND_GAP + CANVAS_PAD }
+})()
+
+// Curved, box-trimmed quadratic edge path (copied from the service map engine).
+type Half = { hw: number; hh: number }
+function edgeGeometry(a: Pt, b: Pt, aHalf: Half, bHalf: Half) {
+  const dx = b.cx - a.cx, dy = b.cy - a.cy
+  const dist = Math.hypot(dx, dy) || 1
+  const ux = dx / dist, uy = dy / dist
+  const boxT = (hw: number, hh: number) => {
+    const tx = Math.abs(ux) < 1e-6 ? Infinity : hw / Math.abs(ux)
+    const ty = Math.abs(uy) < 1e-6 ? Infinity : hh / Math.abs(uy)
+    return Math.min(tx, ty)
+  }
+  const ta = boxT(aHalf.hw, aHalf.hh) + 2
+  const tb = boxT(bHalf.hw, bHalf.hh) + 9
+  const sx = a.cx + ux * ta, sy = a.cy + uy * ta
+  const ex = b.cx - ux * tb, ey = b.cy - uy * tb
+  const mx = (sx + ex) / 2, my = (sy + ey) / 2
+  const curve = Math.min(46, dist * 0.14)
+  const cpx = mx - uy * curve, cpy = my + ux * curve
+  return { d: `M ${sx} ${sy} Q ${cpx} ${cpy} ${ex} ${ey}` }
+}
+
+function mixHex(hex: string, target: string, r: number): string {
+  const a = parseInt(hex.slice(1), 16), b = parseInt(target.slice(1), 16)
+  const ch = (s: number) => Math.round(((a >> s) & 255) + (((b >> s) & 255) - ((a >> s) & 255)) * r)
+  return '#' + ((1 << 24) + (ch(16) << 16) + (ch(8) << 8) + ch(0)).toString(16).slice(1)
+}
+
+// A moving particle bound to an edge path (SMIL). Parent decides whether to mount.
+function FlowParticle({ pathId, color, dur, begin, r = 2.5 }: { pathId: string; color: string; dur: number; begin: number; r?: number }) {
+  return (
+    <circle r={r} fill={color} stroke="var(--surface)" strokeWidth={0.5}>
+      <animateMotion dur={`${dur}s`} begin={`${begin}s`} repeatCount="indefinite" rotate="auto" calcMode="linear">
+        <mpath href={`#${pathId}`} />
+      </animateMotion>
+    </circle>
+  )
+}
+
+type LifeMap = Record<string, { urgency?: string }>
+
+const HALF_H = PILL_H / 2
+const pathId = (a: string, b: string, i: number) => `ix-${a}-${b}-${i}`.replace(/[^a-zA-Z0-9_-]/g, '_')
+
+export default function InfraTopologyPage() {
+  const { t } = useLanguage()
+  const [statuses, setStatuses] = useState<Record<string, { status: Status; latencyMs: number | null; checkedAt: string | null }>>({})
+  const [lifecycle, setLifecycle] = useState<LifeMap>({})
+  const [selected, setSelected] = useState<string | null>(null)
+  const [hovered, setHovered] = useState<string | null>(null)
+  const [filter, setFilter] = useState<'all' | GroupKey>('all')
+  const [flow, setFlow] = useState(true)
+  const [isChecking, setIsChecking] = useState(false)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) setFlow(false)
+  }, [])
+
+  const load = async () => {
+    setIsChecking(true)
+    try {
+      const [sRes, lRes] = await Promise.all([
+        fetch('/api/infra/status', { cache: 'no-store' }),
+        fetch('/api/infra/lifecycle', { cache: 'no-store' }),
+      ])
+      if (sRes.ok) setStatuses(await sRes.json())
+      if (lRes.ok) {
+        const data = await lRes.json() as { components?: { id: string; urgency?: string }[] }
+        const map: LifeMap = {}
+        for (const c of data.components ?? []) map[c.id] = { urgency: c.urgency }
+        setLifecycle(map)
+      }
+    } catch {
+      // graceful — the diagram renders from static topology; badges stay UNKNOWN
+    } finally {
+      setIsChecking(false)
+    }
+  }
+  useEffect(() => { load() }, [])
+
+  const nodeMap = Object.fromEntries(NODES.map(n => [n.id, n]))
+  const activeNode = selected ?? hovered
+  const visibleIds = new Set(NODES.filter(n => filter === 'all' || n.group === filter).map(n => n.id))
+  const visibleEdges = EDGES.filter(e => visibleIds.has(e.from) && visibleIds.has(e.to))
+  const isNeighbor = (id: string) => !!activeNode && (activeNode === id
+    || EDGES.some(e => (e.from === activeNode && e.to === id) || (e.to === activeNode && e.from === id)))
+
+  const selectedNode = selected ? nodeMap[selected] : null
+  const statusOf = (id: string): Status | null => (nodeMap[id]?.live ? (statuses[id]?.status ?? 'UNKNOWN') : null)
+  const selectedEdges = selected ? EDGES.filter(e => e.from === selected || e.to === selected) : []
+
+  const groupLabel = (g: GroupKey) => t(GROUPS[g].cs, GROUPS[g].en)
+  const statusColor = (s: Status) => (s === 'UP' ? '#10b981' : s === 'DOWN' ? '#ef4444' : '#94a3b8')
+
+  return (
+    <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
+      <div className="page-header">
+        <div>
+          <div className="breadcrumb">
+            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
+            <span>{t('Infrastruktura', 'Infrastructure')}</span><span className="breadcrumb-sep">/</span>
+            <span className="breadcrumb-current">{t('Topologie', 'Topology')}</span>
+          </div>
+          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Network size={18} style={{ color: 'var(--accent)' }} />
+            {t('Topologie infrastruktury', 'Infrastructure Topology')}
+          </h1>
+          <p className="page-subtitle">
+            {t('Jak jsou platformní komponenty zapojené — architektura toku dat s živým stavem. Hrany jsou zdokumentovaná architektura (ne odvozená data); uzly nesou živý stav z prób.',
+               'How the platform components are wired — a data-flow architecture with live status. Edges are the documented architecture (not derived data); nodes carry live probe status.')}
+          </p>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px', flexWrap: 'wrap', gap: '12px' }}>
+        <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+          {(['all', ...GROUP_ORDER] as const).map(key => (
+            <button key={key} onClick={() => setFilter(key)}
+              style={{
+                padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
+                border: `1px solid ${filter === key ? 'var(--accent)' : 'var(--border)'}`,
+                background: filter === key ? 'var(--accent)' : 'var(--surface)',
+                color: filter === key ? '#fff' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
+              }}>
+              {key === 'all' ? t('Vše', 'All') : groupLabel(key)}
+            </button>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+          <button onClick={() => setFlow(v => !v)} aria-pressed={flow} title={t('Přepnout tok dat', 'Toggle data flow')}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
+              borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
+              border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
+              background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
+            }}>
+            {flow ? <Pause size={13} /> : <Play size={13} />}{t('Tok dat', 'Data flow')}
+          </button>
+          <button onClick={load} disabled={isChecking} className="btn btn-secondary"
+            style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+            <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
+            {isChecking ? t('Zjišťuji…', 'Checking...') : t('Obnovit stav', 'Refresh Status')}
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: selectedNode ? '1fr 320px' : '1fr', gap: '16px' }}>
+        <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+          <svg viewBox={`0 0 ${WIDTH} ${LAYOUT.height}`} style={{ width: '100%', height: 'auto', display: 'block', background: 'var(--surface)' }}>
+            <defs>
+              {(['control', 'data', 'flow'] as EdgeCat[]).map(cat => (
+                <marker key={cat} id={`ix-arrow-${cat}`} markerWidth="7" markerHeight="7" refX="5.5" refY="3" orient="auto">
+                  <path d="M0,0 L0,6 L7,3 z" fill={CAT_COLOR[cat]} />
+                </marker>
+              ))}
+              <filter id="ix-shadow" x="-40%" y="-40%" width="180%" height="180%">
+                <feDropShadow dx="0" dy="1.5" stdDeviation="2.5" floodColor="#0f172a" floodOpacity="0.14" />
+              </filter>
+            </defs>
+
+            {/* Group bands */}
+            {LAYOUT.bands.filter(b => filter === 'all' || b.key === filter).map(b => {
+              const meta = GROUPS[b.key]
+              return (
+                <g key={b.key}>
+                  <rect x={CANVAS_PAD - 14} y={b.y} width={WIDTH - (CANVAS_PAD - 14) * 2} height={b.h} rx="16"
+                    fill={`${meta.color}0a`} stroke={`${meta.color}33`} strokeWidth="1" />
+                  <text x={CANVAS_PAD} y={b.y + 20} fontSize="11" fill={meta.color} fontWeight="700" letterSpacing="0.08em">
+                    {groupLabel(b.key).toUpperCase()}
+                  </text>
+                </g>
+              )
+            })}
+
+            {/* Edges + particles */}
+            {visibleEdges.map((e, i) => {
+              const a = LAYOUT.pos[e.from], b = LAYOUT.pos[e.to]
+              if (!a || !b) return null
+              const cat = EDGE_CAT[e.type]
+              const color = CAT_COLOR[cat]
+              const touches = !!activeNode && (e.from === activeNode || e.to === activeNode)
+              const dim = !!activeNode && !touches
+              const { d } = edgeGeometry(a, b, { hw: a.w / 2, hh: HALF_H }, { hw: b.w / 2, hh: HALF_H })
+              const pid = pathId(e.from, e.to, i)
+              return (
+                <g key={i} opacity={dim ? 0.1 : touches ? 1 : 0.5} style={{ transition: 'opacity 0.15s' }}>
+                  <path id={pid} d={d} fill="none" stroke={touches ? mixHex(color, '#000000', 0.15) : color}
+                    strokeWidth={touches ? 2 : 1.3} strokeDasharray={CAT_DASHED[cat] ? '5,4' : undefined}
+                    markerEnd={`url(#ix-arrow-${cat})`} />
+                  {flow && <FlowParticle pathId={pid} color={color} dur={2.6 + (i % 5) * 0.26} begin={(i % 7) * 0.18} />}
+                  {touches && (() => {
+                    const lbl = edgeTypeLabel(e.type, t)
+                    const { cx: mx, cy: my } = { cx: (a.cx + b.cx) / 2, cy: (a.cy + b.cy) / 2 }
+                    return (
+                      <g>
+                        <rect x={mx - lbl.length * 3.1 - 5} y={my - 9} width={lbl.length * 6.2 + 10} height="15" rx="7.5"
+                          fill="var(--surface)" stroke={`${color}55`} strokeWidth="0.75" opacity="0.97" />
+                        <text x={mx} y={my + 2} fontSize="9" fill={color} textAnchor="middle" fontWeight="600">{lbl}</text>
+                      </g>
+                    )
+                  })()}
+                </g>
+              )
+            })}
+
+            {/* Nodes */}
+            {NODES.filter(n => visibleIds.has(n.id)).map(n => {
+              const p = LAYOUT.pos[n.id]
+              if (!p) return null
+              const meta = GROUPS[n.group]
+              const emphasized = !activeNode || isNeighbor(n.id)
+              const isSel = selected === n.id
+              const st = statusOf(n.id)
+              const x = p.cx - p.w / 2, y = p.cy - PILL_H / 2
+              return (
+                <g key={n.id} style={{ cursor: 'pointer', transition: 'opacity 0.15s' }} opacity={emphasized ? 1 : 0.25}
+                  onClick={() => setSelected(s => s === n.id ? null : n.id)}
+                  onMouseEnter={() => setHovered(n.id)} onMouseLeave={() => setHovered(h => h === n.id ? null : h)}>
+                  <rect x={x} y={y} width={p.w} height={PILL_H} rx={PILL_H / 2}
+                    fill={isSel ? meta.color : 'var(--surface)'} stroke={meta.color} strokeWidth={isSel ? 1.9 : 1.3}
+                    filter="url(#ix-shadow)" />
+                  <circle cx={x + 15} cy={p.cy} r={4} fill={meta.color} />
+                  <text x={x + 26} y={p.cy + 4} fontSize="11" fontWeight="600" fill={isSel ? '#fff' : 'var(--text-primary)'}>{n.label}</text>
+                  {st && (
+                    <g transform={`translate(${x + p.w - 12}, ${y + 2})`}>
+                      <circle cx="0" cy="0" r="6.5" fill={statusColor(st)} stroke="var(--surface)" strokeWidth="1.5" />
+                      {st === 'UP' && <path d="M-2.5,0 L-0.8,1.8 L2.6,-2.2" fill="none" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />}
+                      {st === 'DOWN' && <path d="M-2,-2 L2,2 M-2,2 L2,-2" fill="none" stroke="#fff" strokeWidth="1.4" strokeLinecap="round" />}
+                      {st === 'UNKNOWN' && <text x="0" y="2.5" fontSize="8" fill="#fff" textAnchor="middle" fontWeight="bold">?</text>}
+                    </g>
+                  )}
+                </g>
+              )
+            })}
+          </svg>
+
+          {/* Legend */}
+          <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', display: 'flex', gap: '18px', flexWrap: 'wrap' }}>
+            {([['control', t('Řízení (nasazení · admission · cert)', 'Control (deploy · admit · cert)')],
+               ['data', t('Data (spravuje · používá · zálohuje)', 'Data (manages · uses · backs up)')],
+               ['flow', t('Tok (škálování · sběr · alerty · mesh)', 'Flow (scale · scrape · alerts · mesh)')]] as [EdgeCat, string][]).map(([cat, lbl]) => (
+              <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke={CAT_COLOR[cat]} strokeWidth="1.6" strokeDasharray={CAT_DASHED[cat] ? '5,3' : undefined} markerEnd={`url(#ix-arrow-${cat})`} /></svg>
+                {lbl}
+              </div>
+            ))}
+            <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+              <span style={{ width: '10px', height: '10px', borderRadius: '50%', background: '#10b981' }} />{t('Živý stav (UP/DOWN)', 'Live status (UP/DOWN)')}
+            </div>
+          </div>
+        </div>
+
+        {/* Detail panel */}
+        {selectedNode && (
+          <div className="card" style={{ padding: '20px', alignSelf: 'start' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
+              <div style={{ width: '28px', height: '28px', borderRadius: '8px', background: `${GROUPS[selectedNode.group].color}1a`, display: 'flex', alignItems: 'center', justifyContent: 'center', color: GROUPS[selectedNode.group].color }}>
+                {(() => { const I = GROUPS[selectedNode.group].Icon; return <I size={16} /> })()}
+              </div>
+              <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{selectedNode.label}</div>
+              {statusOf(selectedNode.id) && (
+                <div style={{
+                  marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '4px', padding: '2px 8px',
+                  borderRadius: '12px', fontSize: '11px', fontWeight: 600,
+                  background: `${statusColor(statusOf(selectedNode.id)!)}22`, color: statusColor(statusOf(selectedNode.id)!),
+                }}>
+                  {statusOf(selectedNode.id) === 'UP' && <CheckCircle2 size={12} />}
+                  {statusOf(selectedNode.id) === 'DOWN' && <XCircle size={12} />}
+                  {statusOf(selectedNode.id) === 'UNKNOWN' && <HelpCircle size={12} />}
+                  {statusOf(selectedNode.id)}
+                </div>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <div>
+                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('VRSTVA', 'LAYER')}</div>
+                <div style={{ fontSize: '12px', color: GROUPS[selectedNode.group].color, fontWeight: 600 }}>{groupLabel(selectedNode.group)}</div>
+              </div>
+              <div>
+                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('POPIS', 'DESCRIPTION')}</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>{t(selectedNode.descCs, selectedNode.descEn)}</div>
+              </div>
+              {selectedNode.live && statuses[selectedNode.id]?.latencyMs != null && (
+                <div>
+                  <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('LATENCE PRÓBY', 'PROBE LATENCY')}</div>
+                  <div style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '12px', color: 'var(--text-primary)' }}>{statuses[selectedNode.id].latencyMs} ms</div>
+                </div>
+              )}
+              {lifecycle[selectedNode.id]?.urgency && lifecycle[selectedNode.id].urgency !== 'ok' && (
+                <div style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+                  <span style={{ width: '8px', height: '8px', borderRadius: '50%', background: 'var(--warning)' }} />
+                  <span style={{ color: 'var(--text-secondary)' }}>{t('Životní cyklus', 'Lifecycle')}: {lifecycle[selectedNode.id].urgency}</span>
+                </div>
+              )}
+              {!selectedNode.live && (
+                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', fontStyle: 'italic' }}>
+                  {t('Architektonický uzel — bez živé próby.', 'Architectural node — no live probe.')}
+                </div>
+              )}
+
+              <div>
+                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '6px' }}>{t('PROPOJENÍ', 'CONNECTIONS')} ({selectedEdges.length})</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                  {selectedEdges.map((e, i) => {
+                    const out = e.from === selectedNode.id
+                    const other = nodeMap[out ? e.to : e.from]
+                    const color = CAT_COLOR[EDGE_CAT[e.type]]
+                    return (
+                      <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+                        <span style={{ color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>{out ? '→' : '←'}</span>
+                        <span style={{ color: GROUPS[other?.group ?? 'data'].color, fontWeight: 600 }}>{other?.label}</span>
+                        <span style={{ marginLeft: 'auto', fontSize: '10px', color, background: `${color}18`, padding: '2px 6px', borderRadius: '4px' }}>{edgeTypeLabel(e.type, t)}</span>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <a href="/infrastructure" style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', padding: '8px 12px',
+                background: 'var(--accent-bg)', color: 'var(--accent)', borderRadius: 'var(--r-md)', fontSize: '12px',
+                fontWeight: 600, textDecoration: 'none', marginTop: '4px', border: '1px solid var(--accent-border, transparent)',
+              }}>
+                <Server size={14} /> {t('Otevřít přehled infrastruktury', 'Open infrastructure overview')}
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -113,18 +113,18 @@ const EDGES: EdgeDef[] = [
   { from: 'strimzi', to: 'kafka', type: 'manages' },
   { from: 'postgres', to: 's3', type: 'backs-up' },
   { from: 'external-secrets', to: 'openbao', type: 'secrets' },
-  { from: 'keda', to: 'kafka', type: 'scales' },
+  { from: 'keda', to: 'kafka', type: 'scales' }, // KEDA scales workloads ON Kafka consumer-lag (see label)
   { from: 'kyverno', to: 'eks', type: 'admits' },
   { from: 'cert-manager', to: 'ingress-nginx', type: 'issues' },
   { from: 'cert-manager', to: 'istio', type: 'issues' },
   { from: 'ingress-nginx', to: 'keycloak', type: 'routes' },
   { from: 'ingress-nginx', to: 'grafana', type: 'routes' },
-  { from: 'istio', to: 'kafka', type: 'mesh' },
   // Backing-service usage
   { from: 'keycloak', to: 'postgres', type: 'uses' },
   { from: 'temporal', to: 'postgres', type: 'uses' },
   { from: 'schema-registry', to: 'kafka', type: 'uses' },
-  { from: 'keycloak', to: 'opa', type: 'auth' },
+  { from: 'kafka-ui', to: 'kafka', type: 'uses' },
+  { from: 'opa', to: 'keycloak', type: 'auth' }, // OPA fetches JWKS to validate Keycloak-issued JWTs
   // Observability pipeline
   { from: 'alloy', to: 'prometheus', type: 'scrapes' },
   { from: 'alloy', to: 'loki', type: 'scrapes' },
@@ -153,8 +153,8 @@ const edgeTypeLabel = (type: EdgeType, t: (cs: string, en: string) => string): s
   deploys: t('nasazuje', 'deploys'), provisions: t('provisiony', 'provisions'), admits: t('admission', 'admits'),
   issues: t('vydává cert', 'issues cert'), manages: t('spravuje', 'manages'), uses: t('používá', 'uses'),
   'backs-up': t('zálohuje', 'backs up'), secrets: t('tajemství', 'secrets'), pulls: t('stahuje', 'pulls'),
-  routes: t('routuje', 'routes'), auth: t('autorizace', 'auth'), scales: t('škáluje', 'scales'),
-  scrapes: t('sběr', 'scrapes'), queries: t('dotazuje', 'queries'), alerts: t('alerty', 'alerts'), mesh: t('mesh mTLS', 'mesh mTLS'),
+  routes: t('routuje', 'routes'), auth: t('validuje JWT', 'validates JWT'), scales: t('škáluje dle lagu', 'scales on lag'),
+  scrapes: t('odesílá', 'ships'), queries: t('dotazuje', 'queries'), alerts: t('alerty', 'alerts'), mesh: t('mesh mTLS', 'mesh mTLS'),
 }[type])
 
 // ---------------------------------------------------------------------------
@@ -443,7 +443,7 @@ export default function InfraTopologyPage() {
           <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', display: 'flex', gap: '18px', flexWrap: 'wrap' }}>
             {([['control', t('Řízení (nasazení · admission · cert)', 'Control (deploy · admit · cert)')],
                ['data', t('Data (spravuje · používá · zálohuje)', 'Data (manages · uses · backs up)')],
-               ['flow', t('Tok (škálování · sběr · alerty · mesh)', 'Flow (scale · scrape · alerts · mesh)')]] as [EdgeCat, string][]).map(([cat, lbl]) => (
+               ['flow', t('Tok (škálování · telemetrie · alerty)', 'Flow (scale · telemetry · alerts)')]] as [EdgeCat, string][]).map(([cat, lbl]) => (
               <div key={cat} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
                 <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke={CAT_COLOR[cat]} strokeWidth="1.6" strokeDasharray={CAT_DASHED[cat] ? '5,3' : undefined} markerEnd={`url(#ix-arrow-${cat})`} /></svg>
                 {lbl}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ import {
   DollarSign, Globe, Repeat, Zap, AlertOctagon, ScanLine,
   Layers, TrendingUp, MessageSquareWarning, Package, Receipt, Server, ShieldAlert, FlaskConical, Cloud,
   PiggyBank, GitBranch, Lock, ClipboardList, Scale, Smartphone,
-  ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature,
+  ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network,
 } from 'lucide-react'
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -99,6 +99,7 @@ const sysNav: NavItem[] = [
   { nameCs: 'Zdraví systému',   nameEn: 'System Health',   href: '/system/health',    icon: HeartPulse,        permission: 'system:view' },
   { nameCs: 'Tech Inventory',   nameEn: 'Tech Inventory',  href: '/system/inventory', icon: Package,           permission: 'system:view' },
   { nameCs: 'Infrastruktura',   nameEn: 'Infrastructure',  href: '/infrastructure',   icon: Server,            permission: 'system:view' },
+  { nameCs: 'Topologie infra',  nameEn: 'Infra Topology',  href: '/infrastructure/topology', icon: Network,     permission: 'system:view' },
   { nameCs: 'Test Coverage',    nameEn: 'Test Coverage',   href: '/system/tests',     icon: FlaskConical,      permission: 'system:view' },
   { nameCs: 'Připravenost prod',nameEn: 'Prod Readiness',  href: '/system/readiness', icon: ClipboardCheck,    permission: 'system:view' },
   { nameCs: 'Konfigurace',      nameEn: 'Configuration',   href: '/system/config',    icon: SlidersHorizontal, permission: 'system:config' },

--- a/openbank-admin-ui/src/test/infrastructure-topology.test.tsx
+++ b/openbank-admin-ui/src/test/infrastructure-topology.test.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Behaviour test for the infrastructure topology page (/infrastructure/topology).
+// render-smoke only covers the all-fetch-fail path; this mounts with real-shaped
+// /api/infra/status + /api/infra/lifecycle payloads so the group bands, live status
+// overlay, SMIL flow animation, and the node detail panel are actually exercised.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import InfraTopologyPage from '@/app/infrastructure/topology/page'
+
+const STATUS = {
+  argocd: { status: 'UP', latencyMs: 12, checkedAt: '2026-07-18T00:00:00Z' },
+  postgres: { status: 'DOWN', latencyMs: null, checkedAt: '2026-07-18T00:00:00Z' },
+  prometheus: { status: 'UP', latencyMs: 8, checkedAt: '2026-07-18T00:00:00Z' },
+}
+const LIFECYCLE = { components: [{ id: 'postgres', urgency: 'patch-available' }] }
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+function mockFetch() {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/infra/status')) return json(STATUS)
+    if (url.includes('/api/infra/lifecycle')) return json(LIFECYCLE)
+    return json({})
+  })
+}
+
+describe('infrastructure topology page', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', mockFetch()) })
+  afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+  it('renders the layered bands with real components', async () => {
+    render(React.createElement(Providers, null, React.createElement(InfraTopologyPage)))
+    await waitFor(() => expect(screen.getByText('ArgoCD')).toBeInTheDocument())
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument()
+    expect(screen.getByText('Prometheus')).toBeInTheDocument()
+    // Band headers are upper-cased and unique to the SVG bands.
+    expect(screen.getByText('AWS SUBSTRATE')).toBeInTheDocument()
+    expect(screen.getByText('OBSERVABILITY')).toBeInTheDocument()
+  })
+
+  it('animates flow by default and stops when the flow toggle is turned off', async () => {
+    const { container } = render(React.createElement(Providers, null, React.createElement(InfraTopologyPage)))
+    await waitFor(() => expect(screen.getByText('ArgoCD')).toBeInTheDocument())
+    expect(container.querySelectorAll('animateMotion').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getByRole('button', { name: /Data flow/i }))
+    await waitFor(() => expect(container.querySelectorAll('animateMotion').length).toBe(0))
+  })
+
+  it('opens a node detail panel with live status and connections on click', async () => {
+    render(React.createElement(Providers, null, React.createElement(InfraTopologyPage)))
+    await waitFor(() => expect(screen.getByText('ArgoCD')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('ArgoCD'))
+    expect(await screen.findByText(/CONNECTIONS/i)).toBeInTheDocument()
+    // ArgoCD deploys Kyverno in the curated backbone → Kyverno appears both as a
+    // node pill and as a connection row in the panel (so ≥2 occurrences).
+    expect(screen.getAllByText('Kyverno').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('overlays live probe status — a DOWN component shows DOWN in its panel', async () => {
+    render(React.createElement(Providers, null, React.createElement(InfraTopologyPage)))
+    await waitFor(() => expect(screen.getByText('PostgreSQL')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('PostgreSQL'))
+    await waitFor(() => expect(screen.getByText('DOWN')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary

A companion to the animated service map, at **`/infrastructure/topology`**: an interactive, animated view of **how the platform components are wired together** — AWS substrate, control plane, data/backing services, and the observability stack — with each component's **live status** overlaid. `/infrastructure` answers "is each piece healthy?"; this answers "how do the pieces fit together?".

## Type of change

- [x] feat (new functionality)

## Linked issues

None — operator-console UI enhancement (follow-up to #1620).

## Changes

- **NEW `src/app/infrastructure/topology/page.tsx`** — four layered bands (AWS · Platform/control plane · Data/backing · Observability) of pill nodes, typed curved edges (control/data/flow), the same SMIL `FlowParticle` animation + Flow/group toggles + `prefers-reduced-motion` as the service map, live status badges (UP/DOWN/UNKNOWN), and a node detail panel (layer, description, probe latency, EoL/CVE lifecycle, connections). Inherits the existing `infrastructure/layout.tsx` shell (no new `layout.tsx`).
- **`src/components/layout/Sidebar.tsx`** — adds an "Infra Topology" nav entry under Infrastructure.
- **NEW `src/test/infrastructure-topology.test.tsx`** — mounts with real-shaped `/api/infra/status` + `/api/infra/lifecycle` payloads and asserts the bands + nodes render, the flow toggle mounts/removes SMIL particles, the detail panel opens with connections, and a DOWN component surfaces its status.

## Honesty contract (read this)

Unlike the service map (100% code-derived), the **infra backbone is not machine-declared anywhere** — the operators live in Terraform `helm_release`, and gitops only has `app→namespace` + `operator→workload` CRs, never the inter-component wiring. So the **edges are a hand-authored, verifiable architectural layer** (ArgoCD deploys, CNPG→Postgres→S3, External Secrets→OpenBao, Karpenter→nodes, observability scrape/query/alert, Istio mesh, ingress routes) — exactly how the existing `cloud-architecture` / `observability/stack` pages already draw infra, but interactive. The **nodes are real** components carrying **live probe status**. The subtitle states this plainly so nobody reads the edges as derived data.

## Definition of Done

- [x] Hexagonal layering — N/A (admin-ui).
- [x] Unit tests added (`infrastructure-topology.test.tsx`, +4; suite → 613).
- [ ] Integration / contract tests — N/A (reuses existing read-only `/api/infra/*` routes, no shape change).
- [x] admin-ui gate green: `type-check` · `test` · `eslint .` (0 errors) · `next build` (route present).
- [x] No new lint errors (2 pre-existing-style `set-state-in-effect` warnings, same pattern as the service map).
- [ ] OpenAPI / Flyway / Avro — N/A.
- [x] Docs — no ADR (a visualization over documented architecture; subtitle carries the honesty note).

## Security checklist

- [x] No secrets/tokens/PII — node/edge data is public architecture; status comes from the existing probe endpoint.
- [x] No new `@Suppress`/`as Any`. No new dependency (existing React/lucide-react). No auth/crypto/payment/PII/cardholder path touched.

## Compliance impact

- [x] None — read-only operator visualization; no new backend, probes, or egress.

## Rollout / Rollback

- Deployment strategy: rolling (standard admin-ui deploy). Rollback: revert the PR; no state/schema/config migration. Data migration reversible: N/A.

## Screenshots / demo (if UI change)

Four layered bands — **AWS SUBSTRATE** (VPC/EKS/EC2/ECR/S3/NAT), **PLATFORM / CONTROL PLANE** (ArgoCD/Karpenter/KEDA/Kyverno/cert-manager/External Secrets/Argo Rollouts/ingress/Istio), **DATA / BACKING SERVICES** (CloudNativePG/PostgreSQL/Strimzi/Kafka/Schema Registry/OpenBao/Valkey/Keycloak/Temporal/OPA), **OBSERVABILITY** (Prometheus/Grafana/Loki/Tempo/Pyroscope/Alloy/OTel/Alertmanager/Pyrra/GlitchTip/GoAlert/ntfy/Kafka UI). Typed edges curve between bands; each live node shows a green/red/grey status badge; a legend documents control/data/flow + live status. _(Screenshot shared with the author in the working session.)_

## Reviewer notes

- **v1 copies the service-map engine** (`edgeGeometry`, `FlowParticle`, `mixHex`, band layout) into this page to keep the just-merged service map untouched. Follow-up (not this PR): extract a shared `src/components/topology/` module used by both.
- **FinOps:** ~$0 recurring — reuses `/api/infra/status` (already polled by `/infrastructure`) + `/api/infra/lifecycle`; curated edges are static; animation is client-side SMIL/CSS.
- Node ids intentionally match the `/api/infra/status` contract so the live badge maps directly; architectural-only nodes (AWS substrate, operators, mesh) render without a badge and say so in the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
