### PR TITLE
feat(edge): PSD2 consent list + revoke for the customer app

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -143,6 +143,9 @@ class CustomerEdgeResource(
     @ConfigProperty(name = "openbank.edge.sdd-service-url")
     lateinit var sddServiceUrl: String
 
+    @ConfigProperty(name = "openbank.edge.consent-service-url")
+    lateinit var consentServiceUrl: String
+
     /** The bank's own SWIFT/BIC — the senderBic on outbound MT103s. */
     @ConfigProperty(name = "openbank.edge.bank-bic", defaultValue = "OPENCZPPXXX")
     lateinit var bankBic: String
@@ -540,6 +543,68 @@ class CustomerEdgeResource(
         o.put("status", m.get("status")?.asText() ?: "")
         m.get("signatureDate")?.asText()?.let { o.put("signatureDate", it) }
         m.get("lastCollectionDate")?.asText()?.takeIf { it.isNotBlank() }?.let { o.put("lastCollectionDate", it) }
+        return o
+    }
+
+    // ── PSD2 consents (ADR-0126) ─────────────────────────────────────────────
+    // The customer's view of who (TPPs, delegated agents) may access their account data, and the
+    // ability to revoke. Consents are party-scoped: consent-service keys them by partyId, so the
+    // edge injects the caller's partyId from the JWT and never trusts a client-supplied one.
+
+    /** The third-party / agent data-access consents granted by the caller. */
+    @GET
+    @Path("/consents")
+    @Authorize(action = "customer.profile.read", resource = "")
+    @Blocking
+    fun listConsents(): Response {
+        val customer = customer()
+        val party = customer.partyId.toString()
+        val resp = upstream.get("$consentServiceUrl/api/v1/consents/party/$party", party)
+        val arr = if (resp.status == 200) {
+            runCatching { objectMapper.readTree(resp.entity?.toString() ?: "") as? ArrayNode }.getOrNull()
+        } else {
+            null
+        } ?: return Response.ok("[]").type(MediaType.APPLICATION_JSON).build()
+        val out = objectMapper.createArrayNode()
+        arr.forEach { c -> out.add(projectConsent(c)) }
+        return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    /**
+     * Revoke a consent the caller owns. consent-service takes partyId as a query param and enforces
+     * that the consent belongs to it, so passing the JWT partyId both authorises and scopes the call
+     * — a customer can never revoke another party's consent even by guessing an id.
+     */
+    @DELETE
+    @Path("/consents/{id}")
+    @Authorize(action = "customer.consent.revoke", resource = "#id")
+    @Blocking
+    fun revokeConsent(@PathParam("id") id: UUID): Response {
+        val customer = customer()
+        val body = objectMapper.createObjectNode().put("reason", "Revoked by customer").toString()
+        val resp = upstream.delete(
+            "$consentServiceUrl/api/v1/consents/$id?partyId=${customer.partyId}",
+            customer.partyId.toString(),
+            body,
+        )
+        return Response.status(resp.status).entity(resp.entity).type(MediaType.APPLICATION_JSON).build()
+    }
+
+    private fun projectConsent(c: com.fasterxml.jackson.databind.JsonNode): ObjectNode {
+        val o = objectMapper.createObjectNode()
+        o.put("id", c.get("id")?.asText())
+        o.put("granteeName", c.get("granteeName")?.asText() ?: "")
+        o.put("granteeType", c.get("granteeType")?.asText() ?: "")
+        o.put("status", c.get("status")?.asText() ?: "")
+        val scopes = objectMapper.createArrayNode()
+        c.get("scopes")?.forEach { scopes.add(it.asText()) }
+        o.set<com.fasterxml.jackson.databind.JsonNode>("scopes", scopes)
+        val ibans = objectMapper.createArrayNode()
+        c.get("accountIbans")?.takeIf { !it.isNull }?.forEach { ibans.add(it.asText()) }
+        o.set<com.fasterxml.jackson.databind.JsonNode>("accountIbans", ibans)
+        c.get("validFrom")?.asText()?.let { o.put("validFrom", it) }
+        c.get("validTo")?.asText()?.let { o.put("validTo", it) }
+        c.get("createdAt")?.asText()?.let { o.put("createdAt", it) }
         return o
     }
 

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/UpstreamClient.kt
@@ -333,6 +333,24 @@ class UpstreamClient {
             .type(MediaType.APPLICATION_JSON).build()
     }
 
+    /** DELETE carrying a JSON body (e.g. consent revoke, which requires a { reason }). */
+    fun delete(url: String, partyId: String, body: String): Response = try {
+        val request = HttpRequest.newBuilder()
+            .uri(validatedUri(url))
+            .header("Authorization", "Bearer ${serviceToken()}")
+            .header(PARTY_HEADER, partyId)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .timeout(Duration.ofMillis(requestTimeoutMs))
+            .method("DELETE", HttpRequest.BodyPublishers.ofString(body)).build()
+        val r = http.send(request, HttpResponse.BodyHandlers.ofString())
+        Response.status(r.statusCode()).entity(r.body()).type(MediaType.APPLICATION_JSON).build()
+    } catch (e: Exception) {
+        Log.error("upstream call to $url failed: ${e::class.qualifiedName}: ${e.message}", e)
+        Response.status(502).entity("""{"error":"upstream unavailable"}""")
+            .type(MediaType.APPLICATION_JSON).build()
+    }
+
     // Idempotency-aware POST: forwards the caller's Idempotency-Key (required by some upstreams,
     // e.g. domestic-payment) so an app retry replays rather than duplicates. A blank/absent key
     // falls back to a generated one so the upstream contract is always satisfied.

--- a/openbank-customer-edge/src/main/resources/application.yaml
+++ b/openbank-customer-edge/src/main/resources/application.yaml
@@ -102,6 +102,7 @@ openbank:
     swift-service-url: ${SWIFT_SERVICE_URL:http://swift-service.payments.svc:8122}
     vop-service-url: ${VOP_SERVICE_URL:http://vop-service.payments.svc:8149}
     sdd-service-url: ${SDD_SERVICE_URL:http://sdd-service.sdd.svc:8129}
+    consent-service-url: ${CONSENT_SERVICE_URL:http://consent-service.consent.svc:8106}
     bank-bic: ${OPENBANK_BANK_BIC:OPENCZPPXXX}
     sca-service-url:     ${SCA_SERVICE_URL:http://sca-service.sca.svc:8110}
     party-service-url:   ${PARTY_SERVICE_URL:http://party-service.party.svc:8111}

--- a/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/accounts/account-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: account-service
     app.kubernetes.io/part-of: accounts
   annotations:
-    openbank.tech/policy-checksum: "148c2ab0b1835cd9"
+    openbank.tech/policy-checksum: "7e47f5429a9cc4ae"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/accounts/account-service.yaml
+++ b/openbank-infra/gitops/components/accounts/account-service.yaml
@@ -37,7 +37,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-account-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "148c2ab0b1835cd9"
+        openbank.tech/policy-checksum: "7e47f5429a9cc4ae"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: anacredit-service
     app.kubernetes.io/part-of: anacredit
   annotations:
-    openbank.tech/policy-checksum: "7cd6fc2661d14160"
+    openbank.tech/policy-checksum: "5f5f1e2cdd001829"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
+++ b/openbank-infra/gitops/components/anacredit/anacredit-service.yaml
@@ -32,7 +32,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-anacredit-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7cd6fc2661d14160"
+        openbank.tech/policy-checksum: "5f5f1e2cdd001829"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/balances/balance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: balance-service
     app.kubernetes.io/part-of: balances
   annotations:
-    openbank.tech/policy-checksum: "f5001a0315256016"
+    openbank.tech/policy-checksum: "a1f6faaa3eec9791"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/balances/balance-service.yaml
+++ b/openbank-infra/gitops/components/balances/balance-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-balance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f5001a0315256016"
+        openbank.tech/policy-checksum: "a1f6faaa3eec9791"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/billing/billing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: billing-service
     app.kubernetes.io/part-of: billing
   annotations:
-    openbank.tech/policy-checksum: "c51c7c315654f5af"
+    openbank.tech/policy-checksum: "879d55e9c0583af5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/billing/billing-service.yaml
+++ b/openbank-infra/gitops/components/billing/billing-service.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-billing-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c51c7c315654f5af"
+        openbank.tech/policy-checksum: "879d55e9c0583af5"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/consent/consent-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: consent-service
     app.kubernetes.io/part-of: consent
   annotations:
-    openbank.tech/policy-checksum: "8fb0694543568c5a"
+    openbank.tech/policy-checksum: "b467a861e27b6344"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/consent/consent-service.yaml
+++ b/openbank-infra/gitops/components/consent/consent-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-consent-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "8fb0694543568c5a"
+        openbank.tech/policy-checksum: "b467a861e27b6344"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: copilot-service
     app.kubernetes.io/part-of: platform
   annotations:
-    openbank.tech/policy-checksum: "27bfebc55ae91d71"
+    openbank.tech/policy-checksum: "2c22095d7fef6278"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/copilot/copilot-service.yaml
+++ b/openbank-infra/gitops/components/copilot/copilot-service.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-copilot-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "27bfebc55ae91d71"
+        openbank.tech/policy-checksum: "2c22095d7fef6278"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: customer-edge
     app.kubernetes.io/part-of: customer-edge
   annotations:
-    openbank.tech/policy-checksum: "95bad196b1d5b2eb"
+    openbank.tech/policy-checksum: "3b905b7241de3df6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -243,6 +243,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -51,7 +51,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-customer-edge-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95bad196b1d5b2eb"
+        openbank.tech/policy-checksum: "3b905b7241de3df6"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: document-service
     app.kubernetes.io/part-of: documents
   annotations:
-    openbank.tech/policy-checksum: "95bad196b1d5b2eb"
+    openbank.tech/policy-checksum: "3b905b7241de3df6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -243,6 +243,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/document-service/document-service-service.yaml
+++ b/openbank-infra/gitops/components/document-service/document-service-service.yaml
@@ -43,7 +43,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-document-service-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "95bad196b1d5b2eb"
+        openbank.tech/policy-checksum: "3b905b7241de3df6"
     spec:
       # ADR-0162 D4 (continued): a dedicated SA (not `default`) is what OpenBao's Kubernetes-auth
       # role `document-service-signing` is bound to — least-privilege, one identity per consumer.

--- a/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fraud-service
     app.kubernetes.io/part-of: fraud
   annotations:
-    openbank.tech/policy-checksum: "bd1472ad4741bc2d"
+    openbank.tech/policy-checksum: "32bb85accb6febeb"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fraud-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "bd1472ad4741bc2d"
+        openbank.tech/policy-checksum: "32bb85accb6febeb"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: fx-service
     app.kubernetes.io/part-of: fx
   annotations:
-    openbank.tech/policy-checksum: "a9ff49b1711f2e26"
+    openbank.tech/policy-checksum: "5813b148941d0d27"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/fx-service/fx-service.yaml
+++ b/openbank-infra/gitops/components/fx-service/fx-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-fx-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "a9ff49b1711f2e26"
+        openbank.tech/policy-checksum: "5813b148941d0d27"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: interest-service
     app.kubernetes.io/part-of: interest
   annotations:
-    openbank.tech/policy-checksum: "dce47bfb86aac25d"
+    openbank.tech/policy-checksum: "7b919218efbbdfc8"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/interest-service/interest-service.yaml
+++ b/openbank-infra/gitops/components/interest-service/interest-service.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-interest-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "dce47bfb86aac25d"
+        openbank.tech/policy-checksum: "7b919218efbbdfc8"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: ledger-service
     app.kubernetes.io/part-of: ledger
   annotations:
-    openbank.tech/policy-checksum: "deebbc07c250bfa1"
+    openbank.tech/policy-checksum: "8ec8c9f1992b4ede"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/ledger/ledger-service.yaml
+++ b/openbank-infra/gitops/components/ledger/ledger-service.yaml
@@ -38,7 +38,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-ledger-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "deebbc07c250bfa1"
+        openbank.tech/policy-checksum: "8ec8c9f1992b4ede"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/lending/lending-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: lending-service
     app.kubernetes.io/part-of: lending
   annotations:
-    openbank.tech/policy-checksum: "ba9de4c6f2cf15b6"
+    openbank.tech/policy-checksum: "237d2fb4d7b58f84"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/lending/lending-service.yaml
+++ b/openbank-infra/gitops/components/lending/lending-service.yaml
@@ -34,7 +34,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-lending-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "ba9de4c6f2cf15b6"
+        openbank.tech/policy-checksum: "237d2fb4d7b58f84"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service-opa-bundle.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/name: notification-service
     app.kubernetes.io/part-of: notifications
   annotations:
-    openbank.tech/policy-checksum: "95bad196b1d5b2eb"
+    openbank.tech/policy-checksum: "3b905b7241de3df6"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -243,6 +243,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/notifications/notification-service.yaml
+++ b/openbank-infra/gitops/components/notifications/notification-service.yaml
@@ -39,7 +39,7 @@ spec:
       annotations:
         # Rolls the Deployment when the OPA policy bundle changes (subPath mounts don't
         # hot-reload). Kept in sync by gen-notification-opa-bundle.sh.
-        openbank.tech/policy-checksum: "95bad196b1d5b2eb"
+        openbank.tech/policy-checksum: "3b905b7241de3df6"
       labels:
         app.kubernetes.io/name: notification-service
         app.kubernetes.io/part-of: notifications

--- a/openbank-infra/gitops/components/party/party-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/party/party-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: party-service
     app.kubernetes.io/part-of: party
   annotations:
-    openbank.tech/policy-checksum: "58889e1082faf5ae"
+    openbank.tech/policy-checksum: "5c1cfe7ea49fbee5"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/party/party-service.yaml
+++ b/openbank-infra/gitops/components/party/party-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-party-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "58889e1082faf5ae"
+        openbank.tech/policy-checksum: "5c1cfe7ea49fbee5"
       labels:
         app.kubernetes.io/name: party-service
         app.kubernetes.io/part-of: party

--- a/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/card-issuance-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: card-issuance-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "7fe16c30fe264ec8"
+    openbank.tech/policy-checksum: "3533a0a765b9cd07"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/clearing-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: clearing-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "e81b33f754cf3902"
+    openbank.tech/policy-checksum: "89e78bf2b44593f1"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/domestic-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: domestic-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "1c069f4d8933fc4f"
+    openbank.tech/policy-checksum: "a8f433383429956c"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -42,7 +42,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-transaction-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "d32325fccee495cb" # transaction-opa-bundle
+        openbank.tech/policy-checksum: "474505a2d5973f09" # transaction-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -375,7 +375,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-payment-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c708df1447874584"
+        openbank.tech/policy-checksum: "d508220ef848e233"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -729,7 +729,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-domestic-payment-opa-bundle.sh via the trailing marker
         # comment (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "1c069f4d8933fc4f" # domestic-payment-opa-bundle
+        openbank.tech/policy-checksum: "a8f433383429956c" # domestic-payment-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1053,7 +1053,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sepa-instant-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "cbb12a941c3e0bc6"
+        openbank.tech/policy-checksum: "e3a6187ec678c9ab"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1369,7 +1369,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-clearing-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "e81b33f754cf3902" # clearing-opa-bundle
+        openbank.tech/policy-checksum: "89e78bf2b44593f1" # clearing-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -1785,7 +1785,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-card-issuance-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "7fe16c30fe264ec8"
+        openbank.tech/policy-checksum: "3533a0a765b9cd07"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2042,7 +2042,7 @@ spec:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-settlement-opa-bundle.sh via the trailing marker comment
         # (do not hand-edit, do not drop the marker).
-        openbank.tech/policy-checksum: "b80f57321aa3ed08" # settlement-opa-bundle
+        openbank.tech/policy-checksum: "c244e7e87b554875" # settlement-opa-bundle
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2443,7 +2443,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-swift-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "4d9be068d484f9d1"
+        openbank.tech/policy-checksum: "4c34cb2f84ca2de2"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -2757,7 +2757,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-vop-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f9230b8ee1834e8f"
+        openbank.tech/policy-checksum: "f8b4a4bb6208f3a9"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-instant-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-instant
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "cbb12a941c3e0bc6"
+    openbank.tech/policy-checksum: "e3a6187ec678c9ab"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/sepa-payment-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sepa-payment
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "c708df1447874584"
+    openbank.tech/policy-checksum: "d508220ef848e233"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/settlement-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: settlement-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "b80f57321aa3ed08"
+    openbank.tech/policy-checksum: "c244e7e87b554875"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/swift-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: swift-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "4d9be068d484f9d1"
+    openbank.tech/policy-checksum: "4c34cb2f84ca2de2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/transaction-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: transaction-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "d32325fccee495cb"
+    openbank.tech/policy-checksum: "474505a2d5973f09"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/payments/vop-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: vop-service
     app.kubernetes.io/part-of: payments
   annotations:
-    openbank.tech/policy-checksum: "f9230b8ee1834e8f"
+    openbank.tech/policy-checksum: "f8b4a4bb6208f3a9"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/pid/pid-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pid-service
     app.kubernetes.io/part-of: pid
   annotations:
-    openbank.tech/policy-checksum: "f16083dfe3a88323"
+    openbank.tech/policy-checksum: "c2429bdb7b798f6d"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/pid/pid-service.yaml
+++ b/openbank-infra/gitops/components/pid/pid-service.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         # Rolls the pod when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-pid-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "f16083dfe3a88323"
+        openbank.tech/policy-checksum: "c2429bdb7b798f6d"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sanctions-service
     app.kubernetes.io/part-of: sanctions
   annotations:
-    openbank.tech/policy-checksum: "e4d811093de7a6f2"
+    openbank.tech/policy-checksum: "0f6934b5b84bf786"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
+++ b/openbank-infra/gitops/components/sanctions-service/sanctions-service.yaml
@@ -49,7 +49,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sanctions-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "e4d811093de7a6f2"
+        openbank.tech/policy-checksum: "0f6934b5b84bf786"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
+++ b/openbank-infra/gitops/components/sca/sca-opa-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: sca-service
     app.kubernetes.io/part-of: sca
   annotations:
-    openbank.tech/policy-checksum: "c3cb2dbe82885463"
+    openbank.tech/policy-checksum: "2a127d38e3dcfbf2"
 data:
   rest.rego: |
     # SPDX-License-Identifier: Apache-2.0
@@ -242,6 +242,21 @@ data:
     	input.principal.id == "service-account-openbank-edge"
     	some family in {"notification.", "device.", "document.", "signatureCeremony."}
     	startswith(input.action, family)
+    }
+
+    # The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+    # lists who may access its account data and revokes a consent. Same edge principal, same
+    # guard as edge-service-notification — the edge injects the caller's authoritative partyId
+    # from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+    # ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+    # consent.partyId != command.partyId), so the edge can never read or revoke another party's
+    # consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+    # `consent.` family — so this grant cannot create, activate, or validate consents on the
+    # edge principal (least privilege; the edge exposes no route for those anyway).
+    allowed_reasons contains "edge-service-consent" if {
+    	input.principal.type == "HUMAN"
+    	input.principal.id == "service-account-openbank-edge"
+    	input.action in {"consent.list", "consent.revoke"}
     }
 
     # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen

--- a/openbank-infra/gitops/components/sca/sca-service.yaml
+++ b/openbank-infra/gitops/components/sca/sca-service.yaml
@@ -28,7 +28,7 @@ spec:
       annotations:
         # Rolls the pods when the OPA bundle changes — subPath mounts do NOT hot-reload.
         # Kept in sync by gen-sca-opa-bundle.sh (do not hand-edit).
-        openbank.tech/policy-checksum: "c3cb2dbe82885463"
+        openbank.tech/policy-checksum: "2a127d38e3dcfbf2"
     spec:
       securityContext:
         runAsNonRoot: true

--- a/openbank-libs/governance/policies/rest.rego
+++ b/openbank-libs/governance/policies/rest.rego
@@ -230,6 +230,21 @@ allowed_reasons contains "edge-service-notification" if {
 	startswith(input.action, family)
 }
 
+# The customer-edge proxying the customer's own PSD2 consent screen (ADR-0126): the app
+# lists who may access its account data and revokes a consent. Same edge principal, same
+# guard as edge-service-notification — the edge injects the caller's authoritative partyId
+# from the JWT (consent-service keys listByParty by that path partyId), and revoke is
+# ownership-enforced downstream (ConsentService throws ConsentNotOwnedByPartyException when
+# consent.partyId != command.partyId), so the edge can never read or revoke another party's
+# consent even with a guessed id. Scoped to the two exact actions the app uses — NOT the
+# `consent.` family — so this grant cannot create, activate, or validate consents on the
+# edge principal (least privilege; the edge exposes no route for those anyway).
+allowed_reasons contains "edge-service-consent" if {
+	input.principal.type == "HUMAN"
+	input.principal.id == "service-account-openbank-edge"
+	input.action in {"consent.list", "consent.revoke"}
+}
+
 # Any M2M service-account caller (e.g. account-service) may trigger a sanctions screen
 # (issue #746, found via issue #669's load benchmark). sanctions.create is called with
 # resource = "" — a resourceless system action — so operator-on-own-tenant (which requires

--- a/openbank-libs/governance/policies/rest_test.rego
+++ b/openbank-libs/governance/policies/rest_test.rego
@@ -609,6 +609,53 @@ test_deny_operator_signature_ceremony_record_decision if {
 	}
 }
 
+# edge-service-consent: the customer's own PSD2 consent screen (ADR-0126). Same edge
+# principal + guard as the notification/document grants — list is party-scoped by the
+# path partyId the edge injects, revoke is ownership-enforced downstream.
+test_allow_service_consent_list if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "consent.list",
+		"resource": {"type": "party", "id": "p-1"},
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "edge-service-consent"
+}
+
+test_allow_service_consent_revoke if {
+	decision := rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "consent.revoke",
+		"resource": {"type": "consent", "id": "c-1"},
+	}
+		with data.openbank.bundle as bundle
+
+	decision.allow == true
+	decision.reason == "edge-service-consent"
+}
+
+# Least privilege: the grant is the two exact actions the app uses, NOT the consent. family
+# — the edge must not be able to create/activate/validate consents on the customer's behalf.
+test_deny_service_consent_create if {
+	not rest.allow with input as {
+		"principal": {"id": "service-account-openbank-edge", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "consent.create",
+		"resource": {"type": "consent", "id": "c-1"},
+	}
+}
+
+# Staff carrying ROLE_OPERATOR must not revoke a customer's consent off this rule — it is
+# pinned to the edge's client_credentials identity, and a human session is a different client.
+test_deny_operator_consent_revoke if {
+	not rest.allow with input as {
+		"principal": {"id": "alice.operator", "type": "HUMAN", "roles": ["ROLE_OPERATOR"]},
+		"action": "consent.revoke",
+		"resource": {"type": "consent", "id": "c-1"},
+	}
+}
+
 # The rule must NOT open other action families to the edge M2M caller (deny-by-default
 # holds) — operator-read-any also does not cover a write like party.update.
 test_deny_service_outside_notification_family if {


### PR DESCRIPTION
Exposes the customer's PSD2/TPP data-access consents (ADR-0126) through customer-edge so the app can show who may read their account data and revoke access.

## Routes (customer.* self-action OPA rule already covers both — no bundle change)
- `GET /customer/v1/consents` → consent-service `GET /api/v1/consents/party/{partyId}`
- `DELETE /customer/v1/consents/{id}` → consent-service `DELETE /api/v1/consents/{id}?partyId=`

## Security
Consents are **party-scoped**: the edge injects the caller's `partyId` from the JWT and never trusts a client-supplied one, so a customer can only ever list/revoke their own consents even by guessing an id. Mirrors the existing SDD/cards ownership pattern.

## Notes
- Adds `UpstreamClient.delete(url, partyId, body)` overload (consent revoke requires a `{ reason }` body; JDK HttpClient DELETE-with-body via `.method()`).
- Adds `openbank.edge.consent-service-url` (default `consent-service.consent.svc:8106`).
- openapi.yaml is a curated subset (does not enumerate /sdd,/cards,/vop either) — no contract entry added, consistent with those features.

Closes #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update: upstream authz
consent-service enforces OPA (AUTHZ_ENFORCE=true), unlike sdd. Added an `edge-service-consent` reason in `rest.rego` scoped to `consent.list`+`consent.revoke` for the edge principal (least privilege, +4 tests) so the routes do not 403.
