### PR TITLE
fix(admin-ui): derive security-graph.json from real gitops manifests

### DIFF
--- a/openbank-admin-ui/scripts/generate-security-graph.mjs
+++ b/openbank-admin-ui/scripts/generate-security-graph.mjs
@@ -4,19 +4,25 @@
 
 // Derive the zero-trust security posture from the REAL platform manifests, so
 // the /docs/zero-trust map is governance-as-code (ADR-0029) — never a hand-drawn
-// claim. Parses three source-of-truth files and emits security-graph.json:
-//   - k8s/base/istio.yaml                  → mTLS mode, JWT rule, L7 authz
-//   - k8s/base/network-policies.yaml       → L3/L4 default-deny + allow-list
-//   - gitops/components/kyverno/verify-images-policy.yaml → admission / supply chain
+// claim. Emits security-graph.json from two source-of-truth trees:
+//   - gitops/components/*/network-policies.yaml (+ temporal's)  → L3/L4 ingress
+//     coverage, per real GitOps-derived NetworkPolicies (gen-network-policies.py)
+//   - gitops/components/kyverno/verify-images-policy.yaml       → admission / supply chain
 //
-// Honest by construction: every status flag below is read from the manifest
-// (STRICT, Audit, the actual ports/issuer/audiences). The narrative copy that
-// frames each layer is authored; the FACTS are derived. A file that cannot be
-// parsed degrades that layer to status:"unknown" — never a fabricated "enforced".
+// Honest by construction: every status flag below is read from a manifest that
+// is actually wired into ArgoCD (no ArgoCD Application or Terraform resource
+// references openbank-infra/k8s/base/{istio,network-policies}.yaml — that tree
+// is a standalone kind/minikube-only playground, k8s/README.md, and ADR-0098
+// states outright that no service mesh runs here). A file that cannot be parsed
+// degrades that layer to status:"unknown"/available:false — never a fabricated
+// "enforced". istio.* is unconditionally `available: false`: there is nothing
+// live to derive it from, so a static parse of an unwired manifest is not an
+// honest substitute (#1666, #1667, #1710). If a mesh is ever actually installed,
+// this should probe live Istio CRDs at deploy time, not a repo-parsed manifest.
 //
 // Usage: node scripts/generate-security-graph.mjs [--repo <path>] [--out <file>]
 
-import { readFileSync, writeFileSync } from 'fs'
+import { readFileSync, writeFileSync, readdirSync } from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { parseAllDocuments } from 'yaml'
@@ -31,117 +37,134 @@ const REPO = path.resolve(getArg('--repo', path.resolve(__dirname, '..', '..')))
 const OUT = path.resolve(getArg('--out', path.resolve(__dirname, '..', 'security-graph.json')))
 
 const INFRA = path.join(REPO, 'openbank-infra')
-const ISTIO_FILE = path.join(INFRA, 'k8s', 'base', 'istio.yaml')
-const NETPOL_FILE = path.join(INFRA, 'k8s', 'base', 'network-policies.yaml')
-const KYVERNO_FILE = path.join(INFRA, 'gitops', 'components', 'kyverno', 'verify-images-policy.yaml')
+const COMPONENTS_DIR = path.join(INFRA, 'gitops', 'components')
+const KYVERNO_FILE = path.join(COMPONENTS_DIR, 'kyverno', 'verify-images-policy.yaml')
 
-function loadDocs(file) {
+// Kinds gen-network-policies.py's callers actually run pods under (ADR-0098
+// migrated ten money-path services from Deployment to Rollout; both remain).
+const WORKLOAD_KINDS = new Set(['Deployment', 'Rollout', 'StatefulSet'])
+
+function parseYamlFile(file) {
   try {
-    return parseAllDocuments(readFileSync(file, 'utf-8'))
-      .map(d => d.toJSON())
-      .filter(Boolean)
+    return parseAllDocuments(readFileSync(file, 'utf-8')).map(d => d.toJSON()).filter(Boolean)
   } catch {
-    return null
+    return []
   }
 }
 
-const byKind = (docs, kind) => (docs ?? []).filter(d => d?.kind === kind)
-
-// ── 1) Istio: mTLS, JWT, L7 authorization ───────────────────────────────────
-function deriveIstio() {
-  const docs = loadDocs(ISTIO_FILE)
-  if (!docs) return { available: false }
-
-  const peers = byKind(docs, 'PeerAuthentication')
-  const strict = peers.find(p => p?.spec?.mtls?.mode === 'STRICT')
-  const exceptions = peers
-    .filter(p => p?.spec?.mtls?.mode && p.spec.mtls.mode !== 'STRICT')
-    .map(p => ({
-      name: p.metadata?.name ?? null,
-      mode: p.spec.mtls.mode,
-      selector: p.spec?.selector?.matchLabels ?? null,
-    }))
-
-  const reqAuth = byKind(docs, 'RequestAuthentication')[0]
-  const jwtRule = reqAuth?.spec?.jwtRules?.[0]
-
-  const authz = byKind(docs, 'AuthorizationPolicy')[0]
-  const rules = authz?.spec?.rules ?? []
-  const requiresJwt = rules.some(r =>
-    (r?.from ?? []).some(f => (f?.source?.requestPrincipals ?? []).length > 0))
-  const allowsMeshSa = rules.some(r =>
-    (r?.from ?? []).some(f => (f?.source?.principals ?? []).some(p => /\/sa\//.test(p))))
-
-  return {
-    available: true,
-    mtls: {
-      mode: strict ? 'STRICT' : (peers[0]?.spec?.mtls?.mode ?? 'unknown'),
-      strict: Boolean(strict),
-      exceptions,
-    },
-    jwt: jwtRule
-      ? { issuer: jwtRule.issuer ?? null, audiences: jwtRule.audiences ?? [], present: true }
-      : { present: false },
-    l7: {
-      action: authz?.spec?.action ?? null,
-      // ALLOW-only with a requestPrincipals["*"] rule == default-deny for
-      // anything without a valid principal (Istio drops unmatched requests).
-      defaultDeny: authz?.spec?.action === 'ALLOW' && (requiresJwt || allowsMeshSa),
-      requiresJwt,
-      allowsMeshServiceAccounts: allowsMeshSa,
-    },
+function listComponentDirs() {
+  try {
+    return readdirSync(COMPONENTS_DIR, { withFileTypes: true })
+      .filter(e => e.isDirectory())
+      .map(e => e.name)
+      .sort()
+  } catch {
+    return []
   }
 }
 
-// ── 2) NetworkPolicy: L3/L4 default-deny + allow-list ───────────────────────
+const appName = d =>
+  d?.spec?.selector?.matchLabels?.['app.kubernetes.io/name'] ??
+  d?.metadata?.labels?.['app.kubernetes.io/name']
+
+// ── NetworkPolicy: real per-namespace ingress coverage + egress posture ─────
 function deriveNetwork() {
-  const docs = loadDocs(NETPOL_FILE)
-  if (!docs) return { available: false }
-  const pols = byKind(docs, 'NetworkPolicy')
+  const dirs = listComponentDirs()
+  if (dirs.length === 0) return { available: false }
 
-  const defaultDeny = pols.some(p =>
-    Object.keys(p?.spec?.podSelector ?? {}).length === 0 &&
-    (p?.spec?.policyTypes ?? []).includes('Ingress') &&
-    (p?.spec?.policyTypes ?? []).includes('Egress') &&
-    !p?.spec?.ingress && !p?.spec?.egress)
-
-  // Flatten egress allow targets into {label, ports} for a readable panel.
+  const gaps = []
   const egress = []
-  for (const p of pols) {
-    for (const rule of p?.spec?.egress ?? []) {
-      const ports = (rule.ports ?? []).map(pt => pt.port).filter(Boolean)
-      for (const to of rule.to ?? []) {
-        const sel = to.podSelector?.matchLabels ?? to.namespaceSelector?.matchLabels
-        const ipBlock = to.ipBlock?.cidr
-        if (ipBlock) { egress.push({ target: `internet:${ipBlock}`, ports }); continue }
-        if (!sel) continue
-        const label = Object.values(sel).join('/')
-        // Skip pure DNS / kube-system noise from the readable data-plane list.
-        if (label.includes('kube-system')) continue
-        egress.push({ target: label, ports })
+  const ingress = []
+  let totalWorkloads = 0
+  const egressRestrictedApps = new Set()
+  const optInLabeledApps = new Set()
+
+  for (const ns of dirs) {
+    const dirPath = path.join(COMPONENTS_DIR, ns)
+    let files
+    try {
+      files = readdirSync(dirPath).filter(f => f.endsWith('.yaml') && f !== 'kustomization.yaml')
+    } catch {
+      continue
+    }
+    const docs = files.flatMap(f => parseYamlFile(path.join(dirPath, f)))
+
+    const workloadNames = new Set(
+      docs.filter(d => WORKLOAD_KINDS.has(d?.kind)).map(appName).filter(Boolean),
+    )
+    if (workloadNames.size === 0) continue
+    totalWorkloads += workloadNames.size
+
+    const netpols = docs.filter(d => d?.kind === 'NetworkPolicy')
+    const coveredNames = new Set(
+      netpols.map(p => p?.spec?.podSelector?.matchLabels?.['app.kubernetes.io/name']).filter(Boolean),
+    )
+    for (const name of workloadNames) {
+      if (!coveredNames.has(name)) gaps.push({ namespace: ns, service: name })
+    }
+
+    for (const p of netpols) {
+      const selectorName = p?.spec?.podSelector?.matchLabels?.['app.kubernetes.io/name']
+      if (selectorName && (p?.spec?.policyTypes ?? []).includes('Egress')) {
+        egressRestrictedApps.add(selectorName)
+      }
+      for (const rule of p?.spec?.egress ?? []) {
+        const ports = (rule.ports ?? []).map(pt => pt.port).filter(Boolean)
+        for (const to of rule.to ?? []) {
+          const sel = to.podSelector?.matchLabels ?? to.namespaceSelector?.matchLabels
+          const ipBlock = to.ipBlock?.cidr
+          if (ipBlock) { egress.push({ target: `internet:${ipBlock}`, ports }); continue }
+          if (!sel) continue
+          const label = Object.values(sel).join('/')
+          if (label.includes('kube-system')) continue
+          egress.push({ target: label, ports })
+        }
+      }
+      for (const rule of p?.spec?.ingress ?? []) {
+        const ports = (rule.ports ?? []).map(pt => pt.port).filter(Boolean)
+        ingress.push({ policy: p.metadata?.name ?? null, namespace: ns, ports })
+      }
+    }
+    // openbank.io/allow-internet-egress is a pod-template label (the Deployment/
+    // Rollout side of the opt-in), not a NetworkPolicy selector — track which
+    // apps actually carry it, then check below whether it's backed by a real
+    // egress-restricting policy for that SAME app (not just present somewhere).
+    for (const d of docs) {
+      if (!WORKLOAD_KINDS.has(d?.kind)) continue
+      if (d?.spec?.template?.metadata?.labels?.['openbank.io/allow-internet-egress'] === 'true') {
+        const name = appName(d)
+        if (name) optInLabeledApps.add(name)
       }
     }
   }
 
-  const internetOptIn = pols.some(p =>
-    p?.spec?.podSelector?.matchLabels?.['openbank.io/allow-internet-egress'] === 'true')
+  // Honest: the opt-in label only means something if the labeled app's own
+  // egress is actually restricted by a matching policy. Today it isn't (e.g.
+  // notification-service carries the label with no egress-restricting policy
+  // of its own) — a handful of unrelated hardened exceptions exist elsewhere
+  // (e.g. the RUM gateway, ADR-0088 D4b) but they don't implement this label's
+  // pattern, so the fleet-wide posture is genuinely "open", not "opt-in".
+  const optInIsReal = optInLabeledApps.size > 0 &&
+    [...optInLabeledApps].every(name => egressRestrictedApps.has(name))
 
-  const ingress = []
-  for (const p of pols) {
-    for (const rule of p?.spec?.ingress ?? []) {
-      const ports = (rule.ports ?? []).map(pt => pt.port).filter(Boolean)
-      ingress.push({ policy: p.metadata?.name ?? null, ports })
-    }
+  return {
+    available: true,
+    defaultDeny: gaps.length === 0,
+    coverage: { total: totalWorkloads, covered: totalWorkloads - gaps.length, gaps },
+    egressTargets: egress,
+    ingressRules: ingress,
+    internetEgress: optInIsReal ? 'opt-in' : 'open',
+    // Apps with a real egress-restricting NetworkPolicy today, whether or not
+    // they carry the opt-in label (e.g. the RUM gateway's bespoke lockdown).
+    egressRestrictedApps: [...egressRestrictedApps].sort(),
   }
-
-  return { available: true, defaultDeny, egressTargets: egress, ingressRules: ingress, internetEgress: internetOptIn ? 'opt-in' : 'open' }
 }
 
-// ── 3) Kyverno: admission / supply-chain verification ───────────────────────
+// ── Kyverno: admission / supply-chain verification ──────────────────────────
 function deriveSupplyChain() {
-  const docs = loadDocs(KYVERNO_FILE)
-  if (!docs) return { available: false }
-  const policy = byKind(docs, 'ClusterPolicy')[0]
+  const docs = parseYamlFile(KYVERNO_FILE)
+  if (docs.length === 0) return { available: false }
+  const policy = docs.find(d => d?.kind === 'ClusterPolicy')
   const rule = policy?.spec?.rules?.[0]
   const verify = rule?.verifyImages?.[0]
   const rekor = verify?.attestors?.[0]?.entries?.[0]?.keyless?.rekor?.url ?? null
@@ -157,24 +180,35 @@ function deriveSupplyChain() {
   }
 }
 
-const istio = deriveIstio()
+// No service mesh runs in the sandbox — see the module comment. Nothing to
+// derive; a static parse of the unwired k8s/base/istio.yaml manifest is not a
+// live signal (that is exactly the bug #1666/#1667/#1710 fixed/track).
+const istio = {
+  available: false,
+  deployed: false,
+  note: 'No service mesh is deployed to the sandbox (ADR-0098). ' +
+    'openbank-infra/k8s/base/istio.yaml exists but is wired into neither ArgoCD nor Terraform.',
+}
 const network = deriveNetwork()
 const supplyChain = deriveSupplyChain()
 
 const out = {
   schema: 'openbank.security-posture/v1',
-  source: 'derived from openbank-infra: k8s/base/istio.yaml, k8s/base/network-policies.yaml, gitops/components/kyverno/verify-images-policy.yaml',
+  source: 'derived from openbank-infra: gitops/components/*/network-policies.yaml, ' +
+    'gitops/components/kyverno/verify-images-policy.yaml (istio: no mesh deployed, see note)',
   collectedAt: new Date().toISOString(),
   istio,
   network,
   supplyChain,
-  available: Boolean(istio.available || network.available),
+  available: Boolean(network.available || supplyChain.available),
 }
 
 writeFileSync(OUT, JSON.stringify(out, null, 2) + '\n')
 console.log(`── security posture →  ${path.relative(REPO, OUT)}`)
-console.log(`   mTLS: ${istio.mtls?.mode ?? '?'} (exceptions: ${istio.mtls?.exceptions?.length ?? 0}) ` +
-  `| JWT: ${istio.jwt?.present ? 'yes' : 'no'} | L7 default-deny: ${istio.l7?.defaultDeny ?? '?'}`)
-console.log(`   NetPol default-deny: ${network.defaultDeny ?? '?'} | egress targets: ${network.egressTargets?.length ?? 0} ` +
-  `| internet: ${network.internetEgress ?? '?'}`)
+console.log(`   Istio: not deployed (${istio.note})`)
+console.log(`   NetPol ingress coverage: ${network.coverage?.covered ?? '?'}/${network.coverage?.total ?? '?'} ` +
+  `(default-deny: ${network.defaultDeny ?? '?'}) | egress: ${network.internetEgress ?? '?'}`)
+if (network.coverage?.gaps?.length) {
+  console.log(`   Gaps: ${network.coverage.gaps.map(g => `${g.namespace}/${g.service}`).join(', ')}`)
+}
 console.log(`   Kyverno: ${supplyChain.policy ?? 'none'} mode=${supplyChain.mode ?? '?'} enforced=${supplyChain.enforced ?? '?'}`)

--- a/openbank-admin-ui/src/app/docs/zero-trust/page.tsx
+++ b/openbank-admin-ui/src/app/docs/zero-trust/page.tsx
@@ -71,11 +71,17 @@ export default async function ZeroTrustPage() {
     )
   }
 
-  const mtls = posture.istio?.mtls
-  const jwt = posture.istio?.jwt
-  const l7 = posture.istio?.l7
   const net = posture.network
   const sc = posture.supplyChain
+  const meshDeployed = Boolean(posture.istio?.available && posture.istio?.deployed)
+  const meshNote = posture.istio?.note ?? t('stav neznámý', 'status unknown')
+  const netGaps = net?.coverage?.gaps ?? []
+  // Partial fleet coverage reads as an "exception" (a known, bounded gap), not
+  // a flat "unknown" — we DO know the coverage number, we're just honest that
+  // it isn't 100%.
+  const netpolStatus: Status = !net?.coverage
+    ? 'unknown'
+    : netGaps.length === 0 ? 'enforced' : (net.coverage.covered > 0 ? 'exception' : 'unknown')
 
   // Perimeters, OUTER → INNER (the path a request travels toward the data plane).
   // Each status flag is read from the derived posture, never asserted.
@@ -86,43 +92,41 @@ export default async function ZeroTrustPage() {
     {
       key: 'netpol', icon: <Network size={15} />, color: '#0891b2',
       title: t('Síťová segmentace (L3/L4)', 'Network segmentation (L3/L4)'),
-      tech: 'Kubernetes NetworkPolicy',
-      status: net?.defaultDeny ? 'enforced' : 'unknown',
-      fact: net?.defaultDeny
-        ? t('default-deny baseline; povolen jen allow-list', 'default-deny baseline; only the allow-list passes')
+      tech: 'Kubernetes NetworkPolicy (gen-network-policies.py)',
+      status: netpolStatus,
+      fact: net?.coverage
+        ? t(`default-deny allow-list na ${net.coverage.covered}/${net.coverage.total} workloadech`
+            + (netGaps.length ? ` · mezery: ${netGaps.slice(0, 4).map(g => `${g.namespace}/${g.service}`).join(', ')}${netGaps.length > 4 ? '…' : ''}` : ''),
+            `default-deny allow-list on ${net.coverage.covered}/${net.coverage.total} workloads`
+            + (netGaps.length ? ` · gaps: ${netGaps.slice(0, 4).map(g => `${g.namespace}/${g.service}`).join(', ')}${netGaps.length > 4 ? '…' : ''}` : ''))
         : t('stav neznámý', 'status unknown'),
       regs: ['NIS2 Art. 21', 'DORA Art. 9'],
     },
     {
       key: 'mtls', icon: <Lock size={15} />, color: '#2563eb',
       title: t('Šifrovaný transport (mTLS)', 'Encrypted transport (mTLS)'),
-      tech: 'Istio PeerAuthentication',
-      status: mtls?.strict ? 'enforced' : 'unknown',
-      fact: mtls?.strict
-        ? t(`STRICT mTLS pro veškerý east-west provoz · ${mtls.exceptions.length} výjimka (edge)`,
-            `STRICT mTLS for all east-west traffic · ${mtls.exceptions.length} exception (edge)`)
-        : t('stav neznámý', 'status unknown'),
+      tech: 'Istio PeerAuthentication (not deployed)',
+      status: meshDeployed ? 'enforced' : 'unknown',
+      fact: meshDeployed ? t('STRICT mTLS pro veškerý east-west provoz', 'STRICT mTLS for all east-west traffic') : meshNote,
       regs: ['NIS2 Art. 21', 'DORA Art. 9'],
     },
     {
       key: 'jwt', icon: <KeyRound size={15} />, color: '#7c3aed',
       title: t('Ověření identity (JWT)', 'Identity authentication (JWT)'),
-      tech: 'Istio RequestAuthentication · Keycloak',
-      status: jwt?.present ? 'enforced' : 'unknown',
-      fact: jwt?.present
-        ? t(`tokeny z Keycloak · audience: ${(jwt.audiences ?? []).join(', ') || '—'}`,
-            `Keycloak-issued tokens · audience: ${(jwt.audiences ?? []).join(', ') || '—'}`)
-        : t('stav neznámý', 'status unknown'),
+      tech: 'Keycloak · quarkus-oidc (per-service, not a mesh edge)',
+      status: 'unknown',
+      fact: t('Keycloak JWT je ověřován per-service přes quarkus-oidc, ne na mesh hraně (žádný mesh není nasazen)',
+        'Keycloak JWT is validated per-service via quarkus-oidc, not at a mesh edge (no mesh is deployed)'),
       regs: ['PSD2 SCA', 'EBA ICT'],
     },
     {
       key: 'l7', icon: <ShieldCheck size={15} />, color: '#059669',
       title: t('Autorizace (L7 default-deny)', 'Authorization (L7 default-deny)'),
-      tech: 'Istio AuthorizationPolicy',
-      status: l7?.defaultDeny ? 'enforced' : 'unknown',
-      fact: l7?.defaultDeny
+      tech: 'Istio AuthorizationPolicy (not deployed)',
+      status: meshDeployed ? 'enforced' : 'unknown',
+      fact: meshDeployed
         ? t('projde jen platný JWT principal nebo in-mesh service account', 'only a valid JWT principal or in-mesh service account passes')
-        : t('stav neznámý', 'status unknown'),
+        : meshNote,
       regs: ['EBA ICT'],
     },
   ]
@@ -199,21 +203,20 @@ export default async function ZeroTrustPage() {
       attack: t('Cizí pod zkusí přímé L3/L4 spojení', 'Foreign pod attempts a direct L3/L4 connection'),
       stop: net?.defaultDeny
         ? t('Zahozeno — NetworkPolicy default-deny', 'Dropped — NetworkPolicy default-deny')
-        : t('Síťová vrstva', 'Network layer'),
+        : t(`Síťová vrstva — zahozeno na ${net?.coverage?.covered ?? 0}/${net?.coverage?.total ?? 0} workloadech s allow-listem, jinde otevřeno`,
+            `Network layer — dropped on ${net?.coverage?.covered ?? 0}/${net?.coverage?.total ?? 0} workloads with an allow-list, open elsewhere`),
     },
     {
       icon: <Lock size={14} />,
       attack: t('Clear-text east-west volání mezi službami', 'Clear-text east-west call between services'),
-      stop: mtls?.strict
+      stop: meshDeployed
         ? t('Odmítnuto — vyžadováno STRICT mTLS', 'Rejected — STRICT mTLS required')
-        : t('Transportní vrstva', 'Transport layer'),
+        : t('Transportní vrstva (žádný mesh — east-west je dnes plaintext)', 'Transport layer (no mesh — east-west is plaintext today)'),
     },
     {
       icon: <KeyRound size={14} />,
       attack: t('Požadavek bez platného JWT na gateway', 'Request without a valid JWT at the gateway'),
-      stop: (jwt?.present && l7?.defaultDeny)
-        ? t('Zamítnuto na L7 — default-deny authz', 'Denied at L7 — default-deny authz')
-        : t('Aplikační vrstva', 'Application layer'),
+      stop: t('Zamítnuto per-service — quarkus-oidc (Keycloak JWT), ne mesh L7', 'Denied per-service — quarkus-oidc (Keycloak JWT), not mesh L7'),
     },
   ]
 
@@ -233,8 +236,8 @@ export default async function ZeroTrustPage() {
           </h1>
           <p className="page-subtitle">
             {t(
-              'Obrana do hloubky odvozená z reálných manifestů (Istio, NetworkPolicy, Kyverno). Každý request musí projít všemi vrstvami, než se dostane k datům.',
-              'Defense in depth derived from the real manifests (Istio, NetworkPolicy, Kyverno). Every request must clear all layers before it reaches the data.',
+              'Obrana do hloubky odvozená z reálných, gitops-nasazených manifestů (NetworkPolicy, Kyverno). Žádný service mesh v sandboxu neběží — mTLS/JWT/L7 řádky níže to říkají otevřeně, ne jako "vynuceno".',
+              'Defense in depth derived from the real, gitops-deployed manifests (NetworkPolicy, Kyverno). No service mesh runs in the sandbox — the mTLS/JWT/L7 rows below say so plainly, not "enforced".',
             )}
           </p>
         </div>

--- a/openbank-admin-ui/src/lib/governance/security.ts
+++ b/openbank-admin-ui/src/lib/governance/security.ts
@@ -3,20 +3,22 @@
 // See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
 
 // Server-side loader for the zero-trust security posture. The build derives
-// security-graph.json from the real platform manifests (istio.yaml,
-// network-policies.yaml, kyverno verify-images-policy.yaml) via
-// scripts/generate-security-graph.mjs — governance-as-code (ADR-0029), never a
-// hand-drawn claim. READ-ONLY consumer (CLAUDE rule #3). Mirrors the
-// service-graph.json sourcing (api/catalog/graph): $OPENBANK_SECURITY_GRAPH or
-// <cwd>/security-graph.json; degrades to null when no snapshot is bundled.
+// security-graph.json from the real, gitops-wired platform manifests
+// (gitops/components/*/network-policies.yaml, kyverno verify-images-policy.yaml)
+// via scripts/generate-security-graph.mjs — governance-as-code (ADR-0029),
+// never a hand-drawn claim. `istio` is unconditionally unavailable: no service
+// mesh runs in the sandbox (ADR-0098; #1666/#1667/#1710), so there is no live
+// signal to derive — see the generator's module comment. READ-ONLY consumer
+// (CLAUDE rule #3). Mirrors the service-graph.json sourcing (api/catalog/graph):
+// $OPENBANK_SECURITY_GRAPH or <cwd>/security-graph.json; degrades to null when
+// no snapshot is bundled.
 
 import { promises as fs } from 'fs'
 import path from 'path'
 
-export interface MtlsException {
-  name: string | null
-  mode: string
-  selector: Record<string, string> | null
+export interface NetworkCoverageGap {
+  namespace: string
+  service: string
 }
 
 export interface SecurityPosture {
@@ -25,16 +27,17 @@ export interface SecurityPosture {
   collectedAt: string | null
   istio: {
     available: boolean
-    mtls?: { mode: string; strict: boolean; exceptions: MtlsException[] }
-    jwt?: { issuer?: string | null; audiences?: string[]; present: boolean }
-    l7?: { action: string | null; defaultDeny: boolean; requiresJwt: boolean; allowsMeshServiceAccounts: boolean }
+    deployed?: boolean
+    note?: string
   }
   network: {
     available: boolean
     defaultDeny?: boolean
+    coverage?: { total: number; covered: number; gaps: NetworkCoverageGap[] }
     egressTargets?: { target: string; ports: number[] }[]
-    ingressRules?: { policy: string | null; ports: number[] }[]
+    ingressRules?: { policy: string | null; namespace?: string; ports: number[] }[]
     internetEgress?: 'opt-in' | 'open'
+    egressRestrictedApps?: string[]
   }
   supplyChain: {
     available: boolean


### PR DESCRIPTION
## Summary

Closes #1710. Follow-up from #1666/#1667: those fixed the Control Tower's compliance-controls.yaml (removed `derivedFrom` keys pointing at the unwired `k8s/base/{istio,network-policies}.yaml`), but `generate-security-graph.mjs` itself still parsed that same dead file at build time, and `/docs/zero-trust` reads `security-graph.json` directly — so that page kept rendering mTLS/JWT/L7 as "Enforced" from a manifest that's never deployed.

## Changes

- **`generate-security-graph.mjs`**: `istio` is now unconditionally `available: false` — no live mesh exists to derive from (ADR-0098; zero ArgoCD Applications or Terraform resources reference `k8s/base/istio.yaml`). `network` now scans every real `gitops/components/*/` directory, matches each Deployment/Rollout/StatefulSet workload by `app.kubernetes.io/name` against the NetworkPolicies `gen-network-policies.py` actually generated for it, and reports genuine coverage instead of a single static-file pattern match.
- **Real findings from running this against the fleet** (not asserted — verified by running the script):
  - Ingress coverage is **76/86** workloads, not the blanket "enforced" the static file implied. Gaps: `copilot`, `document-service` (both app + redis), `external-dns`, `gradle-build-cache`, `kafka-ui`, `registry-cache` (all 3 sub-apps).
  - **Zero** real per-namespace NetworkPolicy declares an `Egress` policyType anywhere in the fleet (checked all 46+ files). The `openbank.io/allow-internet-egress` opt-in label exists on `notification-service`'s pod template, but nothing enforces it — egress is open fleet-wide today, not "denied by default" as the old (static-file-derived) claim said. One unrelated real exception: the RUM gateway has its own bespoke egress lockdown (ADR-0088 D4b) — surfaced but doesn't change the fleet-wide read.
- **`security.ts`**: updated `SecurityPosture` type to match (added `coverage`/`egressRestrictedApps`, removed the now-nonexistent `istio.mtls/jwt/l7` and the unused `MtlsException` export).
- **`/docs/zero-trust` page**: network-segmentation perimeter now shows `Exception` with the real coverage number and gap list instead of a flat boolean; the three mesh-derived rows (mTLS/JWT/L7) explicitly state no mesh is deployed instead of a generic "status unknown"; the JWT row now describes the real mechanism (Keycloak via quarkus-oidc, per-service) instead of a mesh-edge claim; the internet-egress panel now reads "Open egress" instead of the previous false "denied by default, opt-in" claim.

## Linked issues
Closes #1710.

## Test plan
- [x] Ran `generate-security-graph.mjs` against this repo's real `openbank-infra/` tree (not mocked) — output cross-checked by hand against `grep`/`git show` ground truth for both the coverage numbers and the egress finding.
- [x] `npm run type-check` (tsc --noEmit) — clean.
- [x] `npx eslint` on all three touched files — clean.
- [x] `npx vitest run` on the i18n/graceful-state/layout-shell guard tests (288 tests) — all pass (no hardcoded copy, no raw-error patterns introduced).
- [x] **Real signed-in render**: minted the same test-only Auth.js session cookie `e2e/helpers/auth.ts` uses (documented test secret, never a production value), started `next dev` against the real generated `security-graph.json`, and curled `/docs/zero-trust` with that cookie. Confirmed the rendered HTML shows `Exception` + `76/86` + the gap list for network segmentation, `Unknown` + "not deployed" text for all three mesh rows, and "Open egress." for the internet-egress panel.

## Note for reviewer (out of scope, spotted in passing)
The supply-chain panel's descriptive text on this page is hardcoded to "In Audit mode today — unsigned images are reported, nothing is blocked" regardless of the live `sc.enforced` value — today Kyverno's `verify-openbank-image-signatures` policy is actually `mode: Enforce` (confirmed by this same generator run), so the badge correctly says "Enforced" but the paragraph under it still describes Audit mode. Pre-existing, unrelated to this fix — flagging rather than bundling in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
