### PR TITLE
fix(billing): add missing quarkus-opentelemetry extension

### DIFF
--- a/openbank-billing-service/build.gradle.kts
+++ b/openbank-billing-service/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.quarkus.resteasy.reactive.jackson)
     implementation(libs.quarkus.smallrye.health)
     implementation(libs.quarkus.micrometer.registry.prometheus)
+    implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.jackson.module.kotlin)

--- a/openbank-billing-service/src/main/resources/application.yaml
+++ b/openbank-billing-service/src/main/resources/application.yaml
@@ -23,6 +23,13 @@ quarkus:
     level: INFO
     console:
       json: true
+  otel:
+    exporter:
+      otlp:
+        endpoint: http://localhost:4317
+    resource:
+      attributes:
+        service.name: openbank-billing-service
   smallrye-openapi:
     path: /q/openapi
   swagger-ui:


### PR DESCRIPTION
## Root cause (billing tracing anomaly)
While investigating why `SLOMetricAbsent` pages for `openbank-billing-service`, found billing-service is the **only** one of the 18 `money_path_services` whose `build.gradle.kts` is missing `implementation(libs.quarkus.opentelemetry)`. The `openbank.quarkus-service` convention plugin does not add it; the other 17 services each declare it explicitly, billing was overlooked.

Without the extension:
- billing emits **no spans at all** — `traces_spanmetrics_calls_total{service="openbank-billing-service"}` is absent for >24h (fraud/settlement are continuously present).
- the `QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT` env var wired by gitops is silently ignored (no OTel to read it), and **no exporter error is logged**.
- Micrometer HTTP metrics still work (separate extension), which masked the gap.

Consequence: billing's trace-based availability + latency SLOs (`pyrra-slo-money-path.yaml`) can never be evaluated → Pyrra's `SLOMetricAbsent` pages **permanently** for billing regardless of traffic. (This is why billing was the lone hold-out in the SLO-heartbeat testing — it literally cannot produce a span.)

## Fix
- `build.gradle.kts`: add `implementation(libs.quarkus.opentelemetry)`.
- `application.yaml`: add the `otel:` block (OTLP endpoint + `service.name` resource attribute), mirroring the exact pattern of the other 17 services.

## Verification
- `:openbank-billing-service:quarkusBuild` **SUCCESSFUL** — extension wires with no CDI/ArC conflict.
- Diagnosis evidence: billing handles HTTP (Micrometer `http_server_requests` status=404 counted) but 40 in-cluster GETs produced 0 spans; 24h span history empty; billing-db healthy and reachable (a separate transient DB blip today, since recovered, is unrelated).

## Notes
- Observability-only; no change to billing behaviour or its security surface. Money-path service → needs 2 approvals per governance; not self-merging.
- **Separate finding worth its own look:** billing-service had an ~8h DB-connectivity incident today (09:08→~17:05 UTC, Agroal pool "incorrect state VALIDATION" + Vert.x "Result is already complete") while its readiness probe stayed green — silent money-path degradation. Recovered on its own; flagging for a resilience/readiness review.

Refs #669