### PR TITLE
fix(admin-ui): bump brace-expansion off the exponential-expansion DoS

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openbank-admin-ui",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openbank-admin-ui",
-      "version": "0.54.0",
+      "version": "0.54.1",
       "dependencies": {
         "@hookform/resolvers": "5.4.0",
         "@radix-ui/react-dialog": "1.1.20",
@@ -4964,9 +4964,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6220,9 +6220,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8144,9 +8144,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -8495,9 +8495,9 @@
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-13149 (Dependabot alert + Trivy code-scanning finding): `brace-expansion`'s `expand()` is O(2^n) in the number of consecutive non-expanding `{}` groups, so a <100-byte input can hang the calling thread. Three transitive instances were all below the patched line (pulled in via eslint/glob/minimatch): `1.1.15`, `2.1.1`, `5.0.5` → bumped to `1.1.16`, `2.1.2`, `5.0.7`.
- Also fixes `fast-uri` (via ajv → webpack → @sentry/nextjs), which surfaced only via this PR's own Trivy fs scan (not the original Dependabot list): two host-confusion GHSAs fixed in `3.1.4`, was at `3.1.2`.
- `npm update <pkg>` moved each within its existing minimatch/ajv-declared semver range — no override or direct dependency needed.

## Linked issues
N/A — found via the GitHub Security tab (Dependabot + Trivy code scanning), no pre-existing tracked issue.

## Test plan
- [x] `npm run type-check`
- [x] `npm run test -- --run` — 38 files / 642 tests pass
- [x] `npm audit` no longer reports brace-expansion or fast-uri (only `next`/`sharp`, not in GitHub's Security tab, deliberately left — `next`'s suggested fix is a major downgrade to 14.2.35, clearly the wrong direction)