### PR TITLE
feat(admin-ui): add a Temporal workflow flow page

### DIFF
--- a/openbank-admin-ui/src/app/temporal/flow/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/flow/page.tsx
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+'use client'
+import { useState, useEffect } from 'react'
+import { Workflow, RefreshCw, Play, Pause, AlertTriangle } from 'lucide-react'
+import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { FlowParticle } from '@/components/topology/FlowParticle'
+import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
+import { ArrowMarker } from '@/components/topology/TopologyDefs'
+import { MONEY_WORKFLOWS } from '@/lib/temporal/workflows'
+
+// ---------------------------------------------------------------------------
+// Temporal workflow flow (ADR-0100). The third animated topology view: each
+// money-path saga is drawn as a linear step-chain (step → step → … → compensation)
+// with a token flowing through, using the shared topology engine. The saga STEPS
+// are the documented workflow definitions (curated, from lib/temporal/workflows);
+// the throughput METRICS are LIVE but namespace-aggregate (Prometheus via
+// /api/temporal/status) — not per-run replay. The subtitle says so. Per-run
+// history replay would need a Temporal-history API proxy (follow-up).
+// ---------------------------------------------------------------------------
+
+interface TemporalMetrics {
+  workflows: { scheduled1h: number; completed1h: number; failed1h: number; timedOut1h: number }
+  latency: { activityScheduleToStartMs: number | null; workflowTaskScheduleToStartMs: number | null; serverRequestP99Ms: number | null }
+  namespaces: string[]
+}
+interface StatusData { available: boolean; temporalDeployed: boolean; metrics: TemporalMetrics | null }
+
+const WIDTH = 1180
+const PAD = 30
+const BOX_H = 40
+const ROW_Y = 46
+const SVG_H = 88
+
+export default function TemporalFlowPage() {
+  const { t, language } = useLanguage()
+  const [status, setStatus] = useState<StatusData | null>(null)
+  const [flow, setFlow] = useFlowAnimation()
+  const [isChecking, setIsChecking] = useState(false)
+
+  const load = async () => {
+    setIsChecking(true)
+    try {
+      const res = await fetch('/api/temporal/status', { cache: 'no-store' })
+      if (res.ok) setStatus(await res.json())
+      else setStatus({ available: false, temporalDeployed: false, metrics: null })
+    } catch {
+      setStatus({ available: false, temporalDeployed: false, metrics: null })
+    } finally { setIsChecking(false) }
+  }
+  useEffect(() => { load() }, [])
+
+  const m = status?.metrics ?? null
+  const deployed = !!status?.temporalDeployed
+  const failing = (m?.workflows.failed1h ?? 0) > 0 || (m?.workflows.timedOut1h ?? 0) > 0
+  const num = (v: number | null | undefined) => (v == null ? '—' : String(v))
+
+  const metricCards: { label: string; value: string; tone?: 'good' | 'bad' | 'neutral' }[] = [
+    { label: t('Naplánováno (1h)', 'Scheduled (1h)'), value: num(m?.workflows.scheduled1h), tone: 'neutral' },
+    { label: t('Dokončeno (1h)', 'Completed (1h)'), value: num(m?.workflows.completed1h), tone: 'good' },
+    { label: t('Selhalo (1h)', 'Failed (1h)'), value: num(m?.workflows.failed1h), tone: (m?.workflows.failed1h ?? 0) > 0 ? 'bad' : 'neutral' },
+    { label: t('Timeout (1h)', 'Timed out (1h)'), value: num(m?.workflows.timedOut1h), tone: (m?.workflows.timedOut1h ?? 0) > 0 ? 'bad' : 'neutral' },
+    { label: t('Latence aktivit', 'Activity latency'), value: m?.latency.activityScheduleToStartMs != null ? `${m.latency.activityScheduleToStartMs} ms` : '—', tone: 'neutral' },
+  ]
+  const toneColor = (tone?: string) => (tone === 'good' ? 'var(--success)' : tone === 'bad' ? 'var(--danger)' : 'var(--text-primary)')
+
+  return (
+    <div style={{ padding: '28px 32px', maxWidth: '1400px' }}>
+      <div className="page-header">
+        <div>
+          <div className="breadcrumb">
+            <span>OpenBank</span><span className="breadcrumb-sep">/</span>
+            <span>Temporal</span><span className="breadcrumb-sep">/</span>
+            <span className="breadcrumb-current">{t('Tok workflow', 'Workflow Flow')}</span>
+          </div>
+          <h1 className="page-title" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Workflow size={18} style={{ color: 'var(--accent)' }} />
+            {t('Tok Temporal workflow', 'Temporal Workflow Flow')}
+          </h1>
+          <p className="page-subtitle">
+            {t('Money-path ságy jako animované řetězce kroků (krok → krok → kompenzace). Kroky jsou zdokumentované definice ság; metriky jsou živé, ale agregátní za namespace (ne přehrání jednotlivých běhů).',
+               'Money-path sagas as animated step-chains (step → step → compensation). The steps are the documented saga definitions; the metrics are live but namespace-aggregate (not per-run replay).')}
+          </p>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: '14px', gap: '8px' }}>
+        <button onClick={() => setFlow(v => !v)} aria-pressed={flow} title={t('Přepnout tok', 'Toggle flow')}
+          style={{
+            display: 'flex', alignItems: 'center', gap: '5px', padding: '5px 10px', fontSize: '12px', fontWeight: 600,
+            borderRadius: '20px', cursor: 'pointer', fontFamily: 'inherit',
+            border: `1px solid ${flow ? 'var(--accent)' : 'var(--border)'}`,
+            background: flow ? 'var(--accent)' : 'var(--surface)', color: flow ? '#fff' : 'var(--text-secondary)',
+          }}>
+          {flow ? <Pause size={13} /> : <Play size={13} />}{t('Tok', 'Flow')}
+        </button>
+        <button onClick={load} disabled={isChecking} className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '12px' }}>
+          <RefreshCw size={14} className={isChecking ? 'animate-spin' : ''} />
+          {isChecking ? t('Načítám…', 'Loading...') : t('Obnovit', 'Refresh')}
+        </button>
+      </div>
+
+      {/* Live metrics strip (aggregate) */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px', marginBottom: '8px' }}>
+        {metricCards.map((c, i) => (
+          <div key={i} className="card" style={{ padding: '14px 16px' }}>
+            <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '4px' }}>{c.label}</div>
+            <div style={{ fontSize: '22px', fontWeight: 700, color: toneColor(c.tone), fontFamily: 'JetBrains Mono, monospace' }}>{c.value}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', margin: '4px 2px 18px', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        {deployed
+          ? <>{t('Živé agregátní metriky z Prometheu · namespace', 'Live aggregate metrics from Prometheus · namespaces')}: {status?.metrics?.namespaces?.join(', ') || '—'}</>
+          : <><AlertTriangle size={12} style={{ color: 'var(--warning)' }} /> {t('Temporal není nasazený zde — ságy zobrazeny staticky, živé metriky nedostupné.', 'Temporal is not deployed here — sagas shown statically, live metrics unavailable.')}</>}
+      </div>
+
+      {/* One animated saga chain per money-path workflow */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+        {MONEY_WORKFLOWS.map((w, wi) => {
+          const steps = language === 'cs' ? w.stepsCs : w.stepsEn
+          const n = steps.length
+          const availW = WIDTH - PAD * 2
+          const boxW = Math.min(210, (availW - (n - 1) * 26) / n)
+          const gap = n > 1 ? (availW - boxW) / (n - 1) : 0
+          const cx = (i: number) => PAD + boxW / 2 + i * gap
+          const Icon = w.icon
+          return (
+            <div key={wi} className="card" style={{ padding: '14px 16px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '4px' }}>
+                <div style={{ width: '26px', height: '26px', borderRadius: '7px', background: `${w.color}1a`, color: w.color, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  <Icon size={15} />
+                </div>
+                <div style={{ fontSize: '13px', fontWeight: 700, color: 'var(--text-primary)' }}>{t(w.serviceCs, w.serviceEn)}</div>
+                <code style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{w.workflowCs}</code>
+                <span style={{ marginLeft: 'auto', fontSize: '10px', color: 'var(--text-tertiary)', fontFamily: 'monospace' }}>{t(w.flagCs, w.flagEn)}</span>
+              </div>
+              <svg viewBox={`0 0 ${WIDTH} ${SVG_H}`} style={{ width: '100%', height: 'auto', display: 'block' }}>
+                <defs>
+                  <ArrowMarker id={`tf-arrow-${wi}`} color={w.color} />
+                  <ArrowMarker id={`tf-arrow-comp-${wi}`} color="#dc2626" />
+                </defs>
+                {/* segments between consecutive steps */}
+                {steps.slice(0, -1).map((_, i) => {
+                  const isCompEdge = i === n - 2 // edge into the last (compensation) step
+                  const x1 = cx(i) + boxW / 2, x2 = cx(i + 1) - boxW / 2, y = ROW_Y
+                  const color = isCompEdge ? '#dc2626' : w.color
+                  const pid = `tf-${wi}-${i}`
+                  const showComp = isCompEdge ? failing : true
+                  return (
+                    <g key={i}>
+                      <path id={pid} d={`M ${x1} ${y} L ${x2 - 8} ${y}`} fill="none" stroke={color}
+                        strokeWidth={1.6} strokeDasharray={isCompEdge ? '5,4' : undefined}
+                        opacity={isCompEdge && !failing ? 0.4 : 0.85}
+                        markerEnd={`url(#tf-arrow-${isCompEdge ? `comp-${wi}` : wi})`} />
+                      {flow && showComp && <FlowParticle pathId={pid} color={color} dur={1.5 + (i % 3) * 0.2} begin={i * 0.35} r={2.6} />}
+                    </g>
+                  )
+                })}
+                {/* step boxes */}
+                {steps.map((label, i) => {
+                  const isComp = i === n - 1
+                  const color = isComp ? '#dc2626' : w.color
+                  const x = cx(i) - boxW / 2
+                  const short = label.length > 30 ? label.slice(0, 29) + '…' : label
+                  return (
+                    <g key={i}>
+                      <title>{`${i + 1}. ${label}`}</title>
+                      <rect x={x} y={ROW_Y - BOX_H / 2} width={boxW} height={BOX_H} rx={8}
+                        fill="var(--surface)" stroke={color} strokeWidth={1.4} strokeDasharray={isComp ? '4,3' : undefined} />
+                      <circle cx={x + 13} cy={ROW_Y - BOX_H / 2 + 13} r={8} fill={color} />
+                      <text x={x + 13} y={ROW_Y - BOX_H / 2 + 16} fontSize="9" fill="#fff" textAnchor="middle" fontWeight="700">{isComp ? 'C' : i + 1}</text>
+                      <text x={x + 26} y={ROW_Y + 4} fontSize="9.5" fill="var(--text-primary)" fontWeight="500">{short}</text>
+                    </g>
+                  )
+                })}
+              </svg>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Legend */}
+      <div style={{ marginTop: '14px', display: 'flex', gap: '18px', flexWrap: 'wrap', fontSize: '11px', color: 'var(--text-tertiary)' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#6366f1" strokeWidth="1.6" /></svg>
+          {t('Šťastná cesta ságy', 'Saga happy path')}
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <svg width="30" height="10"><line x1="0" y1="5" x2="30" y2="5" stroke="#dc2626" strokeWidth="1.6" strokeDasharray="5,3" /></svg>
+          {t('Kompenzace (jen při selhání)', 'Compensation (only on failure)')}
+        </div>
+        <div>{t('Krok „C" = kompenzační aktivita', 'Step “C” = compensation activity')}</div>
+      </div>
+    </div>
+  )
+}

--- a/openbank-admin-ui/src/app/temporal/page.tsx
+++ b/openbank-admin-ui/src/app/temporal/page.tsx
@@ -5,8 +5,9 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { RefreshCw, CheckCircle, Clock, AlertTriangle, Zap, Database, Shield, GitBranch, Activity, Server, ChevronRight, ArrowRight, CreditCard, Globe, BarChart2, Repeat2 } from 'lucide-react'
+import { RefreshCw, CheckCircle, Clock, AlertTriangle, Zap, Database, Shield, GitBranch, Activity, Server, ChevronRight, ArrowRight } from 'lucide-react'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
+import { MONEY_WORKFLOWS } from '@/lib/temporal/workflows'
 import { AuthGuard } from '@/components/auth/AuthGuard'
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -164,56 +165,6 @@ const COMPARISON = [
 
 // ─── money-path workflow map ──────────────────────────────────────────────────
 
-const MONEY_WORKFLOWS = [
-  {
-    icon: CreditCard,
-    color: '#6366f1',
-    serviceCs: 'Tuzemské platby',
-    serviceEn: 'Domestic payments',
-    svc: 'openbank-domestic-payment-service',
-    workflowCs: 'DomesticPaymentWorkflow',
-    stepsCs: ['Validace IBAN + limit', 'Rezervace sald', 'Odeslání na CERTIS/instant rail', 'Potvrzení settlement', 'Kompenzace při odmítnutí'],
-    stepsEn: ['IBAN + limit validation', 'Balance reservation', 'Submit to CERTIS/instant rail', 'Settlement confirmation', 'Compensation on rejection'],
-    flagCs: 'flag: domestic-payment-temporal-workflow=ON',
-    flagEn: 'flag: domestic-payment-temporal-workflow=ON',
-  },
-  {
-    icon: Globe,
-    color: '#8b5cf6',
-    serviceCs: 'SEPA platby',
-    serviceEn: 'SEPA payments',
-    svc: 'openbank-sepa-payment-service',
-    workflowCs: 'SepaPaymentWorkflow',
-    stepsCs: ['Validace BIC + SEPA pravidla', 'ISO 20022 pacs.008 sestavení', 'Odeslání do SWIFT/EBA', 'SCT/SCT Inst potvrzení', 'Kompenzace přes pacs.004'],
-    stepsEn: ['BIC + SEPA rules validation', 'ISO 20022 pacs.008 assembly', 'Submit to SWIFT/EBA', 'SCT/SCT Inst confirmation', 'Compensation via pacs.004'],
-    flagCs: 'flag: sepa-payment-temporal-workflow=ON',
-    flagEn: 'flag: sepa-payment-temporal-workflow=ON',
-  },
-  {
-    icon: Repeat2,
-    color: '#10b981',
-    serviceCs: 'FX konverze',
-    serviceEn: 'FX conversions',
-    svc: 'openbank-fx-service',
-    workflowCs: 'FxConversionWorkflow',
-    stepsCs: ['Sestavení kurzu (ECB + spread)', 'G5 screening', 'Odpis zdrojové měny', 'Připsání cílové měny', 'Journal entry pár (ADR-0039)'],
-    stepsEn: ['Rate assembly (ECB + spread)', 'G5 screening', 'Debit source currency', 'Credit target currency', 'Journal entry pair (ADR-0039)'],
-    flagCs: 'flag: fx-temporal-workflow=ON',
-    flagEn: 'flag: fx-temporal-workflow=ON',
-  },
-  {
-    icon: BarChart2,
-    color: '#f59e0b',
-    serviceCs: 'Uzávěrky (EoD/EoM/EoY)',
-    serviceEn: 'Closings (EoD/EoM/EoY)',
-    svc: 'openbank-statement-service',
-    workflowCs: 'StatementCloseWorkflow',
-    stepsCs: ['Agregace transakcí dne/měsíce/roku', 'Výpočet úrokových nákladů', 'Export na S3 + Kafka výpis', 'Potvrzení uzávěrky'],
-    stepsEn: ['Aggregate daily/monthly/yearly transactions', 'Compute interest charges', 'Export to S3 + Kafka statement', 'Closing confirmation'],
-    flagCs: 'flag: statement-temporal-workflow=ON',
-    flagEn: 'flag: statement-temporal-workflow=ON',
-  },
-]
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 

--- a/openbank-admin-ui/src/components/layout/Sidebar.tsx
+++ b/openbank-admin-ui/src/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ import {
   DollarSign, Globe, Repeat, Zap, AlertOctagon, ScanLine,
   Layers, TrendingUp, MessageSquareWarning, Package, Receipt, Server, ShieldAlert, FlaskConical, Cloud,
   PiggyBank, GitBranch, Lock, ClipboardList, Scale, Smartphone,
-  ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network, Waypoints,
+  ClipboardCheck, Activity, Boxes, Bluetooth, Fingerprint, FileSignature, Network, Waypoints, Workflow,
 } from 'lucide-react'
 import { hasPermission, Permission } from '@/lib/auth/roles'
 import { useLanguage } from '@/lib/i18n/LanguageContext'
@@ -92,6 +92,7 @@ const platformNav: NavItem[] = [
   { nameCs: 'DevOps',   nameEn: 'DevOps',   href: '/devops',   icon: GitBranch,  permission: 'system:view' },
   { nameCs: 'IAOps',    nameEn: 'IAOps',    href: '/iaops',    icon: Bot,        permission: 'system:view' },
   { nameCs: 'Temporal', nameEn: 'Temporal', href: '/temporal', icon: Zap,        permission: 'system:view' },
+  { nameCs: 'Tok workflow', nameEn: 'Workflow Flow', href: '/temporal/flow', icon: Workflow, permission: 'system:view' },
   { nameCs: 'Observability', nameEn: 'Observability', href: '/observability', icon: Activity, permission: 'system:view' },
   { nameCs: 'Schvalování', nameEn: 'Approvals', href: '/approvals', icon: ClipboardCheck, permission: 'system:view' },
 ]

--- a/openbank-admin-ui/src/lib/temporal/workflows.ts
+++ b/openbank-admin-ui/src/lib/temporal/workflows.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { CreditCard, Globe, Repeat2, BarChart2 } from 'lucide-react'
+
+// The money-path saga workflows migrated to Temporal (ADR-0100). Shared by the
+// Temporal overview page and the Temporal flow page. Each `steps` list is the
+// documented saga — the last step is the compensation branch. Curated (the sagas
+// are documented, not scraped from live histories); live throughput comes from
+// /api/temporal/status (Prometheus).
+export type MoneyWorkflow = {
+  icon: typeof CreditCard
+  color: string
+  serviceCs: string
+  serviceEn: string
+  svc: string
+  workflowCs: string
+  stepsCs: string[]
+  stepsEn: string[]
+  flagCs: string
+  flagEn: string
+}
+
+export const MONEY_WORKFLOWS: MoneyWorkflow[] = [
+  {
+    icon: CreditCard,
+    color: '#6366f1',
+    serviceCs: 'Tuzemské platby',
+    serviceEn: 'Domestic payments',
+    svc: 'openbank-domestic-payment-service',
+    workflowCs: 'DomesticPaymentWorkflow',
+    stepsCs: ['Validace IBAN + limit', 'Rezervace sald', 'Odeslání na CERTIS/instant rail', 'Potvrzení settlement', 'Kompenzace při odmítnutí'],
+    stepsEn: ['IBAN + limit validation', 'Balance reservation', 'Submit to CERTIS/instant rail', 'Settlement confirmation', 'Compensation on rejection'],
+    flagCs: 'flag: domestic-payment-temporal-workflow=ON',
+    flagEn: 'flag: domestic-payment-temporal-workflow=ON',
+  },
+  {
+    icon: Globe,
+    color: '#8b5cf6',
+    serviceCs: 'SEPA platby',
+    serviceEn: 'SEPA payments',
+    svc: 'openbank-sepa-payment-service',
+    workflowCs: 'SepaPaymentWorkflow',
+    stepsCs: ['Validace BIC + SEPA pravidla', 'ISO 20022 pacs.008 sestavení', 'Odeslání do SWIFT/EBA', 'SCT/SCT Inst potvrzení', 'Kompenzace přes pacs.004'],
+    stepsEn: ['BIC + SEPA rules validation', 'ISO 20022 pacs.008 assembly', 'Submit to SWIFT/EBA', 'SCT/SCT Inst confirmation', 'Compensation via pacs.004'],
+    flagCs: 'flag: sepa-payment-temporal-workflow=ON',
+    flagEn: 'flag: sepa-payment-temporal-workflow=ON',
+  },
+  {
+    icon: Repeat2,
+    color: '#10b981',
+    serviceCs: 'FX konverze',
+    serviceEn: 'FX conversions',
+    svc: 'openbank-fx-service',
+    workflowCs: 'FxConversionWorkflow',
+    stepsCs: ['Sestavení kurzu (ECB + spread)', 'G5 screening', 'Odpis zdrojové měny', 'Připsání cílové měny', 'Journal entry pár (ADR-0039)'],
+    stepsEn: ['Rate assembly (ECB + spread)', 'G5 screening', 'Debit source currency', 'Credit target currency', 'Journal entry pair (ADR-0039)'],
+    flagCs: 'flag: fx-temporal-workflow=ON',
+    flagEn: 'flag: fx-temporal-workflow=ON',
+  },
+  {
+    icon: BarChart2,
+    color: '#f59e0b',
+    serviceCs: 'Uzávěrky (EoD/EoM/EoY)',
+    serviceEn: 'Closings (EoD/EoM/EoY)',
+    svc: 'openbank-statement-service',
+    workflowCs: 'StatementCloseWorkflow',
+    stepsCs: ['Agregace transakcí dne/měsíce/roku', 'Výpočet úrokových nákladů', 'Export na S3 + Kafka výpis', 'Potvrzení uzávěrky'],
+    stepsEn: ['Aggregate daily/monthly/yearly transactions', 'Compute interest charges', 'Export to S3 + Kafka statement', 'Closing confirmation'],
+    flagCs: 'flag: statement-temporal-workflow=ON',
+    flagEn: 'flag: statement-temporal-workflow=ON',
+  },
+]

--- a/openbank-admin-ui/src/test/temporal-flow.test.tsx
+++ b/openbank-admin-ui/src/test/temporal-flow.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Behaviour test for the Temporal workflow flow page (/temporal/flow): mounts with
+// a live-shaped /api/temporal/status payload and asserts the saga step-chains, the
+// aggregate metrics strip, the SMIL flow animation, and graceful degradation when
+// Temporal is not deployed.
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { LanguageProvider } from '@/lib/i18n/LanguageContext'
+import { SessionProvider } from '@/components/auth/SessionProvider'
+import TemporalFlowPage from '@/app/temporal/flow/page'
+
+const DEPLOYED = {
+  available: true, temporalDeployed: true,
+  metrics: {
+    workflows: { scheduled1h: 5, completed1h: 4, failed1h: 1, timedOut1h: 0 },
+    latency: { activityScheduleToStartMs: 12, workflowTaskScheduleToStartMs: 8, serverRequestP99Ms: 20 },
+    persistence: { requestsPerSec: 3 }, workers: { totalSlotsAvailable: 10, slotsUsed: 2 },
+    namespaces: ['openbank'],
+  },
+}
+const NOT_DEPLOYED = { available: false, temporalDeployed: false, metrics: null }
+
+function Providers({ children }: { children: React.ReactNode }) {
+  return React.createElement(SessionProvider, null, React.createElement(LanguageProvider, null, children))
+}
+function mockFetch(status: unknown) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const json = (b: unknown) => new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/auth/session')) return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } })
+    if (url.includes('/api/temporal/status')) return json(status)
+    return json({})
+  })
+}
+
+describe('temporal workflow flow page', () => {
+  afterEach(() => { cleanup(); vi.unstubAllGlobals() })
+
+  it('renders the saga step-chains and the aggregate metrics strip', async () => {
+    vi.stubGlobal('fetch', mockFetch(DEPLOYED))
+    render(React.createElement(Providers, null, React.createElement(TemporalFlowPage)))
+    await waitFor(() => expect(screen.getByText('Domestic payments')).toBeInTheDocument())
+    expect(screen.getByText('SEPA payments')).toBeInTheDocument()
+    // a documented saga step
+    expect(screen.getByText('IBAN + limit validation')).toBeInTheDocument()
+    // aggregate live metrics
+    expect(screen.getByText('Completed (1h)')).toBeInTheDocument()
+    expect(screen.getByText('Failed (1h)')).toBeInTheDocument()
+  })
+
+  it('animates flow by default and stops when toggled off', async () => {
+    vi.stubGlobal('fetch', mockFetch(DEPLOYED))
+    const { container } = render(React.createElement(Providers, null, React.createElement(TemporalFlowPage)))
+    await waitFor(() => expect(screen.getByText('Domestic payments')).toBeInTheDocument())
+    expect(container.querySelectorAll('animateMotion').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getByRole('button', { name: /Flow/i }))
+    await waitFor(() => expect(container.querySelectorAll('animateMotion').length).toBe(0))
+  })
+
+  it('degrades gracefully when Temporal is not deployed — chains stay, metrics dash out', async () => {
+    vi.stubGlobal('fetch', mockFetch(NOT_DEPLOYED))
+    render(React.createElement(Providers, null, React.createElement(TemporalFlowPage)))
+    // the curated sagas still render (they are documented, not live)
+    await waitFor(() => expect(screen.getByText('Domestic payments')).toBeInTheDocument())
+    expect(screen.getByText(/not deployed/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

New **`/temporal/flow`** — the third animated topology view. Each money-path saga is drawn as a linear step-chain (step → step → … → compensation) with a token flowing through, over a **live aggregate metrics** strip. Part 3 of 3 of the animation trilogy (built on the shared engine from #1689).

## Type of change
- [x] feat (new functionality)

## Linked issues
None — follow-up to #1689 / #1693 (animation trilogy, part 3 of 3).

## Changes
- NEW `src/lib/temporal/workflows.ts` — the money-path saga defs (domestic/SEPA/FX/statement) extracted so the overview page and the flow page share one source; `temporal/page.tsx` now imports it (local copy + now-unused icon imports removed).
- NEW `src/app/temporal/flow/page.tsx` — one animated saga chain per workflow (shared topology `FlowParticle`); compensation step drawn red/dashed, animating only when failures > 0; live aggregate metrics strip (scheduled/completed/failed/timed-out 1h + activity latency) from `/api/temporal/status`.
- `src/components/layout/Sidebar.tsx` — "Workflow Flow" nav entry.
- NEW `src/test/temporal-flow.test.tsx`.

## Honesty contract
The **steps are the documented saga definitions** (curated); the **metrics are live but namespace-aggregate** (Prometheus), not per-run replay — the subtitle says so. Per-run history replay would need a Temporal-history API proxy (follow-up).

## Definition of Done
- [x] Unit test added (`temporal-flow.test.tsx`, +3).
- [x] admin-ui gate green: `type-check` · `test` (638) · `eslint .` (0 errors) · `next build` (route present).
- [x] Graceful — Temporal not deployed → chains stay, metrics dash out, a note is shown (no raw HTTP).
- [ ] OpenAPI / Flyway / Avro / ADR — N/A (reuses existing read-only `/api/temporal/status`).

## Security checklist
- [x] No secrets/PII; no new deps; no auth/crypto/payment/PII path touched; read-only view.

## Compliance impact
- [x] None — no new backend/probes/egress; reuses the existing Prometheus-backed status route.

## Rollout / Rollback
- Rolling; revert the PR; no migration.

## Screenshots / demo
Aggregate metrics strip (Scheduled/Completed/Failed/Timed-out/latency) over four saga chains (Domestic, SEPA, FX, Closings), each a numbered step chain with a red-dashed compensation step + a legend. _(Screenshot shared with the author in the working session.)_

## Reviewer notes
- FinOps: $0 — reuses `/api/temporal/status` (the overview page already polls it); animation is client-side SMIL.
- Refactor safety: `temporal/page.tsx` behaviour unchanged (data-only extraction; type-check + render-smoke cover it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
