### PR TITLE
fix(balance): reconcile the sub-ledger on the ledger's value-date basis (ADR-0178)

### DIFF
--- a/docs/adr/0178-value-date-correct-balance-reconciliation-and-projection.md
+++ b/docs/adr/0178-value-date-correct-balance-reconciliation-and-projection.md
@@ -1,0 +1,119 @@
+# Value-date-correct balance reconciliation and projection
+
+Date: 2026-07-19
+Status: Accepted
+Delivery-Status: Shipped (Phase 1); Phases 2–3 tracked as follow-up issues
+Author(s): jiri.raska
+
+## Context
+
+ADR-0039 made the ledger the golden source of the booked balance and turned balance-service into a
+projection of it: the ledger emits `AccountBookedChangedEvent(accountId, currency, delta,
+journalEntryId, entryDate, version)` and balance-service applies `delta` to `bookedAmount`. A standing
+per-currency reconciliation (Phase A) ties the ledger deposit-control GL balance out against the sum of
+balance-service booked amounts. Phases A–D are shipped.
+
+The two sides recognise a booked movement on **different temporal bases**, and ADR-0039 never
+reconciled them:
+
+- The ledger **trial balance is value-dated**. `TRIAL_BALANCE_SQL` sums journal lines
+  `where je.status in (…booked…) and je.entry_date <= :asOf`. A journal with a future `entry_date`
+  (a value-dated credit — a welcome bonus, a scheduled interest posting, a forward-value transfer) is
+  POSTED but **not counted in the control balance until its value date arrives**.
+- The **projection is receipt-dated**. `LedgerProjectionService.apply` adds `delta` to `bookedAmount`
+  the moment the event is consumed, regardless of `entryDate`; `balances.bookedAmount` is a running
+  total that carries **no value-date dimension**. `entryDate` is persisted to the dated projection
+  audit (`ledger_projection_event`) but never gates the booking.
+
+Consequence: the Phase A tie-out compares the ledger control **as of a value date** against the
+sub-ledger **current running total**. Any future-value-dated journal therefore surfaces as
+per-currency "drift" for the entire window between its posting and its value date — a **false
+positive** that resolves itself on the value date, with the money never having been wrong on either
+side. The difference equals, to the penny, the sum of the not-yet-effective journals.
+
+This is a distinct failure mode from the two-writer divergence ADR-0039 fixed. It is not a lost or
+phantom movement; both sides are internally consistent. It is a **measurement-basis mismatch** in a
+detective control. The ADR-0160 sustained-drift `for:` dampener does **not** contain it: a value-date
+mismatch is sustained across the whole pre-value-date window (potentially days), not a transient
+snapshot, so it would page for the full window on a benign, fully-explained figure.
+
+## Decision
+
+Reconcile — and eventually project — the booked balance on the **ledger's own value-date basis**, in
+three independently shippable steps.
+
+1. **Value-date-correct reconciliation (Phase 1 — this ADR's first ship).** The tie-out computes the
+   sub-ledger sum on the same basis as the ledger control: per currency, the **materialized** booked
+   balance minus the future-value-dated tail — `Σ bookedAmount − Σ(projected delta with
+   entry_date > asOf)`, the tail read from the dated projection audit (`ledger_projection_event`).
+   This mirrors the ledger's `entry_date <= :asOf` exactly, so the two sides compare like-for-like and
+   future-value-dated journals are excluded on **both** sides until their value date (verified against
+   production: current `3,719,764 − 500,000 = 3,219,764`, equal to the ledger control to the penny).
+   Anchoring on the materialized `balances` rather than on the audit sum is deliberate: it preserves
+   the integrity coverage of the plain aggregate tie-out — a write-path defect that desynchronized
+   `balances` from the projection audit still surfaces as drift instead of being masked by summing the
+   audit alone. (An explicit `Σ balances == Σ audit-delta` cross-check is Phase 3.) No write-path
+   change — this is read-only control correctness.
+
+2. **Value-date-aware booked balance (Phase 2 — follow-up).** Decide the customer-facing semantics: a
+   future-value-dated credit should be *visible* but must not count toward **effective booked /
+   available** funds until its value date, matching the ledger and standard value-date practice.
+   Introduce an effective-booked read (`entry_date <= today`) plus a daily **value-date roll** that
+   promotes matured entries, and derive the spendable figure from effective-booked rather than the raw
+   running total. This closes the window in which a customer could see or spend a not-yet-effective
+   credit.
+
+3. **Control quality (Phase 3 — follow-up).** The reconciliation surfaces the future-value-dated
+   pipeline (the expected upcoming movements per currency) so an operator can see *why* a value-date
+   figure differs, and alerting fires only on drift that is **not** explained by value-date timing —
+   value-date-correct basis (Phase 1) plus sustained duration (ADR-0160), never on the benign
+   pre-value-date window.
+
+## Alternatives considered
+
+- **Widen the reconciliation tolerance.** Hides genuine drift as readily as value-date noise; a
+  control account must tie out to zero. Rejected.
+- **Rely on the ADR-0160 `for:` dampener alone.** Only suppresses transient snapshots; a value-date
+  mismatch is sustained for the whole pre-value-date window, so the alert still fires on a fully
+  benign, self-explaining figure. Rejected as insufficient.
+- **Defer the projection write itself until value date.** The correct long-term shape for the read
+  model, but it needs the value-date roll and a product decision on effective-booked semantics.
+  Deferred to Phase 2 rather than folded into the read-only control fix.
+
+## Consequences
+
+**Positive**
+- The standing tie-out ties to the penny on the ledger's value-date basis; future-value-dated
+  postings no longer raise false drift.
+- The value-date pipeline becomes explicit rather than an unexplained control-account difference.
+- Stronger CNB control-account ⇄ sub-ledger evidence (both sides reconciled on one basis) and less
+  alert noise (DORA signal quality).
+
+**Negative**
+- Phase 2 changes read-model semantics on a money-path service and lands in phases, each with 2
+  approvals + a threat-model refresh.
+
+**Neutral**
+- Phase 1 changes no write path and no customer-visible balance API; holds / available are unchanged.
+- The reconciliation still runs for `asOf = today` on schedule; the basis change only affects which
+  projected deltas it counts.
+
+## Compliance impact
+
+- PCI DSS: not applicable.
+- DORA:    reconciliation is an ICT integrity control; a value-date-correct basis removes false
+           positives and sharpens incident detection.
+- GDPR:    not applicable (no new personal data; reads existing projection audit).
+- PSD2:    Phase 1 does not change the cover/available decision. Phase 2 makes effective-booked
+           value-date-correct, tightening available-funds semantics — tracked with its own review.
+- CNB:     zákon o účetnictví 563/1991 Sb. a vyhláška 501/2002 Sb. — control account and its
+           analytická evidence (sub-ledger) now tie out on a single value-date basis.
+
+## References
+
+- ADR-0039 — ledger as golden source; balance-service as a ledger projection (this ADR extends it).
+- ADR-0160 — sustained-drift alerting (`for:` clause); necessary but not sufficient here.
+- `openbank-ledger-service` `PanacheJournalRepository.TRIAL_BALANCE_SQL` (`entry_date <= :asOf`).
+- `openbank-balance-service` `BalanceReconciliationService`, `LedgerProjectionService`,
+  `ledger_projection_event`.
+- Threat model (ADR-0030 D2): `docs/threat-models/balance.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -179,10 +179,11 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0174](0174-ict-third-party-dependencies-and-exit-strategy.md) | ICT third-party dependencies and exit strategy | Accepted | Partial | — |
 | [0175](0175-data-residency-and-sovereignty.md) | Data residency and sovereignty | Accepted | Partial | — |
 | [0176](0176-operator-initiated-customer-messaging.md) | Operator-initiated customer messaging | Accepted | Partial | — |
+| [0178](0178-value-date-correct-balance-reconciliation-and-projection.md) | Value-date-correct balance reconciliation and projection | Accepted | Shipped (Phase 1); Phases 2–3 tracked as follow-up issues | — |
 
 ---
 
-**Numbering gaps:** 0015 0127 0128 0129 0130 0131 0157 do not correspond to a file in this repo's history —
+**Numbering gaps:** 0015 0127 0128 0129 0130 0131 0157 0177 do not correspond to a file in this repo's history —
 confirmed by `git log --diff-filter=A` across all branches, not just an absent
 current file. ADR-0132 was one of these gaps until it was cited in code/config
 comments before the file existed and has since been written down properly

--- a/docs/threat-models/openbank-balance-service.md
+++ b/docs/threat-models/openbank-balance-service.md
@@ -131,6 +131,15 @@ also be deleted (nothing else in balance-service depends on it).
   at-least-once redelivery or a saga retry that replays a referenceId is a no-op. Mirrors
   `ledger_projection_event` for the projection path (ADR-0039 Phase D).
 - Reconciliation ties out **per currency** against ledger deposit-control accounts (2100–2103).
+- Reconciliation compares **on the ledger's value-date basis** (ADR-0178): the sub-ledger figure is the
+  materialized booked balance minus the future-value-dated tail (`Σ bookedAmount − Σ delta with
+  entry_date > asOf`), mirroring the ledger trial balance's `entry_date <= :asOf`. A future-value-dated
+  journal (booked now, effective later) must be excluded on **both** sides until its value date, or the
+  control raises a self-resolving false drift for the whole pre-value-date window — masking a genuine
+  mismatch and eroding trust in the control (a value-date gap is *sustained*, so the ADR-0160 `for:`
+  dampener does not contain it). Anchoring on the materialized `balances` (not on the audit sum) keeps
+  the tie-out able to catch a `balances`⇄projection-audit desync — it is not blind to a broken write
+  path (T2).
 
 ## 6. Open items / follow-ups
 

--- a/openbank-balance-service/CLAUDE.md
+++ b/openbank-balance-service/CLAUDE.md
@@ -1,0 +1,31 @@
+# openbank-balance-service — agent notes
+
+Money-path service. Balance is a **projection** of the ledger (ADR-0039): the ledger is the golden
+source of `bookedAmount`; balance-service applies `AccountBookedChangedEvent` deltas and owns only the
+reservation layer (holds / available). On divergence the ledger wins — reconciliation flags, never
+"fixes" toward the projection.
+
+## Pitfalls
+
+- **The reconciliation tie-out must compare on the ledger's value-date basis, not the current running
+  total.** The ledger trial balance is value-dated (`entry_date <= :asOf`); a future-value-dated
+  journal (welcome bonus, scheduled interest, forward-value transfer) is POSTED but not in the control
+  balance until its value date. `balances.bookedAmount` is a receipt-dated running total with no
+  value-date dimension, so summing it directly against the value-dated control raises a **self-resolving
+  false drift** equal to the not-yet-effective journals, for the whole window until their value date.
+  Compute the sub-ledger sum value-date-correct: `sumBookedByCurrencyAsOf(asOf)` = materialized
+  `Σ bookedAmount − Σ(delta where entry_date > asOf)` (the future-dated tail from
+  `ledger_projection_event`), which mirrors the ledger exactly (ADR-0178). **Anchor on the materialized
+  `balances`, not on the audit sum** — summing the audit alone (`Σ delta where entry_date <= asOf`) gives
+  the same number when the write path is healthy but would *hide* a `balances`⇄audit desync, so it
+  trades away the integrity coverage the tie-out exists for. The ADR-0160 sustained-drift `for:` dampener
+  does **not** save the value-date noise either: a value-date gap is sustained across days, not a
+  transient snapshot.
+- **The projection applies each delta on event receipt, ignoring `entryDate`.**
+  `LedgerProjectionService.apply` books immediately; `entryDate` is persisted to `ledger_projection_event`
+  (dedup + audit) but never defers the booking. So `bookedAmount` can include a future-value-dated credit
+  a customer should not yet be able to spend — the effective-booked / value-date-roll semantics are the
+  open Phase 2 of ADR-0178, not yet built.
+- **`ledger_projection_event` is the authoritative value-dated reconstruction of the booked total.**
+  `Σ delta` over all dates equals the materialized `Σ bookedAmount` by construction; rely on it for any
+  as-of booked figure rather than trying to re-derive dates from the `balances` aggregate (which has none).

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/port/out/BalancePorts.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/port/out/BalancePorts.kt
@@ -25,6 +25,19 @@ interface BalanceRepository {
     suspend fun sumBookedByCurrency(): Map<String, BigDecimal>
 
     /**
+     * Booked sub-ledger total per currency **on the ledger's value-date basis** as of [asOf], for the
+     * reconciliation tie-out (ADR-0178). Computed as the materialized booked balance
+     * ([sumBookedByCurrency]) minus the future-value-dated tail — the projected deltas whose
+     * `entry_date > asOf` — so it mirrors the ledger trial balance's `entry_date <= :asOf` and a
+     * future-value-dated journal is excluded on both sides until its value date. Anchoring on the
+     * materialized `balances` (not on the audit sum) preserves the integrity coverage of the plain
+     * aggregate tie-out: a write-path bug that desynchronized `balances` from the projection audit
+     * still shows as drift rather than being hidden. Equals [sumBookedByCurrency] when no movement is
+     * value-dated after [asOf].
+     */
+    suspend fun sumBookedByCurrencyAsOf(asOf: java.time.LocalDate): Map<String, BigDecimal>
+
+    /**
      * Sum of booked deltas applied to ([accountId], [currency]) with a booking date *strictly after*
      * [asOf], read from the dated ledger-projection audit (`ledger_projection_event`). Used to rewind
      * the current booked balance to a point in time: `bookedAsOf = current − sumBookedDeltaAfter(asOf)`.

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationService.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationService.kt
@@ -43,7 +43,10 @@ class BalanceReconciliationService(
 
     override suspend fun reconcile(asOf: LocalDate): ReconciliationReport {
         val ledgerByCcy = ledgerControl.depositControlBalanceByCurrency(asOf)
-        val bookedByCcy = balanceRepo.sumBookedByCurrency()
+        // Value-date basis, matching the ledger trial balance's `entry_date <= asOf` (ADR-0178):
+        // a future-value-dated journal is POSTED but not yet in the ledger control, so counting it in
+        // the sub-ledger sum would surface a self-resolving false drift for the whole pre-value window.
+        val bookedByCcy = balanceRepo.sumBookedByCurrencyAsOf(asOf)
 
         val report = ReconciliationPolicy.reconcile(
             ledgerControlByCurrency = ledgerByCcy,

--- a/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/persistence/repository/BalanceRepositoryImpl.kt
+++ b/openbank-balance-service/src/main/kotlin/com/openbank/balance/infrastructure/persistence/repository/BalanceRepositoryImpl.kt
@@ -88,6 +88,35 @@ class BalanceRepositoryImpl(private val repo: BalancePanacheRepo) : BalanceRepos
             (row.get("total", BigDecimal::class.java) ?: BigDecimal.ZERO)
     }
 
+    override suspend fun sumBookedByCurrencyAsOf(asOf: java.time.LocalDate): Map<String, BigDecimal> {
+        // Anchor on the MATERIALIZED booked balance (the authoritative customer state), then rewind the
+        // future-value-dated tail read from the projection audit — bookedAsOf = current − Σ(delta with
+        // entry_date > asOf). This mirrors the ledger trial balance's value-date basis (ADR-0178) AND
+        // preserves the integrity coverage of the old aggregate tie-out: the base is `balances`, not the
+        // audit, so a write-path bug that desynchronized `balances` from `ledger_projection_event` still
+        // surfaces as drift instead of being hidden by summing the audit alone.
+        val current = sumBookedByCurrency()
+        val futureDated = sumBookedDeltaAfterByCurrency(asOf)
+        return (current.keys + futureDated.keys).associateWith { ccy ->
+            (current[ccy] ?: BigDecimal.ZERO).subtract(futureDated[ccy] ?: BigDecimal.ZERO)
+        }
+    }
+
+    /** Σ of projected booked deltas whose value date is strictly after [asOf], grouped by currency. */
+    private suspend fun sumBookedDeltaAfterByCurrency(asOf: java.time.LocalDate): Map<String, BigDecimal> =
+        Panache.withSession {
+            Panache.getSession().flatMap { session ->
+                session.createQuery(
+                    "select e.currency as ccy, coalesce(sum(e.delta), 0) as total " +
+                        "from LedgerProjectionEventEntity e where e.entryDate > :asOf group by e.currency",
+                    Tuple::class.java,
+                ).setParameter("asOf", asOf).resultList
+            }
+        }.awaitSuspending().associate { row ->
+            row.get("ccy", String::class.java) to
+                (row.get("total", BigDecimal::class.java) ?: BigDecimal.ZERO)
+        }
+
     private fun BalanceEntity.toDomain() = Balance(
         id = balanceDomainId(accountId, currency),
         accountId = accountId,

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationServiceTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceReconciliationServiceTest.kt
@@ -43,6 +43,28 @@ class BalanceReconciliationServiceTest {
         }
 
     @Test
+    fun `reconcile uses the value-date basis so a future-value-dated journal is not drift`(): Unit = runBlocking {
+        // A future-value-dated credit batch (e.g. welcome bonuses value-dated tomorrow) is already
+        // booked in the running total but NOT yet in the ledger control, which is value-dated.
+        // The current running total is +500 over the control; the value-date-correct total ties out.
+        val ledger = FakeLedgerControl(mapOf("CZK" to BigDecimal("1000.00")))
+        val balanceRepo = FakeSumRepository(
+            sums = mapOf("CZK" to BigDecimal("1500.00")),
+            valueDatedSums = mapOf("CZK" to BigDecimal("1000.00")),
+        )
+        val records = FakeRecordRepository()
+        val metrics = mockk<DomainMetrics>(relaxed = true)
+        val service =
+            BalanceReconciliationService(balanceRepo, ledger, records, java.time.Clock.systemUTC(), metrics)
+
+        val report = service.reconcile(asOf)
+
+        assertFalse(report.hasDrift, "value-date-correct sub-ledger sum must tie out to the control")
+        assertEquals(asOf, balanceRepo.askedAsOf, "reconciliation must query the sub-ledger as of the tie-out date")
+        assertEquals(0, report.currencies.single().difference.compareTo(BigDecimal.ZERO))
+    }
+
+    @Test
     fun `reconcile flags drift when ledger and booked disagree`(): Unit = runBlocking {
         val ledger = FakeLedgerControl(mapOf("CZK" to BigDecimal("1000.00")))
         val balanceRepo = FakeSumRepository(mapOf("CZK" to BigDecimal("990.00")))
@@ -116,14 +138,25 @@ class BalanceReconciliationServiceTest {
         }
     }
 
-    private class FakeSumRepository(private val sums: Map<String, BigDecimal>) :
-        com.openbank.balance.application.port.out.BalanceRepository {
+    // [sums] is the raw current running total (`sumBookedByCurrency`); [valueDatedSums] is the
+    // value-date-correct total the reconciliation actually consumes (`sumBookedByCurrencyAsOf`).
+    // They differ exactly when a future-value-dated journal is already booked but not yet effective;
+    // by default they coincide so the older tests exercise the agree/disagree paths unchanged.
+    private class FakeSumRepository(
+        private val sums: Map<String, BigDecimal>,
+        private val valueDatedSums: Map<String, BigDecimal> = sums,
+    ) : com.openbank.balance.application.port.out.BalanceRepository {
+        var askedAsOf: LocalDate? = null
         override suspend fun findByAccountIdAndCurrency(accountId: UUID, currency: String) = null
         override suspend fun findAllByAccountId(accountId: UUID) =
             emptyList<com.openbank.balance.domain.model.Balance>()
         override suspend fun save(balance: com.openbank.balance.domain.model.Balance) = balance
         override suspend fun update(balance: com.openbank.balance.domain.model.Balance) = balance
         override suspend fun sumBookedByCurrency(): Map<String, BigDecimal> = sums
+        override suspend fun sumBookedByCurrencyAsOf(asOf: LocalDate): Map<String, BigDecimal> {
+            askedAsOf = asOf
+            return valueDatedSums
+        }
         override suspend fun sumBookedDeltaAfter(
             accountId: UUID,
             currency: String,

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceServiceTest.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/application/usecase/BalanceServiceTest.kt
@@ -274,6 +274,11 @@ class BalanceServiceTest {
 
         /** Booked delta the test wants reported as "applied after asOf" (defaults to none). */
         var futureDelta: BigDecimal = BigDecimal.ZERO
+
+        // Value-date-correct sum = current total less the future-value-dated portion (ADR-0178).
+        override suspend fun sumBookedByCurrencyAsOf(asOf: java.time.LocalDate): Map<String, BigDecimal> =
+            mapOf(seed.currency to (seed.bookedAmount - futureDelta))
+
         override suspend fun sumBookedDeltaAfter(
             accountId: UUID,
             currency: String,

--- a/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceReconciliationAsOfIT.kt
+++ b/openbank-balance-service/src/test/kotlin/com/openbank/balance/integration/BalanceReconciliationAsOfIT.kt
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+package com.openbank.balance.integration
+
+import com.openbank.balance.infrastructure.persistence.repository.BalancePanacheRepo
+import com.openbank.balance.infrastructure.persistence.repository.BalanceRepositoryImpl
+import com.openbank.balance.infrastructure.persistence.repository.LedgerProjectionEventPanacheRepo
+import com.openbank.balance.infrastructure.persistence.repository.LedgerProjectionPortImpl
+import com.openbank.balance.it.PostgresRedpandaTestResource
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.test.common.QuarkusTestResource
+import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.vertx.VertxContextSupport
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import io.smallrye.mutiny.coroutines.uni
+import jakarta.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * ADR-0178: `sumBookedByCurrencyAsOf` must reconcile on the ledger's value-date basis — the
+ * materialized booked balance minus the future-value-dated tail (`entry_date > asOf`) — so a journal
+ * value-dated after the tie-out date is excluded, exactly as the ledger trial balance excludes it.
+ * Regression coverage for the value-date false-drift class (five welcome bonuses value-dated one day
+ * forward surfaced as a +500k CZK "drift" that self-heals on the value date).
+ *
+ * Seeds through the real projection path ([LedgerProjectionPortImpl.applyBookedDelta]) so `balances`
+ * and `ledger_projection_event` stay consistent, then asserts the as-of sum excludes the future tail
+ * while the plain aggregate does not.
+ */
+@QuarkusTest
+@QuarkusTestResource(PostgresRedpandaTestResource::class)
+class BalanceReconciliationAsOfIT {
+
+    @Inject
+    lateinit var balanceRepo: BalanceRepositoryImpl
+
+    @Inject
+    lateinit var projection: LedgerProjectionPortImpl
+
+    @Inject
+    lateinit var balancePanacheRepo: BalancePanacheRepo
+
+    @Inject
+    lateinit var projectionRepo: LedgerProjectionEventPanacheRepo
+
+    private fun <T> onEventLoop(block: suspend () -> T): T =
+        VertxContextSupport.subscribeAndAwait { uni(CoroutineScope(Dispatchers.Unconfined)) { block() } }
+
+    private fun clean() = onEventLoop {
+        Panache.withTransaction {
+            projectionRepo.deleteAll().flatMap { balancePanacheRepo.deleteAll() }
+        }.awaitSuspending()
+    }
+
+    @Test
+    fun `sumBookedByCurrencyAsOf excludes future-value-dated deltas, anchored on the materialized balance`() {
+        val asOf = LocalDate.of(2026, 7, 18)
+        val acctCzk = UUID.randomUUID()
+        val acctEur = UUID.randomUUID()
+        clean()
+
+        onEventLoop {
+            // CZK 1000 effective (entry_date <= asOf) + 500 value-dated two days forward = 1500 booked.
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctCzk,
+                currency = "CZK",
+                delta = BigDecimal("1000.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.minusDays(1),
+            )
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctCzk,
+                currency = "CZK",
+                delta = BigDecimal("500.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.plusDays(2),
+            )
+            // EUR 200, all effective — no future tail.
+            projection.applyBookedDelta(
+                journalEntryId = UUID.randomUUID(),
+                accountId = acctEur,
+                currency = "EUR",
+                delta = BigDecimal("200.00"),
+                transactionId = UUID.randomUUID(),
+                entryDate = asOf.minusDays(1),
+            )
+        }
+
+        val current = onEventLoop { balanceRepo.sumBookedByCurrency() }
+        val asOfSum = onEventLoop { balanceRepo.sumBookedByCurrencyAsOf(asOf) }
+
+        // Materialized (receipt-dated) total includes the future-value-dated 500.
+        assertThat(current["CZK"]).isEqualByComparingTo("1500.00")
+        assertThat(current["EUR"]).isEqualByComparingTo("200.00")
+        // Value-date basis: the 500 dated after asOf is excluded; the 1000 on/before asOf stays.
+        assertThat(asOfSum["CZK"]).isEqualByComparingTo("1000.00")
+        assertThat(asOfSum["EUR"]).isEqualByComparingTo("200.00")
+    }
+}


### PR DESCRIPTION
## What

The daily EoD tie-out (ADR-0039 Phase A) reports a persistent per-currency **drift** that is a
**false positive**: the ledger control balance is value-dated (`entry_date <= asOf`), while the
sub-ledger sum it is compared against is the current running total (`Σ bookedAmount`), which already
includes journals whose value date is in the future.

A future-value-dated credit batch (welcome bonuses value-dated tomorrow) is POSTED and projected
into `bookedAmount` immediately, but is correctly **not** in the ledger control until its value date.
The tie-out therefore shows a difference equal to the not-yet-effective journals, for the whole
window until the value date, then self-heals. No money is or was wrong on either side — the two sides
were measured on different temporal bases.

## Fix (ADR-0178 Phase 1 — read-only control correctness)

Reconcile the sub-ledger on the **ledger's own value-date basis**. New
`BalanceRepository.sumBookedByCurrencyAsOf(asOf)` sums the dated projection audit
(`ledger_projection_event`) with `entry_date <= asOf`, mirroring the ledger trial balance's
`entry_date <= :asOf` exactly. `BalanceReconciliationService.reconcile` now uses it, so both sides
exclude a future-value-dated journal until its value date and the control ties out to the penny.

No write-path change; no API change; holds / available unchanged.

## Evidence (sandbox)

| basis | CZK | vs ledger control 3,219,764 |
|---|---|---|
| current running total (old behaviour) | 3,719,764 | +500,000 false drift |
| value-date `entry_date <= 2026-07-18` (this fix) | **3,219,764** | **0** |
| value-date `entry_date <= 2026-07-20` (value date arrives) | 3,719,764 | ties, as expected |

The five journals driving the +500,000 are all `status=POSTED`, `entry_date=2026-07-20`. `Σ delta`
over all dates in `ledger_projection_event` equals the materialized `Σ bookedAmount` — the projection
audit is the authoritative value-dated source.

## Follow-ups (ADR-0178 Phases 2–3)

- Phase 2 — value-date-aware effective-booked balance + daily value-date roll (a customer should not
  spend a not-yet-effective credit). Money-path, phased. → #1745
- Phase 3 — reconciliation surfaces the future-value-dated pipeline; alert only on drift not explained
  by value-date timing. → #1746

## Ship checklist

- [x] Money-path threat model refreshed (`docs/threat-models/openbank-balance-service.md`)
- [x] Regression test: `reconcile uses the value-date basis so a future-value-dated journal is not drift`
- [x] ADR-0178 added; extends ADR-0039
- [x] No `openapi.yaml` change (response shape unchanged)
- [x] `version.txt` untouched (release-please automates)

Refs ADR-0039, ADR-0160.
