### PR TITLE
chore(gitops): deploy party-service sandbox-ceab2c65 (ADR-0179 merge)

### DIFF
--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -32,7 +32,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: party-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-party-service:sandbox-ceab2c65
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Refs #1782

Bumps party-service to `sandbox-ceab2c65` — the image built from the [#1783](https://github.com/JiRaska/open-bank-oss/pull/1783) merge commit, carrying:

- `V15__party_merge` migration (`merged_into` column + status constraints)
- `POST /api/v1/parties/{id}/merge` (`party.merge`, OPERATOR/ADMIN)
- `PARTY_MERGED` event, fail-closed account guard

The auto-deploy workflow run for `ceab2c65` is **queued** behind runner scaling, so this is the same gitops bump it would open — done by hand so the merge primitive goes live in sandbox rather than waiting on the queue.

## Safety

- Image is **signed + SBOM-attested** (digest `f5d9bdcd`, both `.sig` and `.att` present in ECR), so Kyverno admits it.
- `V15` is a **new** migration, never applied — no Flyway checksum-mismatch risk.
- Flyway `migrate-at-start` applies it on pod startup.

## Why

Enables the merge `6dc763ad → 24977cca` to retire a duplicate Jiří Raška party (no accounts) via the operator token, without the GDPR-erasure path — which would lose the only RČ in the system and orphan an OPEN KYC case, and needs a `ROLE_ADMIN` token that can't be minted via CLI (admin-cli issues lightweight tokens).