### PR TITLE
feat(admin-ui): add a data-lineage flow page

### DIFF
--- a/openbank-admin-ui/src/app/docs/lineage/page.tsx
+++ b/openbank-admin-ui/src/app/docs/lineage/page.tsx
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+import { useState, useEffect } from 'react'
+import { Network, RefreshCw, Play, Pause, ArrowRight, ArrowLeft, BookOpen } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { DataUnavailable, type UnavailableKind } from '@/components/feedback/DataUnavailable'
+import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
+import { FlowParticle } from '@/components/topology/FlowParticle'
+import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
+import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
+
+// ---------------------------------------------------------------------------
+// Data-lineage flow (ADR-0071). Companion to the service map, but the graph here
+// is the DERIVED data-governance lineage: each service declares its upstream /
+// downstream relationships (typed api / topic / datastore) in its governance.yaml,
+// aggregated into governance.json and served read-only at /api/catalog/governance.
+// Nodes = services grouped by data domain; edges = declared lineage, animated as
+// data flowing producer → consumer. Honest-by-construction (code-derived), like
+// the service map — NOT hand-authored.
+// ---------------------------------------------------------------------------
+
+type Role = 'producer' | 'consumer' | 'both' | 'internal'
+type Domain = 'core' | 'payments' | 'compliance' | 'identity' | 'open-banking' | 'platform'
+type Rel = 'api' | 'topic' | 'datastore' | 'unknown'
+type LinkNode = { serviceName: string; relationType: Rel; description?: string }
+type GovService = {
+  serviceName: string
+  dataDomain: Domain | null
+  dataLineageRole: Role | null
+  lineage?: { upstream?: LinkNode[]; downstream?: LinkNode[]; interfaces?: { apis?: string[]; topics?: string[]; datastores?: string[] } }
+}
+
+const DOMAIN_META: Record<Domain, { color: string; cs: string; en: string }> = {
+  core:           { color: '#2563eb', cs: 'Jádro',         en: 'Core' },
+  payments:       { color: '#7c3aed', cs: 'Platby',        en: 'Payments' },
+  compliance:     { color: '#dc2626', cs: 'Compliance',    en: 'Compliance' },
+  identity:       { color: '#059669', cs: 'Identita',      en: 'Identity' },
+  'open-banking': { color: '#d97706', cs: 'Open Banking',  en: 'Open Banking' },
+  platform:       { color: '#6b7280', cs: 'Platforma',     en: 'Platform' },
+}
+const DOMAIN_ORDER: Domain[] = ['core', 'payments', 'compliance', 'identity', 'open-banking', 'platform']
+
+const REL_COLOR: Record<Rel, string> = { api: '#2563eb', topic: '#8b5cf6', datastore: '#059669', unknown: '#94a3b8' }
+const REL_DASHED: Record<Rel, boolean> = { api: false, topic: true, datastore: false, unknown: false }
+const relLabel = (r: Rel, t: (cs: string, en: string) => string) => ({ api: 'API', topic: t('téma', 'topic'), datastore: t('úložiště', 'datastore'), unknown: t('jiné', 'other') }[r])
+const roleLabel = (r: Role | null, t: (cs: string, en: string) => string) =>
+  r === 'producer' ? t('producent', 'producer') : r === 'consumer' ? t('konzument', 'consumer') : r === 'both' ? t('oba', 'both') : r === 'internal' ? t('interní', 'internal') : '—'
+
+const prettyName = (s: string) => s.replace(/-service$/, '')
+
+// Band layout — stacked full-width domain bands, centred wrapped pill grid.
+const WIDTH = 1280
+const CANVAS_PAD = 40
+const PILL_H = 30
+const BAND_HEAD = 28
+const BAND_PAD_Y = 14
+const BAND_GAP = 22
+const PILL_GAP = 14
+const HALF_H = PILL_H / 2
+const pillWidth = (label: string) => Math.max(96, 22 + label.length * 6.6 + 14)
+
+type Pos = { cx: number; cy: number; w: number }
+type Band = { key: Domain; y: number; h: number; count: number }
+
+function buildLayout(byDomain: Record<string, GovService[]>, domains: Domain[]) {
+  const availW = WIDTH - CANVAS_PAD * 2
+  const pos: Record<string, Pos> = {}
+  const bands: Band[] = []
+  let y = CANVAS_PAD
+  for (const dom of domains) {
+    const list = byDomain[dom] ?? []
+    if (!list.length) continue
+    const rows: { id: string; w: number }[][] = [[]]
+    let rowW = 0
+    for (const s of list) {
+      const w = pillWidth(prettyName(s.serviceName))
+      const cur = rows[rows.length - 1]
+      if (cur.length && rowW + PILL_GAP + w > availW) { rows.push([]); rowW = 0 }
+      rows[rows.length - 1].push({ id: s.serviceName, w })
+      rowW += (cur.length ? PILL_GAP : 0) + w
+    }
+    let ry = y + BAND_HEAD
+    for (const row of rows) {
+      const total = row.reduce((s, r) => s + r.w, 0) + PILL_GAP * Math.max(0, row.length - 1)
+      let x = CANVAS_PAD + Math.max(0, (availW - total) / 2)
+      for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: ry + PILL_H / 2, w: r.w }; x += r.w + PILL_GAP }
+      ry += PILL_H + PILL_GAP
+    }
+    const h = BAND_HEAD + rows.length * (PILL_H + PILL_GAP) - PILL_GAP + BAND_PAD_Y
+    bands.push({ key: dom, y, h, count: list.length })
+    y += h + BAND_GAP
+  }
+  return { pos, bands, height: bands.length ? y - BAND_GAP + CANVAS_PAD : CANVAS_PAD }
+}
+
+export default function LineageFlowPage() {
+  const { t } = useLanguage()
+  const [services, setServices] = useState<GovService[]>([])
+  const [unavailable, setUnavailable] = useState<{ kind: UnavailableKind } | null>(null)
+  const [selected, setSelected] = useState<string | null>(null)
+  const [hovered, setHovered] = useState<string | null>(null)
+  const [relFilter, setRelFilter] = useState<'all' | Rel>('all')
+  const [domFilter, setDomFilter] = useState<'all' | Domain>('all')
+  const [flow, setFlow] = useFlowAnimation()
+  const [isChecking, setIsChecking] = useState(false)
+
+  const load = async () => {
+    setIsChecking(true)
+    setUnavailable(null)
+    try {
+      const res = await fetch('/api/catalog/governance', { cache: 'no-store' })
+      if (!res.ok) { setServices([]); setUnavailable({ kind: res.status === 404 ? 'not_deployed' : 'unreachable' }); return }
+      const data = await res.json() as { services?: GovService[]; available?: boolean }
+      const list = Array.isArray(data.services) ? data.services : []
+      setServices(list)
+      if (!list.length) setUnavailable({ kind: 'no_data' })
+    } catch {
+      setServices([]); setUnavailable({ kind: 'unreachable' })
+    } finally { setIsChecking(false) }
+  }
+  useEffect(() => { load() }, [])
+
+  const byId = Object.fromEntries(services.map(s => [s.serviceName, s]))
+  const known = new Set(services.map(s => s.serviceName))
+  const activeNode = selected ?? hovered
+
+  // Directed lineage edges = union of every service's declared upstream/downstream,
+  // deduped. Both endpoints must be known services (no half-anchored lines).
+  const edgeMap = new Map<string, { from: string; to: string; type: Rel }>()
+  for (const s of services) {
+    for (const d of s.lineage?.downstream ?? []) {
+      if (known.has(d.serviceName)) edgeMap.set(`${s.serviceName}|${d.serviceName}|${d.relationType}`, { from: s.serviceName, to: d.serviceName, type: d.relationType })
+    }
+    for (const u of s.lineage?.upstream ?? []) {
+      if (known.has(u.serviceName)) edgeMap.set(`${u.serviceName}|${s.serviceName}|${u.relationType}`, { from: u.serviceName, to: s.serviceName, type: u.relationType })
+    }
+  }
+  const allEdges = [...edgeMap.values()]
+
+  const domainOf = (s: GovService): Domain => (s.dataDomain && DOMAIN_META[s.dataDomain] ? s.dataDomain : 'platform')
+  const visible = services.filter(s => domFilter === 'all' || domainOf(s) === domFilter)
+  const visibleIds = new Set(visible.map(s => s.serviceName))
+  const byDomain: Record<string, GovService[]> = {}
+  for (const s of visible) (byDomain[domainOf(s)] ||= []).push(s)
+  const LAYOUT = buildLayout(byDomain, DOMAIN_ORDER)
+
+  const visibleEdges = allEdges.filter(e =>
+    visibleIds.has(e.from) && visibleIds.has(e.to) && (relFilter === 'all' || e.type === relFilter))
+  const isNeighbor = (id: string) => !!activeNode && (activeNode === id
+    || allEdges.some(e => (e.from === activeNode && e.to === id) || (e.to === activeNode && e.from === id)))
+
+  const selectedSvc = selected ? byId[selected] : null
+  const selectedEdges = selected ? allEdges.filter(e => e.from === selected || e.to === selected) : []
+  const domLabel = (d: Domain) => t(DOMAIN_META[d].cs, DOMAIN_META[d].en)
+
+  return (
+    <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
+      <div className="page-header">
+        <div>
+          <div className="breadcrumb">
+            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
+            <span>{t('Dokumentace', 'Docs')}</span><span className="breadcrumb-sep">/</span>
+            <span className="breadcrumb-current">{t('Datová lineage', 'Data Lineage')}</span>
+          </div>
+          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Network size={18} style={{ color: 'var(--accent)' }} />
+            {t('Tok datové lineage', 'Data Lineage Flow')}
+          </h1>
+          <p className="page-subtitle">
+            {t('Kdo produkuje data pro koho — deklarovaná governance lineage (ADR-0071), odvozená z governance.yaml každé služby, animovaná jako tok producent → konzument.',
+               'Who produces data for whom — the declared data-governance lineage (ADR-0071), derived from each service’s governance.yaml, animated as producer → consumer flow.')}
+          </p>
+        </div>
+      </div>
+
+      {unavailable ? (
+        <DataUnavailable kind={unavailable.kind} service="governance" feature={t('datová lineage', 'data lineage')} dense />
+      ) : (
+        <>
+          {/* Controls */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px', flexWrap: 'wrap', gap: '12px' }}>
+            <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+              {(['all', ...DOMAIN_ORDER] as const).map(key => (
+                <button key={key} onClick={() => setDomFilter(key)}
+                  style={{
+                    padding: '5px 12px', fontSize: '12px', fontWeight: 600, borderRadius: '20px',
+                    border: `1px solid ${domFilter === key ? 'var(--accent)' : 'var(--border)'}`,
+                    background: domFilter === key ? 'var(--accent)' : 'var(--surface)',
+                    color: domFilter === key ? '#fff' : 'var(--text-secondary)', cursor: 'pointer', fontFamily: 'inherit',
+                  }}>
+                  {key === 'all' ? t('Vše', 'All') : domLabel(key)}
+                </button>
+              ))}
+            </div>
+            <div style={{ display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap' }}>
+              {(['all', 'api', 'topic', 'datastore'] as const).map(r => (
+                <button key={r} onClick={() => setRelFilter(r)} aria-pressed={relFilter === r}
+                  style={{
+                    padding: '4px 10px', fontSize: '11px', fontWeight: 600, borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
+                    border: `1px solid ${relFilter === r ? (r === 'all' ? 'var(--accent)' : REL_COLOR[r as Rel]) : 'var(--border)'}`,
+                    background: relFilter === r ? (r === 'all' ? 'var(--accent)' : REL_COLOR[r as Rel]) : 'var(--surface)',
+                    color: relFilter === r ? '#fff' : 'var(--text-secondary)',
+                  }}>
+                  {r === 'all' ? t('Vše', 'All') : relLabel(r as Rel, t)}
+                </button>
+              ))}
+              <button onClick={() => setFlow(v => !v)} aria-pressed={flow} title={t('Přepnout tok dat', 'Toggle data flow')}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
+                  borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
+                  border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
+                  background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
+                }}>
+                {flow ? <Pause size={13} /> : <Play size={13} />}{t('Tok', 'Flow')}
+              </button>
+              <button onClick={load} disabled={isChecking} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+                <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
+                {isChecking ? t('Načítám…', 'Loading...') : t('Obnovit', 'Refresh')}
+              </button>
+            </div>
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: selectedSvc ? '1fr 320px' : '1fr', gap: '16px' }}>
+            <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+              <svg viewBox={`0 0 ${WIDTH} ${LAYOUT.height}`} style={{ width: '100%', height: 'auto', display: 'block', background: 'var(--surface)' }}>
+                <defs>
+                  {(['api', 'topic', 'datastore', 'unknown'] as Rel[]).map(r => (
+                    <ArrowMarker key={r} id={`ln-arrow-${r}`} color={REL_COLOR[r]} />
+                  ))}
+                  <NodeShadow id="ln-shadow" />
+                </defs>
+
+                {/* Domain bands */}
+                {LAYOUT.bands.map(b => (
+                  <g key={b.key}>
+                    <rect x={CANVAS_PAD - 12} y={b.y} width={WIDTH - (CANVAS_PAD - 12) * 2} height={b.h} rx="16"
+                      fill={`${DOMAIN_META[b.key].color}0a`} stroke={`${DOMAIN_META[b.key].color}33`} strokeWidth="1" />
+                    <text x={CANVAS_PAD} y={b.y + 19} fontSize="11" fill={DOMAIN_META[b.key].color} fontWeight="700" letterSpacing="0.08em">
+                      {domLabel(b.key).toUpperCase()} · {b.count}
+                    </text>
+                  </g>
+                ))}
+
+                {/* Edges + particles */}
+                {visibleEdges.map((e, i) => {
+                  const a = LAYOUT.pos[e.from], b = LAYOUT.pos[e.to]
+                  if (!a || !b) return null
+                  const color = REL_COLOR[e.type]
+                  const touches = !!activeNode && (e.from === activeNode || e.to === activeNode)
+                  const dim = !!activeNode && !touches
+                  const { d } = edgeGeometry(a, b, { hw: a.w / 2, hh: HALF_H }, { hw: b.w / 2, hh: HALF_H })
+                  const pid = pathId('ln', e.from, e.to, i)
+                  return (
+                    <g key={i} opacity={dim ? 0.08 : touches ? 1 : 0.42} style={{ transition: 'opacity 0.15s' }}>
+                      <path id={pid} d={d} fill="none" stroke={touches ? mixHex(color, '#000000', 0.15) : color}
+                        strokeWidth={touches ? 2 : 1.2} strokeDasharray={REL_DASHED[e.type] ? '5,4' : undefined}
+                        markerEnd={`url(#ln-arrow-${e.type})`} />
+                      {flow && <FlowParticle pathId={pid} color={color} dur={2.6 + (i % 6) * 0.24} begin={(i % 8) * 0.16} r={2.3} />}
+                    </g>
+                  )
+                })}
+
+                {/* Nodes */}
+                {visible.map(s => {
+                  const p = LAYOUT.pos[s.serviceName]
+                  if (!p) return null
+                  const color = DOMAIN_META[domainOf(s)].color
+                  const emphasized = !activeNode || isNeighbor(s.serviceName)
+                  const isSel = selected === s.serviceName
+                  const x = p.cx - p.w / 2, y = p.cy - PILL_H / 2
+                  return (
+                    <g key={s.serviceName} style={{ cursor: 'pointer', transition: 'opacity 0.15s' }} opacity={emphasized ? 1 : 0.22}
+                      onClick={() => setSelected(v => v === s.serviceName ? null : s.serviceName)}
+                      onMouseEnter={() => setHovered(s.serviceName)} onMouseLeave={() => setHovered(h => h === s.serviceName ? null : h)}>
+                      <rect x={x} y={y} width={p.w} height={PILL_H} rx={PILL_H / 2}
+                        fill={isSel ? color : 'var(--surface)'} stroke={color} strokeWidth={isSel ? 1.9 : 1.2} filter="url(#ln-shadow)" />
+                      <circle cx={x + 13} cy={p.cy} r={3.5} fill={color} />
+                      <text x={x + 23} y={p.cy + 4} fontSize="10.5" fontWeight="600" fill={isSel ? '#fff' : 'var(--text-primary)'}>{prettyName(s.serviceName)}</text>
+                    </g>
+                  )
+                })}
+              </svg>
+
+              {/* Legend */}
+              <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border)', display: 'flex', gap: '18px', flexWrap: 'wrap' }}>
+                {(['api', 'topic', 'datastore'] as Rel[]).map(r => (
+                  <div key={r} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                    <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke={REL_COLOR[r]} strokeWidth="1.6" strokeDasharray={REL_DASHED[r] ? '5,3' : undefined} markerEnd={`url(#ln-arrow-${r})`} /></svg>
+                    {relLabel(r, t)}
+                  </div>
+                ))}
+                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('Šipka míří producent → konzument', 'Arrow points producer → consumer')}</div>
+              </div>
+            </div>
+
+            {/* Detail panel */}
+            {selectedSvc && (
+              <div className="card" style={{ padding: '20px', alignSelf: 'start' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '14px' }}>
+                  <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: DOMAIN_META[domainOf(selectedSvc)].color }} />
+                  <div style={{ fontSize: '14px', fontWeight: 700, color: 'var(--text-primary)' }}>{prettyName(selectedSvc.serviceName)}</div>
+                  <div style={{ marginLeft: 'auto', fontSize: '10px', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', padding: '2px 8px', borderRadius: '12px', background: `${DOMAIN_META[domainOf(selectedSvc)].color}1a`, color: DOMAIN_META[domainOf(selectedSvc)].color }}>
+                    {roleLabel(selectedSvc.dataLineageRole, t)}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+                  <div>
+                    <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '3px' }}>{t('DOMÉNA', 'DOMAIN')}</div>
+                    <div style={{ fontSize: '12px', color: DOMAIN_META[domainOf(selectedSvc)].color, fontWeight: 600 }}>{domLabel(domainOf(selectedSvc))}</div>
+                  </div>
+                  <div>
+                    <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '4px' }}>{t('ROZHRANÍ', 'INTERFACES')}</div>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                      {(selectedSvc.lineage?.interfaces?.apis ?? []).map((a, i) => <span key={`a${i}`} style={{ fontSize: '10px', background: '#dbeafe', color: '#1e40af', padding: '2px 6px', borderRadius: '4px' }}>API: {a}</span>)}
+                      {(selectedSvc.lineage?.interfaces?.topics ?? []).map((tp, i) => <span key={`t${i}`} style={{ fontSize: '10px', background: '#f3e8ff', color: '#6b21a8', padding: '2px 6px', borderRadius: '4px' }}>{t('téma', 'topic')}: {tp}</span>)}
+                      {(selectedSvc.lineage?.interfaces?.datastores ?? []).map((ds, i) => <span key={`d${i}`} style={{ fontSize: '10px', background: '#dcfce7', color: '#166534', padding: '2px 6px', borderRadius: '4px' }}>DB: {ds}</span>)}
+                      {!(selectedSvc.lineage?.interfaces?.apis?.length || selectedSvc.lineage?.interfaces?.topics?.length || selectedSvc.lineage?.interfaces?.datastores?.length) && (
+                        <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('žádná deklarovaná', 'none declared')}</span>
+                      )}
+                    </div>
+                  </div>
+                  {(selectedSvc.lineage?.upstream?.length ?? 0) > 0 && (
+                    <div>
+                      <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginBottom: '4px', display: 'flex', alignItems: 'center', gap: '4px' }}><ArrowLeft size={10} /> {t('Upstream (zdroje)', 'Upstream (sources)')}</div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                        {selectedSvc.lineage!.upstream!.map((u, i) => (
+                          <div key={i} style={{ display: 'flex', justifyContent: 'space-between', gap: '6px', fontSize: '12px', background: 'var(--surface)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--border)' }}>
+                            <span style={{ fontWeight: 500, color: 'var(--text-secondary)', cursor: 'pointer' }} onClick={() => known.has(u.serviceName) && setSelected(u.serviceName)}>{prettyName(u.serviceName)}</span>
+                            <span style={{ fontSize: '10px', color: REL_COLOR[u.relationType] }}>{relLabel(u.relationType, t)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {(selectedSvc.lineage?.downstream?.length ?? 0) > 0 && (
+                    <div>
+                      <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginBottom: '4px', display: 'flex', alignItems: 'center', gap: '4px' }}><ArrowRight size={10} /> {t('Downstream (odběratelé)', 'Downstream (consumers)')}</div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                        {selectedSvc.lineage!.downstream!.map((dn, i) => (
+                          <div key={i} style={{ display: 'flex', justifyContent: 'space-between', gap: '6px', fontSize: '12px', background: 'var(--surface)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--border)' }}>
+                            <span style={{ fontWeight: 500, color: 'var(--text-secondary)', cursor: 'pointer' }} onClick={() => known.has(dn.serviceName) && setSelected(dn.serviceName)}>{prettyName(dn.serviceName)}</span>
+                            <span style={{ fontSize: '10px', color: REL_COLOR[dn.relationType] }}>{relLabel(dn.relationType, t)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('Propojení', 'Connections')}: {selectedEdges.length}</div>
+                  <a href={`/services/${prettyName(selectedSvc.serviceName)}/docs`} style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px', padding: '8px 12px',
+                    background: 'var(--accent-bg)', color: 'var(--accent)', borderRadius: 'var(--r-md)', fontSize: '12px',
+                    fontWeight: 600, textDecoration: 'none', marginTop: '4px', border: '1px solid var(--accent-border, transparent)',
+                  }}>
+                    <BookOpen size={14} /> {t('Dokumentace služby', 'Service documentation')}
+                  </a>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ import {
   DollarSign, Globe, Repeat, Zap, AlertOctagon, ScanLine,
   Layers, TrendingUp, MessageSquareWarning, Package, Receipt, Server, ShieldAlert, FlaskConical, Cloud,
   PiggyBank, GitBranch, Lock, ClipboardList, Scale, Smartphone,
-  ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network,
+  ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network, Waypoints,
 } from 'lucide-react'
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -79,6 +79,7 @@ const docsNav: NavItem[] = [
   { nameCs: 'Cloud architektura', nameEn: 'Cloud Architecture', href: '/docs/cloud-architecture', icon: Cloud, permission: 'docs:view' },
   { nameCs: 'Cluster & kontejner', nameEn: 'Cluster & Container', href: '/docs/cluster', icon: Boxes, permission: 'docs:view' },
   { nameCs: 'Mapa služeb',    nameEn: 'Service Map',        href: '/docs/service-map', icon: Map,         permission: 'docs:view' },
+  { nameCs: 'Datová lineage', nameEn: 'Data Lineage',       href: '/docs/lineage',     icon: Waypoints,   permission: 'docs:view' },
   { nameCs: 'BPMN',           nameEn: 'BPMN',               href: '/docs/bpmn',        icon: FileCode,    permission: 'docs:view' },
   { nameCs: 'Katalog API',    nameEn: 'API Catalog',        href: '/docs/api',         icon: FileCode,    permission: 'docs:view' },
   { nameCs: 'Feature flagy',  nameEn: 'Feature Flags',      href: '/docs/flags',       icon: Flag,        permission: 'docs:view' },

--- a/openbank-admin-ui/src/test/lineage-flow.test.tsx
+++ b/openbank-admin-ui/src/test/lineage-flow.test.tsx
@@ -6,7 +6,7 @@
 // real-shaped /api/catalog/governance payload and asserts the domain bands, the
 // derived lineage edges + SMIL flow, the detail panel, and graceful degradation.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import React from 'react'
 import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
 import { LanguageProvider } from '@/lib/i18n/LanguageContext'

--- a/openbank-admin-ui/src/test/lineage-flow.test.tsx
+++ b/openbank-admin-ui/src/test/lineage-flow.test.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Behaviour test for the data-lineage flow page (/docs/lineage). Mounts with a
+// real-shaped /api/catalog/governance payload and asserts the domain bands, the
+// derived lineage edges + SMIL flow, the detail panel, and graceful degradation.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import LineageFlowPage from '@/app/docs/lineage/page'
+
+const SERVICES = [
+  { serviceName: 'account-service', dataDomain: 'core', dataLineageRole: 'producer', lineage: { downstream: [{ serviceName: 'ledger-service', relationType: 'api' }], interfaces: { apis: ['/api/v1/accounts'] } } },
+  { serviceName: 'ledger-service', dataDomain: 'core', dataLineageRole: 'both', lineage: { upstream: [{ serviceName: 'account-service', relationType: 'api' }], downstream: [{ serviceName: 'sepa-payment', relationType: 'topic' }] } },
+  { serviceName: 'sepa-payment', dataDomain: 'payments', dataLineageRole: 'consumer', lineage: { upstream: [{ serviceName: 'ledger-service', relationType: 'topic' }] } },
+]
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+function mockFetch(governanceOk = true) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/catalog/governance')) return governanceOk ? json({ services: SERVICES, available: true }) : new Response('nope', { status: 404 })
+    return json({})
+  })
+}
+
+describe('data-lineage flow page', () => {
+  afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+  it('renders domain bands with the code-derived lineage nodes', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    render(React.createElement(Providers, null, React.createElement(LineageFlowPage)))
+    await waitFor(() => expect(screen.getByText('account')).toBeInTheDocument())
+    expect(screen.getByText('ledger')).toBeInTheDocument()
+    expect(screen.getByText('sepa-payment')).toBeInTheDocument()
+    expect(screen.getByText('CORE · 2')).toBeInTheDocument()
+    expect(screen.getByText('PAYMENTS · 1')).toBeInTheDocument()
+  })
+
+  it('animates flow by default and stops when toggled off', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    const { container } = render(React.createElement(Providers, null, React.createElement(LineageFlowPage)))
+    await waitFor(() => expect(screen.getByText('account')).toBeInTheDocument())
+    expect(container.querySelectorAll('animateMotion').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getByRole('button', { name: /Flow/i }))
+    await waitFor(() => expect(container.querySelectorAll('animateMotion').length).toBe(0))
+  })
+
+  it('opens a node detail panel with role, interfaces and connections', async () => {
+    vi.stubGlobal('fetch', mockFetch())
+    render(React.createElement(Providers, null, React.createElement(LineageFlowPage)))
+    await waitFor(() => expect(screen.getByText('account')).toBeInTheDocument())
+    fireEvent.click(screen.getByText('account'))
+    expect(await screen.findByText('producer')).toBeInTheDocument()
+    expect(screen.getByText(/INTERFACES/i)).toBeInTheDocument()
+    expect(screen.getByText(/Downstream/i)).toBeInTheDocument()
+  })
+
+  it('degrades gracefully when governance is unavailable', async () => {
+    vi.stubGlobal('fetch', mockFetch(false))
+    render(React.createElement(Providers, null, React.createElement(LineageFlowPage)))
+    // No crash, no raw HTTP — the shared DataUnavailable panel renders instead of the graph.
+    await waitFor(() => expect(screen.queryByText('account')).not.toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary

New **`/docs/lineage`** — a companion to the service map, but the graph is the **DERIVED** data-governance lineage: who produces data for whom, animated producer → consumer. Part 2 of 3 of the animation trilogy (built on the shared engine from #1689).

## Type of change
- [x] feat (new functionality)

## Linked issues
None — follow-up to #1689 (animation trilogy, part 2 of 3).

## Changes
- NEW `src/app/docs/lineage/page.tsx` — 51 services grouped into 6 data-domain bands; edges = the deduped union of every service's declared `lineage.upstream`/`downstream` (typed `api`/`topic`/`datastore`) from `/api/catalog/governance` (`governance.json`, ADR-0071). Animated with the shared topology engine; detail panel (domain, role, interfaces, up/downstream — click to pivot); filters by domain + relation type + flow; `DataUnavailable` when governance is absent.
- `src/components/layout/Sidebar.tsx` — "Data Lineage" nav entry under Docs.
- NEW `src/test/lineage-flow.test.tsx`.

## Honesty contract
Unlike the infra topology (curated), these edges are **code-derived** (governance.json, ADR-0071) — same honest-by-construction contract as the service map; the subtitle says so.

## Definition of Done
- [x] Unit test added (`lineage-flow.test.tsx`, +4).
- [x] admin-ui gate green: `type-check` · `test` (630) · `eslint .` (0 errors) · `next build` (route present).
- [x] Graceful-state (governance unavailable → `DataUnavailable`, no raw HTTP).
- [ ] OpenAPI / Flyway / Avro / ADR — N/A (reuses existing read-only `/api/catalog/governance`).

## Security checklist
- [x] No secrets/PII; no new deps; no auth/crypto/payment/PII path touched; read-only view.

## Compliance impact
- [x] None — no new backend, probes, or egress; reuses the baked `governance.json`.

## Rollout / Rollback
- Rolling; revert the PR; no migration.

## Screenshots / demo
Six data-domain bands (Core·5, Payments·15, Compliance·10, Identity·3, Open Banking·3, Platform·15 = 51 services) with typed lineage edges (API solid / topic dashed / datastore) arrowed producer → consumer, plus a legend. _(Screenshot shared with the author in the working session.)_

## Reviewer notes
- FinOps: $0 — reuses `/api/catalog/governance` (static baked JSON); animation is client-side SMIL.
- Edges render only between known services (no half-anchored lines); domain defaults to `platform` when a service declares none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
