### PR TITLE
chore(gitops): bump customer-edge to sandbox-321e9852 (SDD)

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-b5bd6672
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-321e9852
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Hand-bump ahead of the lagging Auto Deploy gitops step. Signed image `sandbox-321e9852` verified in ECR (+ cosign .sig). Ships the SDD mandates route from #1732.

Refs #1730