### PR TITLE
docs: fix two leftover saga mentions in README missed by #1662

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 | Area | Status |
 |---|---|
 | Core domain (account, ledger, transaction, balance) | 🟢 Implemented, tested, deployed |
-| Payments — intra-bank (transaction saga → ledger → balance) | 🟢 End-to-end, deployed |
+| Payments — intra-bank (transaction Temporal workflow → ledger → balance) | 🟢 End-to-end, deployed |
 | Payments — interbank rails (SEPA, domestic, instant, clearing) | 🟡 ISO 20022 pipeline + clearing simulator wired (ADR-0104/0108); **live interbank network not connected** |
 | PSD2 / Open Banking (consent, SCA, TPP registry) | 🟢 Consent + SCA + XS2A developer portal live (developer.open-bank.tech); TPP registry deployed to sandbox |
 | EUDI / PID digital identity | 🟢 OpenID4VP + OpenID4VCI e2e live (ADR-0094); pid-service deployed |
@@ -63,7 +63,7 @@ OpenBank is an **early-stage, community-driven** banking platform reference impl
 |---|---|---|
 | **Create account** | `POST https://api.open-bank.tech/api/v1/accounts` | Returns IBAN (Czech mod-11 BBAN) |
 | **Get balance** | `GET https://api.open-bank.tech/api/v1/balances/{accountId}` | Multi-currency pockets |
-| **SEPA payment** | `POST https://api.open-bank.tech/api/v1/sepa-payments` | Sanctions/AML gate, saga → ledger |
+| **SEPA payment** | `POST https://api.open-bank.tech/api/v1/sepa-payments` | Sanctions/AML gate, Temporal workflow → ledger |
 | **Domestic payment** | `POST https://api.open-bank.tech/api/v1/domestic-payments` | CERTIS-style Czech domestic |
 | **SEPA Instant** | `POST https://api.open-bank.tech/api/v1/sepa-instant-payments` | 10s settlement window |
 | **Standing orders** | `POST https://api.open-bank.tech/api/v1/standing-orders` | Daily due-date sweep, outbox-backed |


### PR DESCRIPTION
## Summary

Doing a post-merge health check on main after #1632/#1662/#1666/#1667, found two spots #1662 missed: Project Status and the "what works right now" API table still described the payment flow as saga-orchestrated.

## Type of change

- [x] docs

## Linked issues

None — small follow-up to #1662.

## Changes

- `Payments — intra-bank (transaction saga → ledger → balance)` → `... (transaction Temporal workflow → ledger → balance)`
- SEPA payment row: `Sanctions/AML gate, saga → ledger` → `Sanctions/AML gate, Temporal workflow → ledger` (sepa-payment is on Temporal per ADR-0101/ADR-0120, confirmed in `docs/strategy/09-roadmap-M1-M7.md`)

## Definition of Done

- [x] Docs updated
- [ ] N/A: no code/API/DB/schema change

## Security checklist

- [x] No secrets/PII, no new dependency, not an auth/crypto/payment code path

## Compliance impact

- [x] None

## Rollout / Rollback

- N/A (docs only); revert commit to roll back

## Reviewer notes

Builds on #1632/#1662/#1666/#1667 (all merged).