### PR TITLE
fix(infra): raise Loki push limits so node-roll log bursts aren't dropped

### DIFF
--- a/openbank-infra/gitops/apps/loki.yaml
+++ b/openbank-infra/gitops/apps/loki.yaml
@@ -83,6 +83,17 @@ spec:
           limits_config:
             allow_structured_metadata: true
             volume_enabled: true
+            # Global per-tenant push limits. Loki's defaults (4MiB/s rate, 6MiB
+            # burst) are sized for a single small app; here one single-binary
+            # ingests every namespace + ~38 services via Alloy. During a node
+            # roll, Alloy replays hours of buffered logs at once and the default
+            # limit drops them ("ingestion rate limit exceeded for user fake") —
+            # exactly the diagnostics you want during a node incident. Raise the
+            # ceiling; it is an in-memory buffer bound, no infra/$ cost.
+            ingestion_rate_mb: 16
+            ingestion_burst_size_mb: 32
+            per_stream_rate_limit: 8MB
+            per_stream_rate_limit_burst: 16MB
             # FinOps (ADR-0054): sandbox 7d retention (ADR-0088 D3). S3 lifecycle on the
             # bucket also expires objects at 7d (belt-and-suspenders).
             retention_period: 168h


### PR DESCRIPTION
## What
Loki ran on default per-tenant push limits (4 MiB/s rate, 6 MiB burst). The single-binary ingests every namespace + ~38 services via Alloy; during a node roll Alloy replays hours of buffered logs at once and the distributor drops lines:

```
ingestion rate limit exceeded for user fake (limit: 4194304 bytes/sec) while attempting to ingest '1961' lines totaling '1042828' bytes
```

Observed **43 drops / 30 min** on `loki-0` during today's node roll — losing exactly the logs wanted during a node incident.

## Change
`limits_config`: `ingestion_rate_mb` 4->16, `ingestion_burst_size_mb` 6->32, explicit `per_stream_rate_limit` 8MB / burst 16MB.

## Cost
$0 — in-memory buffer ceiling only, no new infra. Retention (7d, ADR-0054) unchanged.

## Verify
After ArgoCD sync, `kubectl -n observability logs loki-0 -c loki --since=30m | grep -c 'ingestion rate limit'` should stay ~0 across a node roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues
Closes #1761
