### PR TITLE
chore(gitops): bump customer-edge to sandbox-bb499c73 (offline token)

### DIFF
--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -62,7 +62,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: customer-edge
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-321e9852
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-customer-edge:sandbox-bb499c73
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Hand-bump ahead of the lagging Auto Deploy gitops step. Signed `sandbox-bb499c73` verified in ECR (+ cosign .sig). Ships the offline_access token-exchange from #1741.

Refs #1740