### PR TITLE
chore(gitops): deploy document-service sandbox-c724041a (idempotency-key archive fix)

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -57,7 +57,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: document-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-b7b47288
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-document-service:sandbox-c724041a
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Hand-bump so #1851 (Refs #1850) + V9 reach sandbox. sandbox-c724041a in ECR with .sig/.att; safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)