### PR TITLE
docs(party): correct stale ADR citations on the KYC+AML activation gate

### DIFF
--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -101,7 +101,7 @@ interface PartyUseCase {
     suspend fun exportPartyData(id: UUID): PartyGdprExport
     suspend fun updateKycStatus(partyId: UUID, status: KycStatus): Party
 
-    /** Record the AML screening outcome; re-evaluates the KYC+AML activation gate (ADR-0073). */
+    /** Record the AML screening outcome; re-evaluates the KYC+AML activation gate. */
     suspend fun updateAmlStatus(partyId: UUID, amlStatus: AmlStatus): Party
 
     /**

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -254,7 +254,7 @@ class PartyService : PartyUseCase {
 
     /**
      * Counts `openbank.parties.verified` once, on the transition INTO the verified (ACTIVE) state
-     * (ADR-0077 / ADR-0079). ACTIVE is the two-key terminal of [deriveStatus] (KYC APPROVED + AML
+     * (ADR-0077 §metric catalogue). ACTIVE is the two-key terminal of [deriveStatus] (KYC APPROVED + AML
      * CLEARED). Guards on the edge `previous != ACTIVE && current == ACTIVE` so it fires exactly
      * once on the verifying step — never on a rejection (→ SUSPENDED) and never on a status update
      * that leaves an already-ACTIVE party ACTIVE.
@@ -266,8 +266,11 @@ class PartyService : PartyUseCase {
     }
 
     /**
-     * Two-key activation gate (ADR-0073): a party becomes ACTIVE only when KYC is APPROVED
+     * Two-key activation gate: a party becomes ACTIVE only when KYC is APPROVED
      * AND AML is CLEARED. Any hard negative (KYC REJECTED or AML BLOCKED) suspends.
+     * No ADR records this conjunction — ADR-0069 defines the ACTIVE gate on the onboarding
+     * journey (KYC only) and ADR-0032 owns the `AmlCase` CLEARED/BLOCKED terminals; the
+     * two-key rule itself lives here in code.
      * Fail-closed: absent either positive signal the party stays PENDING_KYC; a CLOSED party
      * is never re-opened.
      */

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -28,7 +28,7 @@ data class Party(
     val createdAt: Instant,
     val updatedAt: Instant,
     val keycloakSub: String? = null,
-    /** AML screening outcome — the second key of the KYC+AML activation gate (ADR-0073). */
+    /** AML screening outcome — the second key of the KYC+AML activation gate. */
     val amlStatus: AmlStatus = AmlStatus.NOT_SCREENED,
     /** ADR-0072: HMAC-SHA256(pepper, canonical_rc) blind index — null if no RČ or non-Czech. */
     val rcBlindIndex: String? = null,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/KycAmlEventConsumer.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/KycAmlEventConsumer.kt
@@ -14,7 +14,7 @@ import org.jboss.logging.Logger
 import java.util.UUID
 
 /**
- * Drives the party KYC+AML activation gate (ADR-0073) from the compliance event streams.
+ * Drives the party KYC+AML activation gate from the compliance event streams.
  * party-service is the single authority that decides activation: it records the KYC and AML
  * outcomes and [PartyUseCase] flips the party to ACTIVE only when BOTH clear (two-key gate),
  * or to SUSPENDED on a hard negative.

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -96,7 +96,7 @@ mp:
         topic: openbank.party.events
         value.serializer: org.apache.kafka.common.serialization.StringSerializer
     incoming:
-      # KYC + AML activation gate (ADR-0073): consume the KYC and AML case-lifecycle
+      # KYC + AML activation gate: consume the KYC and AML case-lifecycle
       # topics and flip the party to ACTIVE only when both clear (two-key gate).
       kyc-events-in:
         connector: smallrye-kafka

--- a/openbank-party-service/src/main/resources/docs/06-compliance.cs.md
+++ b/openbank-party-service/src/main/resources/docs/06-compliance.cs.md
@@ -7,7 +7,7 @@ party-service drží identitu zákazníka (PII) a životní cyklus KYC/AML, tak�
 | Regulace | Vztah k této službě | Implementace |
 |---|---|---|
 | **GDPR** (Nař. (EU) 2016/679) | Drží kanonický PII záznam o každém zákazníkovi | Endpoint Práva na výmaz (`DELETE /parties/{id}` → anonymizace + tombstone), minimalizace dat (žádné rodné číslo, vyhledávání jen podle jména), pole explicitního souhlasu (`gdpr_consent_at/version`), retenční okna |
-| **AMLD** (4./5./6. AML směrnice) | Zaznamenává výsledky KYC + AML, PEP, rizikové hodnocení; pohání aktivační bránu | `kyc_status`/`aml_status`, dvouklíčová aktivační brána (ADR-0073 v kódu), `pep_flag`, `risk_rating`, `next_review_due`, metadata sanctions kontroly; COMMENTy sloupců citují články |
+| **AMLD** (4./5./6. AML směrnice) | Zaznamenává výsledky KYC + AML, PEP, rizikové hodnocení; pohání aktivační bránu | `kyc_status`/`aml_status`, dvouklíčová aktivační brána (v kódu, bez ADR), `pep_flag`, `risk_rating`, `next_review_due`, metadata sanctions kontroly; COMMENTy sloupců citují články |
 | **PSD2** (Nař. (EU) 2015/2366) | Identita pod účet/consent toky | party je read-only resolvována `account-service`; žádný přímý TPP přístup |
 | **FATCA / CRS** | Reporting daňové rezidence | sloupce `fatca_status`, `crs_status` na party |
 | **DORA** (Nař. (EU) 2022/2554) | Provozní odolnost | health probes, fault-tolerantní outbox (circuit breaker/retry/bulkhead/timeout), poison-pill-safe consumer, audit eventy, SLO, runbooky |

--- a/openbank-party-service/src/main/resources/docs/06-compliance.en.md
+++ b/openbank-party-service/src/main/resources/docs/06-compliance.en.md
@@ -7,7 +7,7 @@ party-service holds customer identity (PII) and the KYC/AML lifecycle, so it is 
 | Regulation | Relation to this service | Implementation |
 |---|---|---|
 | **GDPR** (Reg. (EU) 2016/679) | Holds the canonical PII record of every customer | Right-to-erasure endpoint (`DELETE /parties/{id}` → anonymise + tombstone), data-minimisation (no birth number, name-only search), explicit consent fields (`gdpr_consent_at/version`), retention windows |
-| **AMLD** (4/5/6 AML Directives) | Records KYC + AML outcomes, PEP, risk rating; drives activation gate | `kyc_status`/`aml_status`, two-key activation gate (ADR-0073 in code), `pep_flag`, `risk_rating`, `next_review_due`, sanctions-check metadata; column COMMENTs cite the articles |
+| **AMLD** (4/5/6 AML Directives) | Records KYC + AML outcomes, PEP, risk rating; drives activation gate | `kyc_status`/`aml_status`, two-key activation gate (in code, no ADR), `pep_flag`, `risk_rating`, `next_review_due`, sanctions-check metadata; column COMMENTs cite the articles |
 | **PSD2** (Reg. (EU) 2015/2366) | Identity backing account/consent flows | party is read-only resolved by `account-service`; no direct TPP access |
 | **FATCA / CRS** | Tax-residence reporting | `fatca_status`, `crs_status` columns on the party |
 | **DORA** (Reg. (EU) 2022/2554) | Operational resilience | health probes, fault-tolerant outbox (circuit breaker/retry/bulkhead/timeout), poison-pill-safe consumer, audit events, SLO, runbooks |

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/outbox/PartyOutboxBacklogGaugeTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/outbox/PartyOutboxBacklogGaugeTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 
 /**
  * The gauge registers a supplier backed by a cached value; the scheduled `suspend` tick refreshes
- * that cache from the repository (ADR-0077 / ADR-0079). Verifies the supplier reflects refreshes —
+ * that cache from the repository (ADR-0077 outbox gauge). Verifies the supplier reflects refreshes —
  * i.e. the cache, not a direct per-scrape reactive call, is what Micrometer reads.
  */
 class PartyOutboxBacklogGaugeTest {


### PR DESCRIPTION
## What

Comment-only fix for ADR citations in `openbank-party-service` that point at the wrong ADRs.

### `ADR-0073` — wrong, and no replacement exists

The two-key activation gate (`KYC APPROVED` + `AML CLEARED` ⇒ `ACTIVE`) is cited as ADR-0073 in five places. [`docs/adr/0073-...`](docs/adr/0073-customer-app-hardware-backed-credential-storage.md) is **"Hardware-backed credential storage for the customer app"** — unrelated.

Grepping `docs/adr/` for the two-key rule finds **no ADR that documents it**:
- ADR-0069 (customer onboarding journey) defines the `ACTIVE` gate before account opening, but states `party ACTIVE status = KYC approved` — no AML conjunction.
- ADR-0032 owns the `AmlCase` lifecycle (`OPEN → UNDER_REVIEW | CLEARED | BLOCKED | ESCALATED`), but not the party-status rule.

Per the task's own instruction, no ADR is invented. The citations are dropped and `deriveStatus`'s KDoc now records where the rule actually lives, pointing at both adjacent ADRs for context.

### `ADR-0079` — wrong; `ADR-0077` alone is right

`openbank.parties.verified` and the outbox backlog gauge were cited as "ADR-0077 / ADR-0079".
- **ADR-0077** is correct: `openbank.parties.verified` is listed by name in its metric catalogue (line 135), and `openbank.outbox.pending_events` at line 142.
- **ADR-0079** is "Infrastructure lifecycle & vulnerability intelligence" (component versions, EOL, CVEs). No mention of domain metrics, outbox, or gauges. Dropped.

## Deliberately not changed

`src/main/resources/db/migration/V8__party_aml_status.sql:1` carries the same stale ADR-0073 comment. Flyway checksums the **whole migration file including comments**, so correcting it would trigger a `checksum mismatch` startup failure on every live DB. Left as-is.

## Ship-check

- Comment-only; no behaviour change, no API/DB/event/config-semantics change.
- Type `docs` — a hidden type, so no release is cut on either axis.
- `./gradlew :openbank-party-service:ktlintCheck` → exit 0.
- Every remaining ADR citation in the service was re-resolved against `docs/adr/` filenames; all 20 others match their subject.

Refs #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)