### PR TITLE
feat(customer-edge): expose GET /customer/v1/kyc (own identity-verification status)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -105,6 +105,9 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.interest-service-url")
     lateinit var interestServiceUrl: String
 
+    @ConfigProperty(name = "openbank.edge.kyc-service-url")
+    lateinit var kycServiceUrl: String
+
     // ADR-0109 P2: product-catalog is the authority for which currencies a product permits.
     // Defaulted so a missing env doesn't break startup; reachable in-cluster.
     @ConfigProperty(
@@ -329,6 +332,52 @@ class CustomerEdgeResource(
         val resp = upstream.get("$productCatalogUrl/api/v1/products/$productId/fees", customer.partyId.toString())
         val body = if (resp.status == 200) resp.entity?.toString()?.takeIf { it.isNotBlank() } ?: "[]" else "[]"
         return Response.ok(body).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    // --- KYC / identity verification status (AML Act §8, ADR-0073) ---
+
+    /**
+     * The caller's OWN identity-verification (KYC) status. No path param — the party is taken from
+     * the JWT (`customer().partyId`), so a customer can only ever see their own case. Projects
+     * kyc-service's case down to a customer-safe shape: the overall [status], when it was verified,
+     * and the per-check outcomes (identity / address / sanctions…). Deliberately DROPS the internal
+     * risk level, due-diligence tier, notes and assignee — those are compliance-only. No case yet
+     * (404 upstream) or an unavailable kyc-service returns `{"status":"NONE","checks":[]}` so the app
+     * shows a "not verified yet" state rather than an error.
+     */
+    @GET
+    @Path("/kyc")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun getKycStatus(): Response {
+        val customer = customer()
+        val resp = upstream.get(
+            "$kycServiceUrl/api/v1/kyc/cases/party/${customer.partyId}",
+            customer.partyId.toString(),
+        )
+        val out = objectMapper.createObjectNode()
+        val case = if (resp.status == 200) {
+            runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") }.getOrNull()
+        } else {
+            null
+        }
+        if (case == null) {
+            out.put("status", "NONE")
+            out.set<com.fasterxml.jackson.databind.JsonNode>("checks", objectMapper.createArrayNode())
+            return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+        }
+        out.put("status", case.get("status")?.asText() ?: "NONE")
+        case.get("reviewedAt")?.takeIf { it.isTextual }?.let { out.put("verifiedAt", it.asText()) }
+        val checks = objectMapper.createArrayNode()
+        (case.get("checks") as? com.fasterxml.jackson.databind.node.ArrayNode)?.forEach { c ->
+            val row = objectMapper.createObjectNode()
+            row.put("type", c.get("checkType")?.asText() ?: "")
+            row.put("status", c.get("status")?.asText() ?: "")
+            c.get("performedAt")?.takeIf { it.isTextual }?.let { row.put("performedAt", it.asText()) }
+            checks.add(row)
+        }
+        out.set<com.fasterxml.jackson.databind.JsonNode>("checks", checks)
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
     }
 
     // --- Currency pockets (ADR-0109) ---

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -93,6 +93,7 @@ openbank:
     account-service-url: ${ACCOUNT_SERVICE_URL:http://account-service.accounts.svc:8100}
     balance-service-url: ${BALANCE_SERVICE_URL:http://balance-service.balances.svc:8103}
     interest-service-url: ${INTEREST_SERVICE_URL:http://interest-service.interest.svc:8125}
+    kyc-service-url: ${KYC_SERVICE_URL:http://kyc-service.kyc.svc:8114}
     transaction-service-url: ${TRANSACTION_SERVICE_URL:http://transaction-service.payments.svc:8102}
     domestic-payment-service-url: ${DOMESTIC_PAYMENT_SERVICE_URL:http://domestic-payment.payments.svc:8116}
     sepa-payment-service-url: ${SEPA_PAYMENT_SERVICE_URL:http://sepa-payment.payments.svc:8115}


### PR DESCRIPTION
Lets the customer app show its KYC / identity-verification status. **No path param** — the party is taken from the JWT (`customer().partyId`), so a customer can only ever see their OWN case.

- `GET /customer/v1/kyc` reads kyc-service `GET /api/v1/kyc/cases/party/{partyId}` and projects it to a **customer-safe** shape: `{ status, verifiedAt, checks:[{type,status,performedAt}] }`. Deliberately DROPS the internal risk level, due-diligence tier, notes and assignee — compliance-only.
- **Fail-soft**: no case (404) / unavailable kyc-service → `{ "status":"NONE", "checks":[] }` → app shows "not verified yet", not an error.
- kyc-service `/cases/party` is `@RolesAllowed(...OPERATOR...)`, which the edge's service-account principal carries — no new role/policy.

Deploy needs `KYC_SERVICE_URL` env on customer-edge + regenerated NetworkPolicies (edge→kyc) — at gitops rollout. Live data: 45 APPROVED cases in sandbox (STP auto-approve, ADR-0073).

Pairs with the app KYC screen (openbank-app). Refs AML Act §8.

## Linked issues

N/A — customer-facing KYC-status transparency.