### PR TITLE
fix(libs-testing): bump pinned postgresql test dep off two HIGH pgjdbc CVEs

### DIFF
--- a/openbank-libs-testing/build.gradle.kts
+++ b/openbank-libs-testing/build.gradle.kts
@@ -88,7 +88,13 @@ dependencies {
 
     // Real JDBC round-trip in the kit's own self-test (PostgresTestResourcesTest) — not
     // pulled transitively by testcontainers-postgresql, which only drives the container.
-    testImplementation("org.postgresql:postgresql:42.7.4")
+    // Pinned to the same patched version openbank.dependency-vulnerability-pins.gradle.kts
+    // forces fleet-wide (issue #461) — this module applies openbank.static-analysis, not
+    // openbank.quarkus-service, so that force() block never reaches it; the vulnerable 42.7.4
+    // resolved here unnoticed until a newly-disclosed pgjdbc GHSA pair (insecure-auth fallback
+    // despite channelBinding=require, and unbounded PBKDF2 SCRAM iterations enabling a CPU-
+    // exhaustion DoS) failed dependency-review on the first PR to newly depend on this module.
+    testImplementation("org.postgresql:postgresql:42.7.11")
 
     testImplementation(libs.mockk)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
## Summary
- `openbank-libs-testing/build.gradle.kts` pinned `org.postgresql:postgresql` directly at `42.7.4` for its own self-test's real JDBC round-trip (`PostgresTestResourcesTest`). This module applies `openbank.static-analysis`, not `openbank.quarkus-service`, so the fleet-wide vulnerability-pin `force()` block (`openbank.dependency-vulnerability-pins.gradle.kts`, issue #461, already forces `42.7.11` everywhere that convention plugin applies) never reached it — the same "modules that don't apply the convention plugin re-resolve independently" gap that plugin's own KDoc already documents for `openbank-simulation`.
- Surfaced when `dependency-review` flagged two newly-disclosed HIGH severity pgjdbc GHSAs on PR #1601 (the first PR to newly depend on this module): insecure-authentication fallback despite `channelBinding=require`, and unbounded PBKDF2 iterations in SCRAM authentication enabling a CPU-exhaustion DoS. Every existing consumer of `openbank-libs-testing` (e.g. ledger-service's `ClusterLockIT`/`NoOpClusterLock` usage) carries the same exposure through this module's test classpath.
- Bumped to `42.7.11` — the same patched version already proven elsewhere in the fleet's dependency graph by the existing `force()` pin, same `42.7.x` patch line as before (no API surface change).

## Test plan
- [x] `compileKotlin`/`compileTestKotlin`: green.
- [x] `:openbank-libs-testing:test`: all 7 test suites green. `PostgresTestResourcesTest`'s Docker-backed cases abort cleanly (`TestAbortedException`, not a failure) on this machine due to a pre-existing, unrelated docker-java/daemon API-version mismatch specific to this module's own `docker-java` constraint block — not something this change touches or introduces.
- [x] `ktlintCheck`: green.

Refs #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)