### PR TITLE
chore(gitops): deploy billing sandbox-12ccaa69 (OTel fix #1668)

### DIFF
--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -38,7 +38,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: billing-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-billing-service:sandbox-12ccaa69
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Manual image bump for billing-service: `sandbox-31e6692a` → `sandbox-12ccaa69`.

## Why manual
The auto-deploy pipeline could not land this roll — its runs kept getting **cancelled by cancel-in-progress concurrency** under a stream of main pushes (06:36, 05:43, 05:06, my 06:55 dispatch — all `cancelled`), so billing stayed on the old image with no tracing even though #1668 merged and the image was built.

## Safety pre-checks
- `sandbox-12ccaa69` = the #1668 merge image; `quarkus.opentelemetry` confirmed present in that tree.
- **Pact:** `can-i-deploy` billing 743090b → sandbox = **deployable=true** (ledger `f8c03d90` recorded deployed to sandbox via `openbank-infra/scripts/pact-unblock-billing-sandbox.sh`).
- **Kyverno:** the image carries its `.att` (SBOM attestation) + `.sig` in ECR → admission allowed.

## Effect
billing starts emitting spans → its trace-based money-path availability/latency SLOs can finally evaluate and `SLOMetricAbsent` stops firing for billing. The separate pg-self-heal change deploys later through the normal pipeline once its pact publishes.

Money-path gitops change — not self-merging.

## Linked issues
Refs #669