### PR TITLE
feat(edge): SEPA Direct Debit mandates (inkasa) read view for customers

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -137,6 +137,9 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.swift-service-url")
     lateinit var swiftServiceUrl: String
 
+    @ConfigProperty(name = "openbank.edge.sdd-service-url")
+    lateinit var sddServiceUrl: String
+
     /** The bank's own SWIFT/BIC — the senderBic on outbound MT103s. */
     @ConfigProperty(name = "openbank.edge.bank-bic", defaultValue = "OPENCZPPXXX")
     lateinit var bankBic: String
@@ -453,6 +456,51 @@ class CustomerEdgeResource(
         val out = objectMapper.createArrayNode()
         arr.forEach { i -> out.add(projectInstallment(i)) }
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * The SEPA Direct Debit mandates (inkasa) authorised on one of the caller's OWN accounts.
+     * Ownership enforced HERE: sdd-service's list is scoped by accountId only, so the edge checks
+     * the account belongs to the JWT party (403 otherwise). Projects each mandate to a customer-safe
+     * shape (creditor, UMR, scheme, sequence, status, dates) — internal outbox/version fields dropped.
+     * Fail-soft to `[]` when sdd-service is unavailable (it is KEDA scale-to-zero — the first call
+     * cold-starts it).
+     */
+    @GET
+    @Path("/sdd/mandates")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun listSddMandates(@QueryParam("accountId") accountId: UUID?): Response {
+        val customer = customer()
+        val account = accountId ?: return badRequest("Missing accountId")
+        val accountJson = fetchAccount(account, customer.partyId)
+            ?: return forbidden("Account does not belong to caller")
+        if (extractOwnerPartyId(accountJson) != customer.partyId.toString()) {
+            return forbidden("Account does not belong to caller")
+        }
+        val resp = upstream.get("$sddServiceUrl/api/v1/sdd/mandates?accountId=$account", customer.partyId.toString())
+        val arr = if (resp.status == 200) {
+            runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") as? ArrayNode }.getOrNull()
+        } else {
+            null
+        } ?: return Response.ok("[]").type(MediaType.APPLICATION_JSON).build()
+        val out = objectMapper.createArrayNode()
+        arr.forEach { m -> out.add(projectMandate(m)) }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    private fun projectMandate(m: com.fasterxml.jackson.databind.JsonNode): ObjectNode {
+        val o = objectMapper.createObjectNode()
+        o.put("id", m.get("id")?.asText())
+        o.put("creditorName", m.get("creditorName")?.asText() ?: "")
+        o.put("creditorIdentifier", m.get("creditorIdentifier")?.asText() ?: "")
+        o.put("umr", m.get("umr")?.asText() ?: "")
+        o.put("scheme", m.get("scheme")?.asText() ?: "")
+        o.put("sequenceType", m.get("sequenceType")?.asText() ?: "")
+        o.put("status", m.get("status")?.asText() ?: "")
+        m.get("signatureDate")?.asText()?.let { o.put("signatureDate", it) }
+        m.get("lastCollectionDate")?.asText()?.takeIf { it.isNotBlank() }?.let { o.put("lastCollectionDate", it) }
+        return o
     }
 
     private fun projectLoan(l: com.fasterxml.jackson.databind.JsonNode): ObjectNode {

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -100,6 +100,7 @@ openbank:
     sepa-payment-service-url: ${SEPA_PAYMENT_SERVICE_URL:http://sepa-payment.payments.svc:8115}
     sepa-instant-service-url: ${SEPA_INSTANT_SERVICE_URL:http://sepa-instant.payments.svc:8127}
     swift-service-url: ${SWIFT_SERVICE_URL:http://swift-service.payments.svc:8122}
+    sdd-service-url: ${SDD_SERVICE_URL:http://sdd-service.sdd.svc:8129}
     bank-bic: ${OPENBANK_BANK_BIC:OPENCZPPXXX}
     sca-service-url:     ${SCA_SERVICE_URL:http://sca-service.sca.svc:8110}
     party-service-url:   ${PARTY_SERVICE_URL:http://party-service.party.svc:8111}

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -160,6 +160,11 @@ spec:
               value: http://sepa-instant.payments.svc:8127
             - name: SWIFT_SERVICE_URL
               value: http://swift-service.payments.svc:8122
+            # SEPA Direct Debit mandates (inkasa) read-only view for the customer app (#1730): GET
+            # /customer/v1/sdd/mandates. Declared here so gen-network-policies.py opens the
+            # edge->sdd ingress allow. sdd-service is KEDA scale-to-zero — first call cold-starts it.
+            - name: SDD_SERVICE_URL
+              value: http://sdd-service.sdd.svc:8129
             - name: SCA_SERVICE_URL
               value: http://sca-service.sca.svc:8110
             # Bind management interface to all interfaces so kubelet probes (from node IP)

--- a/openbank-infra/gitops/components/sdd/network-policies.yaml
+++ b/openbank-infra/gitops/components/sdd/network-policies.yaml
@@ -38,6 +38,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
## What
Adds a read-only customer view of the SEPA Direct Debit mandates (inkasa) authorised on an account.

- `GET /customer/v1/sdd/mandates?accountId=`: lists mandates for one of the caller's **own** accounts. Ownership enforced at the edge (sdd-service scopes its list by accountId only → the account must belong to the JWT party, 403 otherwise). Projects each mandate to a customer-safe shape (creditor name/identifier, UMR, scheme, sequence type, status, signature + last-collection dates).
- Fail-soft to `[]` when sdd-service is unavailable — it is **KEDA scale-to-zero**, so the first call cold-starts it.
- `SDD_SERVICE_URL` env on the edge + regenerated derived NetworkPolicies (customer-edge → sdd ingress).

Read-only; mandate create/confirm/suspend/cancel stay operator/officer.

## Verify
- Edge compiles, ktlint clean; sdd-service SddResource reads allow VIEWER+OPERATOR (method-level) so the edge operator token passes.
- 98 demo mandates seeded across 49 current accounts (93 ACTIVE / 5 SUSPENDED).

## Linked issues
Refs #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)