### PR TITLE
security(document-renderer): pin Dockerfile base image and pip by digest/version

### DIFF
--- a/openbank-document-renderer/Dockerfile
+++ b/openbank-document-renderer/Dockerfile
@@ -11,7 +11,10 @@
 # version.txt, so it is built/deployed independently of the fleet's Gradle
 # release axis.
 
-FROM python:3.14-slim AS builder
+# Digest-pinned per Scorecard Pinned-Dependencies (multi-arch manifest-list digest — the
+# platform-specific image is resolved from this at pull time). Refresh alongside a Python
+# patch bump: `crane digest python:3.14-slim` or the registry API.
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS builder
 
 # Build-time-only packages. libpango/libharfbuzz runtime .so's are also
 # installed here so `pip install` can link/validate against them if a
@@ -31,10 +34,10 @@ WORKDIR /build
 COPY requirements.txt .
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
-RUN pip install --no-cache-dir --upgrade pip && \
+RUN pip install --no-cache-dir --upgrade pip==26.1.2 && \
     pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.14-slim AS runtime
+FROM python:3.14-slim@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS runtime
 
 # Runtime-only shared libraries WeasyPrint needs (text shaping via Pango +
 # HarfBuzz, image decoding via libjpeg/openjp2). This mirrors the official


### PR DESCRIPTION
## Summary
Closes 4 OpenSSF Scorecard Pinned-Dependencies findings on `openbank-document-renderer/Dockerfile`:
- Both `FROM python:3.14-slim` stages (builder + runtime) now pin the multi-arch manifest-list digest, not the mutable tag. (Rebased onto the `3.12-slim`→`3.14-slim` Dependabot bump, #1343, that landed on main after this branch was first cut.)
- `pip install --upgrade pip` now pins an exact version (26.1.2) instead of floating to whatever's latest at build time.

`requirements.txt` was already properly pinned (`weasyprint==69.0`, with a GHSA reference in its own comment) — only the Dockerfile itself was unpinned.

## Linked issues
N/A — found via the GitHub Security tab (OpenSSF Scorecard), no pre-existing tracked issue.

## Test plan
- [ ] Docker build (no local daemon in this environment to verify — digest/tag are otherwise identical `python:3.14-slim`, so the build should be unaffected)