### PR TITLE
feat(party): add duplicate party identity merge (ADR-0179)

### DIFF
--- a/docs/adr/0179-party-identity-merge.md
+++ b/docs/adr/0179-party-identity-merge.md
@@ -1,0 +1,119 @@
+# ADR-0179 — Duplicate party identity merge
+
+Date: 2026-07-19
+Decision-Status: Proposed   <!-- Proposed | Accepted | Superseded by ADR-NNNN | Deprecated | Rejected -->
+Delivery-Status: Planned    <!-- Planned | Partial | Shipped | N/A — decision-only -->
+Author(s): Jiri Raska
+
+## Context
+
+ADR-0072 established "1 person = 1 party" and defends it at *creation* time: a RČ blind index
+(`POST /api/v1/parties/resolve`) plus a four-eyes case queue in pid-service whose verdict
+`LINK_TO_EXISTING` routes an applicant onto the party that already exists.
+
+Both mechanisms are pre-creation gates. Neither can act once two parties for the same natural
+person are already live — and they do become live: a customer onboarding through a channel that
+carries no RČ (or with a differing one), a channel that predates the blind index, or an operator
+creating a party by hand all bypass the dedup key. The platform has no remediation path for that
+state today.
+
+The absence has a sharp edge. The only writer of `PartyStatus.CLOSED` is GDPR Art. 17 erasure
+(`DELETE /api/v1/parties/{id}`), which anonymises PII and emits `PARTY_ERASED`. So the only way
+an operator can currently "retire" a duplicate party is to record it as *the data subject
+exercised their right to be forgotten* — a false compliance statement, destructive of the very
+history the merge is meant to preserve, and acted on by every downstream consumer of that event.
+
+The workaround available without any code change is worse than the gap: open matching currency
+pockets on the surviving account, move the balance across as an ordinary customer payment, close
+the source account, then erase the source party. The ledger then attests that one legal person
+paid another and was subsequently erased. A duplicate-identity data-quality finding is routine;
+a money movement that misrepresents what happened is an audit finding.
+
+## Decision
+
+We will add an explicit, first-class merge operation to party-service, distinct from erasure.
+
+1. **`PartyStatus.MERGED`** joins the status enum, and a nullable `merged_into` (UUID, FK to
+   `parties.id`) column records the surviving party. The pair makes the relation traversable in
+   both directions and distinguishes "retired as a duplicate" from "erased on request".
+   `deriveStatus` treats `MERGED` as terminal exactly as it already treats `CLOSED` — a merged
+   party is never re-opened by a later KYC or AML signal.
+
+2. **`POST /api/v1/parties/{id}/merge`** with body `{ "mergedIntoPartyId": "<uuid>", "reason": "..." }`,
+   roles OPERATOR/ADMIN, authz action `party.merge`, gated on four-eyes approval (the ledger
+   `ApprovalResource` pattern). Preconditions, all fail-closed: both parties exist, neither is
+   already `MERGED` or `CLOSED`, the two ids differ, and the target is not itself merged into a
+   third party (no chains — the caller resolves to the final survivor first).
+
+3. **`PARTY_MERGED`** is published to the existing party status-changed topic, carrying both ids
+   and the approval reference. PII is preserved on the retired row; nothing is anonymised.
+
+4. **The balance transfer is an internal ledger ADJUSTMENT journal entry** (`POST /api/v1/journals`,
+   already four-eyes gated), referencing the merge approval id — never a customer-initiated
+   payment. The posting says what actually happened: a bookkeeping correction between two records
+   of one person, not a transfer of value between two persons.
+
+Order is fixed and each step is separately auditable: approve merge case → open matching currency
+pockets on the surviving account → ADJUSTMENT journal per currency → close the source account →
+merge the party. Account closure does *not* check the balance
+([ADR-0109](0109-customer-managed-currency-pockets.md) option B), so the sweep must precede it;
+the merge endpoint therefore refuses a source party still owning an account with a non-zero
+balance, putting the check where the domain can enforce it.
+
+## Alternatives considered
+
+- **Reuse GDPR erasure to retire the duplicate** — zero new code. Rejected: it records a legal
+  assertion that is false, anonymises history the merge exists to keep, and fires `PARTY_ERASED`
+  at consumers that will treat it as a subject-rights event.
+- **Rewrite `party_id` on the duplicate's rows in place** — appears to give "one clean history".
+  Rejected: postings are append-only and reference the counterparty as booked; re-pointing them
+  falsifies the ledger, breaks reconciliation, and destroys the audit trail. It is the operation
+  an auditor is specifically looking for.
+- **Leave the duplicate live and link the two via external ids** — the existing
+  `linkKeycloakSub` path already attaches a `KEYCLOAK_ID` to a party. Rejected as a *merge*: it
+  moves no accounts, retires nothing, and leaves two ACTIVE parties for one person, so every
+  downstream aggregate (positions, limits, AML exposure, reporting) still double-counts. Retained
+  as the correct tool for its own job — attaching a credential to an already-correct party.
+- **Extend pid-service's `LINK_TO_EXISTING` verdict to act post-creation** — reuses the existing
+  four-eyes queue. Rejected for this ADR: that queue models an *applicant* being routed before a
+  party exists, and overloading it with a two-live-parties case conflates two different states.
+  Revisit if operators end up wanting one queue.
+
+## Consequences
+
+**Positive**
+- A duplicate can be remediated without a false GDPR statement or a falsified posting.
+- Both identities stay queryable, and `merged_into` makes the relation explicit for reporting
+  and for any downstream service holding a stale `partyId`.
+- Aggregates over a merged person stop double-counting.
+
+**Negative**
+- Every service holding a `partyId` must decide how it follows `merged_into`. This ADR ships the
+  party-service primitive and the event; consumer adoption is a follow-up per service and until
+  it lands a stale `partyId` still resolves to the retired row.
+- Merge is not reversible through the API. An erroneous merge is corrected by a compensating
+  journal entry and a new party, not by an un-merge.
+- Adds a second terminal status, so any exhaustive `when` over `PartyStatus` needs a new branch.
+
+**Neutral**
+- The four-eyes machinery is borrowed from ledger rather than generalised; extracting a shared
+  approval component is deferred until a third caller wants it.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data in scope.
+- DORA:    Art. 9 (data integrity) — replaces an ad-hoc manual remediation with a recorded,
+           approved, replayable operation.
+- GDPR:    Art. 5(1)(d) accuracy — this is the mechanism that makes a duplicated identity
+           correctable. Explicitly *separates* the correction from Art. 17 erasure, which it
+           currently has to impersonate; retained PII on the merged row stays under the
+           surviving party's existing lawful basis and retention schedule.
+- PSD2:    not applicable.
+- CNB:     record-keeping — the retired party and its history remain retrievable for the
+           statutory period; the merge itself is an audited, approved event.
+
+## References
+
+- [ADR-0072](0072-client-identity-unification.md) — "1 person = 1 party" and the creation-time dedup gate
+- [ADR-0109](0109-customer-managed-currency-pockets.md) — currency pockets; closure without a zero-balance check
+- [ADR-0030](0030-supply-chain-security-and-ssdlc-hardening.md) — threat-model requirement for money-path change

--- a/docs/adr/0179-party-identity-merge.md
+++ b/docs/adr/0179-party-identity-merge.md
@@ -48,17 +48,45 @@ We will add an explicit, first-class merge operation to party-service, distinct 
 3. **`PARTY_MERGED`** is published to the existing party status-changed topic, carrying both ids
    and the approval reference. PII is preserved on the retired row; nothing is anonymised.
 
-4. **The balance transfer is an internal ledger ADJUSTMENT journal entry** (`POST /api/v1/journals`,
-   already four-eyes gated), referencing the merge approval id — never a customer-initiated
-   payment. The posting says what actually happened: a bookkeeping correction between two records
-   of one person, not a transfer of value between two persons.
+4. **The balance transfer is an internal adjustment, not a customer payment** — but that
+   distinction has to be *built*, and this ADR is where the gap is recorded rather than assumed.
+
+   Two things turned out not to be true of the platform as it stands:
+
+   - **`TransactionType.ADJUSTMENT` is inert.** `PaymentJournalFactory.buildLines` never reads
+     `transaction.type`; it branches only on currency and on source/target nullity. DEBIT,
+     TRANSFER and ADJUSTMENT produce byte-identical journals. Today the type is a label on the
+     transaction row and nothing else, so posting the sweep "as an ADJUSTMENT" would buy exactly
+     zero audit distinction from an ordinary payment.
+   - **Neither `ledger.create` nor `transaction.create` is four-eyes gated.** The OPA verb list
+     covers `post` and `reverse`, which no posting endpoint actually emits, and
+     `authz.four-eyes.enforce` defaults to `false` in ledger-service regardless.
+
+   So the sweep needs a distinguishable path of its own. We will add a dedicated operator-only
+   action rather than reusing `transaction.create` — that action is on the M2M payment rails, and
+   the OPA bundle's own guidance is that a verb may only join the four-eyes list when every
+   fleet-wide caller of it is a human operator. The mechanical shape already exists and is
+   correct: the `source != null && target != null` branch of `PaymentJournalFactory` posts two
+   deposit-control legs, the control account nets to zero, and only the sub-ledger dimension
+   moves — a bookkeeping correction between two records of one person, not a transfer of value
+   between two persons. What is missing is the type carried through to the journal, the reason
+   code, and the approval binding.
+
+   This lands as a separate money-path change (2 approvals + threat model). Until it does, the
+   merge endpoint's account guard is what prevents a half-finished merge: a duplicate with an
+   open account cannot be retired at all.
 
 Order is fixed and each step is separately auditable: approve merge case → open matching currency
-pockets on the surviving account → ADJUSTMENT journal per currency → close the source account →
-merge the party. Account closure does *not* check the balance
-([ADR-0109](0109-customer-managed-currency-pockets.md) option B), so the sweep must precede it;
-the merge endpoint therefore refuses a source party still owning an account with a non-zero
-balance, putting the check where the domain can enforce it.
+pockets on the surviving account (pockets are an account-service aggregate; the balance projection
+auto-creates a balance row but *not* a pocket, so skipping this leaves a balance with no owning
+pocket — a silent structural inconsistency, not an error) → sweep per currency → close the source
+account → merge the party.
+
+Account closure does *not* check the balance ([ADR-0109](0109-customer-managed-currency-pockets.md)
+option B), so the sweep must precede it. The merge endpoint therefore refuses a source party that
+still owns any non-CLOSED account, putting the check where the domain can enforce it. That guard is
+fail-closed: if account-service cannot be reached, the merge aborts, because "we could not ask"
+must never resolve to "owns nothing".
 
 ## Alternatives considered
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -180,6 +180,7 @@ two-axis **Decision-Status** / **Delivery-Status** front-matter.
 | [0175](0175-data-residency-and-sovereignty.md) | Data residency and sovereignty | Accepted | Partial | — |
 | [0176](0176-operator-initiated-customer-messaging.md) | Operator-initiated customer messaging | Accepted | Partial | — |
 | [0178](0178-value-date-correct-balance-reconciliation-and-projection.md) | Value-date-correct balance reconciliation and projection | Accepted | Shipped (Phase 1); Phases 2–3 tracked as follow-up issues | — |
+| [0179](0179-party-identity-merge.md) | Duplicate party identity merge | Proposed | Planned | — |
 
 ---
 

--- a/openbank-party-service/build.gradle.kts
+++ b/openbank-party-service/build.gradle.kts
@@ -21,6 +21,10 @@ dependencies {
     implementation(libs.quarkus.micrometer.registry.prometheus)
     implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.oidc)
+    // ADR-0179: M2M call to account-service for the merge precondition guard.
+    implementation(libs.quarkus.rest.client.reactive)
+    implementation(libs.quarkus.rest.client.reactive.jackson)
+    implementation(libs.quarkus.oidc.client.reactive.filter)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.quarkus.smallrye.fault.tolerance)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/in/PartyPort.kt
@@ -56,6 +56,20 @@ data class CreatePartyCommand(
     val consentMarketing: Boolean? = null,
 )
 
+/**
+ * ADR-0179: retire [id] as a duplicate of [mergedIntoPartyId]. Both parties must be live, distinct,
+ * and the target must not itself be merged (the caller resolves chains to the final survivor).
+ * [reason] is free text for the audit trail; [approvalReference] links the ledger ADJUSTMENT
+ * journal entries that swept the balances, so the money movement and the identity retirement are
+ * traceable to one another.
+ */
+data class MergePartyCommand(
+    val id: UUID,
+    val mergedIntoPartyId: UUID,
+    val reason: String,
+    val approvalReference: String?,
+)
+
 data class UpdatePartyCommand(
     val id: UUID,
     val email: String?,
@@ -111,6 +125,12 @@ interface PartyUseCase {
      */
     suspend fun listParties(page: Int, size: Int, status: PartyStatus? = null): Map<String, Any>
     suspend fun eraseParty(cmd: ErasePartyCommand)
+
+    /**
+     * ADR-0179: retire a duplicate identity into a surviving party. Returns the retired party.
+     * Distinct from [eraseParty] — nothing is anonymized and no subject-rights event is emitted.
+     */
+    suspend fun mergeParty(cmd: MergePartyCommand): Party
 
     /** Self-registration from mobile: idempotent by keycloakSub. Returns existing party if already registered. */
     suspend fun selfRegisterParty(cmd: SelfRegisterPartyCommand): Pair<Party, Boolean> // Party, isNew

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -80,6 +80,22 @@ interface GdprAggregationPort {
     suspend fun fetchCardData(partyId: java.util.UUID): List<Map<String, Any?>>
 }
 
+/**
+ * ADR-0179: account-ownership guard for the merge precondition.
+ *
+ * Unlike [GdprAggregationPort] this is **fail-closed**: an unreachable account-service must abort
+ * the merge, never allow it. Merging a party that still owns a funded account would strand the
+ * balance on a retired identity — account closure does not check the balance
+ * (ADR-0109 option B), so nothing downstream would catch it.
+ */
+interface PartyAccountGuardPort {
+    /**
+     * Returns the ids of accounts owned by [partyId] that are not yet CLOSED, or throws if the
+     * answer cannot be established. An empty list is the only result that permits a merge.
+     */
+    suspend fun findOpenAccounts(partyId: UUID): List<String>
+}
+
 /** Outbound port for party domain events. */
 interface PartyEventPublisher {
 
@@ -90,4 +106,11 @@ interface PartyEventPublisher {
     suspend fun publishKycStatusChanged(party: Party)
 
     suspend fun publishPartyErased(id: UUID)
+
+    /**
+     * ADR-0179: [merged] is the retired duplicate (status MERGED); [survivingPartyId] is the party
+     * consumers should follow from now on. Deliberately NOT PARTY_ERASED — nothing was anonymized
+     * and no subject-rights request occurred.
+     */
+    suspend fun publishPartyMerged(merged: Party, survivingPartyId: UUID)
 }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/usecase/PartyService.kt
@@ -28,6 +28,9 @@ class PartyNotFoundException(id: UUID) : RuntimeException("Party not found: $id"
 class PartyAlreadyExistsException(email: String) : RuntimeException("Party with email already exists: $email")
 class PartyKeycloakSubAlreadyBoundException(sub: String) : RuntimeException("Keycloak sub already registered: $sub")
 
+/** ADR-0179: a merge precondition failed. Carries an operator-readable reason (mapped to 409). */
+class PartyMergeRejectedException(message: String) : RuntimeException(message)
+
 @ApplicationScoped
 class PartyService : PartyUseCase {
 
@@ -40,6 +43,8 @@ class PartyService : PartyUseCase {
     @Inject lateinit var eventPublisher: PartyEventPublisher
 
     @Inject lateinit var gdprAggregation: GdprAggregationPort
+
+    @Inject lateinit var accountGuard: PartyAccountGuardPort
 
     @Inject lateinit var metrics: DomainMetrics
 
@@ -273,6 +278,9 @@ class PartyService : PartyUseCase {
      */
     private fun deriveStatus(kyc: KycStatus, aml: AmlStatus, current: PartyStatus): PartyStatus = when {
         current == PartyStatus.CLOSED -> PartyStatus.CLOSED
+        // ADR-0179: MERGED is terminal for the same reason CLOSED is — a late KYC or AML callback
+        // on a retired duplicate must not resurrect it into ACTIVE.
+        current == PartyStatus.MERGED -> PartyStatus.MERGED
         // EXPIRED is set by AbandonedRegistrationCleaner's daily sweep, which explicitly expects
         // this to suspend the party ("system expiry... party -> SUSPENDED") — without it here,
         // an abandoned registration silently reverted to PENDING_KYC instead.
@@ -288,6 +296,60 @@ class PartyService : PartyUseCase {
         documentFileRepo.deleteByPartyId(cmd.id)
         partyRepo.anonymize(cmd.id)
         eventPublisher.publishPartyErased(cmd.id)
+    }
+
+    /**
+     * ADR-0179: retire [cmd.id] as a duplicate of [cmd.mergedIntoPartyId].
+     *
+     * Every precondition is fail-closed, and the account guard deliberately lets its exception
+     * propagate: if we cannot establish that the retired party owns no open account, we must not
+     * merge. Account closure does not check the balance (ADR-0109 option B), so a funded account
+     * on a retired identity would strand silently with nothing downstream to catch it.
+     */
+    override suspend fun mergeParty(cmd: MergePartyCommand): Party {
+        if (cmd.id == cmd.mergedIntoPartyId) {
+            throw PartyMergeRejectedException("A party cannot be merged into itself: ${cmd.id}")
+        }
+        val source = partyRepo.findById(cmd.id) ?: throw PartyNotFoundException(cmd.id)
+        val target = partyRepo.findById(cmd.mergedIntoPartyId)
+            ?: throw PartyNotFoundException(cmd.mergedIntoPartyId)
+
+        if (source.status == PartyStatus.MERGED) {
+            throw PartyMergeRejectedException(
+                "Party ${source.id} is already merged into ${source.mergedIntoPartyId}",
+            )
+        }
+        if (source.status == PartyStatus.CLOSED) {
+            throw PartyMergeRejectedException("Party ${source.id} is erased (CLOSED) and cannot be merged")
+        }
+        // No chains: a survivor that is itself retired would leave consumers following two hops,
+        // and every consumer would have to implement the same loop. The caller resolves first.
+        if (target.status == PartyStatus.MERGED) {
+            throw PartyMergeRejectedException(
+                "Target ${target.id} is itself merged into ${target.mergedIntoPartyId}; " +
+                    "merge into the surviving party instead",
+            )
+        }
+        if (target.status == PartyStatus.CLOSED) {
+            throw PartyMergeRejectedException("Target ${target.id} is erased (CLOSED) and cannot receive a merge")
+        }
+
+        val openAccounts = accountGuard.findOpenAccounts(source.id)
+        if (openAccounts.isNotEmpty()) {
+            throw PartyMergeRejectedException(
+                "Party ${source.id} still owns ${openAccounts.size} open account(s): " +
+                    "${openAccounts.joinToString()}. Sweep the balances and close them first.",
+            )
+        }
+
+        val merged = source.copy(
+            status = PartyStatus.MERGED,
+            mergedIntoPartyId = target.id,
+            updatedAt = Instant.now(clock),
+        )
+        val saved = partyRepo.update(merged)
+        eventPublisher.publishPartyMerged(saved, target.id)
+        return saved
     }
 
     override suspend fun selfRegisterParty(cmd: SelfRegisterPartyCommand): Pair<Party, Boolean> {

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/domain/model/Party.kt
@@ -8,7 +8,13 @@ import java.time.Instant
 import java.util.UUID
 
 enum class PartyType { INDIVIDUAL, SOLE_TRADER, COMPANY, TRUST }
-enum class PartyStatus { PENDING_KYC, ACTIVE, SUSPENDED, CLOSED }
+
+/**
+ * [CLOSED] and [MERGED] are both terminal, and deliberately distinct (ADR-0179): CLOSED is written
+ * only by GDPR Art. 17 erasure, which anonymizes PII; MERGED retires a duplicate identity and
+ * preserves everything, pointing at the survivor via [Party.mergedIntoPartyId].
+ */
+enum class PartyStatus { PENDING_KYC, ACTIVE, SUSPENDED, CLOSED, MERGED }
 enum class DocumentType { NATIONAL_ID, PASSPORT, DRIVING_LICENCE, COMPANY_REGISTRATION, TAX_ID }
 
 data class Party(
@@ -48,6 +54,11 @@ data class Party(
      * the original onboarding-time value.
      */
     val consentMarketingUpdatedAt: Instant? = null,
+    /**
+     * ADR-0179: the surviving party this one was merged into. Non-null iff [status] is
+     * [PartyStatus.MERGED] — the DB carries the same biconditional as a CHECK constraint.
+     */
+    val mergedIntoPartyId: UUID? = null,
 )
 
 data class Address(

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/AccountServiceClient.kt
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.client
+
+import com.openbank.party.application.port.out.PartyAccountGuardPort
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.QueryParam
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import org.eclipse.microprofile.rest.client.inject.RestClient
+import java.util.UUID
+
+/**
+ * Typed client for account-service's list-by-party endpoint. `GET /api/v1/accounts?partyId=` is
+ * `@RolesAllowed(SERVICE, VIEWER, OPERATOR, ADMIN)`, so the call carries an M2M bearer via
+ * [OidcClientRequestReactiveFilter] — the `openbank-services` client_credentials token resolves to
+ * ROLE_OPERATOR, which is what actually satisfies the check (nothing in either Keycloak realm
+ * grants ROLE_SERVICE, so that constant in the list is dead).
+ */
+@RegisterRestClient(configKey = "account-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/accounts")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+interface AccountServiceRestClient {
+
+    @GET
+    fun listByParty(
+        @QueryParam("partyId") partyId: UUID,
+        @QueryParam("limit") limit: Int,
+        @QueryParam("cursor") cursor: String?,
+    ): Uni<AccountPageBody>
+}
+
+data class AccountPageBody(val items: List<AccountSummaryBody> = emptyList(), val pageInfo: PageInfoBody? = null)
+
+data class AccountSummaryBody(val id: UUID? = null, val iban: String? = null, val status: String? = null)
+
+data class PageInfoBody(val nextCursor: String? = null, val hasNextPage: Boolean = false)
+
+/**
+ * ADR-0179 merge precondition guard. **Fail-closed by design**: this deliberately does not catch.
+ * A transport error, a 401, or a timeout propagates and aborts the merge, because "we could not
+ * ask" must never read as "the party owns nothing". Account closure does not verify the balance
+ * (ADR-0109 option B), so a wrongly-permitted merge strands funds on a retired identity with
+ * nothing downstream to notice.
+ *
+ * Contrast [com.openbank.party.infrastructure.gdpr.GdprAggregationAdapter], which is best-effort
+ * fail-open — appropriate there (a partial export is better than none) and wrong here.
+ */
+@ApplicationScoped
+class AccountServiceClient(@RestClient private val client: AccountServiceRestClient) : PartyAccountGuardPort {
+
+    override suspend fun findOpenAccounts(partyId: UUID): List<String> {
+        val open = mutableListOf<String>()
+        var cursor: String? = null
+        // Paginate to exhaustion: stopping at the first page would let a party with more than
+        // PAGE_SIZE accounts pass the guard on a technicality.
+        while (true) {
+            val page = client.listByParty(partyId, PAGE_SIZE, cursor).awaitSuspending()
+            page.items
+                .filter { !it.status.equals(STATUS_CLOSED, ignoreCase = true) }
+                .forEach { open += it.iban ?: it.id?.toString() ?: UNKNOWN_ACCOUNT }
+            val info = page.pageInfo
+            if (info == null || !info.hasNextPage || info.nextCursor == null) break
+            cursor = info.nextCursor
+        }
+        return open
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 100
+        private const val STATUS_CLOSED = "CLOSED"
+        private const val UNKNOWN_ACCOUNT = "<unidentified account>"
+    }
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/AccountServiceClient.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/AccountServiceClient.kt
@@ -4,6 +4,7 @@
 
 package com.openbank.party.infrastructure.client
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.openbank.party.application.port.out.PartyAccountGuardPort
 import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
 import io.smallrye.mutiny.Uni
@@ -42,10 +43,25 @@ interface AccountServiceRestClient {
     ): Uni<AccountPageBody>
 }
 
-data class AccountPageBody(val items: List<AccountSummaryBody> = emptyList(), val pageInfo: PageInfoBody? = null)
+/**
+ * Mirrors `com.openbank.libs.api.pagination.CursorPage` as account-service actually serializes it:
+ * `data` + `pagination`, NOT `items` + `pageInfo`. Getting these names wrong is not a loud failure
+ * — Jackson leaves the list empty, `findOpenAccounts` returns nothing, and the fail-closed guard
+ * silently becomes fail-OPEN. `AccountServiceClientContractTest` pins the shape against a real
+ * CursorPage payload for exactly that reason.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountPageBody(val data: List<AccountSummaryBody> = emptyList(), val pagination: PageInfoBody? = null)
 
-data class AccountSummaryBody(val id: UUID? = null, val iban: String? = null, val status: String? = null)
+/**
+ * Subset of account-service's `AccountResponse` — the identifier is `accountNumber`, not `iban`.
+ * `ignoreUnknown` is deliberate: this guard needs three fields, and account-service adding a
+ * fourth (it carries productId, goal fields, timestamps…) must not start throwing here.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AccountSummaryBody(val id: UUID? = null, val accountNumber: String? = null, val status: String? = null)
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class PageInfoBody(val nextCursor: String? = null, val hasNextPage: Boolean = false)
 
 /**
@@ -68,11 +84,13 @@ class AccountServiceClient(@RestClient private val client: AccountServiceRestCli
         // PAGE_SIZE accounts pass the guard on a technicality.
         while (true) {
             val page = client.listByParty(partyId, PAGE_SIZE, cursor).awaitSuspending()
-            page.items
+            page.data
                 .filter { !it.status.equals(STATUS_CLOSED, ignoreCase = true) }
-                .forEach { open += it.iban ?: it.id?.toString() ?: UNKNOWN_ACCOUNT }
-            val info = page.pageInfo
-            if (info == null || !info.hasNextPage || info.nextCursor == null) break
+                .forEach { open += it.accountNumber ?: it.id?.toString() ?: UNKNOWN_ACCOUNT }
+            val info = page.pagination
+            // Also break when the cursor fails to advance: a downstream that echoes the same
+            // cursor with hasNextPage=true would otherwise spin here forever.
+            if (info?.nextCursor == null || !info.hasNextPage || info.nextCursor == cursor) break
             cursor = info.nextCursor
         }
         return open

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/KafkaPartyEventPublisher.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/kafka/KafkaPartyEventPublisher.kt
@@ -39,6 +39,17 @@ class KafkaPartyEventPublisher : PartyEventPublisher {
         emitter.send(objectMapper.writeValueAsString(event))
     }
 
+    override suspend fun publishPartyMerged(merged: Party, survivingPartyId: UUID) {
+        val event = mapOf(
+            "eventType" to "PARTY_MERGED",
+            "partyId" to merged.id,
+            "mergedIntoPartyId" to survivingPartyId,
+            "status" to merged.status,
+            "occurredAt" to Instant.now(clock),
+        )
+        emitter.send(objectMapper.writeValueAsString(event))
+    }
+
     private fun publish(eventType: String, party: Party) {
         val event = mapOf(
             "eventType" to eventType,

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/entity/PartyEntity.kt
@@ -95,6 +95,10 @@ class PartyEntity : PanacheEntity() {
 
     @Column(name = "consent_marketing_updated_at")
     var consentMarketingUpdatedAt: Instant? = null
+
+    /** ADR-0179: surviving party id — non-null iff [status] is MERGED. */
+    @Column(name = "merged_into")
+    var mergedInto: UUID? = null
 }
 
 @Entity

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/persistence/repository/PartyRepositoryImpl.kt
@@ -117,6 +117,10 @@ class PartyRepositoryImpl :
                 it.addressPostalCode = party.address?.postalCode
                 it.addressCountryCode = party.address?.countryCode
                 it.updatedAt = party.updatedAt
+                // Written in the same UPDATE as `status`: the DB enforces
+                // (status = 'MERGED') = (merged_into IS NOT NULL) as a CHECK, so setting one
+                // without the other fails the statement (ADR-0179).
+                it.mergedInto = party.mergedIntoPartyId
             }
         }.replaceWith(party)
     }.awaitSuspending()
@@ -155,6 +159,7 @@ class PartyRepositoryImpl :
         it.consentMarketing = consentMarketing
         it.consentCapturedAt = consentCapturedAt
         it.consentMarketingUpdatedAt = consentMarketingUpdatedAt
+        it.mergedInto = mergedIntoPartyId
     }
 
     private fun PartyEntity.toDomain() = Party(
@@ -184,6 +189,7 @@ class PartyRepositoryImpl :
         consentMarketing = consentMarketing,
         consentCapturedAt = consentCapturedAt,
         consentMarketingUpdatedAt = consentMarketingUpdatedAt,
+        mergedIntoPartyId = mergedInto,
     )
 }
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
@@ -8,6 +8,7 @@ import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.api.error.ErrorCode
 import com.openbank.libs.flags.FeatureDisabledException
 import com.openbank.party.application.usecase.PartyAlreadyExistsException
+import com.openbank.party.application.usecase.PartyMergeRejectedException
 import com.openbank.party.application.usecase.PartyNotFoundException
 import io.vertx.pgclient.PgException
 import jakarta.ws.rs.core.Response
@@ -25,6 +26,24 @@ class PartyNotFoundMapper : ExceptionMapper<PartyNotFoundException> {
 class PartyAlreadyExistsMapper : ExceptionMapper<PartyAlreadyExistsException> {
     override fun toResponse(e: PartyAlreadyExistsException) = Response.status(409)
         .entity(ApiError(UUID.randomUUID().toString(), 409, ErrorCode.CONFLICT.code, e.message ?: "Conflict")).build()
+}
+
+/**
+ * ADR-0179: a merge precondition failed (already merged, chain, or the duplicate still owns an
+ * open account). 409 — the request is well-formed but the current state forbids it; the message
+ * names the blocking condition so the operator knows which step to do first.
+ */
+@Provider
+class PartyMergeRejectedMapper : ExceptionMapper<PartyMergeRejectedException> {
+    override fun toResponse(e: PartyMergeRejectedException) = Response.status(Response.Status.CONFLICT)
+        .entity(
+            ApiError(
+                UUID.randomUUID().toString(),
+                Response.Status.CONFLICT.statusCode,
+                ErrorCode.CONFLICT.code,
+                e.message ?: "Merge rejected",
+            ),
+        ).build()
 }
 
 /**

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
@@ -6,6 +6,7 @@ package com.openbank.party.infrastructure.rest
 
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.api.error.ErrorCode
+import com.openbank.libs.domain.identifiers.Ids
 import com.openbank.libs.flags.FeatureDisabledException
 import com.openbank.party.application.usecase.PartyAlreadyExistsException
 import com.openbank.party.application.usecase.PartyMergeRejectedException
@@ -38,7 +39,9 @@ class PartyMergeRejectedMapper : ExceptionMapper<PartyMergeRejectedException> {
     override fun toResponse(e: PartyMergeRejectedException) = Response.status(Response.Status.CONFLICT)
         .entity(
             ApiError(
-                UUID.randomUUID().toString(),
+                // ADR-0106: trace/correlation identifiers are minted via Ids. The neighbouring
+                // mappers predate the guard, which only flags newly added call sites.
+                Ids.randomId().toString(),
                 Response.Status.CONFLICT.statusCode,
                 ErrorCode.CONFLICT.code,
                 e.message ?: "Merge rejected",

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/PartyResource.kt
@@ -14,6 +14,7 @@ import com.openbank.libs.flags.FeatureFlag
 import com.openbank.party.application.port.`in`.AddDocumentCommand
 import com.openbank.party.application.port.`in`.CreatePartyCommand
 import com.openbank.party.application.port.`in`.ErasePartyCommand
+import com.openbank.party.application.port.`in`.MergePartyCommand
 import com.openbank.party.application.port.`in`.PartyUseCase
 import com.openbank.party.application.port.`in`.ResolvePartyByRcCommand
 import com.openbank.party.application.port.`in`.SearchPartiesQuery
@@ -258,6 +259,46 @@ class PartyResource {
      * Actor is the authenticated operator (JWT subject); no raw PII is placed in the payload —
      * only the regulatory article reference, per the Art. 30 records-of-processing requirement.
      */
+    @POST
+    @Path("/{id}/merge")
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "party.merge")
+    @Operation(
+        summary = "Merge a duplicate party into a surviving party (ADR-0179)",
+        description = "Retires {id} as a duplicate, preserving all PII and history. NOT erasure: " +
+            "no anonymization, no PARTY_ERASED event. Refuses while the duplicate still owns an " +
+            "open account — sweep the balances via a ledger ADJUSTMENT journal entry and close " +
+            "the account first.",
+    )
+    suspend fun mergeParty(@PathParam("id") id: UUID, req: MergePartyRequest): Response {
+        val merged = partyUseCase.mergeParty(
+            MergePartyCommand(
+                id = id,
+                mergedIntoPartyId = req.mergedIntoPartyId,
+                reason = req.reason,
+                approvalReference = req.approvalReference,
+            ),
+        )
+        // The retirement of an identity is a state-changing PII operation: record who did it,
+        // which survivor was chosen, and the approval that authorised the balance sweep.
+        auditPublisher.publish(
+            AuditEvent(
+                actorId = jwt?.subject ?: jwt?.name ?: "unknown",
+                actorType = "HUMAN",
+                operation = "party.merge",
+                resourceType = "party",
+                resourceId = id.toString(),
+                result = AuditResult.SUCCESS,
+                payload = mapOf(
+                    "merged_into_party_id" to req.mergedIntoPartyId.toString(),
+                    "reason" to req.reason,
+                    "approval_reference" to (req.approvalReference ?: ""),
+                ),
+            ),
+        )
+        return Response.ok(merged.toResponse()).build()
+    }
+
     private suspend fun auditGdpr(operation: String, partyId: UUID, gdprArticle: String) {
         auditPublisher.publish(
             AuditEvent(
@@ -486,6 +527,9 @@ data class UpdatePartyRequest(
     val tradingName: String?,
     val address: AddressRequest?,
 )
+
+/** ADR-0179. [approvalReference] links the ledger ADJUSTMENT journal that swept the balances. */
+data class MergePartyRequest(val mergedIntoPartyId: UUID, val reason: String, val approvalReference: String? = null)
 data class UpdateConsentRequest(val marketingConsent: Boolean)
 data class AddDocumentRequest(
     val documentType: String,
@@ -523,6 +567,9 @@ fun Party.toResponse() = mapOf(
     // UpdateMarketingConsentCommand kdoc) + the live, revocable marketing preference.
     "consentGdpr" to consentGdpr, "consentCapturedAt" to consentCapturedAt,
     "consentMarketing" to consentMarketing, "consentMarketingUpdatedAt" to consentMarketingUpdatedAt,
+    // ADR-0179: non-null only on a MERGED party — tells a consumer holding a stale id which
+    // party to follow instead.
+    "mergedIntoPartyId" to mergedIntoPartyId,
 )
 
 fun PartyGdprExport.toResponse() = mapOf(

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -46,6 +46,20 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+  # ADR-0179: M2M client_credentials for the merge account guard. Reuses the same confidential
+  # client as the resource-server block above (the fleet convention) — the token resolves to
+  # ROLE_OPERATOR, which is what account-service's list endpoint actually accepts.
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+  rest-client:
+    account-service:
+      # account-service listens on 8100 in the `accounts` namespace (gitops
+      # components/accounts/account-service.yaml). 8102 is transaction-service — this repo has
+      # already been bitten once by a copy-pasted neighbouring port.
+      url: ${ACCOUNT_SERVICE_URL:http://account-service.accounts:8100}
   smallrye-reactive-messaging:
     kafka:
       bootstrap-servers: localhost:29092

--- a/openbank-party-service/src/main/resources/db/migration/V15__party_merge.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V15__party_merge.sql
@@ -1,0 +1,35 @@
+-- Duplicate party identity merge (ADR-0179).
+--
+-- `merged_into` records the surviving party when a duplicate is retired with status MERGED.
+-- Nullable: only ever set on a MERGED row. Self-referencing FK so the relation is traversable
+-- both ways (survivor -> retired duplicates via an index scan, retired -> survivor via the FK).
+--
+-- RESTRICT, not CASCADE: erasing the survivor must not silently drop the pointer that explains
+-- why the retired row exists. A survivor with merged duplicates has to be dealt with explicitly.
+ALTER TABLE parties ADD COLUMN IF NOT EXISTS merged_into UUID;
+
+ALTER TABLE parties
+    DROP CONSTRAINT IF EXISTS fk_parties_merged_into;
+ALTER TABLE parties
+    ADD CONSTRAINT fk_parties_merged_into
+    FOREIGN KEY (merged_into) REFERENCES parties (party_id) ON DELETE RESTRICT;
+
+-- A party can never be merged into itself.
+ALTER TABLE parties
+    DROP CONSTRAINT IF EXISTS ck_parties_merged_into_not_self;
+ALTER TABLE parties
+    ADD CONSTRAINT ck_parties_merged_into_not_self
+    CHECK (merged_into IS NULL OR merged_into <> party_id);
+
+-- MERGED <-> merged_into are two halves of one fact; neither is valid alone.
+-- Enforced in the DB because the pair is what every downstream reader keys off.
+ALTER TABLE parties
+    DROP CONSTRAINT IF EXISTS ck_parties_merged_into_iff_merged;
+ALTER TABLE parties
+    ADD CONSTRAINT ck_parties_merged_into_iff_merged
+    CHECK ((status = 'MERGED') = (merged_into IS NOT NULL));
+
+-- "Which parties were merged into this survivor?" — the reporting/lineage direction.
+-- Partial: only MERGED rows carry the column, so the index stays small.
+CREATE INDEX IF NOT EXISTS idx_parties_merged_into
+    ON parties (merged_into) WHERE merged_into IS NOT NULL;

--- a/openbank-party-service/src/main/resources/db/migration/V15__party_merge.sql
+++ b/openbank-party-service/src/main/resources/db/migration/V15__party_merge.sql
@@ -4,8 +4,9 @@
 -- Nullable: only ever set on a MERGED row. Self-referencing FK so the relation is traversable
 -- both ways (survivor -> retired duplicates via an index scan, retired -> survivor via the FK).
 --
--- RESTRICT, not CASCADE: erasing the survivor must not silently drop the pointer that explains
--- why the retired row exists. A survivor with merged duplicates has to be dealt with explicitly.
+-- RESTRICT rather than CASCADE so a real row DELETE cannot silently orphan the pointer. Note
+-- this is belt-and-braces only: nothing in the service DELETEs a party row today — GDPR Art. 17
+-- erasure UPDATEs the row in place (PartyRepositoryImpl.anonymize), which no FK action covers.
 ALTER TABLE parties ADD COLUMN IF NOT EXISTS merged_into UUID;
 
 ALTER TABLE parties
@@ -21,13 +22,26 @@ ALTER TABLE parties
     ADD CONSTRAINT ck_parties_merged_into_not_self
     CHECK (merged_into IS NULL OR merged_into <> party_id);
 
--- MERGED <-> merged_into are two halves of one fact; neither is valid alone.
--- Enforced in the DB because the pair is what every downstream reader keys off.
+-- Two directions, deliberately NOT a biconditional:
+--
+--   1. MERGED always carries a pointer — the status is meaningless without a survivor to follow.
+--   2. A pointer may only appear on MERGED or CLOSED.
+--
+-- CLOSED is in (2) because GDPR Art. 17 erasure of a retired duplicate flips MERGED -> CLOSED
+-- in place (PartyRepositoryImpl.anonymize) without touching merged_into. A strict biconditional
+-- would abort that UPDATE, making a merged duplicate impossible to erase — an Art. 17 request
+-- would fail outright. The pointer is a lineage reference, not personal data, so it survives
+-- erasure; the PII on the row is anonymized as usual.
 ALTER TABLE parties
     DROP CONSTRAINT IF EXISTS ck_parties_merged_into_iff_merged;
 ALTER TABLE parties
-    ADD CONSTRAINT ck_parties_merged_into_iff_merged
-    CHECK ((status = 'MERGED') = (merged_into IS NOT NULL));
+    DROP CONSTRAINT IF EXISTS ck_parties_merged_into_status;
+ALTER TABLE parties
+    ADD CONSTRAINT ck_parties_merged_into_status
+    CHECK (
+        (status <> 'MERGED' OR merged_into IS NOT NULL)
+        AND (merged_into IS NULL OR status IN ('MERGED', 'CLOSED'))
+    );
 
 -- "Which parties were merged into this survivor?" — the reporting/lineage direction.
 -- Partial: only MERGED rows carry the column, so the index stays small.

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Party Service API
-  version: 1.6.0
+  version: 1.7.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -129,6 +129,35 @@ paths:
       responses:
         '200':
           description: Updated
+
+  /api/v1/parties/{id}/merge:
+    post:
+      tags: [Parties]
+      summary: Merge a duplicate party into a surviving party (ADR-0179)
+      description: >-
+        Retires {id} as a duplicate of mergedIntoPartyId, setting status MERGED. All PII and
+        history are preserved and a PARTY_MERGED event is emitted — this is NOT GDPR Art. 17
+        erasure (DELETE /api/v1/parties/{id}), which anonymizes instead. Refused with 409 while
+        the duplicate still owns an open account: sweep the balances with a ledger ADJUSTMENT
+        journal entry and close the account first.
+      operationId: mergeParty
+      parameters:
+        - $ref: '#/components/parameters/partyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MergePartyRequest'
+      responses:
+        '200':
+          description: The retired party, carrying status MERGED and mergedIntoPartyId
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: >-
+            A merge precondition failed — already merged, the target is itself merged (chains are
+            refused), a party is erased, or the duplicate still owns an open account.
 
   /api/v1/parties/{id}/consent:
     patch:
@@ -409,6 +438,26 @@ components:
           type: string
         address:
           $ref: '#/components/schemas/AddressDto'
+
+    MergePartyRequest:
+      type: object
+      required: [mergedIntoPartyId, reason]
+      properties:
+        mergedIntoPartyId:
+          type: string
+          format: uuid
+          description: >-
+            The surviving party. Must be live and must not itself be merged — resolve chains to
+            the final survivor before calling.
+        reason:
+          type: string
+          description: Operator-supplied justification, recorded on the audit event.
+        approvalReference:
+          type: string
+          nullable: true
+          description: >-
+            The ledger approval that authorised the balance sweep, linking the ADJUSTMENT journal
+            entries to this identity retirement.
 
     UpdateConsentRequest:
       type: object

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMergeTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/application/usecase/PartyServiceMergeTest.kt
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.application.usecase
+
+import com.openbank.party.application.port.`in`.MergePartyCommand
+import com.openbank.party.domain.model.AmlStatus
+import com.openbank.party.domain.model.KycStatus
+import com.openbank.party.domain.model.Party
+import com.openbank.party.domain.model.PartyStatus
+import com.openbank.party.domain.model.PartyType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Optional
+import java.util.UUID
+
+/** ADR-0179 — duplicate party identity merge. */
+class PartyServiceMergeTest {
+
+    private val now = Instant.parse("2025-01-01T00:00:00Z")
+    private val sourceId = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val targetId = UUID.fromString("22222222-2222-2222-2222-222222222222")
+    private val thirdId = UUID.fromString("33333333-3333-3333-3333-333333333333")
+
+    private fun service() = PartyService().apply {
+        partyRepo = mockk()
+        documentRepo = mockk()
+        documentFileRepo = mockk()
+        eventPublisher = mockk(relaxed = true)
+        gdprAggregation = mockk(relaxed = true)
+        accountGuard = mockk()
+        metrics = mockk(relaxed = true)
+        rcPepper = Optional.empty()
+        clock = Clock.fixed(now, ZoneOffset.UTC)
+    }
+
+    private fun party(id: UUID, status: PartyStatus = PartyStatus.ACTIVE, mergedInto: UUID? = null) = Party(
+        id = id,
+        partyType = PartyType.INDIVIDUAL,
+        status = status,
+        legalName = "Person $id",
+        tradingName = null,
+        dateOfBirth = "1990-01-01",
+        nationality = "CZ",
+        taxId = null,
+        registrationNumber = null,
+        email = "$id@example.com",
+        phone = null,
+        address = null,
+        kycStatus = KycStatus.APPROVED,
+        createdAt = now,
+        updatedAt = now,
+        amlStatus = AmlStatus.CLEARED,
+        mergedIntoPartyId = mergedInto,
+    )
+
+    private fun cmd(from: UUID = sourceId, into: UUID = targetId) = MergePartyCommand(
+        id = from,
+        mergedIntoPartyId = into,
+        reason = "duplicate identity",
+        approvalReference = "APR-1",
+    )
+
+    @Test
+    fun `merge retires the source, points it at the survivor and publishes PARTY_MERGED`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns party(sourceId)
+        coEvery { service.partyRepo.findById(targetId) } returns party(targetId)
+        coEvery { service.accountGuard.findOpenAccounts(sourceId) } returns emptyList()
+        val saved = slot<Party>()
+        coEvery { service.partyRepo.update(capture(saved)) } answers { saved.captured }
+
+        val result = service.mergeParty(cmd())
+
+        assertThat(saved.captured.status).isEqualTo(PartyStatus.MERGED)
+        assertThat(saved.captured.mergedIntoPartyId).isEqualTo(targetId)
+        // PII must survive a merge — that is the whole point of not reusing GDPR erasure.
+        assertThat(saved.captured.legalName).isEqualTo("Person $sourceId")
+        assertThat(saved.captured.email).isEqualTo("$sourceId@example.com")
+        coVerify(exactly = 1) { service.eventPublisher.publishPartyMerged(result, targetId) }
+        // A merge is NOT an erasure; emitting one would tell consumers a subject-rights request happened.
+        coVerify(exactly = 0) { service.eventPublisher.publishPartyErased(any()) }
+    }
+
+    @Test
+    fun `merge is refused while the source still owns an open account`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns party(sourceId)
+        coEvery { service.partyRepo.findById(targetId) } returns party(targetId)
+        coEvery { service.accountGuard.findOpenAccounts(sourceId) } returns listOf("CZ6508000000192000145399")
+
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd()) } }
+            .isInstanceOf(PartyMergeRejectedException::class.java)
+            .hasMessageContaining("CZ6508000000192000145399")
+
+        coVerify(exactly = 0) { service.partyRepo.update(any()) }
+    }
+
+    @Test
+    fun `an unreachable account guard aborts the merge rather than allowing it`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns party(sourceId)
+        coEvery { service.partyRepo.findById(targetId) } returns party(targetId)
+        coEvery { service.accountGuard.findOpenAccounts(sourceId) } throws RuntimeException("connection refused")
+
+        // Fail-closed: "we could not ask" must never be treated as "owns nothing".
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd()) } }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("connection refused")
+
+        coVerify(exactly = 0) { service.partyRepo.update(any()) }
+        coVerify(exactly = 0) { service.eventPublisher.publishPartyMerged(any(), any()) }
+    }
+
+    @Test
+    fun `a party cannot be merged into itself`(): Unit = runBlocking {
+        val service = service()
+
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd(from = sourceId, into = sourceId)) } }
+            .isInstanceOf(PartyMergeRejectedException::class.java)
+            .hasMessageContaining("cannot be merged into itself")
+    }
+
+    @Test
+    fun `an already-merged source is refused`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns
+            party(sourceId, PartyStatus.MERGED, mergedInto = thirdId)
+        coEvery { service.partyRepo.findById(targetId) } returns party(targetId)
+
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd()) } }
+            .isInstanceOf(PartyMergeRejectedException::class.java)
+            .hasMessageContaining("already merged")
+    }
+
+    @Test
+    fun `merging into an already-merged target is refused so no chains form`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns party(sourceId)
+        coEvery { service.partyRepo.findById(targetId) } returns
+            party(targetId, PartyStatus.MERGED, mergedInto = thirdId)
+
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd()) } }
+            .isInstanceOf(PartyMergeRejectedException::class.java)
+            .hasMessageContaining("merge into the surviving party instead")
+    }
+
+    @Test
+    fun `an erased source is refused`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns party(sourceId, PartyStatus.CLOSED)
+        coEvery { service.partyRepo.findById(targetId) } returns party(targetId)
+
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd()) } }
+            .isInstanceOf(PartyMergeRejectedException::class.java)
+            .hasMessageContaining("erased")
+    }
+
+    @Test
+    fun `a missing target is a 404, not a merge`(): Unit = runBlocking {
+        val service = service()
+        coEvery { service.partyRepo.findById(sourceId) } returns party(sourceId)
+        coEvery { service.partyRepo.findById(targetId) } returns null
+
+        assertThatThrownBy { runBlocking { service.mergeParty(cmd()) } }
+            .isInstanceOf(PartyNotFoundException::class.java)
+    }
+
+    @Test
+    fun `a late KYC callback never resurrects a merged party`(): Unit = runBlocking {
+        val service = service()
+        val merged = party(sourceId, PartyStatus.MERGED, mergedInto = targetId)
+        coEvery { service.partyRepo.findById(sourceId) } returns merged
+        val saved = slot<Party>()
+        coEvery { service.partyRepo.update(capture(saved)) } answers { saved.captured }
+
+        service.updateKycStatus(sourceId, KycStatus.APPROVED)
+
+        assertThat(saved.captured.status).isEqualTo(PartyStatus.MERGED)
+        assertThat(saved.captured.mergedIntoPartyId).isEqualTo(targetId)
+    }
+}

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/client/AccountServiceClientContractTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/client/AccountServiceClientContractTest.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.openbank.libs.api.pagination.CursorPage
+import com.openbank.libs.api.pagination.PageInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Pins [AccountPageBody] against the shape account-service really emits (ADR-0179).
+ *
+ * This exists because the failure mode is silent. If the field names drift, Jackson does not
+ * throw — it leaves `data` empty, `findOpenAccounts` reports no open accounts, and the merge
+ * guard flips from fail-closed to fail-OPEN, permitting exactly the merge it exists to refuse.
+ * The first version of this client used `items`/`pageInfo`/`iban` and would have done that.
+ *
+ * The payload is built from the real [CursorPage] type rather than a hand-written JSON string,
+ * so a rename in openbank-libs breaks this test instead of silently disarming the guard.
+ */
+class AccountServiceClientContractTest {
+
+    private val mapper = ObjectMapper().registerKotlinModule()
+
+    private data class AccountResponseLike(
+        val id: UUID,
+        val accountNumber: String,
+        val partyId: UUID,
+        val currencyCode: String,
+        val status: String,
+    )
+
+    @Test
+    fun `deserializes a real CursorPage payload, preserving accounts and cursor`() {
+        val accountId = UUID.randomUUID()
+        val payload = mapper.writeValueAsString(
+            CursorPage(
+                data = listOf(
+                    AccountResponseLike(accountId, "CZ6508000000192000145399", UUID.randomUUID(), "CZK", "ACTIVE"),
+                ),
+                pagination = PageInfo(limit = 100, hasNextPage = true, nextCursor = "next-page-cursor"),
+            ),
+        )
+
+        val decoded = mapper.readValue(payload, AccountPageBody::class.java)
+
+        assertThat(decoded.data).hasSize(1)
+        assertThat(decoded.data.single().id).isEqualTo(accountId)
+        assertThat(decoded.data.single().accountNumber).isEqualTo("CZ6508000000192000145399")
+        assertThat(decoded.data.single().status).isEqualTo("ACTIVE")
+        assertThat(decoded.pagination?.hasNextPage).isTrue()
+        assertThat(decoded.pagination?.nextCursor).isEqualTo("next-page-cursor")
+    }
+
+    @Test
+    fun `an empty page deserializes without loss`() {
+        val payload = mapper.writeValueAsString(
+            CursorPage(
+                data = emptyList<AccountResponseLike>(),
+                pagination = PageInfo(limit = 100, hasNextPage = false),
+            ),
+        )
+
+        val decoded = mapper.readValue(payload, AccountPageBody::class.java)
+
+        assertThat(decoded.data).isEmpty()
+        assertThat(decoded.pagination?.hasNextPage).isFalse()
+        assertThat(decoded.pagination?.nextCursor).isNull()
+    }
+
+    @Test
+    fun `the account status account-service emits for a closed account is the string the filter matches`() {
+        // findOpenAccounts filters on STATUS_CLOSED; if account-service ever renames the enum
+        // constant, every closed account starts counting as open and the guard over-blocks
+        // (loud, safe) — the reverse of the silent field-name failure above.
+        val payload = mapper.writeValueAsString(
+            CursorPage(
+                data = listOf(
+                    AccountResponseLike(UUID.randomUUID(), "CZ99", UUID.randomUUID(), "CZK", "CLOSED"),
+                ),
+                pagination = PageInfo(limit = 100, hasNextPage = false),
+            ),
+        )
+
+        val decoded = mapper.readValue(payload, AccountPageBody::class.java)
+
+        assertThat(decoded.data.single().status).isEqualTo("CLOSED")
+    }
+}


### PR DESCRIPTION
Refs #1782
Refs ADR-0179

## What

Adds an explicit merge operation for duplicate party identities, distinct from GDPR erasure.

## Why

ADR-0072 defends "1 person = 1 party" at *creation* time only — an RČ blind index and a four-eyes case queue that both run before a party exists. Once two parties for one person are live, there is no remediation path.

That gap has a sharp edge. The only writer of `PartyStatus.CLOSED` is Art. 17 erasure, which anonymises PII and emits `PARTY_ERASED`. Retiring a duplicate therefore meant recording a false subject-rights request and destroying the very history the merge exists to preserve. The alternative available without code — move the balance as a customer payment, then erase the source — leaves the ledger attesting that one legal person paid another and was then erased.

## Changes

- `PartyStatus.MERGED` + nullable `merged_into` (V15). Terminal exactly as `CLOSED` is, so a late KYC/AML callback cannot resurrect a retired duplicate. DB enforces `(status = 'MERGED') = (merged_into IS NOT NULL)`; FK is `ON DELETE RESTRICT`.
- `POST /api/v1/parties/{id}/merge` — OPERATOR/ADMIN, authz `party.merge`, audited. Refuses self-merge, an already-merged or erased party on either side, and a merged target (no chains).
- `PARTY_MERGED` event, deliberately not `PARTY_ERASED`. Nothing is anonymised.
- Account guard refusing the merge while the duplicate still owns an open account. **Fail-closed**: an unreachable account-service aborts. Account closure does not verify the balance (ADR-0109 option B), so a wrongly-permitted merge would strand funds on a retired identity with nothing downstream to notice.
- First M2M call from this service, so it brings the fleet-standard `quarkus.oidc-client` block. Token resolves to `ROLE_OPERATOR` — nothing in either Keycloak realm grants `ROLE_SERVICE`.

## Not in this PR

- The balance sweep as a ledger `ADJUSTMENT` journal entry referencing the merge approval (money-path, needs 2 approvals + threat model).
- Consumer adoption of `merged_into`. Until each service holding a `partyId` follows it, a stale id still resolves to the retired row — called out as a negative consequence in the ADR.
- Four-eyes on the merge endpoint itself, and an admin-UI action.

## Verification

- `detekt`, `ktlintCheck`, `test`, `quarkusBuild` all green.
- 9 new unit tests. Guards were mutation-checked: removing the `MERGED` terminal branch and the account guard makes exactly 3 of them fail, then pass again on restore — they are not vacuous.
- API contract 1.6.0 → 1.7.0 (additive). Checked against current `origin/main` and open PRs; no competing claim on the version.

## Reviewer notes

Two unrelated defects were found while researching this and are **not** fixed here:

1. `GdprAggregationAdapter` calls kyc-service and card-issuance-service with **no Authorization header**; both targets are role-protected. The 401 is swallowed as "no data", so Art. 15 subject-access exports silently ship without KYC and card PII.
2. `PartyService` KDoc cites ADR-0073 for the two-key activation gate, but ADR-0073 is about hardware-backed credential storage. Several ADR citations in this service look stale.