### PR TITLE
fix(gitops): grant sepa-instant Kafka write on its own events topic

### DIFF
--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -77,6 +77,16 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
+      # sepa-instant's own domain-event stream (kafka-producer-sct-inst-events-out ->
+      # openbank.sepa.instant.events). Missing here, the producer got "Topic authorization
+      # failed" once the cluster stopped allowing ANONYMOUS/no-ACL writes, and a submit blocked
+      # on the failing publish. Prefix covers the events topic + any sibling instant streams.
+      - resource:
+          type: topic
+          name: openbank.sepa.instant.
+          patternType: prefix
+        operations: [Write, Describe, Create]
+        host: "*"
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser


### PR DESCRIPTION
sepa-instant's KafkaUser only had Write on `payment.scheme-accepted`, not on `openbank.sepa.instant.events` (its `kafka-producer-sct-inst-events-out` channel). Once the cluster enforced ACLs, the producer logged a repeating `Topic authorization failed for topics [openbank.sepa.instant.events]`, and a customer SCT Inst submit **blocked** on the failing publish (the app's SEPA Instant send hung). Adds a prefix ACL (Write/Describe/Create on `openbank.sepa.instant.`). Strimzi reconciles the ACLs; no image rebuild.

## Linked issues

N/A — unblocks the SEPA Instant send (#1713).