### PR TITLE
chore(gitops): bump balance-service to sandbox-d2423c5d (value-date reconcile)

### DIFF
--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -45,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: balance-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-balance-service:sandbox-71c2f7f2
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-balance-service:sandbox-d2423c5d
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Deploys the ADR-0178 value-date-correct reconciliation fix (#1747, merge `d2423c5d`) by direct image bump.

**Why a direct bump instead of auto-deploy:** the `can-i-deploy` gate is red on a **pre-existing broken Pact provider-state fixture** (duplicate-key on balance seeding in the `@State` callback — see the linked issue), not a real contract break. #1747 makes **zero** balance REST-API change, and the running consumers verify fine against the live pod. Image `sandbox-d2423c5d` is cosign-signed + SBOM-attested (Kyverno-admissible).

After merge: ArgoCD syncs → balance-service pod rolls to the new image → the EoD tie-out recomputes on the value-date basis and the CZK drift clears.

Refs #1747, #1771, ADR-0178, ADR-0092.