### PR TITLE
docs(infra): record glitchtip-pg as unbacked-up by design (#1444)

### DIFF
--- a/openbank-infra/gitops/apps/glitchtip.yaml
+++ b/openbank-infra/gitops/apps/glitchtip.yaml
@@ -111,6 +111,16 @@ spec:
         # `glitchtip-pg-app` secret and wires DATABASE_URL from it automatically —
         # so no external DB and no DATABASE_URL in Vault. Storage on gp3 like
         # tempo/loki; EU residency (ADR-0027). Scale instances/size for prod.
+        #
+        # UNBACKED-UP BY DESIGN (#1444): glitchtip-pg is the only CNPG cluster
+        # (1 of 51) with no ScheduledBackup/barmanObjectStore, deliberately.
+        # Its contents are disposable: error events expire after 30 days
+        # (GLITCHTIP_MAX_EVENT_LIFE_DAYS below), sign-up is closed and the few
+        # operator accounts are re-provisionable; no banking or customer data.
+        # Wiring backups would mean threading barmanObjectStore + an EKS
+        # pod-identity association through third-party chart values for data
+        # we can afford to lose. Revisit only if GlitchTip ever holds state
+        # that outlives its 30-day event window.
         postgresql:
           enabled: true
           cluster:


### PR DESCRIPTION
Closes the last open thread of #1444.

Live state re-verified today: **51/51 clusters ContinuousArchiving=True, 50/51 have a ScheduledBackup** — the four single-instance stragglers from the 07-18 comment (anacredit, product-catalog, govaudit, liveness) recovered after the #1759 pod restarts. The only cluster with zero backup resources is `observability/glitchtip-pg`.

This PR makes that an explicit, documented decision (comment in `glitchtip.yaml`) instead of a silent gap: 30-day event retention, closed sign-up, re-provisionable operators, no banking data. Cost of wiring backups: threading `barmanObjectStore` + an EKS pod-identity association through third-party Helm chart values — disproportionate for disposable state (the S3 cost itself would be cents/month; complexity is the objection, not price).

Closes #1444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)