### PR TITLE
chore(gitops): product-catalog + edge -> sandbox-7f49a11d (fees, #1652)

### DIFF
--- a/openbank-infra/gitops/components/accounts/product-catalog.yaml
+++ b/openbank-infra/gitops/components/accounts/product-catalog.yaml
@@ -69,7 +69,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: product-catalog
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-de3f7d2f
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-product-catalog:sandbox-7f49a11d
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-743090b3
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-7f49a11d
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Rolls out #1652 — product-catalog fee backfill on boot + edge GET /accounts/{id}/fees. Images built + signed by Auto Deploy; hand-bump (runner backlog).

## Linked issues

N/A — deploy bump for the fee-schedule feature.