### PR TITLE
fix(admin-ui): make compliance-controls live-signal join symmetric

### DIFF
--- a/openbank-admin-ui/src/lib/governance/compliance.ts
+++ b/openbank-admin-ui/src/lib/governance/compliance.ts
@@ -90,12 +90,16 @@ export async function loadComplianceCatalog(): Promise<ComplianceCatalog | null>
   const authored = parsed.controls ?? []
 
   // Join live status from the derived security posture where declared.
+  // Symmetric: a true signal promotes to `enforced`; a false signal demotes
+  // an authored `enforced` back down (the live signal disproved the claim),
+  // but leaves an already-honest partial/audit/planned status untouched.
   const posture = await loadSecurityPosture()
   const controls: ComplianceControl[] = authored.map(c => {
     if (!c.derivedFrom) return c
     const signal = signalValue(posture, c.derivedFrom)
     if (signal === undefined) return c
-    return { ...c, status: signal ? 'enforced' : c.status, live: true }
+    if (signal) return { ...c, status: 'enforced', live: true }
+    return { ...c, status: c.status === 'enforced' ? 'planned' : c.status, live: true }
   })
 
   // Per-framework coverage roll-up.


### PR DESCRIPTION
## Summary
- **Superseded in part by #1666** (merged while this PR was open): it already fixed the false-`enforced` data for `encryption-in-transit`/`strong-auth`/`authz-least-privilege` and removed the same-class bad `derivedFrom` on `net-segmentation`, all by removing the `derivedFrom` keys entirely. This PR is now rebased on top of that and reduced to what #1666 didn't touch: the join logic itself.
- `compliance.ts`'s live-signal join was asymmetric — `status: signal ? 'enforced' : c.status` — a `false` signal fell back to the *authored* status instead of demoting it, so it could only ever confirm an authored `enforced`, never disprove one. Harmless today (no remaining control has a `derivedFrom` whose authored status is `enforced`), but the next control that adds one would inherit the same one-way ratchet.
- Fix: make the join symmetric — a `false` signal now demotes an over-claimed `enforced` to `planned`; an already-honest `partial`/`audit`/`planned` status is left untouched.

## Linked issues
Refs #1666 (the data fix this PR builds on). Refs #1673 — filed by me as a `net-segmentation` follow-up before discovering #1666 already fixed it; closing #1673 as a duplicate.

## Test plan
- [x] Standalone simulation of the join logic against: (a) an authored `enforced` + false signal → demotes to `planned`, (b) an honest `partial` + false signal → stays `partial`, (c) `audit` + true signal → promotes to `enforced`, (d) no `derivedFrom` → untouched. All four passed.
- [x] `git diff origin/main -- openbank-libs/governance/compliance-controls.yaml` is empty — no data changes remain in this PR, only the `compliance.ts` join fix.
- [ ] Full `npm run type-check` / dev-server render blocked in this sandbox (no `node_modules` in a fresh worktree, and `.claude/launch.json`'s dev-server env points outside this branch) — reviewer should confirm `/docs/control-tower` still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
