### PR TITLE
fix(ci): suppress json-smart false positive in dependency-review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -82,11 +82,21 @@ jobs:
           retry-on-snapshot-warnings: ${{ steps.deps.outputs.changed == 'true' }}
           retry-on-snapshot-warnings-timeout: 1800
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
-          # No allow-ghsas / allow-dependencies-licenses entries: both suppressions
-          # here existed solely for schemathesis 3.39.16's transitive pins, and the
-          # migration to schemathesis 4.22.3 retired the reasons for both —
-          # starlette now resolves to 1.3.1 (the version that FIXES GHSA-wqp7-x3pw-xc5r
-          # and GHSA-82w8-qh3p-5jfq), and rfc3987 (GPL-3.0-or-later) is no longer in
-          # the resolved set at all. Keeping them would silently re-suppress the same
-          # advisories/licence if a future dependency reintroduced them.
-          # Re-add only with a fresh justification and a tracking issue.
+          # allow-dependencies-licenses: none currently — the schemathesis 3.39.16 rfc3987
+          # (GPL-3.0-or-later) suppression that used to live here was retired once the
+          # 4.22.3 migration dropped rfc3987 from the resolved set entirely. Re-add only
+          # with a fresh justification and a tracking issue.
+          #
+          # allow-ghsas: GHSA-pq2g-wx69-c263 (net.minidev:json-smart Uncontrolled Recursion,
+          # issue #461). json-smart:2.5.0 is a POM-only BOM constraint stub that never
+          # resolves onto any real classpath — confirmed independently via
+          # gradle/verification-metadata.xml, which records only a `.pom` artifact for
+          # 2.5.0 (no `.jar` ever downloaded) while 2.5.2 (the fleet's real, force()-pinned
+          # floor in openbank.dependency-vulnerability-pins.gradle.kts) has both. The
+          # osv-scanner.toml PackageOverrides ignore entry for the same coordinate/version
+          # documents the identical reasoning for that separate scanner; this suppression
+          # is that same, already-established conclusion applied to dependency-review,
+          # which otherwise flags a BOM-management-only entry as if it were an in-use
+          # dependency. Re-verify against verification-metadata.xml before ever removing —
+          # if a future dependency starts resolving 2.5.0 for real, this must be dropped.
+          allow-ghsas: GHSA-pq2g-wx69-c263


### PR DESCRIPTION
## Summary
- `net.minidev:json-smart:2.5.0` has a known HIGH severity GHSA (GHSA-pq2g-wx69-c263, Uncontrolled Recursion) that `dependency-review` started flagging on PR #1728 (a repo-wide dependency-graph scan, not caused by that PR's own diff).
- `2.5.0` is a POM-only BOM constraint stub that never resolves onto any real classpath — `gradle/verification-metadata.xml` records only a `.pom` artifact for `2.5.0` (no `.jar` ever downloaded), while `2.5.2` (the fleet's real floor, already `force()`-pinned fleet-wide by `openbank.dependency-vulnerability-pins.gradle.kts`, issue #461) has both.
- `gradle/osv-scanner.toml` already carries a `PackageOverrides` ignore entry for this exact coordinate/version with the identical reasoning, for a different scanner. This applies that same, already-established conclusion to `dependency-review` via its `allow-ghsas` input — not a fresh judgment call.

## Test plan
- [x] YAML parses.
- [x] `allow-ghsas` value matches the exact advisory ID flagged on PR #1728's failed `dependency-review` run.

Refs #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)