### PR TITLE
feat(edge): expose Verification of Payee at POST /customer/v1/vop/verify

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -137,6 +137,9 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.swift-service-url")
     lateinit var swiftServiceUrl: String
 
+    @ConfigProperty(name = "openbank.edge.vop-service-url")
+    lateinit var vopServiceUrl: String
+
     @ConfigProperty(name = "openbank.edge.sdd-service-url")
     lateinit var sddServiceUrl: String
 
@@ -588,6 +591,28 @@ class CustomerEdgeResource(
             customer.partyId.toString(),
             """{"currencyCode":"$ccy"}""",
         )
+    }
+
+    // --- Verification of Payee (VoP / Confirmation of Payee, EU SEPA rule) ---
+
+    /**
+     * Verify that a creditor account (IBAN) belongs to the named payee BEFORE the customer confirms
+     * a transfer — the anti-APP-fraud check EU makes mandatory for SEPA payments. Pure name lookup:
+     * no money moves, no account ownership needed, so it is safe for any authenticated customer.
+     * Proxies to vop-service `/api/v1/vop/verify`, which returns MATCH / CLOSE_MATCH / NO_MATCH.
+     */
+    @POST
+    @Path("/vop/verify")
+    @Authorize(action = "customer.vop.verify")
+    @Blocking
+    fun verifyPayee(body: String): Response {
+        val customer = customer()
+        val iban = extractTextField(objectMapper, body, "creditorIban")?.trim()
+            ?: return badRequest("Missing creditorIban")
+        val name = extractTextField(objectMapper, body, "creditorName")?.trim()
+            ?: return badRequest("Missing creditorName")
+        if (iban.isEmpty() || name.isEmpty()) return badRequest("creditorIban and creditorName must not be blank")
+        return upstream.post("$vopServiceUrl/api/v1/vop/verify", customer.partyId.toString(), body)
     }
 
     @DELETE

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -100,6 +100,7 @@ openbank:
     sepa-payment-service-url: ${SEPA_PAYMENT_SERVICE_URL:http://sepa-payment.payments.svc:8115}
     sepa-instant-service-url: ${SEPA_INSTANT_SERVICE_URL:http://sepa-instant.payments.svc:8127}
     swift-service-url: ${SWIFT_SERVICE_URL:http://swift-service.payments.svc:8122}
+    vop-service-url: ${VOP_SERVICE_URL:http://vop-service.payments.svc:8149}
     sdd-service-url: ${SDD_SERVICE_URL:http://sdd-service.sdd.svc:8129}
     bank-bic: ${OPENBANK_BANK_BIC:OPENCZPPXXX}
     sca-service-url:     ${SCA_SERVICE_URL:http://sca-service.sca.svc:8110}

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -160,6 +160,10 @@ spec:
               value: http://sepa-instant.payments.svc:8127
             - name: SWIFT_SERVICE_URL
               value: http://swift-service.payments.svc:8122
+            # Verification of Payee (EU SEPA CoP): POST /customer/v1/vop/verify before a transfer.
+            # Declared here so gen-network-policies.py opens the edge->vop-service ingress allow.
+            - name: VOP_SERVICE_URL
+              value: http://vop-service.payments.svc:8149
             # SEPA Direct Debit mandates (inkasa) read-only view for the customer app (#1730): GET
             # /customer/v1/sdd/mandates. Declared here so gen-network-policies.py opens the
             # edge->sdd ingress allow. sdd-service is KEDA scale-to-zero — first call cold-starts it.

--- a/openbank-infra/gitops/components/payments/network-policies.yaml
+++ b/openbank-infra/gitops/components/payments/network-policies.yaml
@@ -570,6 +570,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: admin-ui
       ports:
         - protocol: TCP


### PR DESCRIPTION
Exposes Confirmation of Payee to the app so it can check a payee name against the IBAN before a SEPA transfer (EU anti-APP-fraud). Proxies vop-service; `customer.vop.verify` is a `customer.*` self-action (existing OPA rule allows it). Wires VOP_SERVICE_URL + edge→vop network policy. Edge module compiles. Closes #1856.

App side (VopApi + PaymentScreen VoP gate) ships in openbank-app separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)