### PR TITLE
feat(edge): device-session refresh so passkey sessions can resume

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/DeviceSessionStore.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/DeviceSessionStore.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.customeredge.infrastructure.webauthn
+
+import io.quarkus.redis.datasource.RedisDataSource
+import io.quarkus.redis.datasource.value.SetArgs
+import jakarta.enterprise.context.ApplicationScoped
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * Redis-backed device-session store (ADR-0066 F2 refresh fix).
+ *
+ * The native-passkey session token minted by [WebAuthnKeycloakClient.impersonate] (RFC 8693
+ * token-exchange) carries `azp=openbank-edge-webauthn`, so it is NOT refreshable by the public
+ * `openbank-app` client via a normal `refresh_token` grant ("Token client and authorized client
+ * don't match") — the app could therefore never silently resume a session and re-ran a full passkey
+ * ceremony on every cold start.
+ *
+ * Instead the edge issues an OPAQUE, single-use, rotating device-session id bound to the Keycloak
+ * user. On resume the app presents it and the edge re-mints a fresh access token via `impersonate()`
+ * (which always works) and rotates the id. Security: the id is 256 bits of [SecureRandom], lives
+ * only in the app's biometric-gated Keychain, is revocable (delete the key on logout) and TTL-bounded
+ * ([TTL_SECONDS] idle, extended on each refresh) — matching the app-side 14-day re-auth window.
+ */
+@ApplicationScoped
+class DeviceSessionStore(redis: RedisDataSource) {
+    private val values = redis.value(String::class.java)
+    private val rng = SecureRandom()
+
+    /** Mint a new device-session id bound to [keycloakUserId] (idle TTL [TTL_SECONDS]). */
+    fun issue(keycloakUserId: String): String {
+        val id = newId()
+        values.set(key(id), keycloakUserId, SetArgs().ex(TTL_SECONDS))
+        return id
+    }
+
+    /**
+     * Single-use resolve+rotate: returns the Keycloak user for [deviceSessionId] and atomically
+     * consumes it (getdel), or null if unknown/expired/revoked. The caller issues a fresh id via
+     * [issue] for the same user, so a stolen id is usable at most once before it rotates.
+     */
+    fun consume(deviceSessionId: String): String? = values.getdel(key(deviceSessionId))
+
+    /** Revoke a device session (logout). */
+    fun revoke(deviceSessionId: String) {
+        values.getdel(key(deviceSessionId))
+    }
+
+    private fun newId(): String {
+        val b = ByteArray(ID_BYTES)
+        rng.nextBytes(b)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(b)
+    }
+
+    private fun key(id: String) = "edge:devsession:$id"
+
+    companion object {
+        private const val TTL_SECONDS = 14L * 24 * 60 * 60 // 14-day idle window (matches the app)
+        private const val ID_BYTES = 32 // 256-bit opaque token
+    }
+}

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnModels.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnModels.kt
@@ -42,4 +42,10 @@ data class AuthCompleteRequestDto(
 data class TokenPairDto(
     @JsonProperty("access_token") val accessToken: String,
     @JsonProperty("refresh_token") val refreshToken: String?,
+    // Opaque, rotating device-session id the app stores and presents to /session/refresh to
+    // silently resume without a passkey ceremony (ADR-0066 F2 refresh fix, DeviceSessionStore).
+    @JsonProperty("device_session_id") val deviceSessionId: String? = null,
 )
+
+/** Body of POST /customer/v1/webauthn/session/refresh — the app's opaque device-session id. */
+data class SessionRefreshRequestDto(@JsonProperty("device_session_id") val deviceSessionId: String)

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResource.kt
@@ -65,6 +65,7 @@ class WebAuthnResource(
     private val challengeStore: ChallengeStore,
     private val credentialStore: WebAuthnStore,
     private val keycloakClient: WebAuthnKeycloakClient,
+    private val deviceSessions: DeviceSessionStore,
     private val jsonMapper: ObjectMapper,
 ) {
 
@@ -182,7 +183,8 @@ class WebAuthnResource(
         //
         // The response is additive: a client that only checked the status code keeps working.
         val (accessToken, refreshToken) = keycloakClient.impersonate(keycloakUserId)
-        return Response.ok(TokenPairDto(accessToken, refreshToken)).build()
+        val deviceSessionId = deviceSessions.issue(keycloakUserId)
+        return Response.ok(TokenPairDto(accessToken, refreshToken, deviceSessionId)).build()
     }
 
     // ── Authentication (returning-user login, no browser) ───────────────────────────────────
@@ -272,7 +274,27 @@ class WebAuthnResource(
         )
 
         val (accessToken, refreshToken) = keycloakClient.impersonate(stored.keycloakUserId)
-        return Response.ok(TokenPairDto(accessToken, refreshToken)).build()
+        val deviceSessionId = deviceSessions.issue(stored.keycloakUserId)
+        return Response.ok(TokenPairDto(accessToken, refreshToken, deviceSessionId)).build()
+    }
+
+    /**
+     * Silently resume a native-passkey session WITHOUT a passkey ceremony (ADR-0066 F2 refresh fix).
+     * The app presents the opaque device-session id it got at login; the edge validates+rotates it
+     * (single-use) and re-mints a fresh access token via impersonate() — the exchange-minted token is
+     * not refreshable by the public openbank-app client, so a normal refresh_token grant can't do it.
+     * Public (no bearer): the device-session id IS the credential, device-bound in the app Keychain.
+     */
+    @POST
+    @Path("/session/refresh")
+    @Blocking
+    fun sessionRefresh(request: SessionRefreshRequestDto): Response {
+        val keycloakUserId = deviceSessions.consume(request.deviceSessionId)
+            ?: return Response.status(Response.Status.UNAUTHORIZED)
+                .entity(mapOf("error" to "invalid_device_session")).build()
+        val (accessToken, refreshToken) = keycloakClient.impersonate(keycloakUserId)
+        val rotated = deviceSessions.issue(keycloakUserId)
+        return Response.ok(TokenPairDto(accessToken, refreshToken, rotated)).build()
     }
 
     // ── Internals ─────────────────────────────────────────────────────────────────────────

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/infrastructure/webauthn/WebAuthnResourceTest.kt
@@ -24,12 +24,14 @@ class WebAuthnResourceTest {
     private val challengeStore = mockk<ChallengeStore>()
     private val credentialStore = mockk<WebAuthnStore>()
     private val keycloakClient = mockk<WebAuthnKeycloakClient>()
+    private val deviceSessions = mockk<DeviceSessionStore>(relaxed = true)
 
     private val resource = WebAuthnResource(
         ticketService,
         challengeStore,
         credentialStore,
         keycloakClient,
+        deviceSessions,
         ObjectMapper(),
     ).apply {
         rpId = "open-bank.tech"


### PR DESCRIPTION
## Root cause (verified live)
The native-passkey session token (`impersonate`, RFC 8693 token-exchange) carries `azp=openbank-edge-webauthn` and is **not refreshable** by the public `openbank-app` client (`refresh_token` grant → *'Token client and authorized client don't match'*; no other client works either → *'Session doesn't have required client'*). With a 300s access token, the app session died in minutes and every cold-start resume fell back to a full passkey ceremony — the real cause of passkey-on-every-launch. #222 / #1741 (PIN gate + offline token) did **not** fix this.

## Fix
- `DeviceSessionStore` (Redis, 256-bit SecureRandom id, 14-day idle TTL): opaque `deviceSessionId → keycloakUserId`.
- `auth/complete` + `register/complete` issue a `device_session_id` in the response.
- New public `POST /customer/v1/webauthn/session/refresh`: validates + **consumes** (single-use) the id, re-mints a fresh access token via `impersonate()`, **rotates** the id.
- Revocable (delete key), device-bound (id lives only in the app Keychain).

Pairs with the app change (openbank-app: AuthService routes the opaque device-session id to this endpoint; a dotted JWT refresh token still refreshes at Keycloak for hosted PKCE).

Refs #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)