### PR TITLE
docs(customer-edge): document TokenPair.device_session_id in OpenAPI

### DIFF
--- a/openbank-customer-edge/src/main/resources/openapi.yaml
+++ b/openbank-customer-edge/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Customer Edge API
-  version: 1.13.0
+  version: 1.14.0
   description: >-
     Customer-facing edge proxy (ADR-0065). Single internet-facing entry point for the
     retail customer app. Validates JWTs from the openbank-customers Keycloak realm,
@@ -1017,6 +1017,12 @@ components:
           type: string
         refresh_token:
           type: string
+        device_session_id:
+          type: string
+          description: >-
+            Opaque device-session id (ADR-0066 F2). The passkey-exchange refresh_token is not
+            refreshable by openbank-app, so the app resumes via /webauthn/session/refresh with
+            this id. Emitted by the passkey register/authenticate completion; absent otherwise.
 
     RegisterPartyRequest:
       type: object


### PR DESCRIPTION
## What

`components.schemas/TokenPair` in the customer-edge OpenAPI omitted `device_session_id`, even though `TokenPairDto` **already serializes it** (`@JsonProperty("device_session_id")`, ADR-0066 F2 device-session refresh):

- `WebAuthnResource` issues it on passkey register/authenticate completion (`deviceSessions.issue(...)`)
- `DeviceSessionStore` (Redis) backs it
- `POST /customer/v1/webauthn/session/refresh` consumes it

So the published contract lagged the wire. This adds the property (additive, optional — no behaviour change).

## Why it matters

The openbank-app consumer-driven contract test (`EdgeContractTest`) deliberately leaves `TokenPair` **out** of its validated PAIRS today precisely because the app models `device_session_id` and the edge schema didn't — pairing it would fail as a phantom field. With this merged, the app's daily `edge-contract-sync` job will pick up the new schema and `TokenPair` can be added to the contract test.

Addresses one item of #1773 (the larger part — response schemas for the bare core read endpoints — remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)