### PR TITLE
feat(copilot): short-lived conversation memory across turns

### DIFF
--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CopilotChatService.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/application/CopilotChatService.kt
@@ -12,6 +12,7 @@ import com.openbank.copilot.domain.model.ChatRole
 import com.openbank.copilot.domain.model.ModelRequest
 import com.openbank.copilot.domain.model.StopReason
 import com.openbank.copilot.domain.model.ToolInvocation
+import com.openbank.copilot.infrastructure.persistence.ConversationStore
 import jakarta.enterprise.context.ApplicationScoped
 import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.jboss.logging.Logger
@@ -37,6 +38,7 @@ class CopilotChatService(
     private val tools: CopilotToolRegistry,
     private val actionTools: ActionToolRegistry,
     private val policyGate: CopilotPolicyGate,
+    private val conversations: ConversationStore,
     @ConfigProperty(name = "copilot.enabled", defaultValue = "false")
     private val enabled: Boolean,
 ) {
@@ -52,9 +54,15 @@ class CopilotChatService(
 
         val messages = mutableListOf(
             ChatMessage(ChatRole.SYSTEM, systemPrompt() + " " + PromptInjectionGuard.UNTRUSTED_PREAMBLE),
-            ChatMessage(ChatRole.USER, turn.message),
         )
-        return converse(turn.conversationId, messages, customerId)
+        messages += conversations.load(customerId, turn.conversationId)
+        messages += ChatMessage(ChatRole.USER, turn.message)
+
+        val outcome = converse(turn.conversationId, messages, customerId)
+        if (outcome is ChatOutcome.Replied && outcome.reply.reply.isNotBlank()) {
+            persistTurn(customerId, turn.conversationId, turn.message, outcome.reply.reply)
+        }
+        return outcome
     }
 
     /**
@@ -82,11 +90,22 @@ class CopilotChatService(
 
         val messages = mutableListOf(
             ChatMessage(ChatRole.SYSTEM, systemPrompt() + " " + PromptInjectionGuard.UNTRUSTED_PREAMBLE),
-            ChatMessage(ChatRole.USER, turn.message),
         )
+        messages += conversations.load(customerId, turn.conversationId)
+        messages += ChatMessage(ChatRole.USER, turn.message)
         val toolSpecs = tools.specs() + actionTools.specs()
         val proposals = mutableListOf<ActionProposal>()
         var offerTools = true
+
+        // Tool rounds emit no text (they generate only function specs), so every chunk the model
+        // streams belongs to the final answer — accumulate it to persist as this turn's ASSISTANT
+        // memory. The [PROGRESS]/[PROPOSAL] control markers go out via the raw onChunk below, so
+        // they never enter this buffer.
+        val finalText = StringBuilder()
+        val capturingChunk: suspend (String) -> Unit = { chunk ->
+            finalText.append(chunk)
+            onChunk(chunk)
+        }
 
         repeat(MAX_ITERATIONS) {
             val response = try {
@@ -100,7 +119,7 @@ class CopilotChatService(
                     ),
                     sensitive = false,
                     actorId = customerId,
-                    onChunk = onChunk,
+                    onChunk = capturingChunk,
                 )
             } catch (e: Exception) {
                 onChunk(degradeMessage(e))
@@ -109,6 +128,7 @@ class CopilotChatService(
 
             if (response.stopReason != StopReason.TOOL_USE || response.toolInvocations.isEmpty()) {
                 emitProposalSentinel(proposals, onChunk)
+                persistTurn(customerId, turn.conversationId, turn.message, finalText.toString())
                 return
             }
 
@@ -125,6 +145,23 @@ class CopilotChatService(
 
         log.warnf("stream chat loop hit MAX_ITERATIONS=%d", MAX_ITERATIONS)
         onChunk(MAX_STEPS_MESSAGE)
+    }
+
+    /**
+     * Persist the current exchange (USER message + final ASSISTANT text) into short-lived
+     * conversation memory so the next turn has context. No-op for a blank reply or a non-persistable
+     * conversation id (a stateless turn where the client sent no id) — [ConversationStore] guards both.
+     */
+    private fun persistTurn(customerId: String, conversationId: String, userMessage: String, assistantText: String) {
+        if (assistantText.isBlank()) return
+        conversations.append(
+            customerId,
+            conversationId,
+            listOf(
+                ChatMessage(ChatRole.USER, userMessage),
+                ChatMessage(ChatRole.ASSISTANT, assistantText),
+            ),
+        )
     }
 
     // Deliberately broad: any model/gateway/tool failure must degrade to a friendly reply, never a

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/ConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/ConversationStore.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.infrastructure.persistence
+
+import com.openbank.copilot.domain.model.ChatMessage
+
+/**
+ * Short-lived conversation memory for the copilot (ADR-0089): without it every turn is stateless,
+ * so a follow-up like "ano, potvrzuji" or "a na spořicím?" has no context and the assistant is
+ * unusable for anything multi-turn.
+ *
+ * Only the *conversational* turns are persisted — USER messages and the final ASSISTANT text.
+ * Tool calls, tool results and the system prompt are deliberately NOT stored: replaying a prior
+ * turn's tool output would surface stale balances/rates, and the model re-runs the tools with the
+ * live bearer whenever it needs fresh data. History gives the model what was *asked and answered*,
+ * grounding stays live (D4).
+ *
+ * Isolation: the key is scoped by `customerId`, so a guessed/replayed `conversationId` can never
+ * read another customer's history. History is capped ([MAX_MESSAGES]) and expires ([TTL_SECONDS],
+ * sliding on each write) — it is transient UX state, not a record of account activity.
+ *
+ * Two implementations mirror [ProposalTokenStore]:
+ * - [InMemoryConversationStore] — single-node dev/test (build property `copilot.token-store=memory`)
+ * - [RedisConversationStore] — production Valkey/Redis (default)
+ */
+interface ConversationStore {
+    /** Prior conversational turns for (customer, conversation), oldest first; empty if none/expired. */
+    fun load(customerId: String, conversationId: String): List<ChatMessage>
+
+    /**
+     * Append [newTurns] (typically the current USER message + the final ASSISTANT reply) to the
+     * conversation, trimming to the most recent [MAX_MESSAGES] and (re)setting the TTL.
+     */
+    fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>)
+
+    companion object {
+        /** Sliding TTL. A chat left idle past this loses its context — matches typical session UX. */
+        const val TTL_SECONDS = 1800L // 30 min
+
+        /** Keep the last N conversational messages (~10 exchanges) — bounds prompt size + token cost. */
+        const val MAX_MESSAGES = 20
+
+        /** Sentinel the resource substitutes for a missing client id; such turns are NOT persisted. */
+        const val NO_MEMORY_ID = "new"
+
+        /** A client conversation id longer than this is rejected (Redis key hygiene / abuse guard). */
+        const val MAX_ID_LENGTH = 128
+
+        /** True when [conversationId] is a real, persistable client id (not the stateless sentinel). */
+        fun persistable(conversationId: String): Boolean = conversationId.isNotBlank() &&
+            conversationId != NO_MEMORY_ID &&
+            conversationId.length <= MAX_ID_LENGTH
+    }
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/InMemoryConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/InMemoryConversationStore.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.infrastructure.persistence
+
+import com.openbank.copilot.domain.model.ChatMessage
+import io.quarkus.arc.properties.IfBuildProperty
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Single-node conversation memory for dev/test (active with `copilot.token-store=memory`, mirroring
+ * [InMemoryProposalTokenStore]). Same contract as [RedisConversationStore]; entries expire via [clock].
+ */
+@ApplicationScoped
+@IfBuildProperty(name = "copilot.token-store", stringValue = "memory")
+class InMemoryConversationStore(private val clock: Clock) : ConversationStore {
+    private val log = Logger.getLogger(InMemoryConversationStore::class.java)
+
+    private data class Entry(val messages: List<ChatMessage>, val expiresAt: Instant)
+
+    private val store = ConcurrentHashMap<String, Entry>()
+
+    override fun load(customerId: String, conversationId: String): List<ChatMessage> {
+        if (!ConversationStore.persistable(conversationId)) return emptyList()
+        val entry = store[key(customerId, conversationId)] ?: return emptyList()
+        if (Instant.now(clock).isAfter(entry.expiresAt)) {
+            store.remove(key(customerId, conversationId))
+            return emptyList()
+        }
+        return entry.messages
+    }
+
+    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>) {
+        if (!ConversationStore.persistable(conversationId) || newTurns.isEmpty()) return
+        evictExpired()
+        val k = key(customerId, conversationId)
+        // Strip everything but role + content, mirroring the Redis wire form.
+        val merged = (load(customerId, conversationId) + newTurns)
+            .map { ChatMessage(it.role, it.content) }
+            .takeLast(ConversationStore.MAX_MESSAGES)
+        store[k] = Entry(merged, Instant.now(clock).plusSeconds(ConversationStore.TTL_SECONDS))
+        log.debugf("InMemoryConversationStore: appended %d turn(s) key=%s", newTurns.size, k)
+    }
+
+    private fun evictExpired() {
+        val now = Instant.now(clock)
+        store.entries.removeIf { now.isAfter(it.value.expiresAt) }
+    }
+
+    private fun key(customerId: String, conversationId: String) = "$customerId|$conversationId"
+}

--- a/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/RedisConversationStore.kt
+++ b/openbank-copilot-service/src/main/kotlin/com/openbank/copilot/infrastructure/persistence/RedisConversationStore.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) OpenBank contributors. Licensed under the GNU Affero General Public License v3.0 only.
+// A commercial licence is available from the maintainers as an alternative to the AGPL-3.0.
+// See LICENSES/AGPL-3.0-only.txt or https://www.gnu.org/licenses/agpl-3.0.html for details.
+package com.openbank.copilot.infrastructure.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.copilot.domain.model.ChatMessage
+import com.openbank.copilot.domain.model.ChatRole
+import io.quarkus.arc.properties.UnlessBuildProperty
+import io.quarkus.redis.datasource.ReactiveRedisDataSource
+import io.quarkus.redis.datasource.value.SetArgs
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import kotlinx.coroutines.runBlocking
+import org.jboss.logging.Logger
+
+/**
+ * Production conversation memory (Valkey/Redis). Stores one JSON array of [StoredMessage] per
+ * (customer, conversation) under [key], with a sliding [ConversationStore.TTL_SECONDS] TTL.
+ *
+ * Only role + content are persisted (see [ConversationStore]); tool calls/results are never stored.
+ */
+@ApplicationScoped
+@UnlessBuildProperty(name = "copilot.token-store", stringValue = "memory")
+class RedisConversationStore @Inject constructor(
+    private val redis: ReactiveRedisDataSource,
+    private val mapper: ObjectMapper,
+) : ConversationStore {
+    private val log = Logger.getLogger(RedisConversationStore::class.java)
+    private val values by lazy { redis.value(String::class.java) }
+
+    /** Wire form — deliberately minimal so a schema drift in [ChatMessage] can't corrupt history. */
+    data class StoredMessage(val role: ChatRole = ChatRole.USER, val content: String = "")
+
+    override fun load(customerId: String, conversationId: String): List<ChatMessage> {
+        if (!ConversationStore.persistable(conversationId)) return emptyList()
+        val json = runBlocking { values.get(key(customerId, conversationId)).awaitSuspending() }
+            ?: return emptyList()
+        return runCatching {
+            mapper.readValue(json, Array<StoredMessage>::class.java)
+                .map { ChatMessage(it.role, it.content) }
+        }.getOrElse { e ->
+            log.warnf(e, "RedisConversationStore: failed to deserialise conversation, ignoring")
+            emptyList()
+        }
+    }
+
+    override fun append(customerId: String, conversationId: String, newTurns: List<ChatMessage>) {
+        if (!ConversationStore.persistable(conversationId) || newTurns.isEmpty()) return
+        runBlocking {
+            val existing = load(customerId, conversationId)
+            val merged = (existing + newTurns)
+                .map { StoredMessage(it.role, it.content) }
+                .takeLast(ConversationStore.MAX_MESSAGES)
+            val json = mapper.writeValueAsString(merged)
+            values.set(key(customerId, conversationId), json, SetArgs().ex(ConversationStore.TTL_SECONDS))
+                .awaitSuspending()
+        }
+        log.debugf(
+            "RedisConversationStore: appended %d turn(s) customer=%s conversation=%s ttl=%ds",
+            newTurns.size,
+            customerId,
+            conversationId,
+            ConversationStore.TTL_SECONDS,
+        )
+    }
+
+    // customerId precedes conversationId, so a crafted conversationId can only ever land inside the
+    // SAME customer's namespace — it can never escape to another customer's history.
+    private fun key(customerId: String, conversationId: String) = "copilot:conv:$customerId:$conversationId"
+}

--- a/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/application/CopilotChatServiceTest.kt
+++ b/openbank-copilot-service/src/test/kotlin/com/openbank/copilot/application/CopilotChatServiceTest.kt
@@ -13,13 +13,16 @@ import com.openbank.copilot.domain.model.ModelResponse
 import com.openbank.copilot.domain.model.StopReason
 import com.openbank.copilot.domain.model.ToolInvocation
 import com.openbank.copilot.domain.model.ToolSpec
+import com.openbank.copilot.infrastructure.persistence.InMemoryConversationStore
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.time.Clock
 
 class CopilotChatServiceTest {
 
@@ -28,8 +31,10 @@ class CopilotChatServiceTest {
     private val tools = mockk<CopilotToolRegistry>(relaxed = true)
     private val actionTools = mockk<ActionToolRegistry>(relaxed = true)
     private val policyGate = mockk<CopilotPolicyGate>()
+    private val conversations = InMemoryConversationStore(Clock.systemUTC())
 
-    private fun service(enabled: Boolean) = CopilotChatService(gateway, guard, tools, actionTools, policyGate, enabled)
+    private fun service(enabled: Boolean) =
+        CopilotChatService(gateway, guard, tools, actionTools, policyGate, conversations, enabled)
 
     @Test
     fun `disabled by default returns Disabled and never calls the model`() {
@@ -64,6 +69,68 @@ class CopilotChatServiceTest {
         val outcome = runBlocking { service(enabled = true).handle(ChatTurn("c1", "dobrý den"), "cust-1") }
 
         assertThat((outcome as ChatOutcome.Replied).reply.reply).isEqualTo("Dobrý den")
+    }
+
+    @Test
+    fun `threads prior turns into the next model request for the same conversation`() {
+        coEvery { guard.scanUserInput(any(), any()) } returns null
+        every { guard.blocks() } returns true
+        every { tools.specs() } returns emptyList()
+        val req = slot<com.openbank.copilot.domain.model.ModelRequest>()
+        coEvery { gateway.complete(any(), capture(req), any(), any()) } returnsMany listOf(
+            ModelResponse(content = "Máte dva účty.", stopReason = StopReason.END, modelId = "mock-echo"),
+            ModelResponse(content = "Spořicí má 0 Kč.", stopReason = StopReason.END, modelId = "mock-echo"),
+        )
+
+        val svc = service(enabled = true)
+        runBlocking {
+            svc.handle(ChatTurn("conv-42", "jaké mám účty?"), "cust-1")
+            svc.handle(ChatTurn("conv-42", "a na spořicím?"), "cust-1")
+        }
+
+        // The 2nd turn's request carries the 1st exchange: system + user1 + assistant1 + user2.
+        val contents = req.captured.messages.map { it.content }
+        assertThat(contents).contains("jaké mám účty?", "Máte dva účty.", "a na spořicím?")
+    }
+
+    @Test
+    fun `does not thread history across different customers`() {
+        coEvery { guard.scanUserInput(any(), any()) } returns null
+        every { guard.blocks() } returns true
+        every { tools.specs() } returns emptyList()
+        val req = slot<com.openbank.copilot.domain.model.ModelRequest>()
+        coEvery { gateway.complete(any(), capture(req), any(), any()) } returns
+            ModelResponse(content = "ok", stopReason = StopReason.END, modelId = "mock-echo")
+
+        val svc = service(enabled = true)
+        runBlocking {
+            svc.handle(ChatTurn("conv-42", "tajná zpráva zákazníka A"), "cust-A")
+            svc.handle(ChatTurn("conv-42", "dotaz zákazníka B"), "cust-B")
+        }
+
+        // Same conversationId, different customer → B must NOT see A's history (key is customer-scoped).
+        val contents = req.captured.messages.map { it.content }
+        assertThat(contents).doesNotContain("tajná zpráva zákazníka A")
+    }
+
+    @Test
+    fun `stateless turn without a conversation id is not remembered`() {
+        coEvery { guard.scanUserInput(any(), any()) } returns null
+        every { guard.blocks() } returns true
+        every { tools.specs() } returns emptyList()
+        val req = slot<com.openbank.copilot.domain.model.ModelRequest>()
+        coEvery { gateway.complete(any(), capture(req), any(), any()) } returns
+            ModelResponse(content = "ok", stopReason = StopReason.END, modelId = "mock-echo")
+
+        val svc = service(enabled = true)
+        runBlocking {
+            svc.handle(ChatTurn("new", "první"), "cust-1")
+            svc.handle(ChatTurn("new", "druhá"), "cust-1")
+        }
+
+        // The "new" sentinel means the client sent no id → no memory, each turn is standalone.
+        val contents = req.captured.messages.map { it.content }
+        assertThat(contents).doesNotContain("první")
     }
 
     @Test


### PR DESCRIPTION
## Problem

The copilot is stateless per turn: `CopilotChatService.handle`/`handleStream` build the model context as `[system, user]` only, and `conversationId` is echoed back but never used to load prior turns. Any multi-turn interaction breaks — a follow-up like **"ano, potvrzuji"** or **"a na spořicím?"** reaches the model with no context, so the assistant is unusable for active/confirm operations.

Closes #1777.

## Fix

A `ConversationStore` (Redis default + in-memory dev/test, mirroring `ProposalTokenStore`) keyed by **(customerId, conversationId)**:

- **load** prior turns and thread them between the system prompt and the new user message (both `handle` and streaming `handleStream`);
- **persist** the user message + final assistant text after each turn (streaming accumulates the final-round tokens — control markers stay out of the buffer).

### Safety / grounding
- **Only role + content** are stored — tool calls/results and the system prompt are never persisted, so grounding stays live (D4): the model re-runs tools with the customer bearer for fresh figures instead of replaying stale balances.
- **Customer-scoped key** — a guessed/replayed `conversationId` can only ever land in the same customer's namespace, never another customer's history (covered by a test).
- **Bounded** — `MAX_MESSAGES` cap + sliding `TTL_SECONDS` (30 min). Transient UX state, not account activity.
- **Opt-in per turn** — a turn with no client id (the `"new"` sentinel) stays stateless, exactly as today.

App side threads a stable per-chat `conversationId` (separate openbank-app PR).

## Tests
`CopilotChatServiceTest`: threads prior turns for same conversation; does NOT thread across customers; stateless `"new"` turn is not remembered. Full module `test` + `detekt` + `ktlintCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)