### PR TITLE
fix(document-service): visible signature block, and stop duplicate agreements

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDocumentResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDocumentResource.kt
@@ -81,6 +81,10 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
         val safe = docs.sortedByDescending { it.get("createdAt")?.asText().orEmpty() }.mapNotNull { doc ->
             // Defence in depth: drop anything the upstream returned that isn't actually the caller's.
             if (doc.get("partyRef")?.asText() != partyId) return@mapNotNull null
+            // ARCHIVED is a superseded revision (e.g. an agreement re-issued in another language).
+            // Listing it beside the live one shows the customer several apparently-equal contracts
+            // with no way to tell which one binds them.
+            if (doc.get("status")?.asText().equals(STATUS_ARCHIVED, ignoreCase = true)) return@mapNotNull null
             buildMap<String, Any?> {
                 put("id", doc.get("id")?.asText())
                 put("templateCode", doc.get("templateCode")?.asText())
@@ -171,5 +175,6 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
         const val OK = 200
         const val NOT_FOUND = 404
         const val BAD_REQUEST = 400
+        const val STATUS_ARCHIVED = "ARCHIVED"
     }
 }

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDocumentResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDocumentResourceTest.kt
@@ -80,6 +80,26 @@ class CustomerDocumentResourceTest {
     }
 
     @Test
+    fun `listDocuments hides superseded (ARCHIVED) revisions`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            """
+            [
+              {"id":"$DOC_ID","partyRef":"$caller","templateCode":"RAMCOVA_SMLOUVA_CS","status":"SIGNED",
+               "createdAt":"2026-07-20T10:00:00Z"},
+              {"id":"${UUID.randomUUID()}","partyRef":"$caller","templateCode":"RAMCOVA_SMLOUVA_EN",
+               "status":"ARCHIVED","createdAt":"2026-07-19T10:00:00Z"}
+            ]
+            """.trimIndent(),
+        ).build()
+
+        val body = resource(upstream).listDocuments().entity as String
+
+        assertThat(body).contains("RAMCOVA_SMLOUVA_CS")
+        assertThat(body).doesNotContain("RAMCOVA_SMLOUVA_EN")
+    }
+
+    @Test
     fun `documentContent returns 404 for a document owned by another party (no existence leak)`() {
         val upstream = mockk<UpstreamClient>()
         val otherParty = UUID.randomUUID()

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
@@ -157,8 +157,27 @@ interface SignerVerificationPort {
  * certificate's own lifetime.
  */
 interface ClientSignatureIssuerPort {
-    suspend fun signAsClient(pdf: ByteArray, partyRef: String): ByteArray
+    /**
+     * Apply [partyRef]'s electronic signature to [pdf].
+     *
+     * [visual] is the human-readable evidence to draw onto the page before signing — a PAdES
+     * signature is otherwise invisible in ordinary viewers, so a customer's signed contract looks
+     * unsigned. Passing null signs without a visible block (used where no signer identity is
+     * available to display).
+     */
+    suspend fun signAsClient(pdf: ByteArray, partyRef: String, visual: SignatureVisual? = null): ByteArray
 }
+
+/**
+ * What the visible signature block states. Assembled by the application layer (it owns the signer
+ * lookup and the clock); rendered by the adapter, which owns the PDF mechanics.
+ */
+data class SignatureVisual(
+    val signerName: String,
+    val signedAt: String,
+    val documentId: String,
+    val fingerprint: String,
+)
 
 /**
  * Read-only lookup into `openbank-product-catalog`, scoped to exactly what the onboarding flow

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/port/out/OutboundPorts.kt
@@ -165,19 +165,14 @@ interface ClientSignatureIssuerPort {
      * unsigned. Passing null signs without a visible block (used where no signer identity is
      * available to display).
      */
-    suspend fun signAsClient(pdf: ByteArray, partyRef: String, visual: SignatureVisual? = null): ByteArray
+    suspend fun signAsClient(pdf: ByteArray, partyRef: String, document: SignedDocumentRef? = null): ByteArray
 }
 
 /**
- * What the visible signature block states. Assembled by the application layer (it owns the signer
- * lookup and the clock); rendered by the adapter, which owns the PDF mechanics.
+ * Identifies the document being signed, for the visible signature block. Null means "sign without a
+ * visible block" — the signer's name and the signing time are resolved by the adapter.
  */
-data class SignatureVisual(
-    val signerName: String,
-    val signedAt: String,
-    val documentId: String,
-    val fingerprint: String,
-)
+data class SignedDocumentRef(val documentId: String, val fingerprint: String)
 
 /**
  * Read-only lookup into `openbank-product-catalog`, scoped to exactly what the onboarding flow

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
@@ -225,7 +225,7 @@ class OnboardingDocumentService(
         } catch (e: DuplicateDocumentException) {
             log.infof("Onboarding agreement already rendered for party %s (concurrent tap) — reusing.", partyRef)
             documentQueryUseCase.findByIdempotencyKey(agreementKey)
-                ?: throw IllegalStateException("Duplicate agreement for $partyRef but no document under $agreementKey")
+                ?: error("Duplicate agreement for $partyRef but no document under $agreementKey")
         }
         val ceremony = openOrFindCeremony(document.id, partyRef)
         return OnboardingAgreement(

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
@@ -175,10 +175,18 @@ class OnboardingDocumentService(
 
     private fun onboardingKey(accountId: UUID) = "$ONBOARDING_KEY_PREFIX$accountId"
 
+    /** Names the party's one LIVE framework agreement — language-independent on purpose, so a
+     *  language change supersedes the existing agreement rather than accumulating a second one. */
+    private fun agreementKey(partyRef: String) = "$AGREEMENT_KEY_PREFIX$partyRef"
+
     // ── Customer-driven, language-correct onboarding agreement (ADR-0169 D3) ────────────────────
 
+    // SwallowedException: DuplicateDocumentException IS the "a concurrent tap already rendered this"
+    // signal — caught to resolve to the winning agreement (idempotent), not an error to rethrow.
+    @Suppress("SwallowedException")
     override suspend fun ensureOnboardingAgreement(partyRef: String, lang: String): OnboardingAgreement {
         val wantCode = frameworkCode(lang)
+        val agreementKey = agreementKey(partyRef)
         val agreements = documentQueryUseCase.listByParty(partyRef)
             .filter { it.templateCode.startsWith(FRAMEWORK_BASE) && it.status != DocumentStatus.ARCHIVED }
 
@@ -194,20 +202,31 @@ class OnboardingDocumentService(
         //    returned for any SIGNED one, so everything left is GENERATED/PENDING_SIGNATURE.
         agreements.forEach { documentRepository.save(it.archive()) }
 
-        // 4. Render fresh in the requested language + open the ceremony.
+        // 4. Render fresh in the requested language + open the ceremony. Steps 1-3 are a
+        //    check-then-act over a list read, so two concurrent taps on SIGN can both reach here;
+        //    the idempotency key makes the DB the arbiter (partial unique index, V6) and the loser
+        //    reuses the winner's agreement instead of rendering a second contract. Step 3 released
+        //    the key on the rows it archived, so a language change is still free to re-render.
         val caseRef = "$AGREEMENT_KEY_PREFIX$partyRef"
-        val document = renderUseCase.render(
-            RenderDocumentCommand(
-                templateCode = wantCode,
-                templateVersion = null,
-                data = buildAgreementData(partyRef = partyRef, caseRef = caseRef),
-                contentType = "application/pdf",
-                partyRef = partyRef,
-                caseRef = caseRef,
-                productRef = null,
-                retainUntil = null,
-            ),
-        )
+        val document = try {
+            renderUseCase.render(
+                RenderDocumentCommand(
+                    templateCode = wantCode,
+                    templateVersion = null,
+                    data = buildAgreementData(partyRef = partyRef, caseRef = caseRef),
+                    contentType = "application/pdf",
+                    partyRef = partyRef,
+                    caseRef = caseRef,
+                    productRef = null,
+                    retainUntil = null,
+                    idempotencyKey = agreementKey,
+                ),
+            )
+        } catch (e: DuplicateDocumentException) {
+            log.infof("Onboarding agreement already rendered for party %s (concurrent tap) — reusing.", partyRef)
+            documentQueryUseCase.findByIdempotencyKey(agreementKey)
+                ?: throw IllegalStateException("Duplicate agreement for $partyRef but no document under $agreementKey")
+        }
         val ceremony = openOrFindCeremony(document.id, partyRef)
         return OnboardingAgreement(
             ceremonyId = ceremony.id,

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/OnboardingDocumentService.kt
@@ -223,7 +223,11 @@ class OnboardingDocumentService(
                 ),
             )
         } catch (e: DuplicateDocumentException) {
-            log.infof("Onboarding agreement already rendered for party %s (concurrent tap) — reusing.", partyRef)
+            // No partyRef in the message: it arrives from a token claim, i.e. a user-provided value,
+            // and must never be interpolated into a log line (CodeQL java/log-injection — the same
+            // reason OpenBaoClientSignatureAdapter logs only an exception's type). The event itself
+            // is what's diagnostic here; the losing party is recoverable from the request trace.
+            log.info("Onboarding agreement already rendered for this party (concurrent tap) — reusing.")
             documentQueryUseCase.findByIdempotencyKey(agreementKey)
                 ?: error("Duplicate agreement for $partyRef but no document under $agreementKey")
         }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
@@ -10,9 +10,8 @@ import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
 import com.openbank.document.application.port.out.CeremonyRepositoryPort
 import com.openbank.document.application.port.out.ClientSignatureIssuerPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
-import com.openbank.document.application.port.out.PartyLookupPort
-import com.openbank.document.application.port.out.SignatureVisual
 import com.openbank.document.application.port.out.SignatureSealPort
+import com.openbank.document.application.port.out.SignedDocumentRef
 import com.openbank.document.application.port.out.SignerVerificationPort
 import com.openbank.document.domain.event.SignatureCeremonyCompleted
 import com.openbank.document.domain.model.CeremonyStatus
@@ -27,8 +26,6 @@ import com.openbank.libs.storage.ObjectStorePort
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.Clock
 import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 /**
@@ -47,7 +44,6 @@ class SignatureCeremonyService(
     private val objectStore: ObjectStorePort,
     private val sealPort: SignatureSealPort,
     private val clientSignaturePort: ClientSignatureIssuerPort,
-    private val partyLookupPort: PartyLookupPort,
     private val signerVerificationPort: SignerVerificationPort,
     private val clock: Clock,
     private val objectMapper: ObjectMapper,
@@ -147,28 +143,15 @@ class SignatureCeremonyService(
 
     private suspend fun signAsClient(document: Document, partyRef: String) {
         val pdf = objectStore.get(document.storageKey)
-        val signed = clientSignaturePort.signAsClient(pdf, partyRef, visualFor(document, partyRef))
-        objectStore.put(document.storageKey, signed, document.contentType)
-    }
-
-    /**
-     * What the visible signature block on the page will say. Resolving the signer's legal name is
-     * best-effort: a party-service hiccup must not abort a ceremony the customer has already
-     * authorised with SCA, so the block degrades to the party reference.
-     */
-    private suspend fun visualFor(document: Document, partyRef: String): SignatureVisual {
-        val signerName = runCatching { partyLookupPort.findById(UUID.fromString(partyRef))?.legalName }
-            .getOrNull()
-            ?.takeIf { it.isNotBlank() }
-            ?: partyRef
-        return SignatureVisual(
-            signerName = signerName,
-            signedAt = DateTimeFormatter.ofPattern(SIGNED_AT_PATTERN)
-                .withZone(ZoneOffset.UTC)
-                .format(clock.instant()),
-            documentId = document.id.toString(),
-            fingerprint = document.sha256.take(SHA_PREFIX_LENGTH),
+        val signed = clientSignaturePort.signAsClient(
+            pdf,
+            partyRef,
+            SignedDocumentRef(
+                documentId = document.id.toString(),
+                fingerprint = document.sha256.take(SHA_PREFIX_LENGTH),
+            ),
         )
+        objectStore.put(document.storageKey, signed, document.contentType)
     }
 
     private suspend fun sealDocument(ceremony: SignatureCeremony) {
@@ -198,7 +181,6 @@ class SignatureCeremonyService(
 
     companion object {
         const val EVENT_CEREMONY_COMPLETED = "signature-ceremony.completed.v1"
-        private const val SIGNED_AT_PATTERN = "dd.MM.yyyy HH:mm 'UTC'"
         private const val SHA_PREFIX_LENGTH = 16
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/application/usecase/SignatureCeremonyService.kt
@@ -10,6 +10,8 @@ import com.openbank.document.application.port.`in`.SignatureCeremonyUseCase
 import com.openbank.document.application.port.out.CeremonyRepositoryPort
 import com.openbank.document.application.port.out.ClientSignatureIssuerPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
+import com.openbank.document.application.port.out.PartyLookupPort
+import com.openbank.document.application.port.out.SignatureVisual
 import com.openbank.document.application.port.out.SignatureSealPort
 import com.openbank.document.application.port.out.SignerVerificationPort
 import com.openbank.document.domain.event.SignatureCeremonyCompleted
@@ -25,6 +27,8 @@ import com.openbank.libs.storage.ObjectStorePort
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.Clock
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 /**
@@ -43,6 +47,7 @@ class SignatureCeremonyService(
     private val objectStore: ObjectStorePort,
     private val sealPort: SignatureSealPort,
     private val clientSignaturePort: ClientSignatureIssuerPort,
+    private val partyLookupPort: PartyLookupPort,
     private val signerVerificationPort: SignerVerificationPort,
     private val clock: Clock,
     private val objectMapper: ObjectMapper,
@@ -142,8 +147,28 @@ class SignatureCeremonyService(
 
     private suspend fun signAsClient(document: Document, partyRef: String) {
         val pdf = objectStore.get(document.storageKey)
-        val signed = clientSignaturePort.signAsClient(pdf, partyRef)
+        val signed = clientSignaturePort.signAsClient(pdf, partyRef, visualFor(document, partyRef))
         objectStore.put(document.storageKey, signed, document.contentType)
+    }
+
+    /**
+     * What the visible signature block on the page will say. Resolving the signer's legal name is
+     * best-effort: a party-service hiccup must not abort a ceremony the customer has already
+     * authorised with SCA, so the block degrades to the party reference.
+     */
+    private suspend fun visualFor(document: Document, partyRef: String): SignatureVisual {
+        val signerName = runCatching { partyLookupPort.findById(UUID.fromString(partyRef))?.legalName }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: partyRef
+        return SignatureVisual(
+            signerName = signerName,
+            signedAt = DateTimeFormatter.ofPattern(SIGNED_AT_PATTERN)
+                .withZone(ZoneOffset.UTC)
+                .format(clock.instant()),
+            documentId = document.id.toString(),
+            fingerprint = document.sha256.take(SHA_PREFIX_LENGTH),
+        )
     }
 
     private suspend fun sealDocument(ceremony: SignatureCeremony) {
@@ -173,5 +198,7 @@ class SignatureCeremonyService(
 
     companion object {
         const val EVENT_CEREMONY_COMPLETED = "signature-ceremony.completed.v1"
+        private const val SIGNED_AT_PATTERN = "dd.MM.yyyy HH:mm 'UTC'"
+        private const val SHA_PREFIX_LENGTH = 16
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/domain/model/Document.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/domain/model/Document.kt
@@ -47,9 +47,15 @@ data class Document(
         return copy(status = DocumentStatus.SIGNED)
     }
 
+    /**
+     * Supersede this document. Archiving also RELEASES [idempotencyKey]: the key names the party's
+     * one *live* artifact of its kind, so holding it on a superseded row would permanently block the
+     * legitimate re-render that replaces it (e.g. an onboarding agreement re-issued in another
+     * language). The archived row keeps its content address and stays auditable.
+     */
     fun archive(): Document {
         require(status != DocumentStatus.ARCHIVED) { "Document is already ARCHIVED" }
-        return copy(status = DocumentStatus.ARCHIVED)
+        return copy(status = DocumentStatus.ARCHIVED, idempotencyKey = null)
     }
 
     companion object {

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
@@ -6,7 +6,8 @@ package com.openbank.document.infrastructure.render
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.document.application.port.out.ClientSignatureIssuerPort
-import com.openbank.document.application.port.out.SignatureVisual
+import com.openbank.document.application.port.out.PartyLookupPort
+import com.openbank.document.application.port.out.SignedDocumentRef
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -27,7 +28,11 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
+import java.time.Clock
 import java.time.Duration
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 /**
  * [ClientSignatureIssuerPort] adapter (ADR-0162 D4 continued): issues a fresh, single-use
@@ -46,6 +51,11 @@ import java.time.Duration
  * evidence, exactly like the seal's own dev fallback.
  */
 @ApplicationScoped
+// LongParameterList: six of these nine are @ConfigProperty knobs CDI injects individually; the two
+// collaborators (party lookup, clock) are what the class actually depends on. Bundling the config
+// into a @ConfigMapping would read better but is a refactor of settings other deployments already
+// set by name, so it does not belong in a defect fix.
+@Suppress("LongParameterList")
 class OpenBaoClientSignatureAdapter(
     @ConfigProperty(name = "openbank.signature.client-pki.bao-addr", defaultValue = "http://openbao.vault.svc:8200")
     private val baoAddr: String,
@@ -77,6 +87,8 @@ class OpenBaoClientSignatureAdapter(
     private val requireTrustedIssuer: Boolean,
 
     private val objectMapper: ObjectMapper,
+    private val partyLookupPort: PartyLookupPort,
+    private val clock: Clock,
 ) : ClientSignatureIssuerPort {
 
     private val logger = Logger.getLogger(OpenBaoClientSignatureAdapter::class.java)
@@ -85,35 +97,48 @@ class OpenBaoClientSignatureAdapter(
         .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
         .build()
 
-    override suspend fun signAsClient(
-        pdf: ByteArray,
-        partyRef: String,
-        visual: SignatureVisual?,
-    ): ByteArray = withContext(Dispatchers.IO) {
-        // Idempotent: a retry after a persistence failure must not layer a second signature for a
-        // signer who has already signed this document. This also protects the stamp below — it
-        // rewrites page content, which on an already-signed PDF would invalidate that signature.
-        if (PadesSigning.hasSignatureNamed(pdf, partyRef)) {
-            pdf
-        } else {
-            val identity = issueOneTimeIdentity(partyRef)
-            // Stamp first, sign second, so the visible block is inside the signed byte range: the
-            // page and the signature dictionary then assert the same thing, and neither can be
-            // changed without breaking the other.
-            val stamped = visual?.let {
-                PadesSigning.stampSignatureBlock(
-                    pdf = pdf,
-                    title = SIGNATURE_BLOCK_TITLE,
-                    lines = listOf(
-                        "Signer / Podepsal(a): ${it.signerName}",
-                        "Date / Datum: ${it.signedAt}",
-                        "Document / Dokument: ${it.documentId}",
-                        "Fingerprint / Otisk (SHA-256): ${it.fingerprint}…",
-                    ),
-                )
-            } ?: pdf
-            PadesSigning.applySignature(stamped, identity, partyRef, SIGNATURE_REASON)
+    override suspend fun signAsClient(pdf: ByteArray, partyRef: String, document: SignedDocumentRef?): ByteArray =
+        withContext(Dispatchers.IO) {
+            // Idempotent: a retry after a persistence failure must not layer a second signature for a
+            // signer who has already signed this document. This also protects the stamp below — it
+            // rewrites page content, which on an already-signed PDF would invalidate that signature.
+            if (PadesSigning.hasSignatureNamed(pdf, partyRef)) {
+                pdf
+            } else {
+                val identity = issueOneTimeIdentity(partyRef)
+                // Stamp first, sign second, so the visible block is inside the signed byte range: the
+                // page and the signature dictionary then assert the same thing, and neither can be
+                // changed without breaking the other.
+                val stamped = document?.let {
+                    PadesSigning.stampSignatureBlock(
+                        pdf = pdf,
+                        title = SIGNATURE_BLOCK_TITLE,
+                        lines = signatureBlockLines(partyRef, it),
+                    )
+                } ?: pdf
+                PadesSigning.applySignature(stamped, identity, partyRef, SIGNATURE_REASON)
+            }
         }
+
+    /**
+     * What the block states. Resolving the signer's legal name is best-effort: a party-service
+     * hiccup must not abort a ceremony the customer has already authorised with SCA, so the block
+     * degrades to the party reference rather than failing the signing act.
+     */
+    private suspend fun signatureBlockLines(partyRef: String, document: SignedDocumentRef): List<String> {
+        val signerName = runCatching { partyLookupPort.findById(UUID.fromString(partyRef))?.legalName }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: partyRef
+        val signedAt = DateTimeFormatter.ofPattern(SIGNED_AT_PATTERN)
+            .withZone(ZoneOffset.UTC)
+            .format(clock.instant())
+        return listOf(
+            "Signer / Podepsal(a): $signerName",
+            "Date / Datum: $signedAt",
+            "Document / Dokument: ${document.documentId}",
+            "Fingerprint / Otisk (SHA-256): ${document.fingerprint}...",
+        )
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -217,6 +242,7 @@ class OpenBaoClientSignatureAdapter(
         const val HTTP_OK = 200
         const val EPHEMERAL_VALIDITY_DAYS = 1L
         const val SIGNATURE_REASON = "Client electronic signature (one-time certificate)"
-        const val SIGNATURE_BLOCK_TITLE = "Signed electronically / Podepsáno elektronicky"
+        const val SIGNATURE_BLOCK_TITLE = "Signed electronically / Podepsano elektronicky"
+        const val SIGNED_AT_PATTERN = "dd.MM.yyyy HH:mm 'UTC'"
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapter.kt
@@ -6,6 +6,7 @@ package com.openbank.document.infrastructure.render
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.openbank.document.application.port.out.ClientSignatureIssuerPort
+import com.openbank.document.application.port.out.SignatureVisual
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -84,14 +85,34 @@ class OpenBaoClientSignatureAdapter(
         .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
         .build()
 
-    override suspend fun signAsClient(pdf: ByteArray, partyRef: String): ByteArray = withContext(Dispatchers.IO) {
+    override suspend fun signAsClient(
+        pdf: ByteArray,
+        partyRef: String,
+        visual: SignatureVisual?,
+    ): ByteArray = withContext(Dispatchers.IO) {
         // Idempotent: a retry after a persistence failure must not layer a second signature for a
-        // signer who has already signed this document.
+        // signer who has already signed this document. This also protects the stamp below — it
+        // rewrites page content, which on an already-signed PDF would invalidate that signature.
         if (PadesSigning.hasSignatureNamed(pdf, partyRef)) {
             pdf
         } else {
             val identity = issueOneTimeIdentity(partyRef)
-            PadesSigning.applySignature(pdf, identity, partyRef, SIGNATURE_REASON)
+            // Stamp first, sign second, so the visible block is inside the signed byte range: the
+            // page and the signature dictionary then assert the same thing, and neither can be
+            // changed without breaking the other.
+            val stamped = visual?.let {
+                PadesSigning.stampSignatureBlock(
+                    pdf = pdf,
+                    title = SIGNATURE_BLOCK_TITLE,
+                    lines = listOf(
+                        "Signer / Podepsal(a): ${it.signerName}",
+                        "Date / Datum: ${it.signedAt}",
+                        "Document / Dokument: ${it.documentId}",
+                        "Fingerprint / Otisk (SHA-256): ${it.fingerprint}…",
+                    ),
+                )
+            } ?: pdf
+            PadesSigning.applySignature(stamped, identity, partyRef, SIGNATURE_REASON)
         }
     }
 
@@ -196,5 +217,6 @@ class OpenBaoClientSignatureAdapter(
         const val HTTP_OK = 200
         const val EPHEMERAL_VALIDITY_DAYS = 1L
         const val SIGNATURE_REASON = "Client electronic signature (one-time certificate)"
+        const val SIGNATURE_BLOCK_TITLE = "Signed electronically / Podepsáno elektronicky"
     }
 }

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
@@ -78,9 +78,12 @@ object PadesSigning {
     private const val LINE_SIZE = 8.5f
     private const val LINE_HEIGHT = 12f
     private const val BORDER_WIDTH = 0.7f
-    private val BORDER_GREY = Color(0x99, 0x99, 0x99)
-    private val TEXT_BLACK = Color(0x11, 0x11, 0x11)
-    private val TEXT_GREY = Color(0x55, 0x55, 0x55)
+    private const val BORDER_GREY_RGB = 0x999999
+    private const val TEXT_BLACK_RGB = 0x111111
+    private const val TEXT_GREY_RGB = 0x555555
+    private val BORDER_GREY = Color(BORDER_GREY_RGB)
+    private val TEXT_BLACK = Color(TEXT_BLACK_RGB)
+    private val TEXT_GREY = Color(TEXT_GREY_RGB)
 
     init {
         if (Security.getProvider(BC_PROVIDER) == null) {

--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/render/PadesSigning.kt
@@ -5,6 +5,9 @@
 package com.openbank.document.infrastructure.render
 
 import org.apache.pdfbox.Loader
+import org.apache.pdfbox.pdmodel.PDPageContentStream
+import org.apache.pdfbox.pdmodel.font.PDType1Font
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureInterface
 import org.apache.pdfbox.pdmodel.interactive.digitalsignature.SignatureOptions
@@ -18,6 +21,7 @@ import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
+import java.awt.Color
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.math.BigInteger
@@ -66,6 +70,17 @@ object PadesSigning {
     const val RSA_KEY_SIZE = 2048
     private const val NOT_BEFORE_SKEW_MINUTES = 5L
     private const val EPHEMERAL_VALIDITY_DAYS = 365L
+
+    // Visible signature block geometry (PDF points).
+    private const val BLOCK_MARGIN = 48f
+    private const val BLOCK_PADDING = 12f
+    private const val TITLE_SIZE = 10f
+    private const val LINE_SIZE = 8.5f
+    private const val LINE_HEIGHT = 12f
+    private const val BORDER_WIDTH = 0.7f
+    private val BORDER_GREY = Color(0x99, 0x99, 0x99)
+    private val TEXT_BLACK = Color(0x11, 0x11, 0x11)
+    private val TEXT_GREY = Color(0x55, 0x55, 0x55)
 
     init {
         if (Security.getProvider(BC_PROVIDER) == null) {
@@ -116,6 +131,62 @@ object PadesSigning {
      */
     fun hasSignatureNamed(pdf: ByteArray, name: String): Boolean =
         Loader.loadPDF(pdf).use { document -> document.signatureDictionaries.any { it.name == name } }
+
+    /**
+     * Draws a human-readable signature block onto the last page and returns the new bytes.
+     *
+     * The cryptographic signature lives in the PDF's signature dictionary, which only a validator
+     * (Adobe's signature panel) surfaces — on the page itself it is invisible, so a customer opening
+     * their signed contract in any ordinary viewer sees an unsigned-looking document. This block is
+     * that missing visual evidence.
+     *
+     * Deliberately stamped BEFORE any signature is applied, as ordinary page content rather than a
+     * signature widget's appearance stream: the block is then part of the byte range both the
+     * client signature and the institutional seal cover, so it cannot be altered or stripped without
+     * breaking them. Stamping afterwards would leave the visible text outside the signed bytes —
+     * exactly the discrepancy a signature is supposed to make impossible.
+     *
+     * No-op if [lines] is empty. Callers must not stamp an already-signed PDF (it would invalidate
+     * the existing signature); [hasSignatureNamed] is the guard.
+     */
+    fun stampSignatureBlock(pdf: ByteArray, title: String, lines: List<String>): ByteArray {
+        if (lines.isEmpty()) return pdf
+        return Loader.loadPDF(pdf).use { document ->
+            val page = document.getPage(document.numberOfPages - 1)
+            val box = page.mediaBox
+            val blockHeight = BLOCK_PADDING * 2 + TITLE_SIZE + LINE_HEIGHT * lines.size
+            val top = box.lowerLeftY + BLOCK_MARGIN + blockHeight
+            val left = box.lowerLeftX + BLOCK_MARGIN
+            val width = box.width - BLOCK_MARGIN * 2
+
+            PDPageContentStream(document, page, PDPageContentStream.AppendMode.APPEND, true, true).use { content ->
+                content.setLineWidth(BORDER_WIDTH)
+                content.setStrokingColor(BORDER_GREY)
+                content.addRect(left, box.lowerLeftY + BLOCK_MARGIN, width, blockHeight)
+                content.stroke()
+
+                content.beginText()
+                content.setFont(PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD), TITLE_SIZE)
+                content.setNonStrokingColor(TEXT_BLACK)
+                content.newLineAtOffset(left + BLOCK_PADDING, top - BLOCK_PADDING - TITLE_SIZE)
+                content.showText(title)
+                content.endText()
+
+                content.beginText()
+                content.setFont(PDType1Font(Standard14Fonts.FontName.HELVETICA), LINE_SIZE)
+                content.setNonStrokingColor(TEXT_GREY)
+                content.newLineAtOffset(left + BLOCK_PADDING, top - BLOCK_PADDING - TITLE_SIZE - LINE_HEIGHT)
+                lines.forEach { line ->
+                    content.showText(line)
+                    content.newLineAtOffset(0f, -LINE_HEIGHT)
+                }
+                content.endText()
+            }
+            val output = ByteArrayOutputStream()
+            document.save(output)
+            output.toByteArray()
+        }
+    }
 
     /** Appends one more PAdES signature (an incremental PDF update) using [identity]. */
     fun applySignature(pdf: ByteArray, identity: SigningIdentity, name: String, reason: String): ByteArray =

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
@@ -10,6 +10,7 @@ import com.openbank.document.application.port.`in`.OpenCeremonyCommand
 import com.openbank.document.application.port.out.CeremonyRepositoryPort
 import com.openbank.document.application.port.out.ClientSignatureIssuerPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
+import com.openbank.document.application.port.out.PartyLookupPort
 import com.openbank.document.application.port.out.SignatureSealPort
 import com.openbank.document.application.port.out.SignerVerificationPort
 import com.openbank.document.domain.model.CeremonyStatus
@@ -46,12 +47,14 @@ class SignatureCeremonyServiceTest {
     private val sealPort: SignatureSealPort = mockk()
     private val clientSignaturePort: ClientSignatureIssuerPort = mockk()
     private val signerVerificationPort: SignerVerificationPort = mockk()
+    private val partyLookupPort: PartyLookupPort = mockk(relaxed = true)
     private val service = SignatureCeremonyService(
         ceremonyRepo = ceremonyRepo,
         documentRepo = documentRepo,
         objectStore = objectStore,
         sealPort = sealPort,
         clientSignaturePort = clientSignaturePort,
+        partyLookupPort = partyLookupPort,
         signerVerificationPort = signerVerificationPort,
         clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC),
         objectMapper = ObjectMapper().registerModule(JavaTimeModule()),
@@ -74,7 +77,7 @@ class SignatureCeremonyServiceTest {
         // sealDocument) sees what signAsClient just put -- simulating the object store's own
         // read-your-writes behavior across the two sequential steps.
         coEvery { objectStore.get(document.storageKey) } returns pdf andThen clientSigned
-        coEvery { clientSignaturePort.signAsClient(pdf, "party-1") } returns clientSigned
+        coEvery { clientSignaturePort.signAsClient(pdf, "party-1", any()) } returns clientSigned
         coEvery { objectStore.put(document.storageKey, clientSigned, document.contentType) } returns Unit
         coEvery { sealPort.sealPades(clientSigned, any()) } returns sealed
         coEvery { objectStore.put(document.storageKey, sealed, document.contentType) } returns Unit
@@ -85,7 +88,7 @@ class SignatureCeremonyServiceTest {
 
         assertThat(result.status).isEqualTo(CeremonyStatus.COMPLETED)
         coVerifyOrder {
-            clientSignaturePort.signAsClient(pdf, "party-1")
+            clientSignaturePort.signAsClient(pdf, "party-1", any())
             sealPort.sealPades(clientSigned, any())
         }
         // The bug this pins: a completed ceremony used to seal the PDF bytes but never persist
@@ -109,7 +112,7 @@ class SignatureCeremonyServiceTest {
                 signerVerificationPort.verify("party-1", "evidence-1", document.sha256, ceremony.id.toString())
             } returns true
             coEvery { objectStore.get(document.storageKey) } returns pdf
-            coEvery { clientSignaturePort.signAsClient(any(), "party-1") } returns pdf
+            coEvery { clientSignaturePort.signAsClient(any(), "party-1", any()) } returns pdf
             coEvery { objectStore.put(any(), any(), any()) } returns Unit
             coEvery { sealPort.sealPades(any(), any()) } returns pdf
             coEvery { ceremonyRepo.saveWithOutbox(any(), any()) } answers { firstArg() }
@@ -158,14 +161,14 @@ class SignatureCeremonyServiceTest {
         } returns
             true
         coEvery { objectStore.get(document.storageKey) } returns pdf
-        coEvery { clientSignaturePort.signAsClient(any(), "party-1") } returns pdf
+        coEvery { clientSignaturePort.signAsClient(any(), "party-1", any()) } returns pdf
         coEvery { objectStore.put(any(), any(), any()) } returns Unit
         coEvery { ceremonyRepo.save(any()) } answers { firstArg() }
 
         val result = service.recordDecision(ceremony.id, "party-1", SignerStatus.SIGNED, "evidence-1")
 
         assertThat(result.status).isEqualTo(CeremonyStatus.PARTIALLY_SIGNED)
-        coVerify(exactly = 1) { clientSignaturePort.signAsClient(any(), "party-1") }
+        coVerify(exactly = 1) { clientSignaturePort.signAsClient(any(), "party-1", any()) }
         coVerify(exactly = 0) { sealPort.sealPades(any(), any()) }
         coVerify(exactly = 0) { ceremonyRepo.saveWithOutbox(any(), any()) }
     }
@@ -179,7 +182,7 @@ class SignatureCeremonyServiceTest {
         val result = service.recordDecision(ceremony.id, "party-1", SignerStatus.DECLINED, null)
 
         assertThat(result.status).isEqualTo(CeremonyStatus.DECLINED)
-        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any(), any()) }
         coVerify(exactly = 0) { sealPort.sealPades(any(), any()) }
     }
 
@@ -198,7 +201,7 @@ class SignatureCeremonyServiceTest {
         }
             .isInstanceOf(IllegalStateException::class.java)
 
-        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any(), any()) }
     }
 
     @Test
@@ -213,7 +216,7 @@ class SignatureCeremonyServiceTest {
             runBlocking { service.recordDecision(ceremony.id, "party-2", SignerStatus.SIGNED, "evidence-2") }
         }.isInstanceOf(IllegalArgumentException::class.java)
 
-        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any(), any()) }
         coVerify(exactly = 0) { signerVerificationPort.verify(any(), any(), any(), any()) }
     }
 
@@ -233,7 +236,7 @@ class SignatureCeremonyServiceTest {
 
         assertThat(result.status).isEqualTo(CeremonyStatus.COMPLETED)
         coVerify(exactly = 0) { signerVerificationPort.verify(any(), any(), any(), any()) }
-        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any()) }
+        coVerify(exactly = 0) { clientSignaturePort.signAsClient(any(), any(), any()) }
         coVerify(exactly = 0) { sealPort.sealPades(any(), any()) }
         coVerify(exactly = 0) { ceremonyRepo.save(any()) }
         coVerify(exactly = 0) { ceremonyRepo.saveWithOutbox(any(), any()) }

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/application/usecase/SignatureCeremonyServiceTest.kt
@@ -10,7 +10,6 @@ import com.openbank.document.application.port.`in`.OpenCeremonyCommand
 import com.openbank.document.application.port.out.CeremonyRepositoryPort
 import com.openbank.document.application.port.out.ClientSignatureIssuerPort
 import com.openbank.document.application.port.out.DocumentRepositoryPort
-import com.openbank.document.application.port.out.PartyLookupPort
 import com.openbank.document.application.port.out.SignatureSealPort
 import com.openbank.document.application.port.out.SignerVerificationPort
 import com.openbank.document.domain.model.CeremonyStatus
@@ -47,14 +46,12 @@ class SignatureCeremonyServiceTest {
     private val sealPort: SignatureSealPort = mockk()
     private val clientSignaturePort: ClientSignatureIssuerPort = mockk()
     private val signerVerificationPort: SignerVerificationPort = mockk()
-    private val partyLookupPort: PartyLookupPort = mockk(relaxed = true)
     private val service = SignatureCeremonyService(
         ceremonyRepo = ceremonyRepo,
         documentRepo = documentRepo,
         objectStore = objectStore,
         sealPort = sealPort,
         clientSignaturePort = clientSignaturePort,
-        partyLookupPort = partyLookupPort,
         signerVerificationPort = signerVerificationPort,
         clock = Clock.fixed(FIXED_NOW, ZoneOffset.UTC),
         objectMapper = ObjectMapper().registerModule(JavaTimeModule()),

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/domain/model/DocumentTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/domain/model/DocumentTest.kt
@@ -55,6 +55,19 @@ class DocumentTest {
             .isInstanceOf(IllegalArgumentException::class.java)
     }
 
+    @Test
+    fun `archive releases the idempotency key so the replacement can claim it`() {
+        val live = document(status = DocumentStatus.PENDING_SIGNATURE)
+            .copy(idempotencyKey = "onboarding-agreement:party-1")
+
+        val archived = live.archive()
+
+        // The key names the party's one LIVE artifact. Holding it on a superseded row would make
+        // the partial unique index reject the very re-render that supersedes it (e.g. an agreement
+        // re-issued in another language), so archiving must hand it back.
+        assertThat(archived.idempotencyKey).isNull()
+    }
+
     private fun document(status: DocumentStatus) = Document(
         id = UUID.fromString("00000000-0000-0000-0000-000000000001"),
         templateCode = "LOAN_AGREEMENT",

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/OpenBaoClientSignatureAdapterTest.kt
@@ -5,6 +5,7 @@
 package com.openbank.document.infrastructure.render
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.apache.pdfbox.Loader
 import org.apache.pdfbox.pdmodel.PDDocument
@@ -13,6 +14,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 /**
  * No real OpenBao is available in this test (or in local dev) — a nonexistent ServiceAccount
@@ -30,6 +34,8 @@ class OpenBaoClientSignatureAdapterTest {
         ttl = "300s",
         requireTrustedIssuer = requireTrustedIssuer,
         objectMapper = ObjectMapper(),
+        partyLookupPort = mockk(relaxed = true),
+        clock = Clock.fixed(Instant.parse("2026-07-20T10:00:00Z"), ZoneOffset.UTC),
     )
 
     @Test

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PadesSigningTest.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/render/PadesSigningTest.kt
@@ -7,6 +7,7 @@ package com.openbank.document.infrastructure.render
 import org.apache.pdfbox.Loader
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.text.PDFTextStripper
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.cms.CMSProcessableByteArray
@@ -37,6 +38,42 @@ class PadesSigningTest {
         assertThat(signatures[0].name).isEqualTo("Test Signer")
         assertThat(signatures[0].reason).isEqualTo("unit test signature")
         assertThat(verifies(signatures[0].getContents(signed), signatures[0].getSignedContent(signed))).isTrue()
+    }
+
+    @Test
+    fun `the visible signature block lands on the page and stays inside the signed byte range`() {
+        val pdf = blankPdf()
+        val identity = PadesSigning.generateEphemeralIdentity("party-42")
+
+        val stamped = PadesSigning.stampSignatureBlock(
+            pdf = pdf,
+            title = "Signed electronically",
+            lines = listOf("Signer: Adéla Bartošová", "Date: 20.07.2026 10:00 UTC"),
+        )
+        val signed = PadesSigning.applySignature(stamped, identity, "party-42", "client signature")
+
+        // Visible to a human: the text is real page content, not just a dictionary entry.
+        val text = PDFTextStripper().getText(Loader.loadPDF(signed))
+        assertThat(text).contains("Signed electronically")
+        assertThat(text).contains("Adéla Bartošová")
+
+        // ...and covered by the signature. Signing is an incremental update, so the stamped
+        // document is the literal prefix of the signed file, and the ByteRange's first segment
+        // spans it: those exact bytes are what the CMS signature commits to. (The block can't be
+        // grepped for in the raw bytes — page content is Flate-compressed — so prove containment
+        // by byte range instead.)
+        val signature = Loader.loadPDF(signed).use { it.signatureDictionaries.single() }
+        assertThat(verifies(signature.getContents(signed), signature.getSignedContent(signed))).isTrue()
+        assertThat(signed.copyOfRange(0, stamped.size)).isEqualTo(stamped)
+        assertThat(signature.byteRange[1]).isGreaterThanOrEqualTo(stamped.size)
+        assertThat(PDFTextStripper().getText(Loader.loadPDF(stamped))).contains("Adéla Bartošová")
+    }
+
+    @Test
+    fun `stamping is a no-op without lines so an unsigned-block document is left byte-identical`() {
+        val pdf = blankPdf()
+
+        assertThat(PadesSigning.stampSignatureBlock(pdf, "Signed electronically", emptyList())).isEqualTo(pdf)
     }
 
     @Test


### PR DESCRIPTION
## Linked issues

Closes #1816

## Why

Found by opening a real customer's Documents screen: a signed framework agreement that looked unsigned, sitting next to two more copies of itself.

## What

**1. Visible signature block.** The signing flow now stamps signer, timestamp, document id and fingerprint onto the last page — drawn **before** the signature is applied, so the block is inside the byte range both the client signature and the institutional seal cover. Page and signature dictionary then assert the same thing, and neither can be altered without breaking the other. Stamping afterwards would have put the visible text outside the signed bytes, which is exactly the discrepancy a signature exists to prevent.

Rendered as ordinary page content rather than a signature-widget appearance stream, deliberately: the widget appearance is not part of what the earlier signature commits to.

**2. Duplicate agreements.** `ensureOnboardingAgreement` rendered without an `idempotencyKey`, so V6's partial unique index (`WHERE idempotency_key IS NOT NULL`) never applied and the only guard was the check-then-act list scan V6 was introduced to replace. It now passes the key and reuses the winner's document on a race — the same shape the account-driven path already used.

**3. `archive()` releases the idempotency key.** The key names a party's one *live* artifact; holding it on a superseded row would make the index reject the very re-render that supersedes it (an agreement re-issued in another language).

**4. Edge hides ARCHIVED.** Superseded revisions were listed beside the live contract with nothing to distinguish them.

## Tests

- the block lands on the page (`PDFTextStripper`) **and** the stamped bytes are provably inside the signature's ByteRange
- stamping with no lines is a byte-identical no-op
- `archive()` releases the key
- edge: ARCHIVED rows are filtered out

`:openbank-document-service:test` and `:openbank-customer-edge:test` green locally. One `CeremonyRepositoryImplIT` failure on the first run was `Port already bound: 8081` from a concurrent run on the same machine — passes in isolation.

## Not in this PR

The blank merge fields on those same PDFs are **stale data**, not a live defect (fixed by #1595, deployed 2026-07-17 21:09 UTC). Rendering is not retroactive, so already-issued documents stay blank — re-issuing them is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)