### PR TITLE
chore(gitops): customer-edge -> sandbox-08471c0f + SEPA_INSTANT_SERVICE_URL + netpol (#1713)

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-e4667d1b
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-08471c0f
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -154,6 +154,10 @@ spec:
               value: http://domestic-payment.payments.svc:8116
             - name: SEPA_PAYMENT_SERVICE_URL
               value: http://sepa-payment.payments.svc:8115
+            # SEPA Instant (SCT Inst) send for the customer app (#1713): POST /customer/v1/sepa-instant.
+            # Declared here so gen-network-policies.py opens the edge->sepa-instant ingress allow.
+            - name: SEPA_INSTANT_SERVICE_URL
+              value: http://sepa-instant.payments.svc:8127
             - name: SCA_SERVICE_URL
               value: http://sca-service.sca.svc:8110
             # Bind management interface to all interfaces so kubelet probes (from node IP)

--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -260,6 +260,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: platform
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
Deploys #1713 (SEPA Instant send): edge image bump, SEPA_INSTANT_SERVICE_URL env, regenerated NetworkPolicy (sepa-instant ← customer-edge). Image built + signed by Auto Deploy; hand-bump.

## Linked issues

N/A — deploy for the SEPA Instant feature.