### PR TITLE
feat(customer-edge): customer complaint filing route (ADR-0085)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2324,6 +2324,31 @@ class CustomerEdgeResource(
         return upstream.get("$disputeServiceUrl/api/v1/disputes/account/$accountId", customer.partyId.toString())
     }
 
+    /**
+     * File a regulatory complaint (ADR-0085) from the app. dispute-service owns the statutory
+     * deadline clock and returns the case reference + dueDate, which the app shows the customer.
+     * The edge forces channel=APP; when an accountId is supplied it is ownership-checked (IDOR
+     * guard). A complaint carries no partyId upstream (only an optional accountId), so customer-
+     * facing complaint LISTING is a deliberate follow-up: dispute-service today exposes only an
+     * operator-wide list, and a per-party read needs a scoped query there (issue to follow).
+     */
+    @POST
+    @Path("/complaints")
+    @Authorize(action = "customer.complaints.create")
+    @Blocking
+    fun fileComplaint(body: String): Response {
+        val customer = customer()
+        val accountId = extractTextField(objectMapper, body, "accountId")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { UUID.fromString(it) }.getOrNull() ?: return badRequest("Malformed accountId") }
+        if (accountId != null && !ownsAccount(accountId, customer.partyId)) {
+            return forbidden("Account does not belong to caller")
+        }
+        val enriched = injectField(objectMapper, body, "channel", "APP")
+            ?: return badRequest("Malformed complaint body")
+        return upstream.post("$disputeServiceUrl/api/v1/complaints", customer.partyId.toString(), enriched)
+    }
+
     // --- Internal helpers ---
 
     /**


### PR DESCRIPTION
## What
`POST /customer/v1/complaints` — lets the app file a regulatory complaint. Forwards to dispute-service's complaints subsystem (ADR-0085 statutory deadline clock), forcing `channel=APP` and ownership-checking any supplied `accountId` (IDOR guard). Returns the created complaint (case **reference** + statutory **dueDate**) so the app confirms both to the customer.

## Auth
Allowed by the generic `customer-self-action` rule (any `customer.*` action for an authenticated customer). No OPA change. The edge M2M identity carries ROLE_OPERATOR, satisfying dispute-service's `@RolesAllowed` on complaint filing (same path the dispute create already uses).

## Scope / follow-up
**Filing only.** Customer complaint *listing* is deferred: a `Complaint` carries no `partyId` upstream (only an optional `accountId`) and dispute-service exposes only an operator-wide list — a per-party scoped read must be added there first. Noted in the handler KDoc.

## Verify
`:openbank-customer-edge:compileKotlin` clean (JDK 25). Pairs with the app complaint-filing screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues
N/A — self-initiated feature gap-fill against OSS ADRs; no pre-existing tracking issue (ADR-0052 conscious N/A).