### PR TITLE
chore(signing): enforce real seal (ALLOW_EPHEMERAL_SEALS=false)

### DIFF
--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -134,7 +134,7 @@ spec:
             # REMOVE THIS once the KV is seeded per docs/runbooks/0008-openbao-document-signing-pki.md.
             # It is the only thing standing between the sandbox and real (self-signed org) seals.
             - name: OPENBANK_SIGNATURE_ALLOW_EPHEMERAL_SEALS
-              value: "true"
+              value: "false"
             # Datasource: single document-service-db (document-service-db.yaml).
             # Reactive URL for the app (Panache); JDBC URL for Flyway. Both
             # username/password variants set, matching the billing-service pattern.


### PR DESCRIPTION
Real seal keystore is seeded (OpenBao KV) + loaded (ES SecretSynced, pod has no ephemeral warning). Flip the guard to fail-closed so a worthless ephemeral seal can never be silently applied.

Closes #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)