### PR TITLE
fix(lending): point funding-clearing at the account ledger actually seeded

### DIFF
--- a/openbank-ledger-service/src/main/resources/db/migration/V19__lending_book_accounts.sql
+++ b/openbank-ledger-service/src/main/resources/db/migration/V19__lending_book_accounts.sql
@@ -1,0 +1,38 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+--
+-- ADR-0028 D3 — the leaf GL accounts openbank-lending-service's LendingJournalFactory posts
+-- against. LendingLedgerConfig.Gl documents its defaults as "stable placeholder UUIDs (the
+-- `a0000000-…` family the ledger seeds)", but only `fundingClearing` (1100, 'Customer Cash
+-- Clearing', V3) actually existed — every other default (loans-receivable 1200,
+-- interest-receivable 1300, interest-income 4100, loan-loss-expense 5100, loan-loss-allowance
+-- 1400) was never seeded here. Any real lending posting using the defaults (DISBURSEMENT,
+-- PRINCIPAL_REPAYMENT, INTEREST*, WRITE_OFF*, RESCHEDULE_FORGIVENESS, PROVISIONING) 422s with
+-- "GL account not found" — caught by the nightly full-fleet build once #1623 started deriving the
+-- lending consumer pact body from the real factory + config defaults (issue #1720): the DISBURSEMENT
+-- interaction (DEBIT loans-receivable / CREDIT funding-clearing) failed provider verification
+-- because loans-receivable (1200) didn't exist.
+--
+-- Types/currency follow the V17 interest-capitalization-accounts convention: CZK only (lending is
+-- single-currency per LendingJournalFactory's kdoc — "Loans are single-currency, so every entry is
+-- two-legged and self-balances within that currency"), stable UUID = 'a0000000-…' + zero-padded
+-- code, loan-loss-allowance kept ASSET (contra-asset carried as a negative-balance asset, same
+-- convention CreditRiskPorts.kt documents).
+
+INSERT INTO gl_accounts (id, code, name, type, currency_code, is_leaf, is_enabled) VALUES
+    ('a0000000-0000-0000-0000-000000001200', '1200', 'Loans Receivable', 'ASSET', 'CZK', true, true),
+    ('a0000000-0000-0000-0000-000000001300', '1300', 'Interest Receivable', 'ASSET', 'CZK', true, true),
+    ('a0000000-0000-0000-0000-000000001400', '1400', 'Loan Loss Allowance', 'ASSET', 'CZK', true, true),
+    ('a0000000-0000-0000-0000-000000004100', '4100', 'Interest Income', 'INCOME', 'CZK', true, true),
+    ('a0000000-0000-0000-0000-000000005100', '5100', 'Loan Loss Expense', 'EXPENSE', 'CZK', true, true);
+
+-- Rollback:
+--   DELETE FROM gl_accounts WHERE id IN (
+--       'a0000000-0000-0000-0000-000000001200',
+--       'a0000000-0000-0000-0000-000000001300',
+--       'a0000000-0000-0000-0000-000000001400',
+--       'a0000000-0000-0000-0000-000000004100',
+--       'a0000000-0000-0000-0000-000000005100');
+-- Safe to roll back only before any journal_lines reference these accounts (the FK would block the
+-- DELETE otherwise) — i.e. before openbank-lending-service posts a real disbursement/repayment/
+-- write-off/provisioning entry in a live environment.

--- a/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingLedgerConfig.kt
+++ b/openbank-lending-service/src/main/kotlin/com/openbank/lending/infrastructure/client/LendingLedgerConfig.kt
@@ -12,6 +12,15 @@ import java.util.UUID
  * Ledger-posting configuration for the lending book: the system actor recorded as the journal author
  * and the leaf GL accounts each posting kind debits/credits. Defaults are stable placeholder UUIDs
  * (the `a0000000-…` family the ledger seeds); operators override them to the real chart of accounts.
+ *
+ * [Gl.fundingClearing] is the one exception to the "last UUID segment = account code" convention:
+ * openbank-ledger-service's shared "Customer Cash Clearing" account (code 1100, the same account
+ * openbank-transaction-service's PaymentJournalFactory posts against) was seeded in V3 with a
+ * pre-convention sequential id (`…-000001`), before the code-based-suffix convention existed — so
+ * this default deliberately points at `…-000001`, not `…-001100`. A prior `…-001100` default 422ed
+ * every real disbursement/repayment/interest posting with "GL account not found" (caught by the
+ * nightly full-fleet build, issue #1720, once #1623 started deriving the lending consumer pact body
+ * from this config instead of a hand-written literal).
  */
 @ConfigMapping(prefix = "lending.ledger")
 interface LendingLedgerConfig {
@@ -25,7 +34,7 @@ interface LendingLedgerConfig {
         @WithDefault("a0000000-0000-0000-0000-000000001200")
         fun loansReceivable(): UUID
 
-        @WithDefault("a0000000-0000-0000-0000-000000001100")
+        @WithDefault("a0000000-0000-0000-0000-000000000001")
         fun fundingClearing(): UUID
 
         @WithDefault("a0000000-0000-0000-0000-000000004100")

--- a/openbank-lending-service/src/main/resources/application.yaml
+++ b/openbank-lending-service/src/main/resources/application.yaml
@@ -123,7 +123,10 @@ lending:
     system-actor-id: ${LENDING_LEDGER_SYSTEM_ACTOR_ID:00000000-0000-0000-0000-0000000000aa}
     gl:
       loans-receivable: ${LENDING_GL_LOANS_RECEIVABLE:a0000000-0000-0000-0000-000000001200}
-      funding-clearing: ${LENDING_GL_FUNDING_CLEARING:a0000000-0000-0000-0000-000000001100}
+      # NOT the "…-001100" code-based-suffix convention the other GL defaults use: ledger-service's
+      # shared "Customer Cash Clearing" account (code 1100) was seeded pre-convention in V3 with a
+      # sequential id. See LendingLedgerConfig.Gl.fundingClearing kdoc (issue #1720).
+      funding-clearing: ${LENDING_GL_FUNDING_CLEARING:a0000000-0000-0000-0000-000000000001}
       interest-income: ${LENDING_GL_INTEREST_INCOME:a0000000-0000-0000-0000-000000004100}
       interest-receivable: ${LENDING_GL_INTEREST_RECEIVABLE:a0000000-0000-0000-0000-000000001300}
       loan-loss-expense: ${LENDING_GL_LOAN_LOSS_EXPENSE:a0000000-0000-0000-0000-000000005100}

--- a/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/LendingLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-lending-service/src/test/kotlin/com/openbank/lending/contract/LendingLedgerPostJournalPactConsumerTest.kt
@@ -42,9 +42,16 @@ import java.util.UUID
  * caught by provider verification, because the recorded body was independent of
  * [LendingJournalFactory] and [com.openbank.lending.infrastructure.client.LendingLedgerConfig]'s
  * real defaults. The body below is built from the real factory + real config default GL accounts
- * (`a0000000-...-001200` loans receivable / `a0000000-...-001100` funding clearing, ADR-0028
+ * (`a0000000-...-001200` loans receivable / `a0000000-...-000001` funding clearing, ADR-0028
  * D3/D4) for a DISBURSEMENT posting, serialized with the same Jackson stack the production REST
  * client uses.
+ *
+ * `fundingClearing` is `...-000001`, not the `...-001100` the "last UUID segment = account code"
+ * convention would predict — ledger-service's shared "Customer Cash Clearing" account (code 1100)
+ * was seeded pre-convention in V3 with a sequential id, so that's the id [LendingLedgerConfig]'s
+ * real default now points at too (issue #1720: the old `...-001100` default 422ed provider
+ * verification with "GL account not found" once this pact started deriving its body from the real
+ * config instead of a hand-written literal).
  */
 @ExtendWith(PactConsumerTestExt::class)
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
@@ -52,7 +59,7 @@ class LendingLedgerPostJournalPactConsumerTest {
 
     private val accounts = LendingGlAccounts(
         loansReceivable = UUID.fromString("a0000000-0000-0000-0000-000000001200"),
-        fundingClearing = UUID.fromString("a0000000-0000-0000-0000-000000001100"),
+        fundingClearing = UUID.fromString("a0000000-0000-0000-0000-000000000001"),
         interestIncome = UUID.fromString("a0000000-0000-0000-0000-000000004100"),
         interestReceivable = UUID.fromString("a0000000-0000-0000-0000-000000001300"),
         loanLossExpense = UUID.fromString("a0000000-0000-0000-0000-000000005100"),

--- a/pacts/openbank-lending-service-openbank-ledger-service.json
+++ b/pacts/openbank-lending-service-openbank-ledger-service.json
@@ -32,7 +32,7 @@
               "baseCurrencyCode": "CZK",
               "currencyCode": "CZK",
               "fxRate": null,
-              "glAccountId": "a0000000-0000-0000-0000-000000001100",
+              "glAccountId": "a0000000-0000-0000-0000-000000000001",
               "side": "CREDIT"
             }
           ],


### PR DESCRIPTION
## Summary
- Nightly full-fleet build failure (#1720): `LedgerPactProviderVerificationTest` 422s "GL account not found" verifying the lending disbursement pact, since #1623 started deriving the pact body from `LendingJournalFactory` + `LendingLedgerConfig`'s real defaults instead of a hand-written literal.
- `funding-clearing` defaulted to `a0000000-...-001100` (the "last UUID segment = account code" convention), but ledger-service's "Customer Cash Clearing" account (code 1100) was seeded pre-convention in V3 with a sequential id (`...-000001`) — the same id transaction-service's `PaymentJournalFactory` already posts against. Fixed the default + regenerated the consumer pact.
- Separately, `loans-receivable` (1200), `interest-receivable` (1300), `loan-loss-allowance` (1400), `interest-income` (4100) and `loan-loss-expense` (5100) were never seeded in ledger-service at all, despite `LendingLedgerConfig`'s kdoc claiming these are accounts "the ledger seeds". Added `V19__lending_book_accounts.sql` (same pattern as V17) so every `LendingJournalFactory` posting kind has a real account to post against.

Both gaps mean any real lending posting using the documented defaults would 422 in a live environment, not just in the pact test — this wasn't purely a test-fixture bug.

## Test plan
- [x] `LendingLedgerPostJournalPactConsumerTest` re-run — BUILD SUCCESSFUL, regenerated `pacts/openbank-lending-service-openbank-ledger-service.json` with the corrected `funding-clearing` account id.
- [x] Reproduced the original nightly failure locally against `origin/main` before either change (422 "GL account not found: a0000000-...-001200", then after the migration alone, "...-001100") — confirms both fixes are needed together.
- [ ] CI: `LedgerPactProviderVerificationTest` should go green (local re-verification was blocked by shared-Gradle-cache corruption from concurrent worktree builds on this machine — a `journal-1/file-access.bin` corruption unrelated to this change; CI runs in a clean environment).

Closes #1720