### PR TITLE
fix(party): authenticate the GDPR Art. 15 aggregation hops

### DIFF
--- a/openbank-infra/gitops/components/kyc/network-policies.yaml
+++ b/openbank-infra/gitops/components/kyc/network-policies.yaml
@@ -41,6 +41,9 @@ spec:
               kubernetes.io/metadata.name: customer-edge
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: party
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -67,6 +67,15 @@ spec:
                 secretKeyRef:
                   name: party-service-oidc
                   key: OIDC_CLIENT_SECRET
+            # GDPR Art. 15 aggregation hops (ADR-0118 §6). Declared here — not only in
+            # application.yaml — because gen-network-policies.py derives the NetworkPolicy
+            # edges from the env URLs a Deployment declares: without these two entries the
+            # party → kyc / party → card-issuance calls are DROPPED by the VPC CNI agent
+            # even when the M2M bearer is correct.
+            - name: OPENBANK_KYC_SERVICE_URL
+              value: http://kyc-service.kyc.svc:8114
+            - name: OPENBANK_CARD_SERVICE_URL
+              value: http://card-issuance-service.payments.svc:8118
             - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://tempo.observability.svc:4317"
             - name: OTEL_TRACES_SAMPLER_ARG

--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -41,6 +41,9 @@ spec:
               kubernetes.io/metadata.name: customer-edge
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: party
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: security-scanner
         - namespaceSelector:
             matchLabels:

--- a/openbank-party-service/build.gradle.kts
+++ b/openbank-party-service/build.gradle.kts
@@ -21,6 +21,11 @@ dependencies {
     implementation(libs.quarkus.micrometer.registry.prometheus)
     implementation(libs.quarkus.opentelemetry)
     implementation(libs.quarkus.oidc)
+    // The oidc-client filter mints the openbank-services M2M token the GDPR Art. 15 aggregation
+    // hops to kyc-service / card-issuance-service require — both endpoints are @RolesAllowed.
+    implementation(libs.quarkus.rest.client.reactive)
+    implementation(libs.quarkus.rest.client.reactive.jackson)
+    implementation(libs.quarkus.oidc.client.reactive.filter)
     implementation(libs.quarkus.config.yaml)
     implementation(libs.quarkus.smallrye.openapi)
     implementation(libs.quarkus.smallrye.fault.tolerance)

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/application/port/out/PartyPorts.kt
@@ -69,14 +69,27 @@ interface PartyDocumentFileRepository {
 }
 
 /**
+ * Raised when a GDPR Art. 15 aggregation hop is rejected by the downstream's authorization layer
+ * (401/403). Deliberately NOT folded into the best-effort degradation below: an auth failure means
+ * the data subject's PII exists and we were refused it, which is categorically different from
+ * "this party has no KYC case". Silently returning null there ships an export that is incomplete
+ * and indistinguishable from a complete one — the caller must see a 502 instead.
+ */
+class GdprAggregationAuthException(service: String, status: Int) :
+    RuntimeException("GDPR aggregation refused by $service: HTTP $status")
+
+/**
  * Outbound port for GDPR Art. 15 aggregation: fetches PII from downstream services
  * on a best-effort basis (null = service unavailable, export proceeds with party PII only).
+ *
+ * Best-effort covers *absence* and *unavailability* only. An authorization rejection throws
+ * [GdprAggregationAuthException] rather than degrading — see its KDoc.
  */
 interface GdprAggregationPort {
-    /** Returns the latest KYC case for [partyId], or null if unavailable. */
+    /** Returns the latest KYC case for [partyId], or null if absent/unavailable. */
     suspend fun fetchKycData(partyId: java.util.UUID): Map<String, Any?>?
 
-    /** Returns all cards for [partyId], or empty list if unavailable. */
+    /** Returns all cards for [partyId], or empty list if absent/unavailable. */
     suspend fun fetchCardData(partyId: java.util.UUID): List<Map<String, Any?>>
 }
 

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/GdprDownstreamClients.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/client/GdprDownstreamClients.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.party.infrastructure.client
+
+import io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient
+import java.util.UUID
+
+/**
+ * Typed client for kyc-service's per-party case lookup, used by the GDPR Art. 15 export.
+ *
+ * `GET /api/v1/kyc/cases/party/{partyId}` is `@RolesAllowed(VIEWER, OPERATOR, ADMIN, KYC, …)`, so
+ * the call must carry an M2M bearer via [OidcClientRequestReactiveFilter] (oidc-client
+ * `openbank-services` → ROLE_OPERATOR). Before this client existed the adapter issued a raw
+ * `java.net.http` GET with no Authorization header, which every deployed environment answered 401.
+ */
+@RegisterRestClient(configKey = "kyc-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/kyc/cases")
+@Produces(MediaType.APPLICATION_JSON)
+interface KycServiceRestClient {
+
+    @GET
+    @Path("/party/{partyId}")
+    fun getCaseByParty(@PathParam("partyId") partyId: UUID): Uni<Map<String, Any?>>
+}
+
+/**
+ * Typed client for card-issuance-service's per-party card list, used by the GDPR Art. 15 export.
+ *
+ * `GET /api/v1/cards/party/{partyId}` is `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN")`
+ * plus `@Authorize(action = "card.list")`; the shared `rest.rego` operator-read-any rule admits the
+ * ROLE_OPERATOR the client_credentials token carries, so the same M2M filter covers both hops.
+ */
+@RegisterRestClient(configKey = "card-service")
+@RegisterProvider(OidcClientRequestReactiveFilter::class)
+@Path("/api/v1/cards")
+@Produces(MediaType.APPLICATION_JSON)
+interface CardServiceRestClient {
+
+    @GET
+    @Path("/party/{partyId}")
+    fun listByParty(@PathParam("partyId") partyId: UUID): Uni<List<Map<String, Any?>>>
+}

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/gdpr/GdprAggregationAdapter.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/gdpr/GdprAggregationAdapter.kt
@@ -4,100 +4,78 @@
 
 package com.openbank.party.infrastructure.gdpr
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.openbank.party.application.port.out.GdprAggregationAuthException
 import com.openbank.party.application.port.out.GdprAggregationPort
+import com.openbank.party.infrastructure.client.CardServiceRestClient
+import com.openbank.party.infrastructure.client.KycServiceRestClient
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
 import jakarta.enterprise.context.ApplicationScoped
-import jakarta.inject.Inject
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.eclipse.microprofile.config.inject.ConfigProperty
+import jakarta.ws.rs.WebApplicationException
+import org.eclipse.microprofile.rest.client.inject.RestClient
 import org.jboss.logging.Logger
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.time.Duration
-import java.util.Optional
 import java.util.UUID
 
 /**
- * GDPR Art. 15 aggregation adapter — fetches PII from kyc-service and card-issuance-service
- * on a best-effort basis. A downstream being unavailable must never block the export; null/empty
- * results are acceptable and annotated in the response so the DPO knows to follow up manually.
+ * GDPR Art. 15 aggregation adapter — fetches PII from kyc-service and card-issuance-service.
  *
- * HTTP is made synchronously via java.net.http.HttpClient inside [withContext(Dispatchers.IO)]
- * so the Vert.x event loop is never blocked. No MicroProfile REST client is used to avoid the
- * ClientHeadersFactory classpath issue (issue #247).
+ * Both hops go through a MicroProfile REST client carrying an M2M bearer
+ * ([io.quarkus.oidc.client.reactive.filter.OidcClientRequestReactiveFilter], oidc-client
+ * `openbank-services`). The previous implementation built raw `java.net.http` requests with **no
+ * Authorization header**, which both role-protected endpoints answered 401; the adapter treated
+ * any non-200 as "no data", so every deployed Art. 15 export silently shipped without KYC and card
+ * PII while still reading as successful. The old KDoc justified the raw client with "the
+ * ClientHeadersFactory classpath issue (issue #247)" — #247 is an unrelated (and merged) admin-ui
+ * dossier-status change, so that constraint never applied here.
+ *
+ * Failure handling is deliberately split:
+ *  - 401/403 → [GdprAggregationAuthException]. We were *refused* data that exists; degrading to
+ *    null would be indistinguishable from the subject genuinely having no case/cards.
+ *  - 404 → null / empty list. The subject genuinely has no KYC case or no cards.
+ *  - anything else (timeout, 5xx, DNS) → null / empty list, logged. A downstream outage must not
+ *    block the data subject's request; the DPO follows up from the log.
  */
 @ApplicationScoped
-class GdprAggregationAdapter : GdprAggregationPort {
-
-    @Inject
-    lateinit var objectMapper: ObjectMapper
-
-    @ConfigProperty(name = "openbank.gdpr.kyc-service-url")
-    var kycServiceUrl: Optional<String> = Optional.empty()
-
-    @ConfigProperty(name = "openbank.gdpr.card-service-url")
-    var cardServiceUrl: Optional<String> = Optional.empty()
+class GdprAggregationAdapter(
+    @RestClient private val kycClient: KycServiceRestClient,
+    @RestClient private val cardClient: CardServiceRestClient,
+) : GdprAggregationPort {
 
     private val log = Logger.getLogger(GdprAggregationAdapter::class.java)
 
-    private val http: HttpClient by lazy {
-        HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS.toLong()))
-            .build()
-    }
+    override suspend fun fetchKycData(partyId: UUID): Map<String, Any?>? = kycClient.getCaseByParty(partyId)
+        .onFailure().recoverWithUni(recover<Map<String, Any?>>(KYC, partyId, null))
+        .awaitSuspending()
 
-    override suspend fun fetchKycData(partyId: UUID): Map<String, Any?>? {
-        val base = kycServiceUrl.orElse("").takeIf { it.isNotBlank() } ?: return null
-        return withContext(Dispatchers.IO) {
-            runCatching {
-                val req = HttpRequest.newBuilder()
-                    .uri(URI.create("$base/api/v1/kyc/cases/party/$partyId"))
-                    .timeout(Duration.ofSeconds(READ_TIMEOUT_SECONDS.toLong()))
-                    .GET()
-                    .build()
-                val resp = http.send(req, HttpResponse.BodyHandlers.ofString())
-                if (resp.statusCode() == HTTP_OK) {
-                    @Suppress("UNCHECKED_CAST")
-                    objectMapper.readValue(resp.body(), Map::class.java) as Map<String, Any?>
-                } else {
-                    log.warnf("gdpr.aggregate.kyc status=%d partyId=%s", resp.statusCode(), partyId)
-                    null
-                }
-            }.onFailure { e ->
-                log.warnf(e, "gdpr.aggregate.kyc FAILED partyId=%s", partyId)
-            }.getOrNull()
-        }
-    }
+    override suspend fun fetchCardData(partyId: UUID): List<Map<String, Any?>> = cardClient.listByParty(partyId)
+        .onFailure().recoverWithUni(recover(CARDS, partyId, emptyList()))
+        .awaitSuspending()
 
-    override suspend fun fetchCardData(partyId: UUID): List<Map<String, Any?>> {
-        val base = cardServiceUrl.orElse("").takeIf { it.isNotBlank() } ?: return emptyList()
-        return withContext(Dispatchers.IO) {
-            runCatching {
-                val req = HttpRequest.newBuilder()
-                    .uri(URI.create("$base/api/v1/cards/party/$partyId"))
-                    .timeout(Duration.ofSeconds(READ_TIMEOUT_SECONDS.toLong()))
-                    .GET()
-                    .build()
-                val resp = http.send(req, HttpResponse.BodyHandlers.ofString())
-                if (resp.statusCode() == HTTP_OK) {
-                    @Suppress("UNCHECKED_CAST")
-                    objectMapper.readValue(resp.body(), List::class.java) as List<Map<String, Any?>>
-                } else {
-                    log.warnf("gdpr.aggregate.cards status=%d partyId=%s", resp.statusCode(), partyId)
-                    emptyList()
-                }
-            }.onFailure { e ->
-                log.warnf(e, "gdpr.aggregate.cards FAILED partyId=%s", partyId)
-            }.getOrElse { emptyList() }
+    /**
+     * Splits a downstream failure into "refused" and "absent or unavailable". Expressed as a
+     * Mutiny recovery rather than a `catch` so the authz case propagates as a real failure on the
+     * reactive chain instead of being reconstructed after the fact.
+     */
+    private fun <T> recover(service: String, partyId: UUID, fallback: T?): (Throwable) -> Uni<T> = { t ->
+        val status = (t as? WebApplicationException)?.response?.status
+        if (status == UNAUTHORIZED || status == FORBIDDEN) {
+            log.errorf(
+                "gdpr.aggregate.%s DENIED status=%d partyId=%s — export must not proceed",
+                service,
+                status,
+                partyId,
+            )
+            Uni.createFrom().failure(GdprAggregationAuthException(service, status))
+        } else {
+            log.warnf(t, "gdpr.aggregate.%s degraded status=%s partyId=%s", service, status ?: "unreachable", partyId)
+            Uni.createFrom().item { fallback }
         }
     }
 
     companion object {
-        private const val CONNECT_TIMEOUT_SECONDS = 1
-        private const val READ_TIMEOUT_SECONDS = 3
-        private const val HTTP_OK = 200
+        private const val UNAUTHORIZED = 401
+        private const val FORBIDDEN = 403
+        private const val KYC = "kyc-service"
+        private const val CARDS = "card-issuance-service"
     }
 }

--- a/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
+++ b/openbank-party-service/src/main/kotlin/com/openbank/party/infrastructure/rest/ExceptionMappers.kt
@@ -7,6 +7,7 @@ package com.openbank.party.infrastructure.rest
 import com.openbank.libs.api.error.ApiError
 import com.openbank.libs.api.error.ErrorCode
 import com.openbank.libs.flags.FeatureDisabledException
+import com.openbank.party.application.port.out.GdprAggregationAuthException
 import com.openbank.party.application.usecase.PartyAlreadyExistsException
 import com.openbank.party.application.usecase.PartyNotFoundException
 import io.vertx.pgclient.PgException
@@ -68,4 +69,27 @@ class FeatureDisabledMapper : ExceptionMapper<FeatureDisabledException> {
     override fun toResponse(e: FeatureDisabledException) = Response.status(404).entity(
         ApiError(UUID.randomUUID().toString(), 404, ErrorCode.NOT_FOUND.code, "feature '${e.flag}' is not enabled"),
     ).build()
+}
+
+/**
+ * Maps a [GdprAggregationAuthException] to 502. An Art. 15 export whose KYC/card hop was refused
+ * on authz grounds is NOT a valid export — returning 200 with those sections absent would be
+ * indistinguishable from a subject who genuinely holds no KYC case and no cards, and the data
+ * subject would receive a silently incomplete Right-of-Access response. Fail loudly so the DPO
+ * re-runs it rather than files it.
+ */
+@Provider
+class GdprAggregationAuthMapper : ExceptionMapper<GdprAggregationAuthException> {
+    override fun toResponse(e: GdprAggregationAuthException) = Response.status(BAD_GATEWAY).entity(
+        ApiError(
+            UUID.randomUUID().toString(),
+            BAD_GATEWAY,
+            "GDPR_AGGREGATION_DENIED",
+            e.message ?: "GDPR aggregation refused by a downstream service",
+        ),
+    ).build()
+
+    companion object {
+        private const val BAD_GATEWAY = 502
+    }
 }

--- a/openbank-party-service/src/main/resources/application.yaml
+++ b/openbank-party-service/src/main/resources/application.yaml
@@ -46,6 +46,23 @@ quarkus:
       secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
     tls:
       verification: none
+  # Outbound M2M token for the GDPR Art. 15 aggregation hops. The export reads another service's
+  # PII on the data subject's behalf, so party-service authenticates as the service, not as the
+  # human caller (whose own token has no KYC/card role and never leaves customer-edge anyway).
+  oidc-client:
+    auth-server-url: ${QUARKUS_OIDC_AUTH_SERVER_URL:http://localhost:8080/realms/openbank}
+    client-id: openbank-services
+    credentials:
+      secret: ${OIDC_CLIENT_SECRET:CHANGE_ME_LOCAL_DEV_ONLY}
+    grant:
+      type: client
+  rest-client:
+    kyc-service:
+      url: ${OPENBANK_KYC_SERVICE_URL:http://localhost:8114}
+      scope: jakarta.inject.Singleton
+    card-service:
+      url: ${OPENBANK_CARD_SERVICE_URL:http://localhost:8118}
+      scope: jakarta.inject.Singleton
   smallrye-reactive-messaging:
     kafka:
       bootstrap-servers: localhost:29092
@@ -120,6 +137,8 @@ mp:
         json: false
     oidc:
       enabled: false
+    oidc-client:
+      enabled: false
 "%test":
   quarkus:
     datasource:
@@ -132,6 +151,8 @@ mp:
     management:
       enabled: false
     oidc:
+      enabled: false
+    oidc-client:
       enabled: false
     devservices:
       enabled: false
@@ -151,8 +172,6 @@ openbank:
     commit: "${GIT_COMMIT:unknown}"
   gdpr:
     retention-days: 2555
-    kyc-service-url: "${OPENBANK_KYC_SERVICE_URL:http://kyc-service.kyc:8114}"
-    card-service-url: "${OPENBANK_CARD_SERVICE_URL:http://card-issuance-service.card-issuance:8118}"
   # Feature flags (ADR-0067) — first pilot adopter. flagd serves OFREP HTTP on :8016
   # (8013 is gRPC, 8014 is management). Fail-static: no sidecar reachable → every flag
   # resolves to its caller default, so the same image runs locally without flagd.

--- a/openbank-party-service/src/main/resources/openapi.yaml
+++ b/openbank-party-service/src/main/resources/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: Party Service API
-  version: 1.6.0
+  version: 1.7.0
   description: Legal entity and individual party management with document storage.
   license:
     name: Apache-2.0
@@ -277,9 +277,13 @@ paths:
       tags: [Parties]
       summary: Export all PII held for a party — GDPR Art. 15 Right of Access
       description: >-
-        Returns the party-service-direct PII for the data subject (personal details,
-        address, and identity-document metadata). KYC and card PII are held by the
-        respective services; aggregating them is a tracked follow-up (ADR-0118 §6).
+        Returns the full PII set held for the data subject: the party-service-direct data
+        (personal details, address, identity-document metadata) plus the KYC case and card
+        records aggregated from kyc-service and card-issuance-service (ADR-0118 §6).
+        A downstream that is unreachable or holds no record degrades to an absent section;
+        a downstream that *refuses* the aggregation call on authorization grounds fails the
+        whole export with 502, because a silently incomplete Art. 15 response is
+        indistinguishable from a complete one.
       operationId: exportPartyGdpr
       security:
         - bearerAuth: []
@@ -294,6 +298,14 @@ paths:
                 $ref: '#/components/schemas/GdprExport'
         '404':
           $ref: '#/components/responses/NotFound'
+        '502':
+          description: >-
+            A downstream aggregation hop (kyc-service or card-issuance-service) refused the
+            call with 401/403. The export is NOT returned — retry once the M2M grant is fixed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
 
 components:
   parameters:

--- a/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/gdpr/GdprAggregationAdapterTest.kt
+++ b/openbank-party-service/src/test/kotlin/com/openbank/party/infrastructure/gdpr/GdprAggregationAdapterTest.kt
@@ -4,16 +4,17 @@
 
 package com.openbank.party.infrastructure.gdpr
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.kotlinModule
-import com.sun.net.httpserver.HttpServer
+import com.openbank.party.application.port.out.GdprAggregationAuthException
+import com.openbank.party.infrastructure.client.CardServiceRestClient
+import com.openbank.party.infrastructure.client.KycServiceRestClient
+import io.mockk.every
+import io.mockk.mockk
+import io.smallrye.mutiny.Uni
+import jakarta.ws.rs.WebApplicationException
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import java.net.InetSocketAddress
-import java.util.Optional
 import java.util.UUID
 
 /**
@@ -21,58 +22,34 @@ import java.util.UUID
  * kyc-service (`GET /api/v1/kyc/cases/party/{partyId}`) and card-issuance-service
  * (`GET /api/v1/cards/party/{partyId}`), issue #268 / ADR-0118 §6.
  *
- * Uses a real loopback [HttpServer] rather than mocking [java.net.http.HttpClient] directly — the
- * adapter builds its own HttpClient internally, so the only seam available is the actual socket
- * (same pattern as SanctionsImportServiceTest).
+ * These tests exist for the distinction the previous suite could not express. It drove a loopback
+ * HTTP server and asserted only "200 → data" and "error → degrade", so a **401 on every call in
+ * every deployed environment** (the old raw `java.net.http` client sent no Authorization header,
+ * and both endpoints are `@RolesAllowed`) was indistinguishable from a subject who genuinely holds
+ * no KYC case and no cards. Both read as a successful, empty export.
  *
- * The contract under test is "best-effort": a downstream that is unreachable, absent (404), or
- * misconfigured (no base URL) must never fail the export — it degrades to null/empty so the DPO
- * can follow up manually, rather than blocking the data subject's Art. 15 request entirely.
+ * So the contract has two halves and each needs its own assertion:
+ *  - absent (404) or unavailable (5xx, connect failure) → degrade to null/empty, export ships;
+ *  - refused (401/403) → [GdprAggregationAuthException], export must NOT ship.
  */
 class GdprAggregationAdapterTest {
 
-    private val mapper: ObjectMapper = ObjectMapper()
-        .registerModule(kotlinModule())
-        .registerModule(JavaTimeModule())
+    private val kycClient: KycServiceRestClient = mockk()
+    private val cardClient: CardServiceRestClient = mockk()
+    private val adapter = GdprAggregationAdapter(kycClient, cardClient)
 
-    private var server: HttpServer? = null
+    private val partyId: UUID = UUID.randomUUID()
 
-    @AfterEach
-    fun tearDown() {
-        server?.stop(0)
-    }
-
-    private fun serveOnce(path: String, status: Int, body: String): String {
-        val httpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
-        httpServer.createContext(path) { exchange ->
-            val bytes = body.toByteArray(Charsets.UTF_8)
-            exchange.responseHeaders.add("Content-Type", "application/json")
-            exchange.sendResponseHeaders(status, if (bytes.isEmpty()) -1 else bytes.size.toLong())
-            exchange.responseBody.use { if (bytes.isNotEmpty()) it.write(bytes) }
-        }
-        httpServer.start()
-        server = httpServer
-        return "http://127.0.0.1:${httpServer.address.port}"
-    }
-
-    private fun adapter(kycUrl: String? = null, cardUrl: String? = null) = GdprAggregationAdapter().also {
-        it.objectMapper = mapper
-        it.kycServiceUrl = Optional.ofNullable(kycUrl)
-        it.cardServiceUrl = Optional.ofNullable(cardUrl)
-    }
+    private fun <T> failing(status: Int): Uni<T> = Uni.createFrom().failure(WebApplicationException(status))
 
     // ──── fetchKycData ────────────────────────────────────────────────────────
 
     @Test
-    fun `fetchKycData returns the deserialised case when kyc-service responds 200`(): Unit = runBlocking {
-        val partyId = UUID.randomUUID()
-        val base = serveOnce(
-            "/api/v1/kyc/cases/party/$partyId",
-            200,
-            """{"status":"APPROVED","riskLevel":"LOW"}""",
-        )
+    fun `fetchKycData returns the case when kyc-service responds 200`(): Unit = runBlocking {
+        every { kycClient.getCaseByParty(partyId) } returns
+            Uni.createFrom().item(mapOf<String, Any?>("status" to "APPROVED", "riskLevel" to "LOW"))
 
-        val result = adapter(kycUrl = base).fetchKycData(partyId)
+        val result = adapter.fetchKycData(partyId)
 
         assertThat(result).isNotNull
         assertThat(result!!["status"]).isEqualTo("APPROVED")
@@ -80,72 +57,86 @@ class GdprAggregationAdapterTest {
     }
 
     @Test
-    fun `fetchKycData returns null when kyc-service has no case for the party (404)`(): Unit = runBlocking {
-        val partyId = UUID.randomUUID()
-        val base = serveOnce("/api/v1/kyc/cases/party/$partyId", 404, "")
+    fun `fetchKycData degrades to null when the party genuinely has no KYC case (404)`(): Unit = runBlocking {
+        every { kycClient.getCaseByParty(partyId) } returns failing(404)
 
-        val result = adapter(kycUrl = base).fetchKycData(partyId)
-
-        assertThat(result).isNull()
+        assertThat(adapter.fetchKycData(partyId)).isNull()
     }
 
     @Test
-    fun `fetchKycData returns null without throwing when the base URL is unset`(): Unit = runBlocking {
-        val result = adapter(kycUrl = null).fetchKycData(UUID.randomUUID())
+    fun `fetchKycData degrades to null when kyc-service is unavailable (503)`(): Unit = runBlocking {
+        every { kycClient.getCaseByParty(partyId) } returns failing(503)
 
-        assertThat(result).isNull()
+        assertThat(adapter.fetchKycData(partyId)).isNull()
     }
 
     @Test
-    fun `fetchKycData returns null without throwing when kyc-service is unreachable`(): Unit = runBlocking {
-        // Nothing listening on this port — connection refused must degrade gracefully, not throw.
-        val result = adapter(kycUrl = "http://127.0.0.1:1").fetchKycData(UUID.randomUUID())
+    fun `fetchKycData degrades to null when kyc-service is unreachable`(): Unit = runBlocking {
+        every { kycClient.getCaseByParty(partyId) } returns
+            Uni.createFrom().failure(java.net.ConnectException("connection refused"))
 
-        assertThat(result).isNull()
+        assertThat(adapter.fetchKycData(partyId)).isNull()
+    }
+
+    @Test
+    fun `fetchKycData THROWS on 401 instead of reporting the subject has no KYC case`(): Unit = runBlocking {
+        every { kycClient.getCaseByParty(partyId) } returns failing(401)
+
+        assertThatThrownBy { runBlocking { adapter.fetchKycData(partyId) } }
+            .isInstanceOf(GdprAggregationAuthException::class.java)
+            .hasMessageContaining("kyc-service")
+            .hasMessageContaining("401")
+    }
+
+    @Test
+    fun `fetchKycData THROWS on 403`(): Unit = runBlocking {
+        every { kycClient.getCaseByParty(partyId) } returns failing(403)
+
+        assertThatThrownBy { runBlocking { adapter.fetchKycData(partyId) } }
+            .isInstanceOf(GdprAggregationAuthException::class.java)
     }
 
     // ──── fetchCardData ───────────────────────────────────────────────────────
 
     @Test
-    fun `fetchCardData returns the deserialised card list when card-issuance-service responds 200`(): Unit =
-        runBlocking {
-            val partyId = UUID.randomUUID()
-            val base = serveOnce(
-                "/api/v1/cards/party/$partyId",
-                200,
-                """[{"maskedPan":"**** **** **** 1234","status":"ACTIVE"}]""",
-            )
+    fun `fetchCardData returns the cards when card-issuance-service responds 200`(): Unit = runBlocking {
+        every { cardClient.listByParty(partyId) } returns
+            Uni.createFrom().item(listOf(mapOf<String, Any?>("maskedPan" to "**** **** **** 1234")))
 
-            val result = adapter(cardUrl = base).fetchCardData(partyId)
+        val result = adapter.fetchCardData(partyId)
 
-            assertThat(result).hasSize(1)
-            assertThat(result.single()["maskedPan"]).isEqualTo("**** **** **** 1234")
-        }
+        assertThat(result).hasSize(1)
+        assertThat(result.single()["maskedPan"]).isEqualTo("**** **** **** 1234")
+    }
 
     @Test
     fun `fetchCardData returns an empty list when the party holds no cards`(): Unit = runBlocking {
-        val partyId = UUID.randomUUID()
-        val base = serveOnce("/api/v1/cards/party/$partyId", 200, "[]")
+        every { cardClient.listByParty(partyId) } returns Uni.createFrom().item(emptyList())
 
-        val result = adapter(cardUrl = base).fetchCardData(partyId)
-
-        assertThat(result).isEmpty()
+        assertThat(adapter.fetchCardData(partyId)).isEmpty()
     }
 
     @Test
-    fun `fetchCardData returns an empty list without throwing when the base URL is unset`(): Unit = runBlocking {
-        val result = adapter(cardUrl = null).fetchCardData(UUID.randomUUID())
+    fun `fetchCardData degrades to empty when card-issuance-service errors (500)`(): Unit = runBlocking {
+        every { cardClient.listByParty(partyId) } returns failing(500)
 
-        assertThat(result).isEmpty()
+        assertThat(adapter.fetchCardData(partyId)).isEmpty()
     }
 
     @Test
-    fun `fetchCardData returns an empty list without throwing when card-issuance-service errors`(): Unit = runBlocking {
-        val partyId = UUID.randomUUID()
-        val base = serveOnce("/api/v1/cards/party/$partyId", 500, """{"error":"boom"}""")
+    fun `fetchCardData THROWS on 401 instead of reporting the subject holds no cards`(): Unit = runBlocking {
+        every { cardClient.listByParty(partyId) } returns failing(401)
 
-        val result = adapter(cardUrl = base).fetchCardData(partyId)
+        assertThatThrownBy { runBlocking { adapter.fetchCardData(partyId) } }
+            .isInstanceOf(GdprAggregationAuthException::class.java)
+            .hasMessageContaining("card-issuance-service")
+    }
 
-        assertThat(result).isEmpty()
+    @Test
+    fun `fetchCardData THROWS on 403`(): Unit = runBlocking {
+        every { cardClient.listByParty(partyId) } returns failing(403)
+
+        assertThatThrownBy { runBlocking { adapter.fetchCardData(partyId) } }
+            .isInstanceOf(GdprAggregationAuthException::class.java)
     }
 }


### PR DESCRIPTION
Closes #1784

## What was wrong

`GdprAggregationAdapter` built raw `java.net.http` GETs with **no Authorization header** to two role-protected endpoints:

| hop | guard |
|---|---|
| `GET {kyc}/api/v1/kyc/cases/party/{id}` | `@RolesAllowed(VIEWER, OPERATOR, ADMIN, KYC, KYC_OPENER, KYC_REVIEWER, COMPLIANCE, SERVICE)` |
| `GET {card}/api/v1/cards/party/{id}` | `@RolesAllowed("ROLE_VIEWER","ROLE_OPERATOR","ROLE_ADMIN")` + `@Authorize(action = "card.list")` |

Both answered 401 in every deployed environment. The adapter treated any non-200 as "no data" (`null` / `emptyList` + a `log.warnf`), which is indistinguishable from a party genuinely holding no KYC case and no cards. **Every GDPR Art. 15 subject-access export shipped without the KYC and card PII and still read as successful.**

The class KDoc justified the raw client "to avoid the ClientHeadersFactory classpath issue (issue #247)". I checked: #247 is an unrelated, merged admin-ui dossier-status change. That constraint never applied here — auth looks like collateral of a workaround for a problem that was never this one.

## Second, independent blocker (not in the original report)

`gen-network-policies.py` derives NetworkPolicy edges from the `http://<svc>.<ns>.svc:<port>` URLs a Deployment declares in **env**. Both downstream URLs lived only in `application.yaml`, so `party` was absent from the `kyc-service` and `card-issuance-service` ingress allow-lists. With the VPC CNI agent in standard mode (ADR-0060) those calls are DROPPED — **fixing the bearer alone would not have made this work.** Declared both in `party-service.yaml` and regenerated.

Two traps worth recording:
- The generator matches only URLs carrying the literal `.svc` suffix. My first pass wrote `http://kyc-service.kyc:8114`, the regen ran clean and changed nothing — a silent no-op that looks exactly like "already correct". Caught by diffing the regenerated allow-lists rather than trusting the exit code.
- The pre-existing `application.yaml` default named `card-issuance-service.card-issuance:8118`; card-issuance-service actually runs in `payments`.

## Compliance judgement — please weigh in

I did **not** keep 401/403 best-effort. Being *refused* data is not the same as the data being *absent*, and an Art. 15 response that is silently incomplete is indistinguishable from a complete one — the DPO files it and the data subject never learns anything was withheld. So:

- **401/403** → `GdprAggregationAuthException` → **502**, export does not ship.
- **404** (no case / no cards) → degrade, export ships.
- **5xx / unreachable / timeout** → degrade, export ships. A downstream outage must not block a data subject request; the DPO follows up from the log.

If you would rather have a 200 with an explicit `incomplete: true` annotation instead of a 502, say so — it is a one-line change in the mapper, but it puts the burden on every consumer to notice the flag, which is what failed here in the first place.

## API contract

`openapi.yaml` `info.version` 1.6.0 → 1.7.0 (additive `502` response; the `gdpr-export` description was also stale — it said aggregation was "a tracked follow-up" when it had shipped).

> ⚠️ **Version collision:** open PR #1783 also claims `1.7.0` on this same spec. Whichever of us lands second must re-bump to 1.8.0 — a clean text merge here is the trap, since git sees identical lines, not a taken version. #1783 also touches `PartyPorts.kt`, `ExceptionMappers.kt`, `build.gradle.kts` and `application.yaml`, so expect conflicts either way.

## Tests

The old suite drove a loopback `HttpServer` and asserted only "200 → data" and "error → degrade" — it had no assertion that could tell 401 from an empty result, which is precisely why this was invisible. Rewritten against mocked REST clients with 401 and 403 asserted separately from 404, 5xx, and unreachable, on both hops.

## Verification

`detekt`, `ktlintCheck`, `test`, `quarkusBuild` (CDI/ArC wiring — the only step that catches the new `@RestClient` injection) all green locally on JDK 25.

Not verified end-to-end against the live sandbox: that needs the deploy of both this image and the regenerated NetworkPolicies. Worth a real Art. 15 export against a party that *does* hold a KYC case and a card before this is called done — the whole failure class here is "looks fine from every angle except the one nobody checked".

🤖 Generated with [Claude Code](https://claude.com/claude-code)