### PR TITLE
fix(billing): self-heal the reactive pg pool so a DB blip can't wedge the service

### DIFF
--- a/docs/threat-models/openbank-billing-service.md
+++ b/docs/threat-models/openbank-billing-service.md
@@ -87,7 +87,14 @@ Trust boundaries: every inbound/outbound hop is service↔service over mTLS with
 - **Information disclosure** — `FeeContext` (balance/segment) is processed transiently and not
   re-persisted beyond the audit record; transport is TLS; reads are OPA-authorized.
 - **Denial of service** — assessment is idempotent and bounded per cycle; a redrive replays to the
-  same ledger journal rather than amplifying.
+  same ledger journal rather than amplifying. **Availability (self-inflicted):** a transient DB blip
+  can poison the reactive pg pool, and Quarkus leaves every pool self-heal lever off by default, so
+  the pool has no way to purge dead connections and wedges the service until a pod restart. The
+  datasource readiness probe does not catch this — it is a connectivity check (`SELECT 1` on a fresh
+  connection) that stays green while a reachable DB's pooled connections are dead, so the service
+  keeps receiving traffic it cannot serve, invisibly. Mitigated by `idle-timeout`/`max-lifetime`/
+  `max-size` on the reactive pool (bounds any wedge to `max-lifetime`) plus a 5xx-while-Ready alert
+  independent of the health probe (`BillingServerErrorsWhileHealthy`). Fleet follow-up: #1682.
 - **Elevation of privilege** — no customer-facing write path; only operator/system principals,
   RBAC via OIDC scopes + OPA.
 

--- a/openbank-billing-service/src/main/resources/application.yaml
+++ b/openbank-billing-service/src/main/resources/application.yaml
@@ -83,6 +83,16 @@ quarkus:
     password: ${POSTGRES_PASSWORD:CHANGE_ME_LOCAL_DEV_ONLY}
     reactive:
       url: postgresql://localhost:5432/openbank_billing
+      # Pool self-heal (#1682). Quarkus leaves all three levers OFF by default, so a
+      # transient DB blip that poisons pooled connections leaves them dead forever —
+      # the reactive pool has no way to purge them and wedges the service until a pod
+      # restart (billing sat unable to reach a healthy billing-db for ~8h, 0 restarts).
+      # idle-timeout evicts a dead idle connection within the cleaner period so the next
+      # acquire opens a fresh one; max-lifetime is the hard ceiling on how long any wedge
+      # can survive; max-size bounds the pool so a reconnect storm can't grow it unbounded.
+      idle-timeout: 5M
+      max-lifetime: 30M
+      max-size: 20
     jdbc:
       url: jdbc:postgresql://localhost:5432/openbank_billing
   flyway:

--- a/openbank-infra/gitops/components/billing/prometheus-rules-billing.yaml
+++ b/openbank-infra/gitops/components/billing/prometheus-rules-billing.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Per-service PrometheusRule for openbank-billing-service (money-path, ADR-0143). Refs #1682.
+#
+# WHY 5xx-rate and not the obvious signals:
+#   * Readiness (`/q/health/ready`) is useless for a wedged DB pool. The default datasource
+#     readiness check is a CONNECTIVITY probe (`SELECT 1` on a fresh connection); when the DB is
+#     reachable but the pool holds poisoned connections, the probe grabs a fresh connection and
+#     reports UP while every real request fails. Billing sat green for ~8h through exactly this.
+#   * `openbank_outbox_backlog{service="billing"}` can't see it either — that gauge READS the
+#     outbox table, so during a DB wedge its own query fails and it serves a STALE cached value
+#     instead of rising.
+#   * Billing has no OpenTelemetry (#1668), so trace-based SLOs (traces_spanmetrics_*) have no
+#     series — the lending-style error-rate rule can't be reused here.
+# So the one signal that both fires during a wedge AND does not itself depend on the DB is the
+# micrometer HTTP server metric (quarkus-micrometer-registry-prometheus, scraped at /q/metrics):
+# a request that hits the wedged pool returns 500, and recording that metric needs no DB.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openbank-billing-alerts
+  namespace: billing
+  labels:
+    app.kubernetes.io/part-of: openbank
+    app.kubernetes.io/name: billing-service
+spec:
+  groups:
+    - name: openbank.billing.health
+      rules:
+        - alert: BillingServerErrorsWhileHealthy
+          # Sustained 5xx on billing while the pod stays Ready = the silent-degradation signature
+          # (a wedged datasource pool, a downstream 500 storm, etc.) that readiness cannot surface.
+          # SERVER_ERROR is the stable micrometer outcome tag (covers 500/502/503/... in one series).
+          # On an idle sandbox there is simply no series and the alert never fires — a false negative
+          # with no caller is harmless; a real wedge always has failing callers.
+          expr: |
+            sum(rate(http_server_requests_seconds_count{namespace="billing", outcome="SERVER_ERROR"}[5m])) > 0.1
+          for: 10m
+          labels:
+            severity: critical
+            service: billing
+          annotations:
+            summary: "billing-service is returning 5xx while reporting Ready"
+            description: "billing-service has sustained >0.1 server-error/s for >10m while its readiness probe is green. The DB pool may be wedged (a healthy DB is still reachable for the SELECT-1 readiness check while pooled connections are dead) — verify the reactive pg pool, not just billing-db. Refs #1682."


### PR DESCRIPTION
## What & why

On 2026-07-18 `openbank-billing-service` (money-path) could not reach `billing-db-rw` for ~8h while the CNPG cluster was healthy the whole time (2/2 ready, `-rw` endpoint present, plain TCP connect from the namespace succeeded). A transient DB blip poisoned the **reactive pg pool**; because Quarkus leaves every pool self-heal lever off by default, the pool had no way to purge the dead connections and stayed wedged, serving 5xx, until it recovered on its own ~17:05 (0 pod restarts). Symptoms: `HR000092`, netty `finishConnect` failures, Vert.x `IllegalStateException: Result is already complete`.

Two problems, one incident:

### 1. Wedged pool (root cause)
All three reactive-pool self-heal levers are off by Quarkus default:
- `idle-timeout` — disabled → dead idle connections never evicted
- `max-lifetime` — disabled → connections never recycled
- Vert.x `reconnect-attempts` — 0 → a broken connection is never re-established

Fix: set `idle-timeout: 5M` + `max-lifetime: 30M` + a bounded `max-size: 20` on the reactive datasource. `idle-timeout` purges a dead idle connection within the pool-cleaner period so the next acquire opens a fresh one (the DB is reachable); `max-lifetime` is the hard ceiling on how long any wedge can survive.

### 2. Silent degradation
`/q/health/ready` stayed **green** the whole 8h. This is **not** a missing check — Quarkus already registers the datasource check in the ready group by default, and nothing here disables it. The problem is the check is a **connectivity probe** (`SELECT 1` on a *fresh* connection): the DB was reachable, so the probe passed while the *pooled* connections that serve real traffic were dead. So "add datasource to readiness" would not have helped.

- I deliberately did **not** touch the readiness group. Once the pool self-heals (fix #1) a wedge can't persist, so the default probe becomes adequate; adding an aggressive pool-drain readiness check risks exactly the cascading NotReady we want to avoid.
- Instead: a Prometheus alert (`BillingServerErrorsWhileHealthy`) on sustained 5xx while the pod is Ready. Rationale for the signal choice is in the rule's header comment — the outbox-backlog gauge reads the same wedged DB and goes stale, and billing has no OTel (#1668) so trace-based SLOs are also blind; the micrometer HTTP metric is the one DB-independent signal. A true Loki log-rate alert was rejected: the Loki ruler is not wired to Alertmanager (no `alertmanager_url`, zero existing log rules) — that would be an unproven new alerting substrate.

## Scope
This fixes billing (hit live). The **same latent gap exists fleet-wide** — no reactive-datasource service sets these levers. Tracked in #1682 for a shared-default / governance-guard follow-up rather than hand-copying into ~42 files.

## FinOps
Config-only + one PrometheusRule. No new resources → **$0**, flat. The fleet generalisation (#1682) is also $0.

## Governance (money-path, ADR-0030)
- Threat model updated: `docs/threat-models/openbank-billing-service.md` (DoS/availability).
- Needs **2 approvals**. If self-approval / auto-merge is blocked, that is the correct final state — I will not use `--admin` or any override.

Refs #1682