### PR TITLE
feat(interest): run monthly capitalization so withholding is assembled (#999)

### DIFF
--- a/docs/threat-models/openbank-interest-service.md
+++ b/docs/threat-models/openbank-interest-service.md
@@ -58,4 +58,13 @@ money-path service, not adjacent.
 
 ## 6. Change log
 
+- **2026-07-22** — Activate monthly capitalization (issue #999). `capitalizeAll` was a stub returning 0,
+  so the already-assessed `capitalize()` money-path (claims accruals, posts a GL journal via
+  `LedgerPostingPort`, records withholding) had never run at scale. A new `InterestCapitalizationScheduler`
+  now drives it monthly (cron `0 0 2 1 * ?`), over a work-list read from the accrual table
+  (`findAccountsWithPendingCapitalization`). No new trust boundary or external caller — this activates
+  existing money-path logic on a schedule; per-pair failures are recovered (a wedged account can't stop
+  the batch) and each capitalization keeps its existing ledger idempotency key, so a retry is safe. The
+  downstream effect is that withholding tax is now actually assembled and remitted (the §38d statutory
+  filing owner is decided separately in ADR-0180). Rollback: revert the commit (the scheduler stops).
 - **2026-07-18** — Initial lightweight threat model (ADR-0030 D2), added alongside `openbank-interest-service`'s addition to `money_path_services` (#1478).

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/InterestPorts.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/port/out/InterestPorts.kt
@@ -47,6 +47,16 @@ interface InterestAccrualRepository {
     fun findPendingCapitalization(accountId: UUID, productId: String, toDate: LocalDate): Uni<List<InterestAccrual>>
 
     /**
+     * The distinct `(accountId, productId)` pairs that have at least one pending (`ACCRUING`) accrual
+     * up to [toDate] — the work-list for a fleet-wide monthly capitalization run (issue #999). Unlike
+     * [findPendingCapitalization] (one already-known pair), this discovers *which* pairs have anything
+     * to capitalize, so the scheduler needs no separate account enumeration. Capitalizing is a pure
+     * function of already-persisted accruals, so this is a plain DB read — it never touches
+     * account-service.
+     */
+    fun findAccountsWithPendingCapitalization(toDate: LocalDate): Uni<List<Pair<UUID, String>>>
+
+    /**
      * The accruals of one `(account, product)` already **claimed** by an in-flight capitalization
      * (`CAPITALIZING`), regardless of date.
      *

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/application/usecase/InterestService.kt
@@ -17,6 +17,7 @@ import io.smallrye.mutiny.Uni
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.inject.Inject
 import org.eclipse.microprofile.config.inject.ConfigProperty
+import org.jboss.logging.Logger
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Clock
@@ -66,6 +67,8 @@ class InterestService(
         accruableAccountTypes,
         Clock.systemUTC(),
     )
+
+    private val log = Logger.getLogger(InterestService::class.java)
 
     override fun accrue(request: AccrualRequest): Uni<InterestAccrual> =
         configRepo.findEffectiveRate(request.accountId, request.productId, request.accrualDate).flatMap { config ->
@@ -439,7 +442,45 @@ class InterestService(
         )
     }
 
-    override fun capitalizeAll(toDate: LocalDate): Uni<Int> = Uni.createFrom().item(0)
+    /**
+     * Capitalizes every `(account, product)` with a pending `ACCRUING` set up to [toDate] — the
+     * fleet-wide monthly run behind the capitalization scheduler (issue #999). Returns the number of
+     * pairs actually capitalized.
+     *
+     * The work-list is discovered from the accrual table itself ([findAccountsWithPendingCapitalization]),
+     * NOT by enumerating account-service: capitalization operates purely over already-persisted
+     * accruals, so it needs no live balance and does not touch account-service.
+     *
+     * Per-pair resilience mirrors [accrueAll]: a mixed-currency wedge (#1265), an in-flight claim held
+     * for a different period, a non-positive gross, or a lost race (another run already capitalized the
+     * pair) collapses that one pair to a no-op (0) and is logged, never aborting the batch — one wedged
+     * account must not stop every other account's monthly capitalization. Pairs are processed
+     * sequentially (`concatenate`) to keep a bounded, polite load on the ledger.
+     */
+    override fun capitalizeAll(toDate: LocalDate): Uni<Int> =
+        accrualRepo.findAccountsWithPendingCapitalization(toDate).flatMap { pairs ->
+            if (pairs.isEmpty()) {
+                Uni.createFrom().item(0)
+            } else {
+                Multi.createFrom().iterable(pairs)
+                    .onItem().transformToUniAndConcatenate { (accountId, productId) ->
+                        capitalize(accountId, productId, toDate)
+                            .map { 1 }
+                            .onFailure().invoke { e ->
+                                log.warnf(
+                                    e,
+                                    "capitalization skipped for account %s product %s up to %s: %s",
+                                    accountId,
+                                    productId,
+                                    toDate,
+                                    e.message,
+                                )
+                            }
+                            .onFailure().recoverWithItem(0)
+                    }
+                    .collect().with(java.util.stream.Collectors.summingInt { it })
+            }
+        }
 
     override fun listAllAccruals(): Uni<List<InterestAccrual>> = accrualRepo.findAll()
 

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/persistence/repository/InterestRepositories.kt
@@ -132,6 +132,15 @@ class InterestAccrualRepositoryImpl @Inject constructor(
         ).setParameter("a", accountId).setParameter("p", productId).setParameter("d", toDate).resultList
     }.map { it.map(mapper::toDomain) }
 
+    @WithSession override fun findAccountsWithPendingCapitalization(toDate: LocalDate): Uni<List<Pair<UUID, String>>> =
+        sf.withSession { s ->
+            s.createQuery(
+                "SELECT DISTINCT a.accountId, a.productId FROM InterestAccrualEntity a " +
+                    "WHERE a.status = 'ACCRUING' AND a.accrualDate <= :d",
+                Array<Any>::class.java,
+            ).setParameter("d", toDate).resultList
+        }.map { rows -> rows.map { (it[0] as UUID) to (it[1] as String) } }
+
     @WithSession
     override fun findClaimedForCapitalization(accountId: UUID, productId: String): Uni<List<InterestAccrual>> =
         sf.withSession { s ->

--- a/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/InterestCapitalizationScheduler.kt
+++ b/openbank-interest-service/src/main/kotlin/com/openbank/interest/infrastructure/scheduler/InterestCapitalizationScheduler.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.interest.infrastructure.scheduler
+
+import com.openbank.interest.application.port.`in`.CapitalizeInterestUseCase
+import io.quarkus.scheduler.Scheduled
+import io.smallrye.mutiny.Uni
+import jakarta.enterprise.context.ApplicationScoped
+import org.jboss.logging.Logger
+import java.time.Clock
+import java.time.LocalDate
+
+/**
+ * Drives the monthly interest capitalization. One tick per month (cron in
+ * `openbank.interest.capitalization-cron`, `0 0 2 1 * ?` — 02:00 on the 1st) capitalizes every
+ * `(account, product)` with a pending `ACCRUING` set up to today ([CapitalizeInterestUseCase.capitalizeAll]).
+ * `SKIP` on concurrent execution means a slow run is never doubled up; each per-pair capitalization
+ * claims its accruals `ACCRUING → CAPITALIZING` under a ledger idempotency key, so a retry (or a manual
+ * `POST /capitalize/all`) after a partial run only finishes the pairs that were still pending.
+ *
+ * This is the engine that was previously missing: `capitalizeAll` used to be a stub returning 0, so no
+ * interest was ever capitalized — and therefore no withholding tax was ever assembled or remitted
+ * (issue #999), despite the accrual, capitalization, withholding and remittance machinery all existing.
+ * It mirrors [InterestAccrualScheduler], one rung later in the lifecycle.
+ */
+@ApplicationScoped
+class InterestCapitalizationScheduler(
+    private val capitalizeInterestUseCase: CapitalizeInterestUseCase,
+    private val clock: Clock,
+) {
+    private val log = Logger.getLogger(InterestCapitalizationScheduler::class.java)
+
+    @Scheduled(
+        cron = "{openbank.interest.capitalization-cron}",
+        identity = "interest-monthly-capitalization",
+        concurrentExecution = Scheduled.ConcurrentExecution.SKIP,
+    )
+    fun runMonthlyCapitalization(): Uni<Void> {
+        val toDate = LocalDate.now(clock)
+        log.infof("interest capitalization tick starting up to %s", toDate)
+        return capitalizeInterestUseCase.capitalizeAll(toDate)
+            .onItem().invoke { count ->
+                log.infof("interest capitalization up to %s capitalized %d pair(s)", toDate, count)
+            }
+            .onFailure().invoke { e -> log.errorf(e, "interest capitalization up to %s failed", toDate) }
+            .onFailure().recoverWithItem(0)
+            .replaceWithVoid()
+    }
+}

--- a/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
+++ b/openbank-interest-service/src/test/kotlin/com/openbank/interest/application/usecase/InterestServiceTest.kt
@@ -268,6 +268,41 @@ class InterestServiceTest {
     }
 
     @Test
+    fun `capitalizeAll capitalizes every pending pair and recovers a per-pair failure`() {
+        val toDate = LocalDate.of(2026, 1, 20)
+        val prod = "SAVINGS"
+        val accountA = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        val accountB = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        stubCapitalization()
+
+        every { accrualRepo.findAccountsWithPendingCapitalization(toDate) } returns
+            Uni.createFrom().item(listOf(accountA to prod, accountB to prod))
+        // A has a pending accrual → capitalizes; B's set is empty by the time it runs (a lost race) →
+        // capitalize() fails, and capitalizeAll must recover per-pair rather than abort the whole run.
+        every { accrualRepo.findPendingCapitalization(accountA, prod, toDate) } returns
+            Uni.createFrom().item(listOf(sampleAccrual(accountA, prod, LocalDate.of(2026, 1, 18), BigDecimal("1.50"))))
+        every { accrualRepo.findPendingCapitalization(accountB, prod, toDate) } returns
+            Uni.createFrom().item(emptyList())
+
+        val count = service.capitalizeAll(toDate).await().indefinitely()
+
+        assertThat(count).isEqualTo(1) // only A capitalized; B's failure was swallowed, not propagated
+        verify(exactly = 1) { accrualRepo.findAccountsWithPendingCapitalization(toDate) }
+        verify(exactly = 1) { accrualRepo.findPendingCapitalization(accountA, prod, toDate) }
+        verify(exactly = 1) { accrualRepo.findPendingCapitalization(accountB, prod, toDate) }
+    }
+
+    @Test
+    fun `capitalizeAll returns 0 and does nothing when no pair is pending`() {
+        val toDate = LocalDate.of(2026, 1, 20)
+        every { accrualRepo.findAccountsWithPendingCapitalization(toDate) } returns
+            Uni.createFrom().item(emptyList())
+
+        assertThat(service.capitalizeAll(toDate).await().indefinitely()).isEqualTo(0)
+        verify(exactly = 0) { accrualRepo.findPendingCapitalization(any(), any(), any()) }
+    }
+
+    @Test
     fun `capitalize withholds 15 percent and credits net on CZK interest`() {
         val accountId = UUID.fromString("88888888-8888-8888-8888-888888888888")
         val productId = "SAVINGS_CZK"


### PR DESCRIPTION
## Problem

interest-service withholds tax on capitalized interest (§38d) and the whole downstream chain exists — capitalization records a `WithholdingTax` row, `WithholdingRemittanceService` assembles a monthly batch, a settlement consumer books the cash leg. But **`capitalizeAll` was a stub returning 0**, so nothing ever capitalized fleet-wide → no withholding was ever assembled → nothing was ever remitted (issue #999). `accrueAll` was fixed the same way in #1614 (`InterestAccrualScheduler`); capitalization was the missing next rung.

## Fix

- **`capitalizeAll(toDate)`** now capitalizes every `(account, product)` with a pending `ACCRUING` set up to `toDate`, mirroring `accrueAll`:
  - Work-list from a new repo method **`findAccountsWithPendingCapitalization`** (a `SELECT DISTINCT a.accountId, a.productId … WHERE status='ACCRUING' AND accrualDate<=:d`). Capitalization is a pure function of already-persisted accruals, so this is a plain DB read — it does **not** touch account-service (unlike accrual's balance reads).
  - **Per-pair resilience**: a mixed-currency wedge (#1265), an in-flight claim for a different period, a non-positive gross, or a lost race collapses that one pair to a no-op (0) and is logged, never aborting the batch. Pairs processed sequentially (`concatenate`) for a polite ledger load.
- **`InterestCapitalizationScheduler`** — `@Scheduled(cron="{openbank.interest.capitalization-cron}")` (`0 0 2 1 * ?`, 02:00 on the 1st), `SKIP` on concurrency, mirroring `InterestAccrualScheduler`. The cron key and the docs already described this scheduler (`docs/01-overview`, `05-operations`) — a doc-vs-code drift this closes.

## Verification

`:openbank-interest-service:quarkusBuild :test` — compiles + CDI-wires the scheduler + unit tests. New tests: `capitalizeAll` capitalizes every pending pair and **recovers a per-pair failure** (2 pairs, one wedges → returns 1, both attempted); returns 0 and touches nothing when none pending.

## Scope / follow-ups

- **Design half is decided separately** in ADR-0180 (#1896): the §38d **statutory XML filing** to the finanční úřad is owned by a new `openbank-tax-reporting-service`, not built here. This PR makes capitalization actually run — which is what *produces* the withholding amounts that filing will consume.
- **Follow-up:** a real-DB IT extending `CapitalizationLedgerBoundaryIT` to seed accruals for two accounts and drive `capitalizeAll` end-to-end (a mocked repo can't exercise the `findAccountsWithPendingCapitalization` HQL projection — per the CLAUDE.md real-DB-IT lesson).

## Review bar

interest-service is money-path (`rules.yaml`, added #1616 — capitalize posts real GL journals) → **2 approvals + threat model** before merge. Not merged.

Closes #999
Refs #1614, #1618, #1265, #1039, ADR-0033, ADR-0038, ADR-0180
