### PR TITLE
fix(ci): give record-deployment-on-merge a repo for gh pr diff (#1420)

### DIFF
--- a/.github/workflows/record-deployment-on-merge.yml
+++ b/.github/workflows/record-deployment-on-merge.yml
@@ -52,6 +52,11 @@ jobs:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `gh pr diff` shells out to git and needs either a checkout or an explicit repo. This job
+      # has no checkout, so without --repo it dies "not a git repository", returns nothing, and
+      # every run silently records zero services ("nothing to record") — the deploy tracking then
+      # goes stale with no error. Pass the repo explicitly so it works API-only.
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Record deployed services in the broker
         if: ${{ vars.PACT_BROKER_URL != '' }}
@@ -72,7 +77,7 @@ jobs:
           # Read them from the PR's own diff (added lines only), so an abandoned/other PR can
           # never cause a record here. Pacticipant name == the image name (openbank-<svc>).
           mapfile -t SERVICES < <(
-            gh pr diff "$PR_NUMBER" \
+            gh pr diff "$PR_NUMBER" --repo "$GH_REPO" \
               | grep -E "^\+.*openbank-[a-z0-9-]+:sandbox-${SHORT}" \
               | grep -oE "openbank-[a-z0-9-]+:sandbox-${SHORT}" \
               | sed -E 's/:sandbox-.*//' \


### PR DESCRIPTION
## ⚠️ Hotfix — deploy tracking silently broken since #1608

#1608's `record-deployment-on-merge.yml` job has **no `actions/checkout`**, so `gh pr diff` shells out to git, dies `not a git repository`, returns nothing, and every run records **zero services** (`nothing to record`) — while the job still reports **success**. So record-deployment has recorded nothing since #1608 merged: the broker's deployed-version matrix now silently goes stale on every deploy. Worse than the phantom it replaced, and invisible.

Confirmed on the two production runs (#29666904674 PR #1681, #29664565280 PR #1680): both logged `No openbank-*:sandbox-<sha> image changes … nothing to record`, though the PRs genuinely changed a service image.

## Fix

Pass `--repo "$GH_REPO"` (`github.repository`) so `gh` works API-only without a checkout.

**Verified in the true context** (`/private/tmp`, outside any git repo): `gh pr diff 1681 --repo JiRaska/open-bank-oss` returns the diff and the parse yields `openbank-customer-edge`; without `--repo`, git errors and it yields none.

## Why my #1608 test missed it (honest)

My local parse test ran **from inside the repo** (so `gh` found git context) and on **bash 3.2** (which lacks `mapfile`) — both masked a failure that only appears outside a checkout on CI's bash 5. Reproducing the real execution context, not a convenient one, would have caught it. Same lesson as the rest of #1420.

## After merge

The next `chore/gitops-auto-deploy-*` merge should log `✓ recorded` for its service(s). The 34-service cleanup I ran holds until then; once this is live, records track reality on every merge.

Refs #1420 #1608