### PR TITLE
ci(adr): reject unfilled scaffolds, and correct the required-check claim

### DIFF
--- a/.github/scripts/check-adr-registry.sh
+++ b/.github/scripts/check-adr-registry.sh
@@ -246,6 +246,29 @@ for f in "${adrs[@]}"; do
     declared_sup="$declared_sup $num>$t"
   done <<< "$sup"
 
+  # 4j. an unfilled scaffold must not merge -------------------------------------
+  # The gate checked that a section EXISTS, not that anyone wrote it. So a
+  # `docs/adr/new.sh` scaffold with its tag corrected but its `summary:` left as the
+  # TODO placeholder passed cleanly — and `summary` is the one field the whole
+  # DIGEST.md tier rests on, so the placeholder would have been published as this
+  # ADR's entry in the decision history. Same for the TEMPLATE.md body prompts.
+  # These markers exist only in the scaffolding, so they cannot false-positive.
+  while IFS= read -r marker; do
+    [[ -z "$marker" ]] && continue
+    if grep -qF -- "$marker" "$f"; then
+      err "$base: still contains the unfilled scaffold placeholder \"$marker\" — write the ADR before merging it."
+    fi
+  done <<'MARKERS'
+TODO-pick-from-tags.txt
+summary: "TODO
+authors: [<name>]
+<Short noun phrase>
+<req refs>
+What forces are at play (technical, business, regulatory)?
+State the decision clearly in active voice
+- **Option A** — short description
+MARKERS
+
   # 4i. required body sections -------------------------------------------------
   # Hard-required, EXCEPT on superseded ADRs: those are immutable historical
   # records (ADR-0001) and some are a pointer to their successor and nothing else

--- a/.github/workflows/adr-registry.yml
+++ b/.github/workflows/adr-registry.yml
@@ -9,10 +9,16 @@
 #   - docs/adr/README.md is the deterministic output of gen-index.sh (no rot).
 #
 # Pure bash over docs/adr/ — no Gradle, no Docker — so it is seconds, not minutes,
-# and runs on the cheap always-on pool. Lives in its own workflow (like
-# issue-hygiene) so it is a small, named, required status check rather than a step
-# buried in the heavy services-ci matrix. The job name `adr-registry` is intended
-# to be a required check in the main-protection ruleset — do not rename it.
+# and runs on the cheap always-on pool. Lives in its own workflow (like issue-hygiene)
+# so it is a small, named check rather than a step buried in the heavy services-ci matrix.
+#
+# WHERE THE TEETH ACTUALLY ARE: `adr-registry` is NOT in the main-protection ruleset's
+# required-status-checks list (verified 2026-07-20) — an earlier comment here claimed it
+# was "intended to be" and that was read as if it were. The binding gate is the
+# `ADR registry integrity check` step inside the REQUIRED `Validate manifests` job in
+# ci.yml, which runs this same script. This workflow is the fast, path-filtered echo of
+# it, useful because it reports in seconds on a docs-only PR. Do not delete either
+# without moving the other into the ruleset.
 # -----------------------------------------------------------------------------
 name: ADR registry
 


### PR DESCRIPTION
You asked whether new ADRs are now conceptually covered. I tested the authoring flow end-to-end instead of assuming, and found two gaps.

## 1. An unfilled scaffold could merge

The gate checked that a section **exists**, not that anyone wrote it.

`docs/adr/new.sh` emits `tags: [TODO-pick-from-tags.txt]`, which the tag allowlist rejects — so a raw scaffold does fail, but for exactly one reason. Correct the tag, change nothing else, and it passed cleanly:

```
- **[0180](0180-concept-test.md)** · Concept test decision · `proposed/planned` · TODO one or two sentences: what is decided and why. Max 240 chars.
```

That line is what DIGEST.md would have published as this decision's entry in the history — and `summary` is the single field the whole digest tier rests on. Verified by scaffolding an ADR, fixing only the tag, and watching the gate go green.

**Check 4j** now rejects the scaffold markers from `new.sh` and `TEMPLATE.md`. They exist only in scaffolding, so no false positives — the 171 existing ADRs stay clean, and a half-written one now fails with one message per unfilled spot:

```
0180-ph-test.md: still contains the unfilled scaffold placeholder "summary: "TODO" — write the ADR before merging it.
0180-ph-test.md: still contains the unfilled scaffold placeholder "What forces are at play (technical, business, regulatory)?" — ...
0180-ph-test.md: still contains the unfilled scaffold placeholder "- **Option A** — short description" — ...
```

## 2. The required-check comment was wrong

`adr-registry.yml` claimed its job "is intended to be a required check in the main-protection ruleset". It is **not** in that ruleset. Verified against the API — the required checks on `main` are:

```
Gitleaks · OPA policy gate · Validate manifests · all-green · issue-hygiene
```

The registry *is* genuinely enforced, but via the `ADR registry integrity check` step inside the **required** `Validate manifests` job, added in #1808. So the teeth are real, just not where the comment said. A governance file that misstates its own enforcement is precisely the rot this directory exists to prevent, so the comment now describes the actual topology.

> [!NOTE]
> Worth considering separately: adding `adr-registry` to the ruleset directly, so the fast path-filtered check is also binding. That is a repo-settings change, not a code one — left to you.

## Linked issues

N/A — hardening follow-up to #1808 / #1813, no tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)