### PR TITLE
refactor(admin-ui): extract the shared band layout into the topology engine

### DIFF
--- a/openbank-admin-ui/src/app/docs/lineage/page.tsx
+++ b/openbank-admin-ui/src/app/docs/lineage/page.tsx
@@ -11,6 +11,7 @@ import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
+import { layoutBands } from '@/components/topology/layout'
 
 // ---------------------------------------------------------------------------
 // Data-lineage flow (ADR-0071). Companion to the service map, but the graph here
@@ -62,39 +63,7 @@ const PILL_GAP = 14
 const HALF_H = PILL_H / 2
 const pillWidth = (label: string) => Math.max(96, 22 + label.length * 6.6 + 14)
 
-type Pos = { cx: number; cy: number; w: number }
-type Band = { key: Domain; y: number; h: number; count: number }
-
-function buildLayout(byDomain: Record<string, GovService[]>, domains: Domain[]) {
-  const availW = WIDTH - CANVAS_PAD * 2
-  const pos: Record<string, Pos> = {}
-  const bands: Band[] = []
-  let y = CANVAS_PAD
-  for (const dom of domains) {
-    const list = byDomain[dom] ?? []
-    if (!list.length) continue
-    const rows: { id: string; w: number }[][] = [[]]
-    let rowW = 0
-    for (const s of list) {
-      const w = pillWidth(prettyName(s.serviceName))
-      const cur = rows[rows.length - 1]
-      if (cur.length && rowW + PILL_GAP + w > availW) { rows.push([]); rowW = 0 }
-      rows[rows.length - 1].push({ id: s.serviceName, w })
-      rowW += (cur.length ? PILL_GAP : 0) + w
-    }
-    let ry = y + BAND_HEAD
-    for (const row of rows) {
-      const total = row.reduce((s, r) => s + r.w, 0) + PILL_GAP * Math.max(0, row.length - 1)
-      let x = CANVAS_PAD + Math.max(0, (availW - total) / 2)
-      for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: ry + PILL_H / 2, w: r.w }; x += r.w + PILL_GAP }
-      ry += PILL_H + PILL_GAP
-    }
-    const h = BAND_HEAD + rows.length * (PILL_H + PILL_GAP) - PILL_GAP + BAND_PAD_Y
-    bands.push({ key: dom, y, h, count: list.length })
-    y += h + BAND_GAP
-  }
-  return { pos, bands, height: bands.length ? y - BAND_GAP + CANVAS_PAD : CANVAS_PAD }
-}
+const BAND_CFG = { width: WIDTH, pad: CANVAS_PAD, pillH: PILL_H, bandHead: BAND_HEAD, bandPadY: BAND_PAD_Y, bandGap: BAND_GAP, pillGap: PILL_GAP, measure: pillWidth }
 
 export default function LineageFlowPage() {
   const { t } = useLanguage()
@@ -145,7 +114,10 @@ export default function LineageFlowPage() {
   const visibleIds = new Set(visible.map(s => s.serviceName))
   const byDomain: Record<string, GovService[]> = {}
   for (const s of visible) (byDomain[domainOf(s)] ||= []).push(s)
-  const LAYOUT = buildLayout(byDomain, DOMAIN_ORDER)
+  const LAYOUT = layoutBands(
+    DOMAIN_ORDER.map(dom => ({ key: dom, items: (byDomain[dom] ?? []).map(s => ({ id: s.serviceName, label: prettyName(s.serviceName) })) })),
+    BAND_CFG,
+  )
 
   const visibleEdges = allEdges.filter(e =>
     visibleIds.has(e.from) && visibleIds.has(e.to) && (relFilter === 'all' || e.type === relFilter))

--- a/openbank-admin-ui/src/app/docs/service-map/page.tsx
+++ b/openbank-admin-ui/src/app/docs/service-map/page.tsx
@@ -13,6 +13,7 @@ import { edgeGeometry, mixHex, pathId, type Pt, type Half } from '@/components/t
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
+import { layoutBand } from '@/components/topology/layout'
 
 // Service definitions with positions for the map
 const SERVICES = [
@@ -310,27 +311,7 @@ const chipWidth = (label: string) => Math.max(96, 30 + label.length * 6.6 + 14)
 type TierPos = { cx: number; cy: number; w: number }
 type BandBox = { key: 'infra' | 'external'; x: number; y: number; w: number; h: number }
 // Deterministic flow-layout: centre chips per row, wrapping to the canvas width.
-function layoutBand(nodes: { id: string; label: string }[], availW: number, startY: number) {
-  const rows: { id: string; label: string; w: number }[][] = [[]]
-  let rowW = 0
-  for (const n of nodes) {
-    const w = chipWidth(n.label)
-    const cur = rows[rows.length - 1]
-    if (cur.length && rowW + CHIP_GAP + w > availW) { rows.push([]); rowW = 0 }
-    rows[rows.length - 1].push({ ...n, w })
-    rowW += (cur.length ? CHIP_GAP : 0) + w
-  }
-  const pos: Record<string, TierPos> = {}
-  let y = startY + BAND_HEAD
-  for (const row of rows) {
-    const total = row.reduce((s, r) => s + r.w, 0) + CHIP_GAP * Math.max(0, row.length - 1)
-    let x = CANVAS_PAD + Math.max(0, (availW - total) / 2)
-    for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: y + CHIP_H / 2, w: r.w }; x += r.w + CHIP_GAP }
-    y += CHIP_H + CHIP_GAP
-  }
-  const h = BAND_HEAD + rows.length * (CHIP_H + CHIP_GAP) - CHIP_GAP + BAND_PAD_Y
-  return { pos, height: h }
-}
+const BAND_CFG = { width: LAYOUT.width, pad: CANVAS_PAD, pillH: CHIP_H, bandHead: BAND_HEAD, bandPadY: BAND_PAD_Y, bandGap: BAND_GAP, pillGap: CHIP_GAP, measure: chipWidth }
 
 // A rounded "pill" node for an infra/external tier — visually distinct from the
 // LEGO-brick services so the three tiers read apart at a glance.
@@ -487,7 +468,6 @@ export default function ServiceMapPage() {
   // Tier band geometry below the service grid (computed each render — a handful
   // of chips, cheap). When a tier has no nodes, its band is skipped entirely so
   // the empty-graph page keeps the original height.
-  const availW = LAYOUT.width - CANVAS_PAD * 2
   const chipLabel = (id: string, fallback: string) => t(tierMeta(id)?.labelCs ?? fallback, tierMeta(id)?.labelEn ?? fallback)
   const tierPos: Record<string, TierPos> = {}
   const bandBoxes: (BandBox & { count: number })[] = []
@@ -495,7 +475,7 @@ export default function ServiceMapPage() {
     let y = LAYOUT.height
     const place = (key: 'infra' | 'external', nodes: (InfraNodeT | ExternalNodeT)[]) => {
       y += BAND_GAP
-      const b = layoutBand(nodes.map(n => ({ id: n.id, label: chipLabel(n.id, n.label) })), availW, y)
+      const b = layoutBand(nodes.map(n => ({ id: n.id, label: chipLabel(n.id, n.label) })), y, BAND_CFG)
       Object.assign(tierPos, b.pos)
       bandBoxes.push({ key, x: CANVAS_PAD - 12, y, w: LAYOUT.width - (CANVAS_PAD - 12) * 2, h: b.height, count: nodes.length })
       y += b.height

--- a/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
+++ b/openbank-admin-ui/src/app/infrastructure/topology/page.tsx
@@ -13,6 +13,7 @@ import { edgeGeometry, mixHex, pathId } from '@/components/topology/geometry'
 import { FlowParticle } from '@/components/topology/FlowParticle'
 import { useFlowAnimation } from '@/components/topology/useFlowAnimation'
 import { NodeShadow, ArrowMarker } from '@/components/topology/TopologyDefs'
+import { layoutBands } from '@/components/topology/layout'
 
 // ---------------------------------------------------------------------------
 // Infrastructure topology (ADR-0027/0029). A companion to the code-derived
@@ -174,38 +175,11 @@ const BAND_GAP = 26
 const PILL_GAP = 16
 const pillWidth = (label: string) => Math.max(112, 34 + label.length * 7 + 20)
 
-type Pt = { cx: number; cy: number; w: number }
-type Band = { key: GroupKey; y: number; h: number }
-
-const LAYOUT: { pos: Record<string, Pt>; bands: Band[]; height: number } = (() => {
-  const availW = WIDTH - CANVAS_PAD * 2
-  const pos: Record<string, Pt> = {}
-  const bands: Band[] = []
-  let y = CANVAS_PAD
-  for (const g of GROUP_ORDER) {
-    const list = NODES.filter(n => n.group === g)
-    const rows: { id: string; w: number }[][] = [[]]
-    let rowW = 0
-    for (const n of list) {
-      const w = pillWidth(n.label)
-      const cur = rows[rows.length - 1]
-      if (cur.length && rowW + PILL_GAP + w > availW) { rows.push([]); rowW = 0 }
-      rows[rows.length - 1].push({ id: n.id, w })
-      rowW += (cur.length ? PILL_GAP : 0) + w
-    }
-    let ry = y + BAND_HEAD
-    for (const row of rows) {
-      const total = row.reduce((s, r) => s + r.w, 0) + PILL_GAP * Math.max(0, row.length - 1)
-      let x = CANVAS_PAD + Math.max(0, (availW - total) / 2)
-      for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: ry + PILL_H / 2, w: r.w }; x += r.w + PILL_GAP }
-      ry += PILL_H + PILL_GAP
-    }
-    const h = BAND_HEAD + rows.length * (PILL_H + PILL_GAP) - PILL_GAP + BAND_PAD_Y
-    bands.push({ key: g, y, h })
-    y += h + BAND_GAP
-  }
-  return { pos, bands, height: y - BAND_GAP + CANVAS_PAD }
-})()
+const BAND_CFG = { width: WIDTH, pad: CANVAS_PAD, pillH: PILL_H, bandHead: BAND_HEAD, bandPadY: BAND_PAD_Y, bandGap: BAND_GAP, pillGap: PILL_GAP, measure: pillWidth }
+const LAYOUT = layoutBands(
+  GROUP_ORDER.map(g => ({ key: g, items: NODES.filter(n => n.group === g).map(n => ({ id: n.id, label: n.label })) })),
+  BAND_CFG,
+)
 
 type LifeMap = Record<string, { urgency?: string }>
 

--- a/openbank-admin-ui/src/components/topology/layout.ts
+++ b/openbank-admin-ui/src/components/topology/layout.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+// Shared band layout for the topology pages. A "band" is a full-width region whose
+// items (pills) wrap into centred rows; `layoutBands` stacks several bands top→bottom.
+// The service map (infra/external tiers), the infra topology, and the data-lineage
+// page all used a byte-identical copy of this — extracted here, parameterised by a
+// per-page config (dimensions + a label→width measurer) so each page keeps its own
+// look while sharing the maths.
+
+export type BandItem = { id: string; label: string }
+export type BandPos = { cx: number; cy: number; w: number }
+export type BandBox<K extends string = string> = { key: K; y: number; h: number; count: number }
+export type BandLayoutCfg = {
+  width: number
+  pad: number
+  pillH: number
+  bandHead: number
+  bandPadY: number
+  bandGap: number
+  pillGap: number
+  measure: (label: string) => number
+}
+
+// One band: wrap items into centred rows starting at `startY + bandHead`. Returns
+// each item's centre/width (keyed by id) and the band's total height.
+export function layoutBand(items: BandItem[], startY: number, cfg: BandLayoutCfg): { pos: Record<string, BandPos>; height: number } {
+  const availW = cfg.width - cfg.pad * 2
+  const rows: { id: string; w: number }[][] = [[]]
+  let rowW = 0
+  for (const it of items) {
+    const w = cfg.measure(it.label)
+    const cur = rows[rows.length - 1]
+    if (cur.length && rowW + cfg.pillGap + w > availW) { rows.push([]); rowW = 0 }
+    rows[rows.length - 1].push({ id: it.id, w })
+    rowW += (cur.length ? cfg.pillGap : 0) + w
+  }
+  const pos: Record<string, BandPos> = {}
+  let y = startY + cfg.bandHead
+  for (const row of rows) {
+    const total = row.reduce((s, r) => s + r.w, 0) + cfg.pillGap * Math.max(0, row.length - 1)
+    let x = cfg.pad + Math.max(0, (availW - total) / 2)
+    for (const r of row) { pos[r.id] = { cx: x + r.w / 2, cy: y + cfg.pillH / 2, w: r.w }; x += r.w + cfg.pillGap }
+    y += cfg.pillH + cfg.pillGap
+  }
+  const height = cfg.bandHead + rows.length * (cfg.pillH + cfg.pillGap) - cfg.pillGap + cfg.bandPadY
+  return { pos, height }
+}
+
+// Several bands stacked top→bottom (empty groups skipped). Returns the merged
+// positions, per-band boxes (with item count), and the total stacked height.
+export function layoutBands<K extends string>(groups: { key: K; items: BandItem[] }[], cfg: BandLayoutCfg): { pos: Record<string, BandPos>; bands: BandBox<K>[]; height: number } {
+  const pos: Record<string, BandPos> = {}
+  const bands: BandBox<K>[] = []
+  let y = cfg.pad
+  for (const g of groups) {
+    if (!g.items.length) continue
+    const b = layoutBand(g.items, y, cfg)
+    Object.assign(pos, b.pos)
+    bands.push({ key: g.key, y, h: b.height, count: g.items.length })
+    y += b.height + cfg.bandGap
+  }
+  return { pos, bands, height: bands.length ? y - cfg.bandGap + cfg.pad : cfg.pad }
+}

--- a/openbank-admin-ui/src/test/topology-layout.test.ts
+++ b/openbank-admin-ui/src/test/topology-layout.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+import { describe, it, expect } from 'vitest'
+import { layoutBand, layoutBands, type BandLayoutCfg } from '@/components/topology/layout'
+
+const CFG: BandLayoutCfg = {
+  width: 1000, pad: 50, pillH: 30, bandHead: 20, bandPadY: 10, bandGap: 20, pillGap: 10,
+  measure: () => 100, // fixed 100px pills → availW 900 fits 9 per row
+}
+
+describe('topology band layout', () => {
+  it('layoutBand centres a single row and reports height', () => {
+    const { pos, height } = layoutBand([{ id: 'a', label: 'a' }, { id: 'b', label: 'b' }], 0, CFG)
+    // two 100px pills + 10 gap = 210, centred in availW 900 → startX = 50 + (900-210)/2 = 395
+    expect(pos.a.cx).toBe(395 + 50) // first pill centre = startX + w/2
+    expect(pos.b.cx).toBe(pos.a.cx + 110)
+    expect(pos.a.cy).toBe(0 + 20 + 30 / 2) // startY + bandHead + pillH/2
+    // one row: bandHead + 1*(pillH+pillGap) - pillGap + bandPadY
+    expect(height).toBe(20 + (30 + 10) - 10 + 10)
+  })
+
+  it('layoutBand wraps to a second row past availW', () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ id: `n${i}`, label: 'x' }))
+    const { pos, height } = layoutBand(items, 0, CFG) // 9 fit per row → 2 rows
+    expect(pos.n0.cy).not.toBe(pos.n9.cy) // n9 dropped to row 2
+    expect(height).toBe(20 + 2 * (30 + 10) - 10 + 10)
+  })
+
+  it('layoutBands stacks bands, skips empty groups, counts items', () => {
+    const r = layoutBands([
+      { key: 'g1', items: [{ id: 'a', label: 'a' }] },
+      { key: 'g2', items: [] }, // skipped
+      { key: 'g3', items: [{ id: 'b', label: 'b' }] },
+    ], CFG)
+    expect(r.bands.map(b => b.key)).toEqual(['g1', 'g3'])
+    expect(r.bands[0].count).toBe(1)
+    expect(r.bands[1].y).toBeGreaterThan(r.bands[0].y) // stacked below
+    expect(r.pos.a).toBeDefined()
+    expect(r.pos.b).toBeDefined()
+  })
+
+  it('layoutBands returns just the pad height when everything is empty', () => {
+    const r = layoutBands([{ key: 'g', items: [] }], CFG)
+    expect(r.bands).toHaveLength(0)
+    expect(r.height).toBe(CFG.pad)
+  })
+})


### PR DESCRIPTION
## Summary

Extract the byte-identical **band layout** shared by the three topology pages (service map tiers, infra topology, data lineage) into the topology engine. Behaviour-preserving; completes the engine extraction started in #1689.

## Type of change
- [x] refactor (no behavior change)

## Linked issues
None — follow-up to #1689 / #1693 / #1700 (topology engine).

## Changes
- NEW `src/components/topology/layout.ts` — `layoutBand` (one band: wrap items into centred rows) + `layoutBands` (stack bands top→bottom, skip empty groups, count items), parameterised by a per-page `BandLayoutCfg` (dimensions + a label→width `measure`).
- `docs/service-map/page.tsx` (tier bands), `infrastructure/topology/page.tsx`, `docs/lineage/page.tsx` — drop their local copies, build a `BAND_CFG` from their own constants, call the shared functions.
- NEW `src/test/topology-layout.test.ts`.

## Definition of Done
- [x] Behaviour-preserving — the `service-map-topology`, `infrastructure-topology` and `lineage-flow` tests pass **unchanged** (the refactor's safety net).
- [x] Unit test added (`topology-layout.test.ts`).
- [x] admin-ui gate green: `type-check` · `test` (642) · `eslint .` (0 errors) · `next build`.
- [ ] OpenAPI / Flyway / Avro / ADR — N/A.

## Security checklist
- [x] No secrets/PII; no new deps; no auth/crypto/payment/PII path touched; pure client-side refactor.

## Compliance impact
- [x] None.

## Rollout / Rollback
- Rolling; revert the PR; no migration. FinOps: $0 (zero runtime change).

## Reviewer notes
- The three pages differ only in constants (pill height, gaps, `measure` formula) — now passed as config; the algorithm is shared. The topology module (`src/components/topology/`) now owns geometry, `FlowParticle`, defs, the flow hook, and layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
