### PR TITLE
feat(customer-edge): permanent card block (report lost/stolen)

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2162,6 +2162,29 @@ class CustomerEdgeResource(
     @Blocking
     fun unfreezeCard(@PathParam("id") id: UUID): Response = cardAction(id, "resume")
 
+    /**
+     * Permanently block one of the caller's OWN cards — the report-lost/stolen action. Unlike
+     * freeze (a reversible suspend), block is TERMINAL: card-issuance moves the card to BLOCKED and
+     * it cannot be resumed, so the app gates this behind an explicit confirm. Ownership is enforced
+     * here (same IDOR guard as freeze); the card-issuance audit reason is fixed to LOST_OR_STOLEN
+     * since that is the only customer-initiated block reason.
+     */
+    @POST
+    @Path("/cards/{id}/block")
+    @Authorize(action = "customer.cards.update", resource = "#id")
+    @Blocking
+    fun blockCard(@PathParam("id") id: UUID): Response {
+        val customer = customer()
+        if (!ownsCard(id, customer.partyId)) return forbidden("Card does not belong to caller")
+        return upstream.post(
+            "$cardIssuanceServiceUrl/api/v1/cards/$id/block",
+            customer.partyId.toString(),
+            "{\"reason\":\"LOST_OR_STOLEN\"}",
+            null,
+            mapOf("X-Operator-Id" to "customer:${customer.partyId}"),
+        )
+    }
+
     // Map the customer freeze/unfreeze to card-issuance's suspend/resume. card-issuance requires an
     // X-Operator-Id audit header; for a self-service freeze the actor IS the customer, so the party id
     // is the audit subject. Ownership is enforced here (the card must belong to the JWT party).


### PR DESCRIPTION
## What
`POST /customer/v1/cards/{id}/block` — lets a customer **report a card lost/stolen**: a terminal block, distinct from the reversible **freeze** (suspend). card-issuance already models `/{id}/block`; the edge just didn't expose it.

## How
Mirrors the existing `cardAction` freeze/unfreeze **line-for-line**: ownership-checked (IDOR guard via `ownsCard`), `X-Operator-Id = customer:<partyId>`, forwarded to card-issuance `POST /api/v1/cards/{id}/block` with `{"reason":"LOST_OR_STOLEN"}`. card-issuance's `block` accepts the edge M2M identity (ROLE_OPERATOR), same as `suspend`/`resume`.

## Note on verification
Local `:openbank-customer-edge:compileKotlin` was blocked by a **Gradle build-logic transform-cache corruption** in the shared `~/.gradle` (a concurrent build invalidated `build-logic.jar`) — unrelated to this change, which is a mirror of the production freeze path. CI will compile.

Pairs with the app "report lost/stolen" action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Linked issues
N/A — self-initiated feature gap-fill against OSS ADRs; no pre-existing tracking issue (ADR-0052 conscious N/A).