### PR TITLE
fix(party): allow the merge account guard to reach account-service

### DIFF
--- a/openbank-infra/gitops/components/accounts/network-policies.yaml
+++ b/openbank-infra/gitops/components/accounts/network-policies.yaml
@@ -53,6 +53,9 @@ spec:
               kubernetes.io/metadata.name: interest
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: party
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: payments
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -128,6 +128,14 @@ spec:
             # explicit `false` is load-bearing.
             - name: AUTHZ_ENFORCE
               value: "false"
+            # ADR-0179 merge account guard: party-service calls account-service to refuse a merge
+            # while the retired party still owns an open account. The `.svc`-qualified URL is what
+            # the network-policy generator's URL_RE scans to derive the party→accounts:8100 edge —
+            # without this env the manifest carries no account URL (it defaults inside the image),
+            # so the generator can't see the call and the guard connection times out under the
+            # default-deny NetworkPolicy. Resolves identically to the in-image default.
+            - name: ACCOUNT_SERVICE_URL
+              value: http://account-service.accounts.svc:8100
           startupProbe:
             tcpSocket:
               port: management


### PR DESCRIPTION
Refs #1782

## The bug, found live

The ADR-0179 merge endpoint ([#1783](https://github.com/JiRaska/open-bank-oss/pull/1783)) added a **new cross-namespace call**: party-service's fail-closed account guard asks account-service whether the party being retired still owns an open account. In the cluster that call **times out after 15s** against `account-service.accounts:8100` — a default-deny NetworkPolicy drop, since no policy declared a `party → accounts` edge.

Reproduced end-to-end: merging an account-less party returned **500** `ConnectTimeoutException`. The guard correctly refused to proceed (it couldn't verify zero accounts) — safe fail-closed behaviour, but it blocks the legitimate merge.

## Fix

The network-policy generator (ADR-0081) derives edges by scanning env-var URLs shaped `http://<svc>.<ns>.svc:<port>`. The guard's URL lives in party-service's `application.yaml` (baked into the image), so the gitops manifest carried no account URL and the generator never saw the edge.

Surface it as an explicit `ACCOUNT_SERVICE_URL` env in the `.svc` form and regenerate — account-service's ingress now admits the `party` namespace on 8100. The value resolves identically to the in-image default, so app behaviour is unchanged; it only makes the dependency visible to the generator.

## Verification

- `gen-network-policies.py` re-run: **only** account-service's policy changed (party added to the 8100 ingress block), idempotent on a second run.
- party namespace has `policyTypes: [Ingress]` only — egress is unrestricted, so account's ingress was the sole block.

Last piece before the merge `6dc763ad → 24977cca` can complete: OPA sidecar ([#1796](https://github.com/JiRaska/open-bank-oss/pull/1796), merged) made `party.merge` reachable; this makes the guard behind it reachable.