### PR TITLE
chore(gitops): customer-edge -> sandbox-54b60543 + LENDING_SERVICE_URL + netpol (#1686)

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-6f3937cd
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-54b60543
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -144,6 +144,10 @@ spec:
             # gen-network-policies.py opens the edge->kyc ingress allow.
             - name: KYC_SERVICE_URL
               value: http://kyc-service.kyc.svc:8114
+            # Loans read-only view for the customer app (#1686): GET /customer/v1/loans + schedule.
+            # Declared here so gen-network-policies.py opens the edge->lending ingress allow.
+            - name: LENDING_SERVICE_URL
+              value: http://lending-service.lending.svc:8126
             - name: TRANSACTION_SERVICE_URL
               value: http://transaction-service.payments.svc:8102
             - name: DOMESTIC_PAYMENT_SERVICE_URL

--- a/openbank-infra/gitops/components/lending/network-policies.yaml
+++ b/openbank-infra/gitops/components/lending/network-policies.yaml
@@ -38,6 +38,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP


### PR DESCRIPTION
Deploys #1686 (loans view): edge image bump, LENDING_SERVICE_URL env, regenerated NetworkPolicy (lending ← customer-edge). Image built + signed by Auto Deploy; hand-bump.

## Linked issues

N/A — deploy for the loans feature.