### PR TITLE
chore(gitops): deploy document-service sandbox-b7b47288 (Czech-name signing fix)

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-b6b4faf3
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-b7b47288
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Hand-bump so the signature Unicode-font fix (#1847, Refs #1846) reaches sandbox. `sandbox-b7b47288` is in ECR with its `.sig`/`.att`; ceremony currently 400s on any name with ř/ě/ů. Safe — image already built and signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)