### PR TITLE
fix(lending): let the customer-edge read a customer's own loans

### DIFF
--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/rest/LendingResource.kt
@@ -114,6 +114,17 @@ class LendingResource(
     @GET
     @Path("/loans/{id}")
     @Operation(summary = "Get a loan")
+    // Read endpoint: widen past the class-level staff-only roles so the customer-edge (ROLE_OPERATOR)
+    // can serve a customer their own loan. OPA (lending.read + operator-read-any / customer scoping)
+    // and the edge's per-caller partyId ownership check remain the fine-grained gate.
+    @RolesAllowed(
+        "ROLE_VIEWER",
+        "ROLE_OPERATOR",
+        "ROLE_LENDING_OFFICER",
+        "ROLE_CREDIT_RISK",
+        "ROLE_COMPLIANCE",
+        "ROLE_ADMIN",
+    )
     @Authorize(action = "lending.read", resource = "#id")
     fun getLoan(@PathParam("id") id: UUID): Uni<Response> =
         servicing.getLoan(LoanId(id)).map { it?.let { l -> Response.ok(l).build() } ?: Response.status(404).build() }
@@ -121,12 +132,28 @@ class LendingResource(
     @GET
     @Path("/loans/{id}/schedule")
     @Operation(summary = "Get a loan's repayment schedule")
+    @RolesAllowed(
+        "ROLE_VIEWER",
+        "ROLE_OPERATOR",
+        "ROLE_LENDING_OFFICER",
+        "ROLE_CREDIT_RISK",
+        "ROLE_COMPLIANCE",
+        "ROLE_ADMIN",
+    )
     @Authorize(action = "lending.read", resource = "#id")
     fun getSchedule(@PathParam("id") id: UUID) = servicing.getSchedule(LoanId(id))
 
     @GET
     @Path("/loans")
     @Operation(summary = "List a party's loans")
+    @RolesAllowed(
+        "ROLE_VIEWER",
+        "ROLE_OPERATOR",
+        "ROLE_LENDING_OFFICER",
+        "ROLE_CREDIT_RISK",
+        "ROLE_COMPLIANCE",
+        "ROLE_ADMIN",
+    )
     @Authorize(action = "lending.list", resource = "")
     fun listLoans(@QueryParam("partyId") partyId: UUID) = servicing.listLoans(partyId)
 


### PR DESCRIPTION
LendingResource has a class-level `@RolesAllowed(LENDING_OFFICER, CREDIT_RISK, COMPLIANCE, ADMIN)` — staff-only, gating **every** endpoint including the read-only servicing reads. The customer-edge (ROLE_OPERATOR service-account) got a **403 at the JAX-RS layer**, before OPA, so the app loans screen showed nothing.

Adds a **method-level** `@RolesAllowed` to the three read endpoints (getLoan, getSchedule, listLoans) widening them to ROLE_VIEWER + ROLE_OPERATOR alongside the staff roles. Writes (apply/decide/disburse/repay/writeoff) keep the staff-only class default. OPA (`lending.read/list` via operator-read-any) + the edge's per-caller partyId ownership guard remain the fine-grained gate.

## Linked issues

N/A — unblocks the read-only loans feature (#1686).