### PR TITLE
chore(gitops): customer-edge -> sandbox-6f3937cd + KYC_SERVICE_URL + netpol (#1676)

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-7f49a11d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-6f3937cd
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -139,6 +139,11 @@ spec:
             # application.yaml) so gen-network-policies.py opens the edge->interest ingress allow.
             - name: INTEREST_SERVICE_URL
               value: http://interest-service.interest.svc:8125
+            # KYC / identity-verification status for the customer app (#1676): GET
+            # /accounts... no — GET /customer/v1/kyc reads the caller's own case. Declared here so
+            # gen-network-policies.py opens the edge->kyc ingress allow.
+            - name: KYC_SERVICE_URL
+              value: http://kyc-service.kyc.svc:8114
             - name: TRANSACTION_SERVICE_URL
               value: http://transaction-service.payments.svc:8102
             - name: DOMESTIC_PAYMENT_SERVICE_URL

--- a/openbank-infra/gitops/components/kyc/network-policies.yaml
+++ b/openbank-infra/gitops/components/kyc/network-policies.yaml
@@ -38,6 +38,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
Deploys #1676 (KYC status route): edge image bump, KYC_SERVICE_URL env, regenerated NetworkPolicy (kyc ← customer-edge). Image built + signed by Auto Deploy; hand-bump.

## Linked issues

N/A — deploy for the KYC-status feature.