### PR TITLE
docs(adr): back-fill Alternatives/Compliance, graduate both gates to enforcing

### DIFF
--- a/.github/scripts/check-adr-registry.sh
+++ b/.github/scripts/check-adr-registry.sh
@@ -148,7 +148,6 @@ fi
 # Collected for check 4h (bidirectional supersession) after the per-file pass.
 declared_supby=""   # "NNNN>TTTT" pairs: NNNN declares it is superseded by TTTT
 declared_sup=""     # "NNNN>TTTT" pairs: NNNN declares it supersedes TTTT
-soft=0
 
 for f in "${adrs[@]}"; do
   base=$(basename "$f")
@@ -255,12 +254,18 @@ for f in "${adrs[@]}"; do
     grep -q '^## Context' "$f"                        || err "$base: missing a '## Context' section."
     grep -qiE '^## (The )?Decision' "$f"              || err "$base: missing a '## Decision' section."
     grep -q '^## Consequences' "$f"                   || err "$base: missing a '## Consequences' section."
-    # Advisory, not blocking: 32 and 42 pre-schema ADRs respectively lack these,
-    # and back-filling them is a content job for their authors, not something a
-    # structural gate can or should force in one sweep. Graduate to `err` once the
-    # backlog is closed (ADR-0144 gate-graduation).
-    grep -q '^## Alternatives' "$f" || { soft=$((soft + 1)); echo "::warning file=$f::$base: no '## Alternatives considered' section."; }
-    grep -q '^## Compliance'   "$f" || { soft=$((soft + 1)); echo "::warning file=$f::$base: no '## Compliance impact' section."; }
+    # GRADUATED to blocking (ADR-0144 gate-graduation). These were advisory while 32
+    # and 42 pre-schema ADRs respectively lacked them; that backlog is now closed, so
+    # the rule enforces instead of nagging — an advisory rule nobody can ever act on
+    # is just noise, and a rule with no remaining violations is free to enforce.
+    #
+    # On writing them: reconstruct, do not invent. An ADR whose alternatives were
+    # never recorded should say so explicitly rather than manufacture a plausible
+    # rejected option, and a compliance row must not carry an article or requirement
+    # number that does not appear in the ADR's own text. A confident fabrication in
+    # this directory is read by auditors as a claim about the platform.
+    grep -q '^## Alternatives' "$f" || err "$base: missing a '## Alternatives considered' section (see TEMPLATE.md; if none was recorded, say so explicitly)."
+    grep -q '^## Compliance'   "$f" || err "$base: missing a '## Compliance impact' section (see TEMPLATE.md; 'not applicable — <reason>' is a valid and common answer)."
   fi
 done
 
@@ -283,7 +288,6 @@ for pair in $declared_sup; do
   esac
 done
 
-[[ "$soft" -gt 0 ]] && echo "::notice::check-adr-registry: $soft advisory section warning(s) — not blocking (see check 4i)." >&2
 
 # --- 5. Dangling ADR-NNNN references repo-wide -------------------------------
 # Every "ADR-NNNN" mention outside docs/adr/ (code comments, gitops YAML, other

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -59,11 +59,24 @@ Every ADR has the following sections:
 > ADRs a grep happened to surface.
 >
 > Section requirements are unchanged and now checked (`## Context`, `## Decision`,
-> `## Consequences`), except on superseded ADRs, which stay immutable historical
-> records. `## Alternatives considered` and `## Compliance impact` are advisory
-> warnings for now — 32 and 42 pre-schema ADRs respectively lack them, and
-> back-filling is authoring work, not something a structural gate can force in one
-> sweep. They graduate to errors under ADR-0144 once that backlog is closed.
+> `## Consequences`, `## Alternatives considered`, `## Compliance impact`), except on
+> superseded ADRs, which stay immutable historical records. The last two were advisory
+> at first, because 32 and 42 pre-schema ADRs respectively lacked them; that backlog
+> was back-filled and the rules graduated to errors under ADR-0144.
+>
+> **Writing those two sections honestly.** Making a rule blocking creates pressure to
+> satisfy it with something rather than nothing, and in this directory that pressure is
+> dangerous: these files are read by auditors and by the CNB, so a confident invention
+> is far worse than an acknowledged gap. Two standing rules:
+>
+> - **Alternatives** are *reconstructed, never invented.* If an ADR genuinely recorded
+>   no rejected option, it says so in as many words rather than manufacturing a
+>   plausible-looking one.
+> - **Compliance rows carry no article, clause or requirement number unless that exact
+>   citation appears in the ADR's own text.** Otherwise: name the engagement in plain
+>   words, or write `not applicable — <specific reason>`. For most internal engineering
+>   decisions four or five of the five rows are honestly "not applicable", and that is
+>   the correct answer, not a sign of a lazy ADR.
 
 An ADR is **required** when:
 
@@ -79,6 +92,13 @@ An ADR is **required** when:
 ADRs are **immutable once accepted**. To change a decision, write a new
 ADR with `Supersedes: ADR-NNNN` in the header, and update the old ADR
 status to `Superseded by ADR-MMMM`.
+
+## Alternatives considered
+
+- **Tribal knowledge (the status quo)** — leave significant architectural choices undocumented and carried by the people who made them. Rejected: the ADR states tribal knowledge is insufficient for a regulated platform, where decisions must be defensible to internal review, external auditors (Big-4, QSA) and the CNB, with rationale written down at the time of the decision.
+- **Prose ADR headers (the pre-amendment status quo)** — keep the header as free prose. Rejected in the amendment: by ~170 ADRs the fleet carried four coexisting header conventions plus an undocumented fifth delivery value, every consumer needed its own fallback regex, and the generated index truncated statuses to 40 characters; the header is now YAML front matter defined by SCHEMA.md and enforced in CI.
+- **A registry with no digest tier** — publish the ADRs and rely on readers loading them. Rejected in the amendment: at ~1.6 MB of Markdown nobody, human or AI agent, reads the fleet, so the consequence "onboarding is faster" stopped being true; DIGEST.md trades ~16k tokens for the complete decision history instead of whichever ADRs a grep surfaced.
+- **Editing accepted ADRs in place** — revise a decision by rewriting its record. Rejected: ADRs are immutable once accepted; a change requires a new ADR with `Supersedes: ADR-NNNN` and a status update on the old one, so the historical record stays intact.
 
 ## Consequences
 
@@ -97,6 +117,14 @@ status to `Superseded by ADR-MMMM`.
 - ADR template in this repo.
 - PR template asks whether an ADR is needed.
 - CODEOWNERS requires architect review for `docs/adr/`.
+
+## Compliance impact
+
+- PCI DSS: not applicable — decision-record governance, no cardholder data in scope.
+- DORA:    not applicable — documentation practice, no ICT resilience control claimed here.
+- GDPR:    not applicable — ADRs record design rationale, not personal data.
+- PSD2:    not applicable — no payment-service interface or TPP surface decided.
+- CNB:     engaged — the ADR requires decisions be defensible to the regulator; no specific provision cited in this ADR.
 
 ## References
 

--- a/docs/adr/0002-hexagonal-architecture-per-service.md
+++ b/docs/adr/0002-hexagonal-architecture-per-service.md
@@ -54,6 +54,10 @@ Rules:
 
 CODEOWNERS for `domain/` and `application/` requires architect review; pure refactors in `infrastructure/` may merge with a single reviewer.
 
+## Alternatives considered
+
+- **Business logic coupled to framework code (the status quo)** — let domain rules live in Quarkus/Spring REST controllers and JPA entities, as the ADR says happened historically. Rejected: it makes domain logic untestable without spinning a container, leaks rules into controllers and entities, makes infrastructure (DB, broker) hard to replace without rewriting business logic, and leaves auditors unable to find where a business rule lives because it is scattered.
+
 ## Consequences
 
 **Positive**
@@ -69,6 +73,14 @@ CODEOWNERS for `domain/` and `application/` requires architect review; pure refa
 **Mitigation**
 - Use Kotlin's data classes + extension functions to minimise mapper boilerplate.
 - Code review enforces: business rules live in `domain/`, orchestration lives in `application/`.
+
+## Compliance impact
+
+- PCI DSS: not applicable — source layout decision, no cardholder data in scope.
+- DORA:    not applicable — code structure, no ICT resilience control claimed here.
+- GDPR:    not applicable — no personal data processing decided by this layout.
+- PSD2:    not applicable — internal service structure, no TPP-facing interface.
+- CNB:     engaged — the ADR claims auditors can locate business rules consistently in `domain/`; no specific provision cited in this ADR.
 
 ## References
 

--- a/docs/adr/0003-transactional-outbox-for-kafka.md
+++ b/docs/adr/0003-transactional-outbox-for-kafka.md
@@ -59,6 +59,12 @@ Note the operational footgun ADR-0050 documents: `openbank.outbox.dispatch-enabl
 `false`, so a service with an outbox entity that never sets it `true` silently never dispatches —
 enforced by `.github/scripts/check-outbox-dispatch-enabled.sh`.
 
+## Alternatives considered
+
+- **Dual write: update the DB and publish to Kafka directly (the status quo)** — call `kafkaTemplate.send(...)` from request-handling code alongside the business transaction. Rejected: the two operations are not atomic, producing lost events, duplicate events on retry after a crash, or ghost events for a transaction that rolled back — each of which the ADR says produces real money inconsistencies. Direct `kafkaTemplate.send(...)` from request handling is a code-review blocker.
+- **Distributed XA / 2PC across DB and broker** — make the state change and the publish one distributed transaction. Rejected: operationally heavy and not supported by Kafka.
+- **Debezium CDC (WAL tailing) as the dispatch mechanism** — tail the database write-ahead log to move outbox rows to Kafka. Originally specified by this ADR, but per the 2026-07-16 amendment the implementation never went that way; the mechanism of record is the `openbank-libs` application-level poller (ADR-0013, hardened by ADR-0050), and Debezium remains only for the ClickHouse analytics feed.
+
 ## Consequences
 
 **Positive**
@@ -78,6 +84,14 @@ enforced by `.github/scripts/check-outbox-dispatch-enabled.sh`.
 - Dispatch lag and backlog are exposed as per-service Micrometer gauges (ADR-0050); alerts key
   off backlog and `attempt_count` reaching `MAX_ATTEMPTS`.
 - Janitor is a scheduled job with alert on backlog > 1M rows.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data scoped to the outbox in this ADR.
+- DORA:    engaged — atomic publication, replay and dispatch alerting are ICT resilience controls; specific articles not mapped in this ADR.
+- GDPR:    not applicable — ADR does not scope personal data in event payloads.
+- PSD2:    not applicable — internal event publication, no TPP-facing interface.
+- CNB:     engaged — the ADR claims auditability and forensics of every published event; no specific provision cited in this ADR.
 
 ## References
 

--- a/docs/adr/0004-saga-for-multi-service-workflows.md
+++ b/docs/adr/0004-saga-for-multi-service-workflows.md
@@ -35,6 +35,13 @@ Stuck sagas (no progress for > tier-specific threshold) raise an alert and have 
 
 [ADR-0045](0045-saga-framework-lightweight-custom-in-libs.md) records the specific saga framework choice (lightweight custom primitive in `openbank-libs`, not Axon or Temporal).
 
+## Alternatives considered
+
+- **XA / 2PC across services** — run the multi-service workflow as one distributed transaction. Rejected: the ADR states XA/2PC is not viable across microservices — heavy, fragile, blocks resources, and not supported across heterogeneous resources.
+- **Ad-hoc chains of REST calls (the status quo)** — let each team wire the steps together directly without an explicit pattern. Rejected: this leaves the system in inconsistent states when one step fails partway through.
+- **Orchestration for every workflow** — always drive steps from a saga coordinator. Not rejected outright but not made the default: choreography is the default, and orchestration is reserved for workflows with more than four steps or those needing explicit timeout / compensation logic.
+- **An off-the-shelf saga framework (Axon, Temporal)** — adopt an existing framework rather than building one. Rejected per ADR-0045, which records the choice of a lightweight custom primitive in `openbank-libs` instead; that ADR, not this one, carries the reasoning.
+
 ## Consequences
 
 **Positive**
@@ -52,6 +59,14 @@ Stuck sagas (no progress for > tier-specific threshold) raise an alert and have 
 - Saga framework provides primitives so developers focus on business logic, not coordination plumbing.
 - Property-based tests on saga state machines catch compensation bugs early.
 - Reconciliation jobs run continuously to detect saga inconsistencies.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data scoped in this workflow pattern.
+- DORA:    engaged — crash-resumable workflows, stuck-saga alerting and remediation runbooks are ICT resilience controls; specific articles not mapped in this ADR.
+- GDPR:    not applicable — ADR decides workflow coordination, not personal data handling.
+- PSD2:    not applicable — internal workflow pattern, no TPP-facing interface decided.
+- CNB:     not applicable — no supervisory reporting or regulatory obligation discussed here.
 
 ## References
 

--- a/docs/adr/0005-openapi-design-first.md
+++ b/docs/adr/0005-openapi-design-first.md
@@ -37,6 +37,10 @@ Internal east-west APIs (service-to-service within the cluster) may use code-fir
 
 Kafka topics are documented analogously via AsyncAPI 3.0 — see ADR-0006.
 
+## Alternatives considered
+
+- **Code-first** — write the implementation and generate the OpenAPI spec from annotations. Rejected for externally-exposed APIs: the ADR says it looks easier but consistently produces incomplete specs and incentivises ad-hoc additions, whereas design-first front-loads design rigour, produces consistent specs, and enables parallel client and server work. Code-first remains permitted for internal east-west APIs where the consumer is in the same repo and there is no external observer.
+
 ## Consequences
 
 **Positive**
@@ -53,6 +57,14 @@ Kafka topics are documented analogously via AsyncAPI 3.0 — see ADR-0006.
 **Mitigation**
 - Allow `application/x-experimental+json` content type for early prototyping; promote to spec when stabilised.
 - Pin openapi-generator version; pre-build CI caches.
+
+## Compliance impact
+
+- PCI DSS: not applicable — API contract governance, no cardholder data in scope.
+- DORA:    not applicable — contract discipline, no ICT resilience control claimed here.
+- GDPR:    not applicable — spec-authoring process, no personal data processing decided.
+- PSD2:    engaged — the ADR cites PSD2 conformance audits failing on spec drift and TPP integrators needing authoritative documentation; no specific article cited in this ADR.
+- CNB:     not applicable — ADR names EBA/TPP conformance, not CNB supervisory reporting.
 
 ## References
 

--- a/docs/adr/0006-asyncapi-for-kafka-topics.md
+++ b/docs/adr/0006-asyncapi-for-kafka-topics.md
@@ -39,6 +39,11 @@ Every Kafka topic in OpenBank MUST be documented in AsyncAPI 3.0 format:
 - Schema evolution rules: backward-compatible by default; breaking changes require a new topic version (`*-v2-events-out`) and parallel running until migration complete.
 - AsyncAPI specs are linted in CI; missing or stale specs block release.
 
+## Alternatives considered
+
+- **Undocumented Kafka topics as an implicit API (the status quo)** — let services produce and consume events with no formal contract. Rejected: schema changes break downstream consumers without warning, new consumers cannot discover what events exist or what they mean, auditors cannot trace which service emits which event for what reason, and there is no equivalent of OpenAPI for browsing or generating clients.
+- **Breaking a topic's schema in place** — evolve an existing topic incompatibly. Rejected: evolution is backward-compatible by default, and a breaking change requires a new topic version (`*-v2-events-out`) with parallel running until migration is complete.
+
 ## Consequences
 
 **Positive**
@@ -54,6 +59,14 @@ Every Kafka topic in OpenBank MUST be documented in AsyncAPI 3.0 format:
 **Mitigation**
 - Schema Registry is mature; managed offerings widely available.
 - CI scaffolding generates spec skeletons from message classes when missing.
+
+## Compliance impact
+
+- PCI DSS: not applicable — event-contract documentation, no cardholder data in scope.
+- DORA:    not applicable — documentation and schema governance, no resilience control claimed.
+- GDPR:    not applicable — ADR does not scope personal data in event payloads.
+- PSD2:    not applicable — internal Kafka topics, no TPP-facing interface decided.
+- CNB:     engaged — the ADR requires every topic have a documented purpose, producer and retention so auditors can trace event emission; no specific provision cited in this ADR.
 
 ## References
 

--- a/docs/adr/0007-vault-for-secrets-management.md
+++ b/docs/adr/0007-vault-for-secrets-management.md
@@ -78,6 +78,13 @@ Vault is in scope of `openbank-infra/`; helm charts and ArgoCD apps will be adde
 
 Operators MAY substitute Vault with their preferred secret manager (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault) at deployment time; the External Secrets Operator supports all major backends. The reference architecture assumes Vault.
 
+## Alternatives considered
+
+- **Secrets in environment variables committed to git** — static secret values checked into the repository. Rejected as wrong practice in itself; gitleaks would block it, but the ADR rejects the approach regardless.
+- **Secrets in Kubernetes Secrets stored unencrypted in etcd** — rely on K8s Secrets as the system of record. Rejected because the values sit unencrypted in etcd.
+- **Cloud-provider secret managers used as the reference backend** — AWS Secrets Manager, GCP Secret Manager or Azure Key Vault as the platform default. Rejected for the reference architecture because it is not portable/cloud-agnostic; operators MAY still substitute one at deployment time via the External Secrets Operator.
+- **Per-service ad-hoc secret handling** — each service manages its own secrets its own way. Rejected because the platform needs a single source of truth, dynamic short-lived credentials, PKI and an audit trail of every secret access.
+
 ## Consequences
 
 **Positive**
@@ -94,6 +101,14 @@ Operators MAY substitute Vault with their preferred secret manager (AWS Secrets 
 - Vault HA with auto-unseal eliminates manual unseal on restart.
 - External Secrets Operator caches secrets in K8s Secrets so steady-state operation does not depend on Vault availability.
 - Vault snapshot backups daily, tested restore quarterly.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data named in this ADR's scope.
+- DORA:    DORA Art. 9 (protection of information assets) — secrets management explicitly required, as cited in this ADR's References.
+- GDPR:    not applicable — secrets are credentials and keys, not personal data.
+- PSD2:    not applicable — no payment initiation or account-access interface here.
+- CNB:     not applicable — no CNB requirement is referenced in this ADR.
 
 ## References
 

--- a/docs/adr/0008-opentelemetry-for-observability.md
+++ b/docs/adr/0008-opentelemetry-for-observability.md
@@ -35,6 +35,11 @@ OpenTelemetry is the **only** observability instrumentation standard for OpenBan
 
 Direct integrations to vendor SDKs (Datadog DD-trace, New Relic agent) are **forbidden** in this codebase. Operators choosing those vendors do so via OTel Collector exporters.
 
+## Alternatives considered
+
+- **Per-vendor observability solutions (Datadog, New Relic)** — instrument services directly against a vendor SDK such as DD-trace or the New Relic agent. The ADR accepts that these work, but rejects them because they lock operators into a single vendor and a single billing model, which fails the cloud-agnostic, operator-choice requirement; direct vendor SDK integrations are forbidden in the codebase, and operators who choose those vendors route to them through OTel Collector exporters instead.
+- **Status quo: no unified instrumentation** — engineers grep and correlate logs across 26 services by hand and outages surface as customer complaints rather than alerts. Rejected as operationally illegible for a banking platform.
+
 ## Consequences
 
 **Positive**
@@ -50,6 +55,14 @@ Direct integrations to vendor SDKs (Datadog DD-trace, New Relic agent) are **for
 **Mitigation**
 - Sampling: 100% of error traces, 10% of slow traces (> p95), 1% baseline.
 - Tail-based sampling at Collector for richer per-trace decisions.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data in the signals described here.
+- DORA:    engaged — this is an ICT monitoring and incident-detection control; specific articles not mapped in this ADR.
+- GDPR:    engaged — trace baggage carries a pseudonymous customer ID and tenant ID; specific articles not mapped in this ADR.
+- PSD2:    not applicable — instrumentation standard, no payment interface changed.
+- CNB:     not applicable — no CNB requirement is referenced in this ADR.
 
 ## References
 

--- a/docs/adr/0009-postgres-per-service.md
+++ b/docs/adr/0009-postgres-per-service.md
@@ -34,6 +34,11 @@ OpenBank adopts **database-per-service** as the default:
 
 Tier-A operators may shard further (per-customer-segment shards within a service); this is operator concern, not maintainer concern.
 
+## Alternatives considered
+
+- **Shared database** — multiple services read and write the same DB. Simple, but it couples services through the schema; the ADR holds that schema coupling is the single biggest source of cross-team breakage, where a "small ALTER" in one service breaks five others sharing the table.
+- **Schema-per-service in a shared DB cluster** — each service owns a Postgres schema inside one shared cluster, for operational simplicity. Not adopted as the default; it survives only as the documented minimum for services that genuinely share a bounded context (e.g. account + balance + ledger), which MAY co-locate in one cluster with separate schemas.
+
 ## Consequences
 
 **Positive**
@@ -51,6 +56,14 @@ Tier-A operators may shard further (per-customer-segment shards within a service
 - Use PgBouncer / managed Postgres to reduce per-cluster operational overhead.
 - Provide data-composition libraries (BFF pattern, GraphQL gateway) to handle UI joins.
 - Reference data sync via Kafka + CDC keeps duplicates consistent.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data storage discussed in this ADR.
+- DORA:    engaged — the ADR claims failure isolation between service databases; specific articles not mapped in this ADR.
+- GDPR:    not applicable — data-ownership pattern, no processing purpose changed.
+- PSD2:    not applicable — internal persistence topology, no payment interface.
+- CNB:     not applicable — no CNB requirement is referenced in this ADR.
 
 ## References
 

--- a/docs/adr/0010-kubernetes-argocd-gitops.md
+++ b/docs/adr/0010-kubernetes-argocd-gitops.md
@@ -34,6 +34,14 @@ OpenBank reference deployment uses:
 
 Operators MAY substitute equivalents (Linkerd for Istio, Flux for ArgoCD, etc.) per their existing standards.
 
+## Alternatives considered
+
+- **Ad-hoc `kubectl apply` deployment** — push manifests to the cluster by hand. Rejected because it is not reproducible and fails the cloud-agnostic test; GitOps instead keeps the cluster matching Git, makes rollback a git revert, and gives every change an audit trail with author and reviewer.
+- **Terraform-only deployment** — drive workloads from Terraform without a GitOps reconciler. Rejected on the same cloud-agnostic/reproducibility grounds.
+- **Vendor-specific deployment tooling** — a cloud provider's own deployment stack. Rejected because it fails the cloud-agnostic test.
+- **Knative** — serverless/scale-to-zero layer on Kubernetes. Explicitly NOT adopted; the ADR leaves it to be revisited if scale-to-zero proves needed.
+- **Equivalent substitutes (Linkerd for Istio, Flux for ArgoCD)** — not rejected as such: operators MAY substitute them per their existing standards, but the reference deployment picks ArgoCD and Istio.
+
 ## Consequences
 
 **Positive**
@@ -51,6 +59,14 @@ Operators MAY substitute equivalents (Linkerd for Istio, Flux for ArgoCD, etc.) 
 **Mitigation**
 - ADR documents each layer; debugging guide in runbooks.
 - Service mesh is opt-in per service initially; mandatory by M5.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data in scope of this ADR.
+- DORA:    engaged — this is an ICT change-management and resilience control (reproducible deployment, git-revert rollback, change audit trail); specific articles not mapped in this ADR.
+- GDPR:    not applicable — deployment topology, no personal data processed.
+- PSD2:    not applicable — runtime and packaging choice, no payment interface.
+- CNB:     not applicable — no CNB requirement is referenced in this ADR.
 
 ## References
 

--- a/docs/adr/0011-testing-pyramid.md
+++ b/docs/adr/0011-testing-pyramid.md
@@ -64,6 +64,14 @@ OpenBank adopts a standard testing pyramid with four explicit layers:
 - **Scope:** Critical services (ledger, payment, saga coordinators) only.
 - **Trigger:** Weekly; alert on mutation score < 70%.
 
+## Alternatives considered
+
+- **Status quo: no tests at all** — the repository has zero tests today. Rejected as not sustainable for a banking platform; a formal testing strategy is required before any production deployment.
+- **Inverted pyramid** — many slow E2E tests over few unit tests. Named as an anti-pattern to avoid, hence the pyramid shape with unit tests as the most numerous layer.
+- **Mock-heavy unit tests** — unit suites that end up testing the mocks rather than the code. Named as an anti-pattern to avoid.
+- **Integration tests sharing state across runs** — rejected as an anti-pattern; the decision instead runs integration tests on Testcontainers-provided real Postgres, Kafka and Redis.
+- **Load tests only before releases** — rejected because they never catch regressions; load tests are therefore run nightly with a p99 regression gate.
+
 ## Consequences
 
 **Positive**
@@ -80,6 +88,14 @@ OpenBank adopts a standard testing pyramid with four explicit layers:
 - Parallelise test execution in CI.
 - Cache Testcontainers images.
 - Run mutation + chaos out-of-band (weekly), not per PR.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data in scope of this ADR.
+- DORA:    engaged — this is an ICT testing and resilience-verification control, including chaos testing; specific articles not mapped in this ADR.
+- GDPR:    not applicable — test strategy, no personal data processing described.
+- PSD2:    not applicable — internal quality practice, no payment interface changed.
+- CNB:     not applicable — no CNB requirement is referenced in this ADR.
 
 ## References
 

--- a/docs/adr/0019-docs-as-service.md
+++ b/docs/adr/0019-docs-as-service.md
@@ -148,6 +148,12 @@ Each bump is **additive only** — older clients ignore unknown fields. Removal
 of a field requires a major schema bump and a 6-month deprecation overlap
 identical to the API versioning rule from ADR 0009.
 
+## Alternatives considered
+
+- **Status quo: docs bundled into the admin-ui image** — per-service Markdown baked into the admin-ui Docker image at build time and served by a filesystem proxy in admin-ui, as in the original Docs-1/Docs-2/Docs-3 pilot. Rejected for three forcing problems: docs version drifts from code version (wrong by construction for audit and runbooks), the static bundle needs a dev host mount plus a custom bake step and gives no per-service live signal, and any docs change forces a fleet-wide admin-ui rebuild and bundle re-upload.
+- **Backstage TechDocs** — a portal that aggregates service-owned docs, the same idea at a higher level. Not adopted: the ADR states we don't need Backstage today, but keeps the file layout Backstage-compatible so a future migration is mechanical.
+- **BPMN diagram viewer** — deliberately out of scope; a heavy front-end dependency, so diagrams are Mermaid only.
+
 ## Consequences
 
 **Positive.**
@@ -194,3 +200,11 @@ identical to the API versioning rule from ADR 0009.
 - ADR 0020 — Kover coverage gate on libs (covers the docs primitives)
 - Pilot services: `openbank-libs/docs/`, `openbank-account-service/src/main/resources/docs/`,
   `openbank-balance-service/src/main/resources/docs/`
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data in bundled service documentation.
+- DORA:    engaged — the ADR motivates the change by audit and operations-runbook accuracy; specific articles not mapped in this ADR.
+- GDPR:    not applicable — service documentation content, no personal data.
+- PSD2:    not applicable — documentation endpoint, no payment interface.
+- CNB:     not applicable — no CNB requirement is referenced in this ADR.

--- a/docs/adr/0020-code-coverage-kover-regression-floor.md
+++ b/docs/adr/0020-code-coverage-kover-regression-floor.md
@@ -78,6 +78,13 @@ anything (e.g. the `@Provider` exception mappers in `libs/api/error`) is likewis
    the `kover {}` block into every `build.gradle.kts`. This lands with the build-logic
    consolidation work (roadmap Fáze 4).
 
+## Alternatives considered
+
+- **JaCoCo** — the de-facto JVM coverage standard, bundled with Gradle. Rejected because it is bytecode-based and does not understand Kotlin inline functions, `data class` synthetic members or coroutine state machines, so it systematically under-reports coverage on a Kotlin-first codebase and needs hand-maintained exclusion lists.
+- **A flat aspirational coverage target** (e.g. "70% everywhere") — one global threshold for all modules. Rejected because it would fail the build on day one (libs sits at ~40% line) and invite assertion-free tests written only to move the number.
+- **Keep the status quo: no coverage tooling at all** — the project had no coverage configured in any module, so "saga coverage" could not be measured and nothing signalled when a change removed tests or shipped untested code. Rejected because coverage was effectively unenforced.
+- **Copy a `kover {}` block into every service `build.gradle.kts`** — per-service duplication instead of a shared `build-logic/` convention plugin. Rejected to keep the recipe DRY across the service fleet.
+
 ## Consequences
 
 **Positive**
@@ -91,6 +98,14 @@ anything (e.g. the `@Provider` exception mappers in `libs/api/error`) is likewis
   (mitigated by the convention plugin carrying a sane default once rollout starts).
 - A floor can sit stale (true but unraised) if reviewers forget to bump it; it still prevents
   regression, which is the load-bearing guarantee.
+
+## Compliance impact
+
+- PCI DSS: not applicable — build-tooling decision, no cardholder data in scope.
+- DORA:    not applicable — code-coverage gate, no ICT resilience control claimed here.
+- GDPR:    not applicable — coverage measurement processes no personal data.
+- PSD2:    not applicable — no payment-service or authentication behaviour affected.
+- CNB:     not applicable — internal engineering quality gate, no supervisory reporting.
 
 ## References
 

--- a/docs/adr/0021-sca-decoupled-device-approval-no-auto-approve.md
+++ b/docs/adr/0021-sca-decoupled-device-approval-no-auto-approve.md
@@ -64,6 +64,11 @@ The challenge state machine already supports this: `ScaChallenge` has `PENDING �
 (approval present) and `PENDING → FAILED` (denied / max attempts / expired). Only the
 verification *input* is missing, not the states.
 
+## Alternatives considered
+
+- **Keep the status quo: `verify` auto-approves `PUSH_NOTIFICATION` and `BIOMETRIC`** — the current code returns a literal `true` for both device-based methods. Rejected because it is critical audit finding K2, a full SCA bypass in which the possession/inherence factor is never checked and PSD2 RTS dynamic linking is not enforced.
+- **Wait and ship the whole decoupled approval channel in one release** — leave push/biometric as-is until device enrolment, key management and the `ScaDecisionStore` are all built. Rejected because step 2 depends on a device/credential registry that does not yet exist; the fail-closed change is shipped on its own first, since an unusable factor is strictly safer than a bypassable one and a system must not present a known SCA bypass while the substantive work lands.
+
 ## Consequences
 
 **Positive**
@@ -86,6 +91,14 @@ verification *input* is missing, not the states.
   keep working as the available SCA methods in the interim.
 - Track step 2 (device enrolment + WebAuthn/signed-push + `ScaDecisionStore`) as its own
   milestone; it is the substantive PSD2-compliance work.
+
+## Compliance impact
+
+- PCI DSS: not applicable — SCA challenge flow, no cardholder data in scope.
+- DORA:    not applicable — this ADR frames the gap as SCA correctness, not ICT resilience.
+- GDPR:    not applicable — no change to personal-data processing or retention.
+- PSD2:    engaged — PSD2 RTS, Commission Delegated Regulation (EU) 2018/389, Art. 4–5 (SCA elements and dynamic linking); the auto-approve path was a direct breach.
+- CNB:     not applicable — ADR cites the EU PSD2 RTS only, no CNB-specific requirement.
 
 ## References
 

--- a/docs/adr/0022-analytics-layer-event-fed-clickhouse.md
+++ b/docs/adr/0022-analytics-layer-event-fed-clickhouse.md
@@ -109,6 +109,15 @@ Yes, by design rather than by hope:
 - **Provability** — reconciliation + the in-libs projection give a point-in-time tie-out
   between OLTP and the warehouse for regulators.
 
+## Alternatives considered
+
+- **CDC out of the operational databases (Debezium/WAL replication)** — a second extraction path straight out of the per-service Postgres stores. Rejected because it couples analytics to physical OLTP schemas, adds replication-slot load and operational risk to the very databases the design protects, bypasses the domain meaning the services already encode, and duplicates the transactional outbox stream that is already paid for.
+- **A full lakehouse (Iceberg + Trino + dbt + Dagster)** — the "modern" analytics stack. Rejected as real infrastructure with real operational cost: overkill for OpenBank's volume and contradicting the project's operability philosophy for a small team. It can be adopted later as an opt-in without changing the producer contract, because the bronze layer is already an append-only log.
+- **Reporting queries against the operational per-service Postgres databases** — the status quo of having no separate analytics store. Rejected because a few months of growth plus analysts running ad-hoc queries would degrade customer-facing latency.
+- **Treat Kafka as the durable replay source** — the ADR's own addendum corrects claim (2): Kafka retention is finite, so the log of record is the bronze layer and the durable replay source is the per-service outbox or its archive/export.
+- **Mutate or delete original bronze rows to apply corrections** — rejected in favour of re-publishing a corrected batch at a higher `aggregateVersion`, so the log of record stays immutable and only the current-state view changes.
+- **Auto-remediate detected drift** — rejected: the reconciliation job reports drift only, because reloading a 10-year store is a deliberate operator action via the backfill endpoint.
+
 ## Consequences
 
 **Positive.** No OLTP read load from reporting; one well-understood store (ClickHouse) a small
@@ -173,6 +182,14 @@ record-keeping obligation, which is the documented, defensible position.
 **Still stubbed (honest):** the ClickHouse client, the outbox/export `BackfillSource` reader, and the
 OLTP/warehouse reconciliation readers are `@Default` no-ops so the service is offline-buildable. All
 *orchestration and decision logic* around them is implemented and unit-tested.
+
+## Compliance impact
+
+- PCI DSS: not applicable — event-fed warehouse, no cardholder data in scope.
+- DORA:    not applicable — specific ICT resilience obligations are not discussed in this ADR.
+- GDPR:    engaged — GDPR Art. 25/17 (PII masked at the sink so the long-lived bronze layer never holds raw identifiers) and Art. 17(3)(b) (pseudonymous `aggregateId` retained under the legal-obligation basis).
+- PSD2:    not applicable — reporting layer, no payment initiation or authentication surface.
+- CNB:     engaged — the layer exists to serve regulatory reports and point-in-time tie-out evidence; no specific requirement mapped in this ADR.
 
 ## References
 - ADR-0003 — transactional outbox + Kafka (the single extraction path)

--- a/docs/adr/0023-analytics-regulatory-hardening.md
+++ b/docs/adr/0023-analytics-regulatory-hardening.md
@@ -194,6 +194,17 @@ exist yet. The warehouse side is real, so the drift check runs one-sided until t
 F2's adapter now exists (`S3WormArchive`); it needs a provisioned S3 Object-Lock bucket (cloud) to be
 active in an environment — the code is no longer the gap.
 
+## Alternatives considered
+
+- **Keep the status quo from ADR-0022: bronze as the claimed "record of truth"** — rely on the ClickHouse `ReplacingMergeTree` bronze table as the legal record. Rejected because a bronze row can be rewritten by anyone with table access, so bronze alone is not a legal record (BCBS 239 §3 integrity); it is reframed as a derived, rebuildable projection with tamper-evidence moved to WORM-anchored Merkle roots.
+- **A strict global hash-chain over all events** — the obvious tamper-evidence construction. Rejected in favour of Merkle-per-batch (leaves sorted), which is parallel- and replay-friendly where a strict global chain is not.
+- **A flat 10-year retention for all data** — the original ADR-0022 retention floor applied uniformly. Rejected because it violates GDPR storage-limitation and left no erasure path; replaced by per-`DataCategory` retention with an Art. 17(3)(b) statutory hold only where it applies.
+- **MinIO as the Object-Lock target** — the obvious local WORM target. Rejected because its community edition was put into maintenance mode (Dec 2025) and the repository was archived as no longer maintained (2026).
+- **SeaweedFS (or similar lightweight local emulators) for local WORM** — rejected because SeaweedFS, though actively maintained, does not enforce Object-Lock retention as of 2026 (objects remain deletable), which would make the seal theatre.
+- **The ClickHouse `integrity_anchors` mirror as the authoritative seal** — rejected as only a queryable mirror, honestly logged at WARN as not authoritative because the store is operator-mutable; the S3 Object-Lock COMPLIANCE-mode seal is the genuine WORM guarantee.
+- **Adding Maven dependencies for the adapters (AWS SDK, ClickHouse client, registry client)** — rejected in favour of the JDK `HttpClient` with pure, unit-tested request building and signing, so the modules stay offline-buildable.
+- **Failing the boot when the schema registry is unreachable** — rejected: `ApicurioSchemaCatalogSource` returns an empty catalogue (gate open) and logs loudly instead, mirroring the "open by default" config source.
+
 ## Consequences
 
 **Positive.** Every examiner-visible gap now has a named, tested control and a clear assurance level;
@@ -207,6 +218,14 @@ mis-configured (Object-Lock-disabled) S3 bucket would silently weaken F1/F2/F4, 
 must be verified, not assumed. All the real adapters (F1/F2/F3/F6/F7) are build-time gated, so a
 deployment that forgets a gate silently keeps the no-op default — the gates must be part of the
 production profile.
+
+## Compliance impact
+
+- PCI DSS: not applicable — analytics warehouse controls, no cardholder data in scope.
+- DORA:    engaged — ICT monitoring and RPO (freshness/lag metrics and readiness gate, F8); specific articles not mapped in this ADR.
+- GDPR:    engaged — GDPR Art. 5(1)(e) storage limitation, Art. 17 erasure via crypto-shred against the append-only log, Art. 17(3)(b) statutory hold for AML/accounting/KYC, and Art. 44 data-residency guard (F9).
+- PSD2:    not applicable — reporting and integrity controls, no payment or authentication surface.
+- CNB:     engaged — the nine findings are framed as gaps a CNB/EBA examiner could write up (with BCBS 239 §3 and EBA/GL on outsourcing and segregation of duties cited); no specific CNB requirement number given.
 
 ## References
 - ADR-0022 — the analytics layer these findings harden

--- a/docs/adr/0026-oltp-reconciliation-source-readers.md
+++ b/docs/adr/0026-oltp-reconciliation-source-readers.md
@@ -272,6 +272,18 @@ drift generator. This is a producer-side change (4 services + the sink's `inferA
 out of scope for this ADR's reconciliation-reader work and tracked as its own follow-up; account-service
 remains the single verified 🟢 reference until it lands.
 
+## Alternatives considered
+
+- **The sink reads each domain service's Postgres database directly** — the shortest route to per-aggregate `max(version)` and counts. Rejected because the analytics-sink owns no OLTP database (ADR-0022), it would break service-DB ownership boundaries and put read load on operational stores — precisely the second extraction path the Kappa/outbox design exists to avoid.
+- **Keep the status quo: leave `ReconciliationSource` bound to `NoOpReconciliationSource`** — reconciliation stays one-sided, comparing the warehouse against nothing authoritative. Rejected because it cannot answer the examiner question of whether the 10-year warehouse has silently lost or diverged from the operational record; it is retained only as the offline `@Default` binding so the service stays buildable.
+- **A new `openbank-contracts/` module for the shared DTO and JAX-RS interface** — rejected because `openbank-libs` already houses the reconciliation primitives and is already depended on by both the sink and every domain service, so a new module would only add build/version overhead.
+- **Per-service duplication of the endpoint contract (path, media type, `@RolesAllowed`)** — rejected in favour of a shared JAX-RS interface carrying the role gate, so the security gate cannot be forgotten or weakened per service; `@PermitAll` is explicitly never allowed.
+- **A bespoke service-to-service token mechanism for the sink's calls** — rejected in favour of the existing `@RegisterRestClient` + `@OidcClientFilter` / `ServiceTokenProvider` client-credentials path, so no new token handling lives in the adapter.
+- **Exposing the source-side version *sequence* to support completeness (F5)** — rejected because the OLTP store keeps only current state (one row per aggregate with its JPA `@Version`), not the historical event sequence; completeness stays inherently warehouse-only and the port declares no `versionsByAggregate()`.
+- **A single buffered JSON document for the high-volume `transaction` table** — kept as the baseline for small services but rejected at volume in favour of streamed NDJSON with cursor paging, so neither side buffers the full result set.
+- **Failing the whole reconciliation pass when a source service is unreachable** — rejected: the unreachable service is logged loudly and excluded from that pass, surfacing as warehouse-only for its keys.
+- **Building Phase 2 (balance, party, kyc, consent) as originally designed, before the producers are fixed** — rejected by the 2026-05-30 finding: those producers emit a constant or absent `version`, and balance/kyc emit no `aggregateType`, so a faithful source endpoint would manufacture drift on every aggregate. The chosen path is to fix the producers first.
+
 ## Consequences
 
 **Positive.** F4/F5 become genuinely two-sided: the sink finally has an authoritative source to
@@ -292,6 +304,14 @@ ADR-0023 adapters the integration is build-time gated, so a deployment that forg
 `openbank.analytics.reconcile.source.backend=http` (or omits an endpoint from the config map) silently
 keeps the no-op for the missing services — the gate and the endpoint map must be part of the production
 profile and verified, not assumed.
+
+## Compliance impact
+
+- PCI DSS: not applicable — reconciliation metadata only, no cardholder data in scope.
+- DORA:    engaged — ICT monitoring (the drift check and its sealed evidence); specific articles not mapped in this ADR.
+- GDPR:    not applicable — endpoint returns aggregate ids, versions and counts only.
+- PSD2:    not applicable — internal reconciliation surface, no payment or authentication flow.
+- CNB:     engaged — this closes the source side of the examiner-facing F4/F5 tie-out (BCBS 239 §3 accuracy/completeness/integrity and EBA/GL segregation of duties are cited); no specific CNB requirement number given.
 
 ## References
 - ADR-0023 — analytics regulatory hardening (F4 count tie-out, F5 completeness; this ADR closes the

--- a/docs/adr/0027-cloud-agnostic-in-cluster-substrate.md
+++ b/docs/adr/0027-cloud-agnostic-in-cluster-substrate.md
@@ -75,6 +75,15 @@ ADR is their origin:
 4. **Secrets never in IaC state**, KMS-unsealed, ESO-synced (see ADR-0017 / runbook 0005).
 5. **Default-deny network posture** between namespaces (NetworkPolicy baseline, ADR-0081).
 
+## Alternatives considered
+
+- **Cloud-managed proprietary primitives in the request or money path (Lambda/Fargate, DynamoDB, SQS in the money path, API Gateway, Cognito)** — the cheapest managed building blocks, tempting on a tight FinOps budget. Rejected because they create the deepest lock-in and would break the EU data-residency, DORA operational-resilience and regulator-facing exit/portability story; anything proposing an AWS-only primitive in the path is rejected by default unless it cites a go-live condition.
+- **Hand-rolled deployment outside Git (`kubectl apply`)** — rejected in favour of a single ArgoCD app-of-apps where merged-to-`main` is deployed, so there is no drift outside Git.
+- **In-memory storage for regulated stores (e.g. Apicurio in-memory)** — rejected; SQL storage is required, and "no in-memory state for regulated stores" is one of the go-live conditions.
+- **Kong as the gateway** — originally considered, superseded in implementation by nginx ingress (recorded as an as-built delta).
+- **Adding Tier-2 production capabilities speculatively** — rejected: they are added only when the go-live conditions are met, and never by reaching for a proprietary managed service that breaks the cloud-agnostic rule.
+- **A cloud SMS/voice/email dependency for paging and notifications** — rejected because it would punch a hole in the VPC-internal, egress-only posture; paging and notifications stay in-cluster or egress-only.
+
 ## Consequences
 
 - **Portability preserved.** No FaaS lock-in; the banking services are plain Quarkus containers on
@@ -96,3 +105,11 @@ ADR-0008 (OpenTelemetry), ADR-0010 (Kubernetes + ArgoCD GitOps), ADR-0017 (Vault
 ADR-0029 (governance-as-code gates), ADR-0030 (supply-chain / admission signature verification),
 ADR-0041 / ADR-0057 / ADR-0083 (scale-to-zero tiers as in-cluster operators), ADR-0054 (FinOps
 lifecycle), ADR-0081 (cluster segmentation / default-deny baseline), ADR-0088 (egress-only paging).
+
+## Compliance impact
+
+- PCI DSS: not applicable — platform substrate decision, no cardholder data in scope.
+- DORA:    engaged — DORA Art. 12 is cited for the durable, immutable account audit go-live condition (CloudTrail + AWS Config); the portability/exit posture is the wider resilience concern.
+- GDPR:    engaged — EU data residency is a stated obligation shaping the substrate; no article cited in this ADR.
+- PSD2:    not applicable — infrastructure substrate, no payment or authentication surface.
+- CNB:     not applicable — ADR cites DORA and EU residency, no CNB-specific requirement.

--- a/docs/adr/0028-lending-bounded-context.md
+++ b/docs/adr/0028-lending-bounded-context.md
@@ -231,6 +231,14 @@ change, not a domain change.
   event wiring to `openbank-anacredit-service` (which has no stage/DPD logic of its own today) — this is
   the remaining payoff that closes the downstream reporting/ICAAP gaps, tracked as a follow-up.
 
+## Alternatives considered
+
+- **No lending domain (status quo)** — deposits, payments, cards, FX and the compliance domains exist, but there is no loan account, repayment schedule, arrears tracking or impairment; the only traces of credit are a product-catalog enum value and a few comments. Rejected: it blocks AnaCredit (ECB/2016/13, CNB), FINREP F 18 / F 12 and the credit-risk input to ICAAP, none of which can be sourced without an exposure book.
+- **Split lending into four micro-services (one per capability)** — origination, servicing, collateral and provisioning as separate deployables. Rejected: it would scatter a single consistency boundary — a disbursement must atomically close the application, open the loan, register the schedule and emit the ledger posting — across network calls and sagas for no ownership benefit; they are one team's one book.
+- **Keep the credit mathematics inside the service** — `Amortization`, `Ifrs9` and `Delinquency` behind the service boundary rather than in `openbank-libs`. Rejected: the math is pure, deterministic and examiner-auditable, and is identical whether it runs in the service, a batch job, a test or a future reporting module, so it belongs in libs like the analytics reconciliation primitives (ADR-0026 D2).
+- **The loan book owning customer balances / the general ledger** — lending mutating balances directly. Rejected: those are owned by `openbank-balance-service` and `openbank-ledger-service`; every cash event in a loan's life is a ledger posting lending emits, never a balance it mutates itself.
+- **Outbox to Kafka as the ledger-posting channel** — carry cash events to the ledger over the existing transactional-outbox stream. Considered and rejected in the ADR: it could not reach the ledger end-to-end, because `openbank-ledger-service` ingests journals only through `POST /api/v1/journals` and has no Kafka posting consumer. The outbox is retained for the analytics/downstream plane only.
+
 ## Consequences
 
 **Positive.** The platform gains its largest missing business domain with the credit *mathematics*
@@ -250,6 +258,14 @@ separate, sizeable piece of work (and its own model-governance concern) not solv
 field-level mapping is genuinely large and deferred to Phase 3 — this ADR provides the primitives
 (stage, DPD bucket, impairment) those returns need, not the returns themselves. Introducing a new
 deployable adds one more service to the CI/build matrix and the operational footprint.
+
+## Compliance impact
+
+- PCI DSS: not applicable — no cardholder data in the loan book.
+- DORA:    engaged — the ledger-posting path is a guarded ICT dependency (retry, timeout, circuit breaker); specific articles not mapped in this ADR.
+- GDPR:    engaged — loan, schedule, arrears and impairment data are customer financial data; read endpoints are role-gated and access is audit-logged. No article cited in this ADR.
+- PSD2:    not applicable — credit origination and servicing, not a payment or account-access service.
+- CNB:     engaged — the ADR names CNB/AnaCredit (ECB Reg. 2016/13) granularity, FINREP F 18 / F 12, IFRS 9 §5.5, CRR Art. 178 and EBA/GL/2020/06 as the anchors lending must honour; the field-level AnaCredit/FINREP mapping is explicitly not yet built.
 
 ## References
 - ADR-0045 — lightweight ports + offline-buildable no-op defaults (the realization pattern)

--- a/docs/adr/0034-unified-opa-authz-mcp-and-rest.md
+++ b/docs/adr/0034-unified-opa-authz-mcp-and-rest.md
@@ -215,6 +215,12 @@ versus ~100 MB if we ran two.
 - **Network-layer authz** (mTLS service identity) is owned by ADR-0033
   (Op-ex 5 Istio) — orthogonal.
 
+## Alternatives considered
+
+- **Two parallel OPA stacks (status quo of the two drafts)** — keep ADR-0018's REST-authz sidecar and ADR-0031's MCP `/tools/call` gate as independently drafted stacks. Rejected: two OPA sidecars per pod double memory and management surface, two bundles ship divergent Rego conventions and complicate audit, and two query shapes (`data.openbank.agents.allow` vs `data.openbank.allow`) break the single-decision-point mental model that makes OPA reviewable.
+- **Leave business endpoints on `@PermitAll` / plain role checks** — the pre-existing state that K7 of the 2026-05-28 audit flagged as 36 `@PermitAll` on business endpoints. Rejected: K7 is the forcing function for REST authz; the decision replaces those with fine-grained, attribute-aware `@Authorize` checks.
+- **Cedar as the REST policy language** — mentioned alongside OPA in the task #32 description. Rejected for now (D6): OPA is already deployed and AI agents use it, so adopting a second policy language for REST would re-fragment the audit surface this ADR exists to prevent. May be revisited for graph-shaped authorization such as document sharing.
+
 ## Consequences
 
 **Positive.**

--- a/docs/adr/0053-ephemeral-scale-to-zero-arc-runners.md
+++ b/docs/adr/0053-ephemeral-scale-to-zero-arc-runners.md
@@ -2,7 +2,7 @@
 date: 2026-06-01
 decision-status: accepted
 delivery-status: shipped
-authors: [Jiri Raska Supersedes: ADR-0082 (CI runner governance — renumbered from ADR-0051 on 2026-06-11 to resolve a duplicate number with the service-discovery ADR-0051)]
+authors: [Jiri Raska]
 supersedes: [0082]
 superseded-by: []
 delivery-repos: []
@@ -11,6 +11,8 @@ summary: "CI runners become per-job ephemeral scale-to-zero ARC scale sets on EK
 ---
 
 # ADR-0053 — Ephemeral scale-to-zero ARC runners — supersedes ADR-0082
+
+**Supersedes:** ADR-0082 (CI runner governance — renumbered from ADR-0051 on 2026-06-11 to resolve a duplicate number with the service-discovery ADR-0051)
 
 ## Context
 

--- a/docs/adr/0056-admin-ui-bff-sole-browser-to-cluster-path.md
+++ b/docs/adr/0056-admin-ui-bff-sole-browser-to-cluster-path.md
@@ -115,3 +115,11 @@ Concretely:
 
 - Optional `/api/services/openapi-index` aggregation to collapse the catalog's fan-out.
 - Apply the same `svcUrl` discipline to any remaining surface that still hand-builds service URLs.
+
+## Compliance impact
+
+- PCI DSS: not applicable — operator docs surfaces carry no cardholder data.
+- DORA:    engaged — this is an ICT access-path control (single authenticated egress path, proxy refuses unauthenticated callers); specific articles not mapped in this ADR.
+- GDPR:    not applicable — proxies service metadata, health and changelogs only.
+- PSD2:    not applicable — internal operator tooling, no payment-service interface.
+- CNB:     not applicable — internal admin UI, no regulatory return affected.

--- a/docs/adr/0058-fck-nat-egress-cost-sandbox.md
+++ b/docs/adr/0058-fck-nat-egress-cost-sandbox.md
@@ -153,3 +153,11 @@ live) will give the real run-rate within days — **decide on the real number, n
   while prod stays managed-NAT by default.
 - **This ADR applies nothing.** It is a proposal for approval; implementation is a
   follow-up PR with its own plan/review/cutover.
+
+## Compliance impact
+
+- PCI DSS: not applicable — sandbox outbound network path, no cardholder data.
+- DORA:    engaged — the swap changes the sandbox egress availability posture (single-instance SPOF, ASG auto-recovery, reversible cutover); specific articles not mapped in this ADR.
+- GDPR:    not applicable — egress-only NAT, no personal data processed.
+- PSD2:    not applicable — infrastructure cost change, no payment interface.
+- CNB:     not applicable — sandbox-scoped; prod keeps the managed NAT Gateway.

--- a/docs/adr/0061-dora-metrics-from-in-house-sources.md
+++ b/docs/adr/0061-dora-metrics-from-in-house-sources.md
@@ -85,6 +85,14 @@ honest `available:false` when a source is absent. Each metric is sourced from th
   phases. The page states each honestly rather than showing a fabricated number.
 - A squash-merged trunk means Lead Time needs a deploy-event log (Phase 2 work).
 
+## Compliance impact
+
+- PCI DSS: not applicable — delivery metrics only, no cardholder data.
+- DORA:    DORA / EU 2022/2554 Art. 17 — MTTR is sourced from the mandated in-house ICT incident register rather than a SaaS proxy.
+- GDPR:    not applicable — aggregate deployment metrics, no personal data in scope here.
+- PSD2:    not applicable — internal DevOps reporting, no payment interface.
+- CNB:     not applicable — engineering metrics page, no CNB return involved.
+
 ## References
 
 - ADR-0029 — derive-from-code / show-in-UI; read-only consumer (rule #3).

--- a/docs/adr/0063-consumer-driven-contract-testing-pact-git-pact.md
+++ b/docs/adr/0063-consumer-driven-contract-testing-pact-git-pact.md
@@ -102,6 +102,13 @@ Data flows: CI produces `quality-report.json` (pitest XML + pact verification re
 the admin-ui image alongside the existing `test-results.json`). The page degrades gracefully when
 the file is absent (dev / no-CI environments).
 
+## Alternatives considered
+
+- **Leave Layer 3 and mutation testing at `enforced: planned` (status quo)** — the ADR-0011 pyramid had both unimplemented. Rejected: without contract tests, inter-service API drift is caught late, in integration environments or production; without mutation testing, statement coverage can be satisfied by assertions that never actually validate the financial arithmetic.
+- **A Pact Broker (PactFlow or self-hosted) instead of git-pact** — pacts published to a broker with a cross-service `can-i-deploy` gate. Rejected at the time: it adds operational burden and a deploy gate before the team has proven the workflow, and in a monorepo where consumer and provider co-evolve in a single PR, git storage is sufficient; a broker was recorded as the natural follow-up once services need independent deploy cadences. (The ADR notes this was later superseded in part by ADR-0092, which did introduce a broker.)
+- **Run pitest per-PR** — mutation testing on every pull request rather than a weekly scheduled job. Rejected: pitest is 10-50x slower than normal test execution and per-PR runs would exceed acceptable CI budgets on money-path services.
+- **Mutate the whole codebase, not just the domain package** — including infrastructure, REST resources and CDI producers. Rejected: mutation testing there would produce noise, not signal; the domain layer is where the financial arithmetic lives.
+
 ## Consequences
 
 **Positive**
@@ -116,6 +123,14 @@ the file is absent (dev / no-CI environments).
 - Pitest is slow; weekly-only means a mutation regression can persist up to a week.
 - Provider verification requires the ledger to boot (Testcontainers), which adds ~30 s to the
   ledger service CI job.
+
+## Compliance impact
+
+- PCI DSS: not applicable — test tooling and CI gates, no cardholder data.
+- DORA:    engaged — pre-deployment testing of ICT systems supporting money-path services; specific articles not mapped in this ADR.
+- GDPR:    not applicable — contract and mutation tests use no personal data.
+- PSD2:    not applicable — no payment-service interface is changed by this ADR.
+- CNB:     not applicable — internal engineering quality gate, no regulatory return affected.
 
 ## References
 

--- a/docs/adr/0076-admin-ui-integration-and-e2e-testing.md
+++ b/docs/adr/0076-admin-ui-integration-and-e2e-testing.md
@@ -194,6 +194,16 @@ are additive; each phase builds on the MSW handler definitions established in Ph
   ROI is low outside domain arithmetic (ADR-0063 scope).
 - **Performance / load testing** — admin UI is low-frequency operator tooling; not a priority.
 
+## Alternatives considered
+
+- **Cypress** - mature browser-automation ecosystem, considered as the E2E layer instead of Playwright. Rejected: CommonJS, slower startup, weaker TypeScript support, and Next.js recommends Playwright.
+- **Storybook + Chromatic** - visual regression testing of admin-UI components. Rejected: visual, not behavioral; it does not verify data-fetch correctness. Full Storybook visual regression is recorded as a distinct concern for a separate ADR.
+- **Supertest (Next.js `createServer`)** - fast, browser-free HTTP testing of the BFF. Rejected as the E2E layer: it tests only BFF routes, not page rendering.
+- **Extend Pact to the admin UI** - contract-level precision for the admin-UI-as-consumer gap (Gap 4). Rejected: Pact JVM is service-side while the admin UI is Next.js/TypeScript, requiring a different Pact client and more config; the Docs-as-Service schema is too simple to justify the Pact bootstrap. A REST-assured `DocsSchemaGuardTest` in the provider's own CI is taken instead. Revisit if the admin UI starts consuming money-path APIs directly.
+- **Keep the status quo (CI runs lint + type-check + build only)** - the existing `ui` job never calls `npm run test`, so the 14 existing test files and their guards are not enforced at PR time, and the BFF data-loading paths, live-state pages, and service-API contract have no coverage at all. Rejected: this is precisely the state the ADR's four audit gaps describe; Phase 0 adds `npm run test` to CI immediately.
+- **Mutation testing for the admin UI** - considered and placed out of scope: admin-UI logic is predominantly display/routing, so mutation-testing ROI is low outside domain arithmetic (ADR-0063 scope).
+- **Performance / load testing of the admin UI** - considered and placed out of scope: the admin UI is low-frequency operator tooling, not a priority.
+
 ## Consequences
 
 ### Positive

--- a/docs/adr/0077-observability-three-pillar-strategy.md
+++ b/docs/adr/0077-observability-three-pillar-strategy.md
@@ -2,7 +2,7 @@
 date: 2026-06-10
 decision-status: accepted
 delivery-status: partial
-authors: [@JiRaska Relates to:** ADR-0008 (OpenTelemetry), ADR-0029 (Governance as Code), ADR-0054 (FinOps)]
+authors: [@JiRaska]
 supersedes: []
 superseded-by: []
 delivery-repos: []
@@ -11,6 +11,8 @@ summary: "Observability is built as three pillars in four phases: domain busines
 ---
 
 # ADR-0077 — Observability Three-Pillar Strategy for OpenBank
+
+**Relates to:** ADR-0008 (OpenTelemetry), ADR-0029 (Governance as Code), ADR-0054 (FinOps)
 
 > **Amendment 2026-06-19 — implementation complete (non-money-path; money-path pending approvals).**
 >
@@ -305,3 +307,11 @@ Before production launch, the following must be in place:
 - [ ] Tier-1 alerts active and tested (runbook linked in each alert)
 - [ ] 30-day SLO baseline established for each payment rail
 - [ ] Outbox lag alert proven in chaos test (kill ledger-service, confirm alert fires < 15 min)
+
+## Compliance impact
+
+- PCI DSS: not applicable - no cardholder data in observability signals.
+- DORA:    engaged - this is an ICT monitoring, incident-detection and alerting control; specific articles not mapped in this ADR.
+- GDPR:    not applicable - telemetry carries no personal data; amounts excluded from labels.
+- PSD2:    engaged - the ADR states PSD2/EBA requires demonstrating payment instructions were processed within defined SLAs, and this metrics/trace/SLO evidence is what proves it; no article cited in this ADR.
+- CNB:     not applicable - no CNB-specific supervisory requirement identified in this ADR.

--- a/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
+++ b/docs/adr/0083-t1-http-scale-to-zero-native-pilot.md
@@ -322,3 +322,11 @@ adds the *measured* gate before flipping the declared tier.
   reads only.
 - **This ADR applies nothing.** It is a proposal; the native-build PR, the tofu add-on
   install, and the cutover are separate, individually-reviewed follow-ups.
+
+## Compliance impact
+
+- PCI DSS: not applicable - no cardholder data; product-catalog is a read-only catalog service.
+- DORA:    engaged - scaling a service to zero is an availability and resilience trade-off for an ICT service, gated here on a measured cold-start/latency SLO; specific articles not mapped in this ADR.
+- GDPR:    not applicable - no personal data processed by this packaging and autoscaling decision.
+- PSD2:    not applicable - money-path services never enter T1, staying always-on.
+- CNB:     not applicable - internal compute-tiering decision, no supervisory requirement cited.

--- a/docs/adr/0087-observability-correlation-and-profiling-layer.md
+++ b/docs/adr/0087-observability-correlation-and-profiling-layer.md
@@ -2,7 +2,7 @@
 date: 2026-06-11
 decision-status: accepted
 delivery-status: partial
-authors: [@JiRaska Relates to:** ADR-0008 (OpenTelemetry), ADR-0077 (Three-Pillar Observability), ADR-0075 (Mobile Crash Monitoring), ADR-0027 (Cloud Substrate, FinOps), ADR-0054 (FinOps)]
+authors: [@JiRaska]
 supersedes: []
 superseded-by: []
 delivery-repos: []
@@ -11,6 +11,8 @@ summary: "A correlation layer keyed on trace_id and the correlation id links Lok
 ---
 
 # ADR-0087 — Observability Correlation & Profiling Layer
+
+**Relates to:** ADR-0008 (OpenTelemetry), ADR-0077 (Three-Pillar Observability), ADR-0075 (Mobile Crash Monitoring), ADR-0027 (Cloud Substrate, FinOps), ADR-0054 (FinOps)
 
 ---
 
@@ -106,6 +108,17 @@ refreshed so the Past-EoL Loki/Tempo cards clear.
 5. **Business metrics sweep** — `DomainMetrics` callsites + outbox backlog per service *(follow-up, 1 PR/service; money-path + threat model)*.
 6. **Mobile shared-trace** — app emits W3C `trace_id` so crash links straight to backend trace *(openbank-app follow-up)*.
 
+## Alternatives considered
+
+- **Keep the status quo (three unlinked pillars on the existing stores)** - metrics, traces and logs stay as separate signals on the `loki-stack` chart with Loki 2.6.1 and bundled Promtail. Rejected: Loki 2.6.1 is Past-EoL (no TSDB, no structured metadata, no native OTLP) and Promtail is itself EoL; logs carried `correlationId` but not `trace_id`/`span_id`, so a log line could not link back to its trace, and a bank cannot debug a stuck payment across three disconnected tools.
+- **A commercial APM vendor** - a hosted APM product instead of the self-hosted LGTM(P) stack. Rejected: the decision is to maximise what the community stack gives a bank while staying fully self-hosted and EU-resident (ADR-0027), with no APM vendor.
+- **eBPF auto-instrumentation** - kernel-level auto-instrumentation as the source of service telemetry. Recorded as not in scope here, carrying forward the rejection in ADR-0077 alternative B; revisit for production.
+- **Per-service instrumentation for RED metrics and the service graph** - instrument every service to emit request/error/duration metrics and dependency edges. Rejected in favour of the Tempo metrics-generator, which produces fleet-wide `traces_spanmetrics_*` and `traces_service_graph_*` with zero service instrumentation.
+- **Promoting correlation ids to Loki stream labels** - carry `traceId`/`spanId`/`correlationId` as ordinary stream labels. Rejected: they would become high-cardinality stream labels; Alloy lifts them into Loki structured metadata instead, keeping them queryable and linkable without that cost. The ADR's cardinality contract is unchanged - amounts go to histograms, ids to structured metadata, neither becomes a label.
+- **Fleet-wide always-on JVM profiling** - enable the Pyroscope Java agent across all services by default. Rejected: profiling is opt-in and off by default because a bank enables profiling deliberately, never fleet-wide-on, and it carries roughly 1-2% CPU overhead per profiled JVM; piloted on `sepa-payment` first.
+- **OTLP-native log export to Tempo/OTel** - move logs onto the OTLP path rather than Loki. Recorded as not in scope; logs stay Loki-via-Alloy.
+- **Tail-based sampling** - sample traces on the OTel Collector after the fact. Recorded as not in scope here; deferred to a separate follow-up on the OTel Collector.
+
 ## Consequences
 
 ### Positive
@@ -150,3 +163,11 @@ follow-up issues as noted in the Phases section above.
 - [ ] Tier-1 alerts active and tested (outbox-backlog alert proven by chaos test).
 - [ ] 30-day SLO baseline per payment rail.
 - [ ] Control Tower shows no Past-EoL observability components.
+
+## Compliance impact
+
+- PCI DSS: not applicable - no cardholder data in traces, logs, metrics or profiles.
+- DORA:    engaged - this is an ICT incident-detection, correlation and reconstruction control, including alerting and SLO burn-rate rules; specific articles not mapped in this ADR.
+- GDPR:    not applicable - no personal-data handling decided here; ids stay non-label metadata.
+- PSD2:    engaged - the ADR claims regulatory-grade SLO and error-budget evidence for PSD2/EBA, exportable from this layer; no article cited in this ADR.
+- CNB:     not applicable - no CNB-specific supervisory requirement identified in this ADR.

--- a/docs/adr/0088-observability-extension-oncall-slo-retention-mobile-rum.md
+++ b/docs/adr/0088-observability-extension-oncall-slo-retention-mobile-rum.md
@@ -2,7 +2,7 @@
 date: 2026-06-13
 decision-status: accepted
 delivery-status: partial
-authors: [@JiRaska Relates to:** ADR-0008 (OpenTelemetry), ADR-0077 (Three-Pillar Observability), ADR-0087 (Correlation & Profiling Layer), ADR-0075 (Mobile Crash Monitoring), ADR-0056 (Grafana internal-only), ADR-0027 (Cloud Substrate, FinOps), ADR-0054 (FinOps lifecycle), ADR-0061 (DORA metrics)]
+authors: [@JiRaska]
 supersedes: []
 superseded-by: []
 delivery-repos: []
@@ -11,6 +11,8 @@ summary: "Observability is extended with GoAlert plus ntfy for on-call, Pyrra fo
 ---
 
 # ADR-0088 — Observability Extension: On-Call, SLO-as-Code, Durable Retention & Mobile RUM
+
+**Relates to:** ADR-0008 (OpenTelemetry), ADR-0077 (Three-Pillar Observability), ADR-0087 (Correlation & Profiling Layer), ADR-0075 (Mobile Crash Monitoring), ADR-0056 (Grafana internal-only), ADR-0027 (Cloud Substrate, FinOps), ADR-0054 (FinOps lifecycle), ADR-0061 (DORA metrics)
 
 > **Implementation summary 2026-06-25 — D1/D2/D3 confirmed live; D4 split-tracked.**
 >
@@ -240,3 +242,11 @@ Three non-negotiables for a bank (these, not the SDK, are why this is an ADR):
 See **Explicitly rejected / deferred** above (Mimir, Beyla, Tetragon, Faro, full Sentry, session replay).
 The overarching alternative — an external APM (Datadog/New Relic) — was already rejected in ADR-0077
 (cost, data residency); this ADR keeps the strictly-OSS substrate.
+
+## Compliance impact
+
+- PCI DSS: not applicable - no cardholder data; amounts and IBANs are redacted before storage.
+- DORA:    engaged - the ADR cites DORA Art. 17 for both incident response (a reachable human with an escalation path) and incident reconstruction (traces and logs that outlive a node and span the audit window).
+- GDPR:    engaged - mobile RUM collects device-side telemetry from customer devices, so the ADR requires server-side PII scrubbing, pseudonymous party_id only, and consent with collection off by default; session replay is rejected outright as a GDPR/PII non-starter. No article cited in this ADR.
+- PSD2:    not applicable - no payment-service interface or SCA obligation addressed here.
+- CNB:     not applicable - no CNB-specific supervisory requirement identified in this ADR.

--- a/docs/adr/0089-customer-facing-ai-assistant.md
+++ b/docs/adr/0089-customer-facing-ai-assistant.md
@@ -2,7 +2,7 @@
 date: 2026-06-14
 decision-status: accepted
 delivery-status: partial
-authors: [@JiRaska Relates to:** ADR-0031 (AI agent governance — reused primitives), ADR-0034 (unified OPA authz), ADR-0021, 0073 (SCA & device-bound credentials), ADR-0064 (customer app KMP), ADR-0065 (customer edge), ADR-0067 (feature flags & four-eyes on money-path flips), ADR-0030 (threat-model requirement), ADR-0027 (cloud substrate, FinOps), ADR-0002 (hexagonal), ADR-0048 (two version axes), ADR-0077 (DomainMetrics), ADR-0086 (payment non-repudiation & audit chain), ADR-0084 (fraud), ADR-0019 (Docs-as-Service — RAG corpus)]
+authors: [@JiRaska]
 supersedes: []
 superseded-by: []
 delivery-repos: []
@@ -11,6 +11,8 @@ summary: "A new openbank-copilot-service behind the customer edge is the custome
 ---
 
 # ADR-0089 — Customer-Facing AI Assistant (Mobile Copilot)
+
+**Relates to:** ADR-0031 (AI agent governance — reused primitives), ADR-0034 (unified OPA authz), ADR-0021, 0073 (SCA & device-bound credentials), ADR-0064 (customer app KMP), ADR-0065 (customer edge), ADR-0067 (feature flags & four-eyes on money-path flips), ADR-0030 (threat-model requirement), ADR-0027 (cloud substrate, FinOps), ADR-0002 (hexagonal), ADR-0048 (two version axes), ADR-0077 (DomainMetrics), ADR-0086 (payment non-repudiation & audit chain), ADR-0084 (fraud), ADR-0019 (Docs-as-Service — RAG corpus)
 
 ---
 

--- a/docs/adr/0092-pact-broker-contract-pipeline.md
+++ b/docs/adr/0092-pact-broker-contract-pipeline.md
@@ -103,6 +103,14 @@ broker pipeline is demonstrably green across the fleet, a follow-up issue remove
 pacts, the `pact.rootDir` system property, and the `@IgnoreNoPactsToVerify` local-dev escape.
 This honours ADR-0063's "keep git-pact as fallback" until the broker is load-bearing.
 
+## Alternatives considered
+
+- **Keep git-pact storage (the ADR-0063 status quo)** - committed `pacts/*.json` verified by providers via `@PactFolder("../pacts")`. Rejected as the end state: git-pact structurally cannot provide a `can-i-deploy` gate, because there is no record of which provider version verified which consumer version in which environment, so an unverified contract change can ship. ADR-0063 itself named a broker as the natural follow-up once services need independent deploy cadences, and the workflow is now proven on 4 live contracts. git-pact is nonetheless retained as a fallback through the rollout, per ADR-0063's own condition, and retired for covered pairs only once the broker pipeline is green.
+- **PactFlow SaaS (a hosted broker) or a managed database behind it** - rejected: everything stateful stays in-cluster OSS per ADR-0027, so the broker runs self-hosted as `pactfoundation/pact-broker` on a single-owner CNPG Postgres.
+- **Keep the broker in-cluster only (no Ingress)** - the ADR-0056 default of no public pre-auth surface. Rejected: the `openbank-build` runner pool is mixed, and the external runners (Hetzner VMs, a Mac mini) cannot reach the broker over cluster DNS, so an in-cluster-only broker cannot serve the CI pipeline. The public Ingress is taken as a deliberate, documented exception, justified by Basic auth on every path except the heartbeat, a payload of API contracts rather than customer data, and a machine/CI rather than browser-console audience.
+- **Tighten the exposure instead - an nginx IP-allowlist to runner egress, or pinning the contract jobs to ARC-only runners** - considered and deferred rather than rejected outright; to be revisited if the external runners are retired.
+- **Back up `pact-broker-db`** - the treatment money-path databases get. Rejected: pact and verification data are fully reproducible because every CI build republishes them, which keeps the broker out of the backup-coverage obligation and at under $1/mo.
+
 ## Consequences
 
 - **Positive:** a real `can-i-deploy` gate; per-version/-branch/-environment contract history
@@ -117,3 +125,11 @@ This honours ADR-0063's "keep git-pact as fallback" until the broker is load-bea
   model (ADR-0030); it still requires 2 approvals as money-path PRs.
 - `rules.yaml: api_change` stays `advisory`; the broker does not change the gate's severity, it
   makes the "consumer-driven contract test updated (Pact)" requirement *enforceable at deploy*.
+
+## Compliance impact
+
+- PCI DSS: not applicable - no cardholder data; the broker stores API contracts only.
+- DORA:    engaged - a fail-closed deploy gate and contract-verification history are ICT change-control and testing evidence; specific articles not mapped in this ADR.
+- GDPR:    not applicable - payload is API contracts, not customer data, per this ADR.
+- PSD2:    not applicable - no payment-service interface obligation addressed by this pipeline.
+- CNB:     not applicable - internal CI and contract tooling, no supervisory requirement cited.

--- a/docs/adr/0093-public-developer-portal-for-psd2-xs2a.md
+++ b/docs/adr/0093-public-developer-portal-for-psd2-xs2a.md
@@ -81,3 +81,11 @@ on later.
 - The OpenAPI is duplicated into the portal image at build time; a content change in the service contract
   means a portal rebuild. Acceptable; the build copies from the service's source-of-truth spec.
 - WAF false positives are possible; CRS paranoia level starts at 1 and audit logs go to stdout for tuning.
+
+## Compliance impact
+
+- PCI DSS: not applicable — static documentation site, no cardholder data in scope.
+- DORA:    engaged — a new internet-facing ICT surface with WAF, rate limiting and a required threat model; specific articles not mapped in this ADR.
+- GDPR:    not applicable — zero-backend static docs, no personal data processed.
+- PSD2:    PSD2 RTS Art. 30 — the "usable dedicated interface" obligation this portal documents for TPPs.
+- CNB:     not applicable — no supervisory reporting or ČNB-facing artefact in this ADR.

--- a/docs/adr/0096-entity-level-statutory-accounting-close.md
+++ b/docs/adr/0096-entity-level-statutory-accounting-close.md
@@ -72,6 +72,13 @@ the GL-close engine would fork the source of truth) and **render** statements fr
    allocation journals it is asked to post). Statements + attestations surface in the admin-ui
    `regulatory` page. Scope of *this* ADR: statements + attested close. Prudential returns are ADR-0097.
 
+## Alternatives considered
+
+- **Outsource the GL-close engine to a vendor** — buy the close orchestration rather than build it. Rejected — the ledger already owns double-entry truth, and outsourcing the close would fork the source of truth; only the statement *forms* mapping is left open to a vendor template later.
+- **Keep the status quo: treat the existing per-customer statement close as the statutory close** — rely on ADR-0078/0035 period closes. Rejected — those close *customer sub-ledgers*, not the entity's general ledger, and emit no attested, immutable, entity-wide artefact.
+- **Keep the trial balance as a read API only** — continue serving `/api/v1/journals/trial-balance` as a point-in-time query. Rejected — a point-in-time query is not a frozen, reproducible, attestable record and does not satisfy průkaznost/úplnost.
+- **Rely on the existing point-in-time / event-fed reporting** (AnaCredit render-only ADR-0037, withholding tax, reconciliation, analytics). Rejected — these complement but do not substitute a close, as none derives from an attested period close.
+
 ## Consequences
 
 **Positive:** a real, attestable statutory close satisfying zákon 563/1991 + vyhláška 501/2002;
@@ -85,6 +92,14 @@ license-gated, so this is **Proposed** until a licence track is prioritised.
 
 **Build vs outsource:** build the orchestration + freeze (ledger-native); the statement *forms* mapping
 could later adopt a vendor template, but the attested TB and close stay in-house.
+
+## Compliance impact
+
+- PCI DSS: not applicable — entity-level general-ledger close, no cardholder data in scope.
+- DORA:    not applicable — accounting-close architecture, not an ICT resilience control.
+- GDPR:    not applicable — entity-level GL aggregates, not personal data.
+- PSD2:    not applicable — no payment initiation or account-access interface involved.
+- CNB:     zákon č. 563/1991 Sb. §18–19 (účetní závěrka, průkaznost/úplnost) and vyhláška ČNB č. 501/2002 Sb. (bank financial-statement forms); auditor attestation of the frozen trial balance.
 
 ## References
 - Issue #471 (gap placeholder); ADR-0039, ADR-0078, ADR-0035, ADR-0026, ADR-0037, ADR-0086.

--- a/docs/adr/0097-supervisory-prudential-returns-finrep-corep.md
+++ b/docs/adr/0097-supervisory-prudential-returns-finrep-corep.md
@@ -96,6 +96,13 @@ to the ledger). Reuse the AnaCredit render pattern (pure-domain mapper + builder
    statements-reconciliation tie-out result, and submission status. Derived, never hand-faked
    (ADR-0074/0079 house rule).
 
+## Alternatives considered
+
+- **Derive the returns from a live, point-in-time trial-balance query** — build FINREP/COREP straight off `GET /api/v1/ledger/trial-balance` instead of the attested close. Rejected as the target state — it would make the returns non-reproducible and non-reconcilable to the závěrka; this is exactly the interim gap the Phase 1/Phase 2 delivery note flags as open work against ADR-0096.
+- **Reuse the AnaCredit render-only shape (ADR-0037) with transmission as a follow-up** — render the dataset and defer the submission channel. Rejected — AnaCredit is the cautionary template: without a transmission path the regulatory output is never actually produced, so transmission is in scope here.
+- **Start Phase 2 on a COREP template other than C 01.00** — geographical-breakdown and ALMM/maturity-ladder templates were evaluated. Rejected — each carries the same missing-data dependency one layer down (exposure-class/risk-weight data, or contractual maturity-bucket data) that the platform also does not have.
+- **Omit or estimate the own-funds rows the ledger cannot source** — silently drop the rows or supply a guessed value where no capital-structure GL data exists. Rejected — every such row is reported as an explicit, flagged zero (`isDataGap` + `gapReason`), never a silently omitted or guessed value.
+
 ## Consequences
 
 **Positive:** real prudential returns reconciled to an attested close (CRR/CRD); transmission is
@@ -106,6 +113,14 @@ reuses the proven AnaCredit/hexagonal pattern.
 capital data not yet modelled (Phase 2 is materially larger); EBA XBRL/DPM taxonomy is heavy and
 versioned (a maintenance commitment); the ČNB transmission channel needs real credentials/onboarding
 (prereq-gated, like the AnaCredit SDMX channel). License-gated → **Proposed**.
+
+## Compliance impact
+
+- PCI DSS: not applicable — aggregated prudential returns, no cardholder data in scope.
+- DORA:    not applicable — supervisory financial reporting, not an ICT resilience control.
+- GDPR:    not applicable — entity-level aggregate cells, not personal data.
+- PSD2:    not applicable — no payment initiation or account-access interface involved.
+- CNB:     CRR (Regulation (EU) 575/2013) / CRD and the EBA Implementing Technical Standards on supervisory reporting (FINREP/COREP, DPM/XBRL taxonomy); ČNB supervisory reporting is the transmission destination.
 
 ## References
 - Issue #471; ADR-0096 (attested close), ADR-0037 (AnaCredit render-only + transmission gap), ADR-0039.

--- a/docs/adr/0108-rail-settlement-via-transaction-service.md
+++ b/docs/adr/0108-rail-settlement-via-transaction-service.md
@@ -118,6 +118,14 @@ Shipped in PRs: #1869 (tx-consumer + `TransactionSettledEvent`), #1870 (rail con
 #1862 (funds-in-transit GL + Flyway migration), #1872 (clearing-reserve journal entries),
 #1867 (settlement-service retire). All merged to `main`; sandbox-deployed.
 
+## Compliance impact
+
+- PCI DSS: not applicable — SEPA/domestic/SWIFT rail settlement, no cardholder data in scope.
+- DORA:    engaged — this is a money-path settlement control (idempotent posting, compensation, reconcilable settlement window); specific articles not mapped in this ADR.
+- GDPR:    engaged — the scheme-accepted event carries debtor/creditor IBANs and account ids; specific articles not mapped in this ADR.
+- PSD2:    engaged — this completes execution of customer payment transactions; specific articles not mapped in this ADR.
+- CNB:     not applicable — no supervisory reporting or licensing matter in this ADR.
+
 ## References
 
 - ADR-0039 — Ledger as golden source, balance as projection (the settlement engine this reuses)

--- a/docs/adr/0110-same-account-fx-exchange.md
+++ b/docs/adr/0110-same-account-fx-exchange.md
@@ -129,6 +129,14 @@ endpoint remains for operator/admin use and is documented in the account-service
 - **Outbox event from account-service:** eventual consistency complicates the client's "exchange
   now" UX and the FX rate may change between publish and consume — rejected.
 
+## Compliance impact
+
+- PCI DSS: not applicable — exchange between a customer's own currency pockets, no cardholder data.
+- DORA:    engaged — the §3 account-service path has a known non-atomic failure mode (dangling debit) with a monitoring alert as follow-up; specific articles not mapped in this ADR.
+- GDPR:    not applicable — same-account, own-funds movement, no new personal data processed.
+- PSD2:    PSD2 RTS Art. 15 — the exchange is an own-account operation and therefore SCA-exempt.
+- CNB:     not applicable — no supervisory reporting or licensing matter in this ADR.
+
 ## References
 
 - ADR-0021 (SCA scope), ADR-0024/0025 (pockets, per-currency ledger), ADR-0065 (edge proxy)

--- a/docs/adr/0111-payment-r-transaction-returns-pacs004.md
+++ b/docs/adr/0111-payment-r-transaction-returns-pacs004.md
@@ -100,6 +100,14 @@ PRs: feat/returns-pacs004-reader (libs `Pacs004Reader`), feat/returns-transactio
 (transaction-service `/reverse` endpoint), feat/returns-sepa-payment (sepa-payment-service
 `/returns` endpoint + state machine), feat/returns-clearing-simulator (sandbox `/returns`).
 
+## Compliance impact
+
+- PCI DSS: not applicable — SEPA credit-transfer returns, no cardholder data in scope.
+- DORA:    engaged — a new money-path reversal endpoint requiring threat-model review, plus XXE-hardened parsing of externally supplied XML; specific articles not mapped in this ADR.
+- GDPR:    not applicable — parsed return fields are references, amounts and reason codes.
+- PSD2:    engaged — return/reversal of an executed customer payment transaction; specific articles not mapped in this ADR.
+- CNB:     not applicable — EPC SCT Rulebook obligation (DS-04), not ČNB reporting.
+
 ## References
 
 - ADR-0039 — Ledger as golden source; reversal / REVERSAL type

--- a/docs/adr/0112-ai-finops-agent.md
+++ b/docs/adr/0112-ai-finops-agent.md
@@ -112,6 +112,11 @@ Agent je **control-plane agent** (ADR-0031):
 | **P3 — Diagnose** | finops-agent Temporal service (collect+detect+diagnose) | feat/finops-agent-svc |
 | **P4 — Propose** | HITL queue + GitHub PR generování + IAOps approval UI | feat/finops-hitl-ui |
 
+## Alternatives considered
+
+- **Keep the status quo — post-hoc reaction to cost incidents** — NAT drain found on the invoice, EBS multi-attach found by pod crashloop, CI aio-max-nr exhaustion found by a red pipeline. Rejected: none of these incidents is unpredictable, all have measurable precursors at least an hour ahead, so detection after the fact is a choice rather than a limit.
+- **Let the agent apply infrastructure fixes directly to AWS** — instead of opening IaC pull requests for human approval. Rejected: the agent is a control-plane agent with deny-by-default policy and a read-only IAM role; it operates at the `write_proposal` tier and never writes directly to AWS, with HITL mandatory for anything that changes infrastructure.
+
 ## Consequences
 
 **Pozitivní:**
@@ -124,6 +129,14 @@ Agent je **control-plane agent** (ADR-0031):
 - Nový agent = nový Temporal workflow = další dependency na Temporal cluster
 - AWS Cost Explorer API má 1h granularitu — real-time NAT spike vyžaduje CloudWatch (nižší latence)
 - Langfuse→Prometheus bridge = nový exporter k maintainovat
+
+## Compliance impact
+
+- PCI DSS: not applicable — infrastructure cost telemetry, no cardholder data in scope.
+- DORA:    engaged — this is an ICT operational monitoring and resilience control; specific articles not mapped in this ADR.
+- GDPR:    not applicable — cost, cluster and token-usage metrics only, no personal data.
+- PSD2:    not applicable — no payment initiation or account access involved.
+- CNB:     not applicable — internal cloud cost tooling, no supervisory reporting affected.
 
 ## References
 

--- a/docs/adr/0123-relicense-to-apache-2.0.md
+++ b/docs/adr/0123-relicense-to-apache-2.0.md
@@ -62,6 +62,11 @@ contributors under DCO with no third-party-assigned copyright that withholds con
 therefore within the project's authority. Any future external contributions are made under Apache-2.0 via
 the DCO sign-off on each commit.
 
+## Alternatives considered
+
+- **Keep MPL-2.0 (the status quo of ADR-0012)** — file-level weak copyleft on the whole platform, chosen to protect against pure-extraction forks. Rejected: many banks and large IT shops treat any copyleft as a legal-review trigger, which cost more adoption than the protection bought; the ecosystem OpenBank lives in defaults to Apache-2.0; and the anti-extraction moat had already moved to the AGPL-3.0-only agent services, so MPL was protecting the open core against a threat it does not need protection from.
+- **Introduce a CLA for the platform alongside the new licence** — instead of keeping the existing contribution mechanism. Rejected: Apache-2.0 plus DCO v1.1 is a standard, well-understood pairing, and keeping DCO adds no new contributor friction.
+
 ## Consequences
 
 **Positive**
@@ -79,6 +84,14 @@ the DCO sign-off on each commit.
 - Agent-runtime AGPL-3.0 + commercial open-core model (ADR-0031 D8) is untouched.
 - DCO, governance gates, and `version.txt`/release-please mechanics are unaffected — this is a licence
   metadata change, not a behaviour change.
+
+## Compliance impact
+
+- PCI DSS: not applicable — source licence metadata only, no cardholder data in scope.
+- DORA:    not applicable — licence change, no ICT risk or resilience control altered.
+- GDPR:    not applicable — no personal data processed by a licence header change.
+- PSD2:    not applicable — no payment or account-access behaviour is changed.
+- CNB:     not applicable — no regulated banking function or reporting is affected.
 
 ## References
 

--- a/docs/adr/0126-unified-consent-lifecycle.md
+++ b/docs/adr/0126-unified-consent-lifecycle.md
@@ -105,6 +105,13 @@ regression). The pre-flip validation record: `authz-coverage-report.py` + the ge
 assertions replace a manual staging soak (there is no separate staging environment —
 sandbox is the validation stage, ADR-0042).
 
+## Alternatives considered
+
+- **Keep the status quo — three overlapping consent regimes with no unified ADR** — PSD2 account-access consents, GDPR data-processing consents and AI agent delegation scopes governed separately. Rejected: delivery gaps accumulated in the absence of a single lifecycle, notably no sweeper moving expired consents out of `ACTIVE`, no explicit GDPR propagation path for withdrawal, and no rationale or flip plan for advisory OPA.
+- **Leave OPA authorization in advisory mode (`authz.enforce=false`)** — the mode consent-service was previously running in. Rejected: it lacked explicit rationale and a flip plan; enforcement is now shipped with per-endpoint `@Authorize`, a consent-specific rego extension and `AUTHZ_ENFORCE=true` in gitops.
+- **Publish revocation events directly to Kafka from the service (`@Channel` emitter)** — the mechanism revoke/reject originally used. Rejected: it is a dual-write on a money-path service that could drop a `ConsentRevoked`/`ConsentRejected` event on a crash between the DB commit and the Kafka send; the transactional outbox persists the status change and the event row in one transaction instead.
+- **A manual staging soak before flipping OPA to enforce** — the conventional pre-flip validation. Rejected: there is no separate staging environment (sandbox is the validation stage), so the coverage report plus the policy generator's decision assertions serve as the pre-flip validation record, with rollout guarded by the money-path canary analysis.
+
 ## Consequences
 
 - **resource servers** must subscribe to `consent.events` and cache the validation result for the configured `frequencyPerDay` window to avoid hammering the consent API (ADR-0090 N3).
@@ -112,6 +119,14 @@ sandbox is the validation stage, ADR-0042).
 - The 90-day AISP cap is enforced at consent creation time by the domain model (hard constraint). A TPP re-consent flow is required after expiration — this is by PSD2 design, not a gap.
 - `TELEMETRY_RUM` consents are NOT subject to the SCA requirement or the 90-day cap. They are opt-in UX consents, not account-access consents.
 - `openbank-consent-service` is a **money-path service** (rules.yaml). Any change requires 2 approvals + threat model review (docs/threat-models/openbank-consent-service.md).
+
+## Compliance impact
+
+- PCI DSS: not applicable — consent records carry no cardholder data.
+- DORA:    not applicable — consent lifecycle governance, no ICT resilience control defined here.
+- GDPR:    engaged — GDPR Art. 7 (demonstrable consent, incl. `TELEMETRY_RUM`) and Art. 17 (processors cease processing within 72 h of `ConsentRevoked`/`ConsentExpired`).
+- PSD2:    engaged — PSD2 Directive (EU) 2015/2366 Art. 65/66/67 account-access consents and EBA RTS on SCA (EU) 2018/389 Art. 10 validity and frequency caps.
+- CNB:     engaged — the CZ national profile (COBS 2.x) scope group is covered by the same consent authority; no specific CNB provision is cited in this ADR.
 
 ## References
 

--- a/docs/adr/0136-agent-services-agpl-in-repo-open-core.md
+++ b/docs/adr/0136-agent-services-agpl-in-repo-open-core.md
@@ -85,3 +85,11 @@ contributors submit to those services, so dual-licensing rights are preserved.
   licence.
 - `scripts/add-license-headers.sh` must be made path-aware (Apache by default, AGPL for the
   four agent paths) so new agent files get the right header — tracked as a follow-up.
+
+## Compliance impact
+
+- PCI DSS: not applicable — source licensing decision, no cardholder data in scope.
+- DORA:    not applicable — licence boundary only, no ICT risk or resilience control changed.
+- GDPR:    not applicable — no personal data involved in licence headers or texts.
+- PSD2:    not applicable — no payment or account-access behaviour is changed.
+- CNB:     not applicable — no regulated banking function or reporting is affected.

--- a/docs/adr/0158-account-opening-validates-against-product-catalog.md
+++ b/docs/adr/0158-account-opening-validates-against-product-catalog.md
@@ -115,3 +115,11 @@ the account-opening path; mitigated by the fail-open posture (never blocks on an
 **Neutral:** no DB migration (validation only, no new persisted field); no change to the
 existing sanctions/IBAN checks; money-path controls (2 approvals, threat model) apply to
 this PR since `openbank-account-service` is in `rules.yaml: money_path_services`.
+
+## Compliance impact
+
+- PCI DSS: not applicable — product reference-data validation, no cardholder data in scope.
+- DORA:    engaged — this is an ICT dependency and failure-posture control (fail-open on catalogue outage); specific articles not mapped in this ADR.
+- GDPR:    not applicable — validates a product identifier, no personal data processed.
+- PSD2:    not applicable — account opening, not TPP access or payment initiation.
+- CNB:     not applicable — no supervisory reporting or CZ profile requirement cited here.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -41,6 +41,9 @@ State the decision clearly in active voice: "We will ..."
 - **Option A** — short description. Pros / cons. Why rejected.
 - **Option B** — short description. Pros / cons. Why rejected.
 
+<!-- Required (enforced). Reconstruct, never invent: if no alternative was genuinely
+     considered, say exactly that instead of manufacturing a plausible rejected option. -->
+
 ## Consequences
 
 **Positive**
@@ -53,6 +56,12 @@ State the decision clearly in active voice: "We will ..."
 - ...
 
 ## Compliance impact
+
+<!-- Required (enforced). Do NOT write an article, clause or requirement number unless
+     that exact citation appears in this ADR's own text — auditors read these rows as
+     claims about the platform. Otherwise name the engagement in plain words, or write
+     "not applicable — <specific reason>". For most internal engineering decisions,
+     four or five rows are honestly "not applicable". That is the right answer. -->
 
 - PCI DSS: <req refs> / not applicable
 - DORA:    <req refs> / not applicable


### PR DESCRIPTION
Closes the backlog #1808 deferred. 29 ADRs had no `## Alternatives considered`, 39 had no `## Compliance impact` — 68 advisory warnings on every run. An advisory rule nobody ever acts on is just noise, so the backlog is filled and both rules now **block** (ADR-0144 gate graduation).

## How this was written — the part that matters

These files are read by external auditors and by the ČNB. **A confident invention here is far worse than an acknowledged gap**, and making a rule blocking creates pressure to satisfy it with *something* rather than nothing. So two rules were applied, and are now written into `TEMPLATE.md` and the ADR-0001 amendment so they survive this PR:

- **Alternatives are reconstructed from each ADR's own prose, never invented.** All 29 turned out to name real rejected options inline ("not CDC, not a lakehouse", "keep Kotlin coroutines", the status quo being replaced), so the *"no alternative was recorded"* escape hatch was never needed — but it exists, and it is the required answer when an ADR genuinely recorded none.
- **No compliance row carries an article, clause or requirement number unless that exact citation already appears in the ADR's own text.** Otherwise: plain-words engagement, or `not applicable — <specific reason>`.

Typical result, and the correct one for an internal engineering decision:

```
- PCI DSS: not applicable — decision-record governance, no cardholder data in scope.
- DORA:    not applicable — documentation practice, no ICT resilience control claimed here.
- GDPR:    not applicable — ADRs record design rationale, not personal data.
- PSD2:    not applicable — no payment-service interface or TPP surface decided.
- CNB:     engaged — the ADR requires decisions be defensible to the regulator; no specific provision cited in this ADR.
```

**The citation rule was machine-verified, not trusted.** Every citation-shaped token in every generated row was checked against its source ADR body. Exactly one mismatch surfaced — `Art. 4-5` against the body's `Art. 4–5` in ADR-0021 — an en-dash difference, not a fabrication; normalised.

## Also fixes real damage from the #1808 migration

Found while reading these files: my header parser's line-continuation handling swallowed a trailing `Relates to:` / `Supersedes:` line into the `authors` field in **ADR-0053, 0077, 0087, 0088, 0089**. Example of what was committed to `main`:

```yaml
authors: [@JiRaska Relates to:** ADR-0008 (OpenTelemetry), ADR-0029 (Governance as Code), ADR-0054 (FinOps)]
```

Authors corrected, swallowed prose restored to each body. The `supersedes` / `superseded-by` **relationships were unaffected** — they are derived by inversion rather than parsed — so no link was lost, only the prose note. The schema validator did not catch this because `authors` only had to be non-empty.

## Verification

```
check-adr-registry: OK — 171 ADRs: unique numbers, headings match filenames,
front-matter valid, supersession bidirectional, derived artefacts fresh.
```

Negative-tested: deleting a `## Compliance impact` section now fails the gate with an actionable message that names the `not applicable` escape hatch. No ADR ended up with a duplicate section.

## Linked issues

N/A — closes the deferred backlog from #1808, which had no tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)