### PR TITLE
feat(edge): international SWIFT (MT103) wire transfer for customers

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -37,6 +37,8 @@ import jakarta.ws.rs.core.Response
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.jwt.JsonWebToken
 import java.time.Clock
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 /**
@@ -131,6 +133,13 @@ class CustomerEdgeResource(
 
     @ConfigProperty(name = "openbank.edge.sepa-instant-service-url")
     lateinit var sepaInstantServiceUrl: String
+
+    @ConfigProperty(name = "openbank.edge.swift-service-url")
+    lateinit var swiftServiceUrl: String
+
+    /** The bank's own SWIFT/BIC — the senderBic on outbound MT103s. */
+    @ConfigProperty(name = "openbank.edge.bank-bic", defaultValue = "OPENCZPPXXX")
+    lateinit var bankBic: String
 
     @ConfigProperty(name = "openbank.edge.sca-service-url")
     lateinit var scaServiceUrl: String
@@ -1394,6 +1403,89 @@ class CustomerEdgeResource(
     }
 
     /**
+     * Initiate an international SWIFT (MT103) credit transfer from one of the caller's OWN accounts.
+     * The customer supplies only the beneficiary (name, account/IBAN, receiver BIC), amount, currency
+     * and reference; the edge assembles the bank-operational MT103 fields — senderBic (the bank's own
+     * BIC), message type, transaction reference, value date, the ordering-customer identity resolved
+     * from the debtor account/party, and the amount in minor units. Ownership + SCA gate as for the
+     * other payment rails.
+     */
+    @POST
+    @Path("/swift")
+    @Authorize(action = "customer.payments.initiate")
+    @Blocking
+    fun createSwift(
+        body: String,
+        @HeaderParam("Idempotency-Key") idempotencyKey: String?,
+        @HeaderParam("X-SCA-Challenge-Id") scaChallengeId: String?,
+    ): Response {
+        val customer = customer()
+        val debtor = parseDebtorAccountId(objectMapper, body)?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+            ?: return forbidden("Missing or malformed debtorAccountId")
+        val accountJson = fetchAccount(debtor, customer.partyId)
+            ?: return forbidden("Debtor account does not belong to caller")
+        if (extractOwnerPartyId(accountJson) != customer.partyId.toString()) {
+            return forbidden("Debtor account does not belong to caller")
+        }
+        val debtorIban = extractTextField(objectMapper, accountJson, "accountNumber")
+            ?: return badRequest("Cannot resolve debtor IBAN")
+        val debtorName = fetchPartyLegalName(customer.partyId) ?: return badRequest("Cannot resolve debtor name")
+        val beneficiaryIban = extractTextField(objectMapper, body, "creditorIban")
+            ?: return badRequest("Missing creditorIban")
+        val beneficiaryName = extractTextField(objectMapper, body, "creditorName")
+            ?: return badRequest("Missing creditorName")
+        val receiverBic = extractTextField(objectMapper, body, "bic")
+            ?: return badRequest("Missing beneficiary BIC")
+        val amount = extractAmountField(objectMapper, body) ?: return badRequest("Missing amount")
+        val currency = extractTextField(objectMapper, body, "currency") ?: "EUR"
+        scaGate(scaChallengeId, customer, amount, currency, beneficiaryIban, "payments.swift")?.let { return it }
+        val key = idempotencyKey?.takeIf { it.isNotBlank() } ?: "swift-$debtor-$beneficiaryIban-$amount"
+        val request = buildSwiftRequest(
+            key, debtor.toString(), debtorIban, debtorName, beneficiaryIban, beneficiaryName,
+            receiverBic, amount, currency, extractTextField(objectMapper, body, "reference"),
+        )
+        val resp = upstream.post("$swiftServiceUrl/api/v1/swift", customer.partyId.toString(), request, key)
+        auditPayment(resp, customer, "payments.swift", amount, currency, beneficiaryIban, scaChallengeId)
+        return resp
+    }
+
+    @Suppress("LongParameterList")
+    private fun buildSwiftRequest(
+        key: String,
+        debtorAccountId: String,
+        debtorIban: String,
+        debtorName: String,
+        beneficiaryIban: String,
+        beneficiaryName: String,
+        receiverBic: String,
+        amount: String,
+        currency: String,
+        reference: String?,
+    ): String {
+        val minor = runCatching { java.math.BigDecimal(amount).movePointRight(2).toLong() }.getOrDefault(0L)
+        val out = objectMapper.createObjectNode()
+        out.put("idempotencyKey", key)
+        out.put("messageType", "MT103")
+        out.put("senderBic", bankBic)
+        out.put("receiverBic", receiverBic)
+        // SWIFT transaction reference is Max16Text; strip non-alphanumerics and cap.
+        out.put("transactionReference", key.filter { it.isLetterOrDigit() }.take(SWIFT_REF_MAX_LEN))
+        // swift-service validates valueDate as YYYYMMDD (BASIC_ISO_DATE), not ISO with dashes.
+        out.put("valueDate", LocalDate.now(clock).format(DateTimeFormatter.BASIC_ISO_DATE))
+        out.put("currency", currency)
+        out.put("amountMinorUnits", minor)
+        out.put("orderingCustomerAccount", debtorIban)
+        out.put("orderingCustomerAccountId", debtorAccountId)
+        out.put("orderingCustomerName", debtorName)
+        out.put("beneficiaryAccount", beneficiaryIban)
+        out.put("beneficiaryName", beneficiaryName)
+        reference?.let { out.put("remittanceInfo", it) }
+        out.put("chargeCode", "SHA")
+        out.put("priority", "NORMAL")
+        return objectMapper.writeValueAsString(out)
+    }
+
+    /**
      * Read the current status of one of the caller's own SEPA payments (settlement-honest, ADR-0108).
      * The twin of [getDomesticPaymentStatus]: the app polls this after a create returns merely accepted
      * (RECEIVED/VALIDATED/PROCESSING) so the green success screen only appears once the payment is
@@ -2380,6 +2472,9 @@ class CustomerEdgeResource(
 
         /** SEPA endToEndId max length (ISO 20022 pain.001 Max35Text). */
         private const val E2E_ID_MAX_LEN = 35
+
+        /** SWIFT transactionReference is a Max16Text field. */
+        private const val SWIFT_REF_MAX_LEN = 16
 
         /** Amount may arrive as JSON number or string; normalise to its decimal text form. */
         internal fun extractAmountField(mapper: ObjectMapper, json: String): String? = runCatching {

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -99,6 +99,8 @@ openbank:
     domestic-payment-service-url: ${DOMESTIC_PAYMENT_SERVICE_URL:http://domestic-payment.payments.svc:8116}
     sepa-payment-service-url: ${SEPA_PAYMENT_SERVICE_URL:http://sepa-payment.payments.svc:8115}
     sepa-instant-service-url: ${SEPA_INSTANT_SERVICE_URL:http://sepa-instant.payments.svc:8127}
+    swift-service-url: ${SWIFT_SERVICE_URL:http://swift-service.payments.svc:8122}
+    bank-bic: ${OPENBANK_BANK_BIC:OPENCZPPXXX}
     sca-service-url:     ${SCA_SERVICE_URL:http://sca-service.sca.svc:8110}
     party-service-url:   ${PARTY_SERVICE_URL:http://party-service.party.svc:8111}
     pid-service-url:     ${PID_SERVICE_URL:http://pid-service.pid.svc:8105}

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -158,6 +158,8 @@ spec:
             # Declared here so gen-network-policies.py opens the edge->sepa-instant ingress allow.
             - name: SEPA_INSTANT_SERVICE_URL
               value: http://sepa-instant.payments.svc:8127
+            - name: SWIFT_SERVICE_URL
+              value: http://swift-service.payments.svc:8122
             - name: SCA_SERVICE_URL
               value: http://sca-service.sca.svc:8110
             # Bind management interface to all interfaces so kubelet probes (from node IP)

--- a/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
+++ b/openbank-infra/gitops/components/payments/kafka-scheme-accepted-acl.yaml
@@ -137,6 +137,16 @@ spec:
           patternType: literal
         operations: [Write, Describe]
         host: "*"
+      # swift-service's own domain-event stream (swift-events-out ->
+      # openbank.payments.swift.event). Missing here, the producer gets "Topic
+      # authorization failed" and a synchronous send HANGS on the failing publish —
+      # same trap fixed for sepa-instant above (#1717).
+      - resource:
+          type: topic
+          name: openbank.payments.swift.
+          patternType: prefix
+        operations: [Write, Describe, Create]
+        host: "*"
 ---
 # ── Consumer: transaction-service ───────────────────────────────────────────
 # Reads scheme-accepted, writes its DLQ, and joins its dedicated consumer group.

--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -457,6 +457,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## What
Adds a customer-facing international SWIFT wire (MT103) rail via the customer-edge, mirroring the SEPA Instant work.

- `POST /customer/v1/swift`: customer supplies beneficiary (name, IBAN, receiver BIC), amount, currency, reference. Edge resolves ordering-customer identity from the debtor account/party, enforces **ownership** + the **SCA gate**, assembles the operational MT103 `SendSwiftCommand` (senderBic = bank BIC, valueDate = today, amount in minor units), proxies swift-service `POST /api/v1/swift`.
- **Kafka ACL:** grant swift-service KafkaUser `Write/Describe/Create` on prefix `openbank.payments.swift.` — its `swift-events-out` producer publishes there; without the ACL a synchronous send HANGS on the failing publish (same trap as sepa-instant #1717).
- `SWIFT_SERVICE_URL` env on the edge Deployment + regenerated derived NetworkPolicies (customer-edge → swift-service ingress).

## Verify
- Edge compiles, ktlint + detekt clean.
- swift-service `schemeSubmissionEnabled=false` in sandbox → send records the MT103, no network egress/hang.

## Linked issues
Refs #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)