### PR TITLE
fix(sdd): OPA advisory (AUTHZ_ENFORCE=false) — unblock the Inkasa read

### DIFF
--- a/openbank-infra/gitops/components/sdd/sdd-service.yaml
+++ b/openbank-infra/gitops/components/sdd/sdd-service.yaml
@@ -90,6 +90,15 @@ spec:
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG
               value: "0.1"
+            # OPA advisory mode (ADR-0034): sdd-service has no OPA policy-decision sidecar
+            # (unlike money-path services such as lending/payments/accounts), so @Authorize
+            # would otherwise fail closed ("OPA call failed") on every endpoint. Same posture
+            # as interest-service / anacredit — non-money-path services run authz advisory.
+            # Access stays enforced by JAX-RS @RolesAllowed (operator/viewer roles) and, for
+            # customer traffic, by the customer-edge ownership (IDOR) check before it ever
+            # reaches this service. Refs #1730.
+            - name: AUTHZ_ENFORCE
+              value: "false"
           startupProbe:
             tcpSocket:
               port: management


### PR DESCRIPTION
sdd-service has **no OPA sidecar** (unlike lending/payments/accounts), so `@Authorize` failed closed ("OPA call failed", HTTP 422) on every endpoint. The customer Inkasa read (#1730) got 422 → fail-soft empty list.

Set `AUTHZ_ENFORCE=false` (advisory) — same posture as **interest-service** / anacredit (non-money-path services without a sidecar). Access stays enforced by JAX-RS `@RolesAllowed` + the customer-edge ownership check.

**Verified live:** with the flag off, `GET /api/v1/sdd/mandates?accountId=` returns the seeded mandates (HTTP 200, e.g. Netflix ACTIVE / Spotify SUSPENDED) instead of 422.

Refs #1730