### PR TITLE
feat(cards): customer-settable daily/monthly spending limits

### DIFF
--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/in/CardPorts.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/in/CardPorts.kt
@@ -24,12 +24,20 @@ data class IssueCardCommand(
 
 data class CardStatusCommand(val cardId: UUID, val reason: String?, val changedBy: String)
 
+data class UpdateLimitsCommand(
+    val cardId: UUID,
+    val dailyLimitMinorUnits: Long,
+    val monthlyLimitMinorUnits: Long,
+    val changedBy: String,
+)
+
 interface CardUseCase {
     suspend fun issueCard(cmd: IssueCardCommand): Card
     suspend fun activateCard(cmd: CardStatusCommand): Card
     suspend fun blockCard(cmd: CardStatusCommand): Card
     suspend fun suspendCard(cmd: CardStatusCommand): Card
     suspend fun resumeCard(cmd: CardStatusCommand): Card
+    suspend fun updateLimits(cmd: UpdateLimitsCommand): Card
     suspend fun getCard(id: UUID): Card?
     suspend fun listAll(): List<Card>
     suspend fun listByAccount(accountId: UUID): List<Card>

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardService.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardService.kt
@@ -67,6 +67,19 @@ class CardService(private val repo: CardRepository, private val mapper: ObjectMa
 
     override suspend fun resumeCard(cmd: CardStatusCommand): Card = changeStatus(cmd) { it.resume(Instant.now(clock)) }
 
+    override suspend fun updateLimits(cmd: UpdateLimitsCommand): Card {
+        val card = repo.findById(cmd.cardId) ?: error("Card not found: ${cmd.cardId}")
+        val updated = card.withLimits(cmd.dailyLimitMinorUnits, cmd.monthlyLimitMinorUnits, Instant.now(clock))
+        val event = CardLimitsChanged(
+            updated.id,
+            updated.dailyLimitMinorUnits,
+            updated.monthlyLimitMinorUnits,
+            cmd.changedBy,
+            updated.updatedAt,
+        )
+        return repo.save(updated, outboxMessage(updated.id, EVENT_CARD_LIMITS_CHANGED, event))
+    }
+
     /**
      * Shared status-transition path: load the card, apply [transition], then persist the updated
      * aggregate and its CardStatusChanged event in one transaction (ADR-0050).
@@ -100,5 +113,6 @@ class CardService(private val repo: CardRepository, private val mapper: ObjectMa
     companion object {
         const val EVENT_CARD_ISSUED = "card.issued.v1"
         const val EVENT_CARD_STATUS_CHANGED = "card.status_changed.v1"
+        const val EVENT_CARD_LIMITS_CHANGED = "card.limits_changed.v1"
     }
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/event/CardEvents.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/event/CardEvents.kt
@@ -29,3 +29,10 @@ data class CardStatusChanged(
     val changedBy: String,
     override val occurredAt: Instant = Instant.EPOCH,
 ) : CardEvent()
+data class CardLimitsChanged(
+    override val cardId: UUID,
+    val dailyLimitMinorUnits: Long,
+    val monthlyLimitMinorUnits: Long,
+    val changedBy: String,
+    override val occurredAt: Instant = Instant.EPOCH,
+) : CardEvent()

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
@@ -51,4 +51,16 @@ data class Card(
     fun resume(now: Instant = Instant.EPOCH) = also {
         require(status == CardStatus.SUSPENDED) { "Only SUSPENDED cards can be resumed" }
     }.copy(status = CardStatus.ACTIVE, updatedAt = now)
+
+    /**
+     * Customer-set spending limits. Only a live card may be re-limited (a BLOCKED/CANCELLED/EXPIRED
+     * card has no spend to cap). Limits are non-negative and daily must not exceed monthly.
+     */
+    fun withLimits(dailyMinor: Long, monthlyMinor: Long, now: Instant = Instant.EPOCH) = also {
+        require(status in setOf(CardStatus.ACTIVE, CardStatus.SUSPENDED, CardStatus.PENDING)) {
+            "Cannot change limits on a card in status $status"
+        }
+        require(dailyMinor >= 0 && monthlyMinor >= 0) { "Limits must be non-negative" }
+        require(dailyMinor <= monthlyMinor) { "Daily limit ($dailyMinor) cannot exceed monthly ($monthlyMinor)" }
+    }.copy(dailyLimitMinorUnits = dailyMinor, monthlyLimitMinorUnits = monthlyMinor, updatedAt = now)
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardResource.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardResource.kt
@@ -6,8 +6,10 @@ package com.openbank.cardissuance.infrastructure.rest
 
 import com.openbank.cardissuance.application.port.`in`.CardStatusCommand
 import com.openbank.cardissuance.application.port.`in`.CardUseCase
+import com.openbank.cardissuance.application.port.`in`.UpdateLimitsCommand
 import com.openbank.cardissuance.infrastructure.rest.dto.CardStatusRequest
 import com.openbank.cardissuance.infrastructure.rest.dto.IssueCardRequest
+import com.openbank.cardissuance.infrastructure.rest.dto.UpdateLimitsRequest
 import com.openbank.cardissuance.infrastructure.rest.dto.toResponse
 import com.openbank.libs.authz.Authorize
 import jakarta.annotation.security.RolesAllowed
@@ -15,6 +17,7 @@ import jakarta.ws.rs.Consumes
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.HeaderParam
 import jakarta.ws.rs.POST
+import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.PathParam
 import jakarta.ws.rs.Produces
@@ -106,4 +109,20 @@ class CardResource(private val cardUseCase: CardUseCase) {
     @Operation(summary = "Resume a suspended card")
     suspend fun resume(@PathParam("id") id: UUID, @HeaderParam("X-Operator-Id") operatorId: String): Response =
         Response.ok(cardUseCase.resumeCard(CardStatusCommand(id, null, operatorId)).toResponse()).build()
+
+    @PUT
+    @Path("/{id}/limits")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "card.limits.update", resource = "#id")
+    @Operation(summary = "Set a card's daily and monthly spending limits")
+    suspend fun updateLimits(
+        @PathParam("id") id: UUID,
+        req: UpdateLimitsRequest,
+        @HeaderParam("X-Operator-Id") operatorId: String,
+    ): Response = Response.ok(
+        cardUseCase.updateLimits(
+            UpdateLimitsCommand(id, req.dailyLimitMinorUnits, req.monthlyLimitMinorUnits, operatorId),
+        ).toResponse(),
+    ).build()
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/dto/CardDtos.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/dto/CardDtos.kt
@@ -60,3 +60,6 @@ fun Card.toResponse() = CardResponse(
     dailyLimitMinorUnits, monthlyLimitMinorUnits, currency, deliveryAddress,
     activatedAt, blockedAt, blockedReason, createdAt, updatedAt,
 )
+
+/** Customer/operator request to set a card's spending limits (minor units). */
+data class UpdateLimitsRequest(val dailyLimitMinorUnits: Long, val monthlyLimitMinorUnits: Long)

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2328,6 +2328,24 @@ class CustomerEdgeResource(
         )
     }
 
+    /** Set daily/monthly spending limits on one of the caller's OWN cards. Body:
+     *  {"dailyLimitMinorUnits":N,"monthlyLimitMinorUnits":M}. */
+    @PUT
+    @Path("/cards/{id}/limits")
+    @Authorize(action = "customer.cards.update", resource = "#id")
+    @Blocking
+    fun updateCardLimits(@PathParam("id") id: UUID, body: String): Response {
+        val customer = customer()
+        if (!ownsCard(id, customer.partyId)) return forbidden("Card does not belong to caller")
+        return upstream.put(
+            "$cardIssuanceServiceUrl/api/v1/cards/$id/limits",
+            customer.partyId.toString(),
+            body,
+            null,
+            mapOf("X-Operator-Id" to "customer:${customer.partyId}"),
+        )
+    }
+
     private fun ownsCard(id: UUID, partyId: UUID): Boolean {
         val resp = upstream.get("$cardIssuanceServiceUrl/api/v1/cards/$id", partyId.toString())
         if (resp.status != 200) return false

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -289,6 +289,33 @@ class UpstreamClient {
             .type(MediaType.APPLICATION_JSON).build()
     }
 
+    /** PUT with the M2M operator token + party header + extra headers (e.g. X-Operator-Id). */
+    fun put(
+        url: String,
+        partyId: String,
+        body: String,
+        idempotencyKey: String?,
+        extraHeaders: Map<String, String>,
+    ): Response = try {
+        val builder = HttpRequest.newBuilder()
+            .uri(validatedUri(url))
+            .header("Authorization", "Bearer ${serviceToken()}")
+            .header(PARTY_HEADER, partyId)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .timeout(Duration.ofMillis(requestTimeoutMs))
+        idempotencyKey?.let { builder.header("Idempotency-Key", it) }
+        extraHeaders.forEach { (k, v) -> builder.header(k, v) }
+        val r = http.send(
+            builder.PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+        Response.status(r.statusCode()).entity(r.body()).type(MediaType.APPLICATION_JSON).build()
+    } catch (e: Exception) {
+        Log.error("upstream PUT to $url failed: ${e::class.qualifiedName}: ${e.message}", e)
+        Response.status(502).entity("""{"error":"upstream unavailable"}""").type(MediaType.APPLICATION_JSON).build()
+    }
+
     /** DELETE with the M2M operator token + party header (e.g. cancel a standing order). */
     fun delete(url: String, partyId: String): Response = try {
         val request = HttpRequest.newBuilder()


### PR DESCRIPTION
Adds spending-limit controls: `Card.withLimits()` + `CardLimitsChanged` + card-issuance `PUT /api/v1/cards/{id}/limits`, exposed at the edge as `PUT /customer/v1/cards/{id}/limits` (customer.cards.update, ownership-checked). New `UpstreamClient.put` header overload. Both modules compile. Closes #1862.

First slice of card controls (#4). Channel toggles (needs a migration), virtual-card issuance, and PIN/reveal-PAN (PCI — must not cross the edge in cleartext) follow separately. App slider ships in openbank-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)