### PR TITLE
feat(edge): offline_access token for the mobile app (Face ID resume, not passkey every launch)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnKeycloakClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnKeycloakClient.kt
@@ -156,8 +156,14 @@ class WebAuthnKeycloakClient {
      */
     fun impersonate(keycloakUserId: String): Pair<String, String?> {
         val grantType = URLEncoder.encode(TOKEN_EXCHANGE_GRANT_TYPE, StandardCharsets.UTF_8)
+        // scope=offline_access → the minted refresh token is an OFFLINE token (long-lived, survives
+        // the 30-min online SSO idle) so the app can silently resume a session behind the on-device
+        // biometric for days instead of re-running a full passkey ceremony on every cold start. The
+        // openbank-app client carries offline_access as an optional scope; offlineSessionIdleTimeout
+        // (30d) bounds it server-side, the app's 14-day window + biometric LockScreen bound it on the
+        // device. Native passkey path (ADR-0066 F2).
         val formBody = "grant_type=$grantType&client_id=$clientId&client_secret=$clientSecret" +
-            "&requested_subject=$keycloakUserId&audience=openbank-app"
+            "&requested_subject=$keycloakUserId&audience=openbank-app&scope=offline_access"
         val resp = http.send(
             HttpRequest.newBuilder()
                 .uri(URI.create("$adminUrl/realms/$realm/protocol/openid-connect/token"))

--- a/openbank-infra/gitops/components/keycloak/customers-realm-template.json
+++ b/openbank-infra/gitops/components/keycloak/customers-realm-template.json
@@ -55,7 +55,8 @@
         "statements:read",
         "sca:enroll-device",
         "sca:decide",
-        "telemetry:rum"
+        "telemetry:rum",
+        "offline_access"
       ],
       "protocolMappers": [
         {


### PR DESCRIPTION
## What
The native passkey login exchanged for an **online** session token, which dies after the `openbank-customers` 30-min SSO idle — so the app re-ran a full passkey ceremony on nearly every cold start. Request `scope=offline_access` in the token-exchange so the minted refresh token is an **offline** token (`offlineSessionIdleTimeout` = 30d). The app then resumes silently behind the on-device biometric within its 14-day window; passkey only after long inactivity.

- `WebAuthnKeycloakClient.impersonate`: `&scope=offline_access`.
- `openbank-app` client carries `offline_access` as an **optional** scope — assigned **live via kcadm** (import runs only on cold start) and mirrored into `customers-realm-template.json` for a consistent re-import.

## Verified live
Token-exchange with `scope=offline_access` now returns a refresh token with `typ=Offline` (no exp, 30-day server idle).

Pairs with openbank-app#222 (mandatory app-lock enrolment + biometric resume + 14-day window + PIN lockout).

## Linked issues
Refs #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)