### PR TITLE
test(domestic-payment): pact sends the real transaction type (DEBIT)

### DIFF
--- a/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentTransactionServicePactConsumerTest.kt
+++ b/openbank-domestic-payment/src/test/kotlin/com/openbank/domestic/contract/DomesticPaymentTransactionServicePactConsumerTest.kt
@@ -28,10 +28,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 @PactTestFor(providerName = "openbank-transaction-service", pactVersion = PactSpecVersion.V3)
 class DomesticPaymentTransactionServicePactConsumerTest {
 
+    // `type` must be a real TransactionType enum constant AND what SettlementAdapter actually
+    // sends ("DEBIT", SettlementAdapter.kt). The original "DOMESTIC_CREDIT_TRANSFER" is not in
+    // the provider's enum, so provider verification failed 400-vs-201 forever (result 9194) —
+    // the same consumer-invents-an-enum bug sepa-payment fixed in #937.
     private val requestBody = """
         {
           "idempotencyKey": "pact-domestic-txn-001",
-          "type": "DOMESTIC_CREDIT_TRANSFER",
+          "type": "DEBIT",
           "sourceAccountId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
           "amount": 1000.00,
           "currencyCode": "CZK",

--- a/pacts/openbank-domestic-payment-openbank-transaction-service.json
+++ b/pacts/openbank-domestic-payment-openbank-transaction-service.json
@@ -18,7 +18,7 @@
           "idempotencyKey": "pact-domestic-txn-001",
           "rail": "DOMESTIC",
           "sourceAccountId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-          "type": "DOMESTIC_CREDIT_TRANSFER",
+          "type": "DEBIT",
           "valueDate": "2026-01-20"
         },
         "headers": {


### PR DESCRIPTION
## Why

The domestic-payment→transaction consumer pact sends `"type": "DOMESTIC_CREDIT_TRANSFER"` — not a `TransactionType` enum constant (`Transaction.kt:72`), so the provider's `valueOf()` throws and verification fails `expected status of 201 but was 400` against **every** provider version (broker result 9194 vs yesterday's main). Production `SettlementAdapter.kt:92` sends `"DEBIT"`. Identical to the sepa-payment bug fixed by #937.

One of the three code fixes unblocking the #1348 can-i-deploy deadlock.

## What

- pact request `type` → `DEBIT` + guard comment pointing at the enum and the prod adapter
- committed `pacts/openbank-domestic-payment-openbank-transaction-service.json` regenerated by running the consumer test (`pact.rootDir` writes it directly)

## Verification

`:openbank-domestic-payment:test --tests '*DomesticPaymentTransactionServicePact*'` green; regenerated JSON carries `"type": "DEBIT"`.

## Linked issues

Refs #1348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)