### PR TITLE
fix(customer-edge): hide only superseded documents, not every ARCHIVED one

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDocumentResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerDocumentResource.kt
@@ -78,13 +78,21 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
             ?: return Response.ok("[]").build()
         // document-service returns rows unordered; a document list is read newest-first, so sort here
         // rather than making every client do it.
-        val safe = docs.sortedByDescending { it.get("createdAt")?.asText().orEmpty() }.mapNotNull { doc ->
-            // Defence in depth: drop anything the upstream returned that isn't actually the caller's.
-            if (doc.get("partyRef")?.asText() != partyId) return@mapNotNull null
-            // ARCHIVED is a superseded revision (e.g. an agreement re-issued in another language).
-            // Listing it beside the live one shows the customer several apparently-equal contracts
-            // with no way to tell which one binds them.
-            if (doc.get("status")?.asText().equals(STATUS_ARCHIVED, ignoreCase = true)) return@mapNotNull null
+        val mine = docs.filter { it.get("partyRef")?.asText() == partyId }
+        // Template families that still have a live document, e.g. RAMCOVA_SMLOUVA for a party whose
+        // RAMCOVA_SMLOUVA_CS was superseded by RAMCOVA_SMLOUVA_EN.
+        val supersededFamilies = mine
+            .filterNot { it.get("status")?.asText().equals(STATUS_ARCHIVED, ignoreCase = true) }
+            .mapNotNull { it.get("templateCode")?.asText()?.let(::templateFamily) }
+            .toSet()
+        val safe = mine.sortedByDescending { it.get("createdAt")?.asText().orEmpty() }.mapNotNull { doc ->
+            // Hide an ARCHIVED revision only when a live one of the same family replaced it —
+            // otherwise it IS the customer's only copy. Blanket-hiding ARCHIVED looked right until
+            // the sandbox showed every account agreement sitting in that state: the filter would
+            // have silently removed a contract the customer has no other way to reach.
+            val archived = doc.get("status")?.asText().equals(STATUS_ARCHIVED, ignoreCase = true)
+            val family = doc.get("templateCode")?.asText()?.let(::templateFamily)
+            if (archived && family in supersededFamilies) return@mapNotNull null
             buildMap<String, Any?> {
                 put("id", doc.get("id")?.asText())
                 put("templateCode", doc.get("templateCode")?.asText())
@@ -178,3 +186,6 @@ class CustomerDocumentResource(private val upstream: UpstreamClient) {
         const val STATUS_ARCHIVED = "ARCHIVED"
     }
 }
+
+/** `RAMCOVA_SMLOUVA_CS` and `RAMCOVA_SMLOUVA_EN` are two languages of one contract, not two. */
+private fun templateFamily(templateCode: String): String = templateCode.removeSuffix("_CS").removeSuffix("_EN")

--- a/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDocumentResourceTest.kt
+++ b/openbank-customer-edge/src/test/kotlin/com/openbank/customeredge/CustomerDocumentResourceTest.kt
@@ -100,6 +100,25 @@ class CustomerDocumentResourceTest {
     }
 
     @Test
+    fun `listDocuments keeps an ARCHIVED document that nothing replaced`() {
+        val upstream = mockk<UpstreamClient>()
+        every { upstream.get(any(), any()) } returns Response.ok(
+            """
+            [
+              {"id":"$DOC_ID","partyRef":"$caller","templateCode":"UCET_SMLOUVA_CS","status":"ARCHIVED",
+               "createdAt":"2026-07-17T17:13:45Z"}
+            ]
+            """.trimIndent(),
+        ).build()
+
+        val body = resource(upstream).listDocuments().entity as String
+
+        // Every account agreement in the sandbox sits in ARCHIVED. Hiding it would remove the
+        // customer's only copy of a contract they are party to.
+        assertThat(body).contains("UCET_SMLOUVA_CS")
+    }
+
+    @Test
     fun `documentContent returns 404 for a document owned by another party (no existence leak)`() {
         val upstream = mockk<UpstreamClient>()
         val otherParty = UUID.randomUUID()


### PR DESCRIPTION
## Linked issues

Refs #1840

## Why

The blanket ARCHIVED filter I shipped in #1817 was wrong, and checking the sandbox data afterwards is what caught it: **every** `UCET_SMLOUVA_CS` — the per-account contract — is in ARCHIVED state. The filter therefore removed the customer's only copy of a contract they are party to.

## What

An ARCHIVED document is hidden only when a live document of the same **template family** replaced it. `RAMCOVA_SMLOUVA_CS` superseded by `RAMCOVA_SMLOUVA_EN` is one contract in two languages, so the archived one is noise; an ARCHIVED document with no live sibling IS the record and stays visible.

## Tests

- an ARCHIVED document with no live sibling is kept (the account-agreement case)
- an ARCHIVED document superseded by a live sibling is still hidden (existing test)

## Open question

Why those account agreements are ARCHIVED at all is unexplained — the only `archive()` call in document-service is scoped to `RAMCOVA_*`, there is no retention job (`retain_until` is NULL) and no status-changing endpoint. Filed as #1840; this change stops the customer-visible symptom regardless of the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)