### PR TITLE
fix(onboarding): release the idempotency key when an agreement is archived

### DIFF
--- a/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
+++ b/openbank-document-service/src/main/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImpl.kt
@@ -94,5 +94,12 @@ class DocumentRepositoryImpl :
         sha256 = document.sha256
         sizeBytes = document.sizeBytes
         contentType = document.contentType
+        // MUST propagate the idempotency key: Document.archive() nulls it so the partial unique
+        // index (uq_documents_idempotency_key, WHERE idempotency_key IS NOT NULL) is released and a
+        // fresh agreement can re-render under the same key. Omitting it left the archived row
+        // holding the key, so ensureOnboardingAgreement's re-render hit a DuplicateDocumentException
+        // and its fallback resolved back to the ARCHIVED document — whose ceremony then failed to
+        // sign with "Only PENDING_SIGNATURE documents can be signed" (every onboarding language switch).
+        idempotencyKey = document.idempotencyKey
     }
 }

--- a/openbank-document-service/src/main/resources/db/migration/V9__release_archived_idempotency_keys.sql
+++ b/openbank-document-service/src/main/resources/db/migration/V9__release_archived_idempotency_keys.sql
@@ -1,0 +1,14 @@
+-- Data repair for the applyFrom idempotency-key bug (DocumentRepositoryImpl):
+-- Document.archive() nulled the key in the domain, but the entity update never copied it, so
+-- ARCHIVED rows kept their idempotency_key. Under the partial unique index
+-- (uq_documents_idempotency_key WHERE idempotency_key IS NOT NULL) that key stayed taken, so the
+-- next ensureOnboardingAgreement re-render hit a duplicate and fell back to the ARCHIVED document —
+-- whose ceremony then rejected signing with "Only PENDING_SIGNATURE documents can be signed".
+--
+-- An ARCHIVED document is never resolved by idempotency key again (design: the key belongs to the
+-- live, supersedable agreement), so releasing it here is safe and unblocks every party currently
+-- stuck mid-onboarding. The code fix stops the key from being retained on future archives.
+UPDATE documents
+SET idempotency_key = NULL
+WHERE status = 'ARCHIVED'
+  AND idempotency_key IS NOT NULL;

--- a/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImplIT.kt
+++ b/openbank-document-service/src/test/kotlin/com/openbank/document/infrastructure/persistence/repository/DocumentRepositoryImplIT.kt
@@ -108,6 +108,28 @@ class DocumentRepositoryImplIT {
     }
 
     @Test
+    fun `archiving a document releases its idempotency key so a fresh agreement can re-render`(): Unit =
+        onVertxContext {
+            val key = "onboarding:${UUID.randomUUID()}"
+            val original = onboardingDoc(key)
+            repo.saveWithOutbox(original, outbox(original.id))
+
+            // Onboarding language switch: archive() nulls the key. The UPDATE must persist that null,
+            // or the partial unique index stays taken and the re-render below can never happen — the
+            // exact bug that left the archived agreement resolvable and unsignable ("Only
+            // PENDING_SIGNATURE documents can be signed").
+            repo.save(original.archive())
+
+            assertThat(repo.findByIdempotencyKey(key)).isNull()
+            assertThat(repo.findById(original.id)!!.status).isEqualTo(DocumentStatus.ARCHIVED)
+
+            // The fresh agreement re-renders under the SAME key — previously a DuplicateDocumentException.
+            val fresh = onboardingDoc(key)
+            repo.saveWithOutbox(fresh, outbox(fresh.id))
+            assertThat(repo.findByIdempotencyKey(key)!!.id).isEqualTo(fresh.id)
+        }
+
+    @Test
     fun `save inserts a document that does not exist yet`(): Unit = onVertxContext {
         val doc = onboardingDoc("onboarding:${UUID.randomUUID()}")
 


### PR DESCRIPTION
## Problem

Signing the framework agreement fails with `400 "Only PENDING_SIGNATURE documents can be signed"`, and toggling CS/EN doesn't change the displayed contract language. Confirmed live for the affected party.

`DocumentEntity.applyFrom` never copied `idempotencyKey`. `Document.archive()` nulls it in the domain, but the UPDATE dropped that null, so **ARCHIVED rows kept their key** under the partial unique index `uq_documents_idempotency_key (WHERE idempotency_key IS NOT NULL)`. So every onboarding **language switch** goes:

1. archive the current agreement — key *retained* in the DB (bug),
2. re-render in the new language under the same key → `DuplicateDocumentException`,
3. `ensureOnboardingAgreement`'s fallback `findByIdempotencyKey` resolves back to the **ARCHIVED** document,
4. its still-PENDING ceremony is returned → signing 400s, and the shown contract stays in the old language.

Closes #1850.

## Fix

- `applyFrom` now copies `idempotencyKey`, so archiving actually releases the key and a fresh agreement re-renders under it. Regression test in `DocumentRepositoryImplIT` drives a **real Postgres**: save → `archive()` → key released (`findByIdempotencyKey` null) → re-insert under the same key succeeds. (The old "save updates..." test only flipped status, so it never caught this.)
- **V9** migration nulls `idempotency_key` on already-ARCHIVED rows, unblocking parties already wedged mid-onboarding.

Verified live: doc-service logs showed `ensureOnboardingAgreement` repeatedly hitting "already rendered … reusing" (the duplicate fallback) and resolving to the ARCHIVED doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)