### PR TITLE
chore(gitops): bump customer-edge to sandbox-b5bd6672 (SWIFT)

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-08471c0f
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-b5bd6672
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Hand-bump ahead of the lagging Auto Deploy gitops step. Signed image `sandbox-b5bd6672` verified present in ECR (+ cosign .sig). Ships the `POST /customer/v1/swift` route from #1719.

Refs #1718