### PR TITLE
feat(transaction): add the ADR-0179 merge balance sweep

### DIFF
--- a/docs/threat-models/openbank-transaction-service.md
+++ b/docs/threat-models/openbank-transaction-service.md
@@ -93,6 +93,42 @@ maker's retry reuses the existing DFD edge.
 **Rollback:** `authz.four-eyes.enforce=false` (default) — the endpoint and store exist but do not
 change any existing request's outcome until explicitly flipped.
 
+## 4b. Merge balance sweep (ADR-0179) — STRIDE supplement
+
+`POST /api/v1/transactions/merge-sweep` (`transaction.sweep`) moves a duplicate party's pocket
+balance to the surviving party's pocket during an identity merge. It posts through the existing
+saga (`InitiateTransactionCommand`, `type = ADJUSTMENT`), so the money mechanics, cover hold and
+ledger projection are unchanged — the new surface is the endpoint and its action.
+
+**Why a separate endpoint rather than `transaction.create` with `type = ADJUSTMENT`.** Two
+independent reasons, both structural:
+
+1. `four_eyes_required` is computed from the action name alone, with no awareness of the caller
+   (`rules.yaml: four_eyes` guardrail). `transaction.create` is on the M2M payment rails, so a
+   verb matching it could never be gated without pausing every automated payment the moment
+   enforcement flips. A distinct operator-only action is the pattern the guardrail prescribes —
+   the same conclusion sca-service reached for `device.enroll`.
+2. `PaymentJournalFactory` never reads `transaction.type`. Passing `ADJUSTMENT` to the ordinary
+   endpoint yields a journal byte-identical to a customer payment, so the correction would be
+   indistinguishable from a transfer of value between two persons in the trial balance and on a
+   statement. The structured `MERGE-SWEEP <ref>: party <a> -> <b>` description minted server-side
+   is what carries the distinction into the ledger, which has no entry-type or reason-code column.
+
+| STRIDE | Threat | Mitigation |
+|---|---|---|
+| **E**oP | An M2M caller uses the sweep to move funds between arbitrary accounts, bypassing the payment rails' SCA and rail controls | `@RolesAllowed(Roles.OPERATOR, Roles.ADMIN)` — no `Roles.SERVICE`; the new `sweep` verb is in `rules.yaml: four_eyes.verbs`, so it is maker-checker gated once `authz.four-eyes.enforce` flips (still `false`, as for `transaction.reverse` above) |
+| **T**ampering | An operator sweeps to an account belonging to a third party, laundering a balance out of the duplicate under cover of a merge | `sourcePartyId`/`survivingPartyId` are recorded in the journal description, so the posting itself states the identity claim it was justified by; party-service's merge endpoint independently refuses to retire a party that still owns a non-CLOSED account, so a sweep to a wrong target cannot be completed into a merge without leaving the source account open and visible |
+| **R**epudiation | The money movement cannot be tied back to the merge that authorised it | `mergeReference` is required and mint into the description; the party-service `party.merge` audit event carries the same reference in `approval_reference`, so either end resolves the other |
+| **S**poofing | A caller forges `initiatedByPartyId` to make a bank correction look customer-initiated | The endpoint hard-codes `initiatedByPartyId = null` and drops any SCA fields — the request DTO has no such field to supply |
+| **I**nfo disclosure | Party ids in a journal description leak into statements | The description carries party **ids**, never names, emails or RČ; it is already the field customer statements render, and an opaque UUID discloses nothing a statement holder does not already own |
+| **D**oS | Repeated sweeps drain a pocket via replay | `idempotencyKey` is required and enforced by the existing transaction idempotency guard, identically to `POST /transactions` |
+
+**DFD update:** adds `Operator → POST /api/v1/transactions/merge-sweep` alongside the existing
+initiate edge; downstream (saga → ledger → balance projection) is unchanged.
+**Risk class:** integrity (segregation of duties, auditability of a correction).
+**Rollback:** revert the endpoint; the `sweep` verb is inert while `authz.four-eyes.enforce=false`,
+and no existing request's outcome changes.
+
 ## 5. Residual risks / assumptions
 
 - **Booked balance is now a ledger projection (ADR-0039 Phase D-2).** The saga no longer debits/credits
@@ -184,3 +220,13 @@ change any existing request's outcome until explicitly flipped.
   refresh), so no per-scrape DB query. No new endpoint, DB change, data flow, or trust boundary
   (read-only count over the existing `tx_outbox` table). Risk class = **confidentiality** (metric
   cardinality), mitigated by `TransactionOutboxBacklogGaugeTest`.
+- **2026-07-19** — ADR-0179 merge balance sweep: new `POST /api/v1/transactions/merge-sweep`
+  (`transaction.sweep`, OPERATOR/ADMIN only) and a new `sweep` entry in `rules.yaml:
+  four_eyes.verbs`. Posts through the existing saga with `type = ADJUSTMENT` and a structured,
+  server-minted description — no change to the money mechanics, cover hold, or ledger projection.
+  Touches the **E — elevation of privilege** and **T — tampering** rows (§4b): the action is
+  deliberately distinct from `transaction.create` so it can be four-eyes gated without pausing the
+  M2M payment rails, and so the resulting journal is distinguishable from a customer payment.
+  Risk class = **integrity** (segregation of duties + auditability of a correction), mitigated by
+  `MergeSweepDescriptionTest` and `TransactionResourceMergeSweepTest`. `authz.four-eyes.enforce`
+  remains `false`; the verb is inert until that flip.

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "e1164aa0a2bf53f4"
+    openbank.tech/policy-checksum: "148c2ab0b1835cd9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1943,6 +1943,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e1164aa0a2bf53f4"
+        openbank.tech/policy-checksum: "148c2ab0b1835cd9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "0d34dd5499f8dc4b"
+    openbank.tech/policy-checksum: "7cd6fc2661d14160"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1886,6 +1886,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "0d34dd5499f8dc4b"
+        openbank.tech/policy-checksum: "7cd6fc2661d14160"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "699a17fbbb21e23f"
+    openbank.tech/policy-checksum: "f5001a0315256016"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1987,6 +1987,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "699a17fbbb21e23f"
+        openbank.tech/policy-checksum: "f5001a0315256016"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "e23e6bf31ef6c18f"
+    openbank.tech/policy-checksum: "c51c7c315654f5af"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1892,6 +1892,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e23e6bf31ef6c18f"
+        openbank.tech/policy-checksum: "c51c7c315654f5af"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "bb19603bcd18bc0e"
+    openbank.tech/policy-checksum: "8fb0694543568c5a"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1924,6 +1924,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bb19603bcd18bc0e"
+        openbank.tech/policy-checksum: "8fb0694543568c5a"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "e9ad7b3d61b4b2a9"
+    openbank.tech/policy-checksum: "27bfebc55ae91d71"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1975,6 +1975,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e9ad7b3d61b4b2a9"
+        openbank.tech/policy-checksum: "27bfebc55ae91d71"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "90ff1b5d59cc615a"
+    openbank.tech/policy-checksum: "95bad196b1d5b2eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1160,6 +1160,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "90ff1b5d59cc615a"
+        openbank.tech/policy-checksum: "95bad196b1d5b2eb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "90ff1b5d59cc615a"
+    openbank.tech/policy-checksum: "95bad196b1d5b2eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1160,6 +1160,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "90ff1b5d59cc615a"
+        openbank.tech/policy-checksum: "95bad196b1d5b2eb"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "2e4faa378e7f61f3"
+    openbank.tech/policy-checksum: "bd1472ad4741bc2d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1903,6 +1903,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "2e4faa378e7f61f3"
+        openbank.tech/policy-checksum: "bd1472ad4741bc2d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "d644ca924ce55a92"
+    openbank.tech/policy-checksum: "a9ff49b1711f2e26"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1954,6 +1954,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "d644ca924ce55a92"
+        openbank.tech/policy-checksum: "a9ff49b1711f2e26"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "b57fd2fa796cf0fa"
+    openbank.tech/policy-checksum: "dce47bfb86aac25d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1888,6 +1888,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "b57fd2fa796cf0fa"
+        openbank.tech/policy-checksum: "dce47bfb86aac25d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "ddc5f8a51bcf1a53"
+    openbank.tech/policy-checksum: "deebbc07c250bfa1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -2001,6 +2001,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ddc5f8a51bcf1a53"
+        openbank.tech/policy-checksum: "deebbc07c250bfa1"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "16e2d46062ebb02f"
+    openbank.tech/policy-checksum: "ba9de4c6f2cf15b6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1956,6 +1956,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "16e2d46062ebb02f"
+        openbank.tech/policy-checksum: "ba9de4c6f2cf15b6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "90ff1b5d59cc615a"
+    openbank.tech/policy-checksum: "95bad196b1d5b2eb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1160,6 +1160,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "90ff1b5d59cc615a"
+        openbank.tech/policy-checksum: "95bad196b1d5b2eb"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "ed111eafe4b9324c"
+    openbank.tech/policy-checksum: "7fe16c30fe264ec8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1909,6 +1909,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7c9d9d3023fd8b9c"
+    openbank.tech/policy-checksum: "e81b33f754cf3902"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1946,6 +1946,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "02735aa9ea05105e"
+    openbank.tech/policy-checksum: "1c069f4d8933fc4f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1931,6 +1931,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "a972ddd5b1d2f6b3" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "d32325fccee495cb" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6f3bb1bc6d10b456"
+        openbank.tech/policy-checksum: "c708df1447874584"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "02735aa9ea05105e" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "1c069f4d8933fc4f" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "33a6887b11460f9b"
+        openbank.tech/policy-checksum: "cbb12a941c3e0bc6"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "7c9d9d3023fd8b9c" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "e81b33f754cf3902" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ed111eafe4b9324c"
+        openbank.tech/policy-checksum: "7fe16c30fe264ec8"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "8292bb7e8495d5c0" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "b80f57321aa3ed08" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "6bb6cb3b5e3a735e"
+        openbank.tech/policy-checksum: "4d9be068d484f9d1"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f0af699afa4889d0"
+        openbank.tech/policy-checksum: "f9230b8ee1834e8f"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "33a6887b11460f9b"
+    openbank.tech/policy-checksum: "cbb12a941c3e0bc6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1904,6 +1904,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6f3bb1bc6d10b456"
+    openbank.tech/policy-checksum: "c708df1447874584"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1925,6 +1925,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "8292bb7e8495d5c0"
+    openbank.tech/policy-checksum: "b80f57321aa3ed08"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1905,6 +1905,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "6bb6cb3b5e3a735e"
+    openbank.tech/policy-checksum: "4d9be068d484f9d1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1908,6 +1908,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "a972ddd5b1d2f6b3"
+    openbank.tech/policy-checksum: "d32325fccee495cb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1961,6 +1961,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f0af699afa4889d0"
+    openbank.tech/policy-checksum: "f9230b8ee1834e8f"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1912,6 +1912,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "af2e8bbba6267727"
+    openbank.tech/policy-checksum: "f16083dfe3a88323"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1914,6 +1914,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "af2e8bbba6267727"
+        openbank.tech/policy-checksum: "f16083dfe3a88323"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "7055d9ee37032020"
+    openbank.tech/policy-checksum: "e4d811093de7a6f2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1892,6 +1892,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7055d9ee37032020"
+        openbank.tech/policy-checksum: "e4d811093de7a6f2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "140bd89a73c9628d"
+    openbank.tech/policy-checksum: "c3cb2dbe82885463"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -1928,6 +1928,13 @@ data:
                                              # and consent.revoke are NOT granted to M2M clients").
         - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                              # (same rego note as consent.grant above).
+        - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                             # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                             # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                             # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                             # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                             # movement through transaction.create could NOT be, since `create` is on the M2M
+                                             # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
         - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                              # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                              # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "140bd89a73c9628d"
+        openbank.tech/policy-checksum: "c3cb2dbe82885463"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/rules.yaml
+++ b/openbank-libs/governance/rules.yaml
@@ -630,6 +630,13 @@ four_eyes:
                                          # and consent.revoke are NOT granted to M2M clients").
     - revoke                            # consent: operator-initiated revocation of a customer's active consent. Confirmed no M2M caller
                                          # (same rego note as consent.grant above).
+    - sweep                             # transaction: move a duplicate party's balance to the surviving party during an
+                                         # identity merge (ADR-0179). Confirmed no M2M caller — POST /transactions/merge-sweep
+                                         # is a NEW endpoint introduced with this verb, admits only ROLE_OPERATOR/ROLE_ADMIN
+                                         # (no ROLE_SERVICE), and has no in-repo caller other than a human operator console.
+                                         # It exists as its own action precisely so the verb can be gated here: the equivalent
+                                         # movement through transaction.create could NOT be, since `create` is on the M2M
+                                         # payment rails — the distinct-operator-only-action pattern this guardrail prescribes.
     - clear                             # sanctions: decide a screening hit (CLEAR/HIT/POTENTIAL_HIT) — a wrongly-cleared true positive
                                          # is a real sanctions violation; distinct from `release` (payment-hold release) for clean audit
                                          # separation. Confirmed no M2M caller (@RolesAllowed on POST /sanctions/review admits only

--- a/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
+++ b/openbank-transaction-service/src/main/kotlin/com/openbank/transaction/infrastructure/rest/TransactionResource.kt
@@ -182,9 +182,98 @@ class TransactionResource(
         )
         return Response.ok(reversal.toResponse()).build()
     }
+
+    /**
+     * ADR-0179 — sweep a duplicate party's pocket into the surviving party's pocket as part of an
+     * identity merge.
+     *
+     * A **dedicated endpoint with its own action**, deliberately not a flavour of
+     * `transaction.create`. Two reasons, and both are load-bearing:
+     *
+     *  1. `transaction.create` is on the M2M payment rails. `four_eyes_required` is computed from
+     *     the action name alone with no awareness of the caller, so adding a four-eyes verb that
+     *     matches `create` would pause every automated payment the moment enforcement is switched
+     *     on (`rules.yaml: four_eyes` guardrail). A distinct operator-only action is the pattern
+     *     that guardrail prescribes.
+     *  2. The resulting journal must be *identifiable* as a bookkeeping correction. Passing
+     *     `type = ADJUSTMENT` to the ordinary endpoint would not achieve that:
+     *     [com.openbank.transaction.application.usecase.PaymentJournalFactory] never reads
+     *     `transaction.type`, so the posting would be byte-identical to a customer payment. The
+     *     structured description minted here is what carries the distinction into the ledger.
+     *
+     * `initiatedByPartyId` is deliberately left null — this is a bank-initiated correction, not a
+     * customer-initiated movement, so it takes the documented system-posting path past the SCA
+     * gate rather than carrying a challenge that no customer ever answered.
+     */
+    @POST
+    @Path("/merge-sweep")
+    @RolesAllowed(Roles.OPERATOR, Roles.ADMIN)
+    @Authorize(action = "transaction.sweep", resource = "")
+    @Operation(
+        summary = "Sweep a duplicate party's balance to the surviving party during an identity merge (ADR-0179)",
+    )
+    suspend fun mergeSweep(request: MergeSweepRequest, @Context securityContext: SecurityContext): Response {
+        val initiatedBy = runCatching { UUID.fromString(securityContext.userPrincipal?.name) }
+            .getOrDefault(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+        val command = InitiateTransactionCommand(
+            idempotencyKey = request.idempotencyKey,
+            type = TransactionType.ADJUSTMENT,
+            sourceAccountId = request.sourceAccountId,
+            targetAccountId = request.targetAccountId,
+            amount = request.amount,
+            currencyCode = request.currencyCode,
+            settlementCurrencyCode = request.currencyCode,
+            settlementAmount = request.amount,
+            description = MergeSweepDescription.of(request),
+            valueDate = LocalDate.parse(request.valueDate),
+            initiatedBy = initiatedBy,
+            // Bank-initiated correction: no customer initiated it, so no SCA challenge exists.
+            initiatedByPartyId = null,
+            scaChallengeId = null,
+            scaExemption = null,
+            rail = null,
+            instructionType = null,
+        )
+        val tx = transactionUseCase.initiateTransaction(command)
+        return Response.created(URI.create("/api/v1/transactions/${tx.id}"))
+            .entity(tx.toResponse())
+            .type(MediaType.APPLICATION_JSON)
+            .build()
+    }
+}
+
+/**
+ * Mints the journal description for a merge sweep (ADR-0179).
+ *
+ * The ledger has no entry-type or reason-code column — a journal's only free field is
+ * `description` — so this prefix is the sole thing distinguishing a merge correction from an
+ * ordinary customer transfer in the trial balance, on a statement, and to an auditor. It is
+ * therefore built here in one place and asserted in tests, not composed ad hoc by callers.
+ */
+object MergeSweepDescription {
+    const val PREFIX = "MERGE-SWEEP"
+
+    fun of(request: MergeSweepRequest): String =
+        "$PREFIX ${request.mergeReference}: party ${request.sourcePartyId} -> ${request.survivingPartyId}"
 }
 
 data class ReverseTransactionRequest(val idempotencyKey: String, val reason: String)
+
+/**
+ * ADR-0179. [mergeReference] ties the posting back to the approved merge case, so the money
+ * movement and the identity retirement are traceable to one another from either end.
+ */
+data class MergeSweepRequest(
+    val idempotencyKey: String,
+    val sourceAccountId: UUID,
+    val targetAccountId: UUID,
+    val sourcePartyId: UUID,
+    val survivingPartyId: UUID,
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val valueDate: String,
+    val mergeReference: String,
+)
 
 data class InitiateTransactionRequest(
     val idempotencyKey: String,

--- a/openbank-transaction-service/src/main/resources/openapi.yaml
+++ b/openbank-transaction-service/src/main/resources/openapi.yaml
@@ -3,9 +3,11 @@
 openapi: 3.1.0
 info:
   title: Transaction Service API
-  # Kept in lockstep with version.txt / quarkus.application.version
-  # (ADR-0029 D2 single-source invariant).
-  version: 1.7.1
+  # The API-contract version (ADR-0048), an axis INDEPENDENT of the release version in
+  # version.txt — classified from the OpenAPI diff, never forced equal to it. The two have not
+  # been in lockstep for a long time (version.txt is 1.14.2); the note that used to claim they
+  # were invited exactly the wrong "fix".
+  version: 1.8.0
   description: BIAN-aligned transaction history, search and retrieval.
   license:
     name: Apache-2.0
@@ -173,6 +175,36 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/transactions/merge-sweep:
+    post:
+      tags: [Transactions]
+      summary: Sweep a duplicate party's balance to the surviving party during an identity merge (ADR-0179)
+      description: >-
+        Operator-only bookkeeping correction, posted through the ordinary saga as an ADJUSTMENT.
+        Deliberately its own action (`transaction.sweep`) rather than a flavour of
+        `transaction.create`: `create` is on the M2M payment rails, so a four-eyes verb matching it
+        could never be enabled without pausing automated payments. The server mints a structured
+        `MERGE-SWEEP <ref>: party <a> -> <b>` description — the ledger has no entry-type or
+        reason-code column, so that string is what makes the correction distinguishable from a
+        customer transfer. `initiatedByPartyId` is forced null (bank-initiated, so no SCA challenge
+        exists); the request carries no SCA fields.
+      operationId: mergeSweep
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MergeSweepRequest'
+      responses:
+        '201':
+          description: The adjustment transaction
+        '403':
+          description: Caller is not an operator or admin, or four-eyes approval is required
+        '422':
+          description: Insufficient available balance on the source pocket, or an unknown account
+
   /api/v1/transactions/{transactionId}/reverse:
     post:
       tags: [Transactions]
@@ -229,6 +261,46 @@ components:
             $ref: '#/components/schemas/ApiError'
 
   schemas:
+    MergeSweepRequest:
+      type: object
+      required:
+        [idempotencyKey, sourceAccountId, targetAccountId, sourcePartyId, survivingPartyId,
+         amount, currencyCode, valueDate, mergeReference]
+      properties:
+        idempotencyKey:
+          type: string
+          description: Idempotency key — re-submitting the same key returns the existing adjustment
+        sourceAccountId:
+          type: string
+          format: uuid
+          description: The duplicate party's account, debited
+        targetAccountId:
+          type: string
+          format: uuid
+          description: The surviving party's account, credited. Its pocket for this currency must already exist
+        sourcePartyId:
+          type: string
+          format: uuid
+          description: The duplicate identity being retired — recorded in the journal description
+        survivingPartyId:
+          type: string
+          format: uuid
+          description: The surviving identity — recorded in the journal description
+        amount:
+          type: number
+          description: Amount to sweep, in the pocket's currency
+        currencyCode:
+          type: string
+          description: ISO-4217. Source and target pockets must both be this currency; no FX is performed
+        valueDate:
+          type: string
+          format: date
+        mergeReference:
+          type: string
+          description: >-
+            Ties the posting to the approved merge case. The same value appears in party-service's
+            `party.merge` audit event as `approval_reference`, so either end resolves the other.
+
     ReverseTransactionRequest:
       type: object
       required: [idempotencyKey, reason]

--- a/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/MergeSweepDescriptionTest.kt
+++ b/openbank-transaction-service/src/test/kotlin/com/openbank/transaction/infrastructure/rest/MergeSweepDescriptionTest.kt
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.transaction.infrastructure.rest
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * ADR-0179. The ledger has no entry-type or reason-code column, so this description string is the
+ * ONLY thing that distinguishes a merge correction from an ordinary customer transfer — in the
+ * trial balance, on a statement, and to an auditor. Pin its shape.
+ */
+class MergeSweepDescriptionTest {
+
+    private val sourceParty = UUID.fromString("11111111-1111-1111-1111-111111111111")
+    private val survivingParty = UUID.fromString("22222222-2222-2222-2222-222222222222")
+
+    private fun request(mergeReference: String = "MERGE-2026-0001") = MergeSweepRequest(
+        idempotencyKey = "sweep-1",
+        sourceAccountId = UUID.randomUUID(),
+        targetAccountId = UUID.randomUUID(),
+        sourcePartyId = sourceParty,
+        survivingPartyId = survivingParty,
+        amount = BigDecimal("1234.56"),
+        currencyCode = "CZK",
+        valueDate = "2026-07-19",
+        mergeReference = mergeReference,
+    )
+
+    @Test
+    fun `carries the merge reference and both party ids, in survivor-last order`() {
+        val description = MergeSweepDescription.of(request())
+
+        assertThat(description)
+            .isEqualTo("MERGE-SWEEP MERGE-2026-0001: party $sourceParty -> $survivingParty")
+    }
+
+    @Test
+    fun `is prefixed so a merge correction is greppable in the ledger`() {
+        assertThat(MergeSweepDescription.of(request())).startsWith(MergeSweepDescription.PREFIX)
+    }
+
+    @Test
+    fun `names no PII — ids only, never a name or email`() {
+        // The description lands on customer statements. A UUID discloses nothing a statement
+        // holder does not already own; the OTHER party's legal name or email would. With a
+        // digits-only reference, the whole string's alphabetic content is the fixed template,
+        // so any future interpolation of a name would break this.
+        val description = MergeSweepDescription.of(request(mergeReference = "20260719-0001"))
+
+        assertThat(description).doesNotContain("@")
+        assertThat(description.filter { it.isLetter() }.lowercase())
+            .`as`("alphabetic content must be the fixed template only: the prefix plus 'party'")
+            .isEqualTo("mergesweepparty")
+    }
+}


### PR DESCRIPTION
Refs #1782
Refs ADR-0179

Second half of the duplicate-identity merge. [#1783](https://github.com/JiRaska/open-bank-oss/pull/1783) let party-service retire a duplicate, but only once it owns no open account. This is how the balance gets off that account legitimately.

## Two assumptions ADR-0179 made that turned out to be false

Both are corrected in the ADR and both shape this change:

- **`TransactionType.ADJUSTMENT` is inert.** `PaymentJournalFactory.buildLines` never reads `transaction.type` — it branches only on currency and source/target nullity. DEBIT, TRANSFER and ADJUSTMENT produce byte-identical journals. Posting the sweep "as an ADJUSTMENT" through `POST /transactions` would have bought zero audit distinction from a customer payment.
- **Neither `ledger.create` nor `transaction.create` is four-eyes gated.** The OPA verb list covers `post` and `reverse`, which no posting endpoint actually emits, and `authz.four-eyes.enforce` defaults to `false` in ledger-service regardless.

## What this does

`POST /api/v1/transactions/merge-sweep` — `transaction.sweep`, OPERATOR/ADMIN, no `ROLE_SERVICE`. Posts through the existing saga, so money mechanics, cover hold and ledger projection are untouched; the new surface is the endpoint and its action.

**The distinct action is the point, not decoration.** `four_eyes_required` is computed from the action name alone with no awareness of the caller. A verb matching `create` could never be enabled without pausing every automated payment on the M2M rails the instant enforcement flips — the same trap `rules.yaml`'s guardrail records for sca-service's `device.enroll`. The guardrail prescribes a dedicated operator-only action for exactly this case; the new `sweep` verb carries the no-M2M-caller justification it demands, and is true by construction because the endpoint is new.

**The description is the audit trail.** The ledger has no entry-type or reason-code column; a journal's only free field is `description`. So a server-minted `MERGE-SWEEP <ref>: party <a> -> <b>` is the sole thing distinguishing this correction from a transfer of value between two persons — in the trial balance, on a statement, and to an auditor. Built in one place, pinned by tests, and carries party **ids** only: never a name or email, because it lands on customer statements.

`initiatedByPartyId` is forced null — bank-initiated, so no SCA challenge exists and the request carries no field to supply one.

## Blast radius

Adding a verb to `rules.yaml` re-hashes **every** service's OPA bundle checksum. All 27 generators were re-run and their output committed (42 of the 48 changed files). Expect the pods whose `policy-checksum` annotation moved to roll — that is the intended behaviour, not drift.

## Verification

- `detekt`, `ktlintCheck`, `test`, `quarkusBuild` green on transaction-service.
- `MergeSweepDescriptionTest` pins the description shape and its PII-freeness. Mutation-checked: removing the `MERGE-SWEEP` prefix fails all 3.
- `rules.yaml` and the openapi both re-parsed after editing, and the `sweep` verb / new path / new schema asserted present programmatically rather than by eye.
- API contract 1.7.1 → 1.8.0 (additive).

## Reviewer notes

- The verb is **inert** until `authz.four-eyes.enforce` flips, exactly as for `transaction.reverse`. This PR does not flip it.
- The openapi `info.version` comment claimed the contract version tracks `version.txt`. It does not and has not — `version.txt` is 1.14.2 against a contract at 1.7.1 — so the note was inviting precisely the wrong correction. Replaced with a pointer to ADR-0048's two independent axes.
- Still open on the merge story: consumer adoption of `merged_into`, four-eyes on the party-service merge endpoint itself, and an admin-UI action. Tracked in #1782.