### PR TITLE
test(swift): re-enable the message pact provider verification

### DIFF
--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -81,15 +81,12 @@ tasks.withType<Test> {
     // Gradle-level exclusion prevents JUnit5 from ever discovering the class, so Quarkus never boots.
     // The class still runs locally (CI env var is not set outside GHA). Re-enable per #2404.
     //
-    // SwiftMessagePactProviderVerificationTest: @PactBroker triggers broker network calls during
-    // JUnit5 test-template expansion; the broker returns HTTP 404 (no consumer pact yet) and the
-    // Pact client hangs waiting for a response — causing the same 43-min job timeout pattern.
-    // @Disabled alone is insufficient because Pact's extension invokes the broker before JUnit5
-    // condition evaluation. Gradle-level exclusion prevents class discovery entirely.
-    // Remove both exclusions once a consumer pact exists (re-enable per #2404).
+    // SwiftMessagePactProviderVerificationTest re-enabled 2026-07-23: the 404-hang reason is
+    // gone — transaction-service publishes a consumer pact for openbank-swift-service on every
+    // main push, so /for-verification returns content. The class stays
+    // @EnabledIfSystemProperty(pactbroker.url)-gated, so it runs only in the main-push lane.
     if (System.getenv("CI") == "true") {
         exclude("**/SwiftBootSmokeIT*")
-        exclude("**/SwiftMessagePactProviderVerificationTest*")
         // SwiftEventPactConsumerTest: PactConsumerTestExt auto-publishes the generated pact
         // to pactbroker.url (forwarded from CI) in AfterTestTemplate — broker returns 401/hangs,
         // stalling the JVM for 30+ min. Exclude in CI; pact publishing runs as a dedicated step.

--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftMessagePactProviderVerificationTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftMessagePactProviderVerificationTest.kt
@@ -18,7 +18,6 @@ import com.openbank.swift.domain.model.SwiftMessageType
 import com.openbank.swift.domain.model.SwiftPriority
 import com.openbank.swift.domain.model.SwiftStatus
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty
 import org.junit.jupiter.api.extension.ExtendWith
@@ -33,12 +32,13 @@ import java.util.UUID
  * Does NOT boot Quarkus — message providers return raw JSON from [PactVerifyProvider]
  * methods, so this is a pure unit-level verification (no DB, no Kafka).
  */
-// CI-hang #2: this is the SECOND swift test that stalls the build to the 45-min timeout. With no
-// consumer pact for provider `openbank-swift-service` in the broker, `/for-verification` 404s and —
-// despite `@IgnoreNoPactsToVerify` — the broker HTTP client leaves the forked test JVM unable to
-// exit. It only runs in CI (`@EnabledIfSystemProperty(pactbroker.url)`). Disabled until a consumer
-// pact exists (transaction-service publishes one). See #2404.
-@Disabled("#2404 — no consumer pact for openbank-swift-service yet; broker 404 hangs :test to the CI timeout")
+// Re-enabled 2026-07-23: the original disable reason ("no consumer pact for
+// openbank-swift-service in the broker; /for-verification 404s and the broker HTTP client hangs
+// the forked JVM to the CI timeout" — pre-split #2404) no longer holds. transaction-service
+// commits and publishes pacts/openbank-transaction-service-openbank-swift-service.json on every
+// main push, and this class's @PactVerifyProvider matches its message description exactly. The
+// missing verification is what makes can-i-deploy block both transaction-service and
+// swift-service on this edge (#1348). Only runs where pactbroker.url is set (main-push lane).
 @Provider("openbank-swift-service")
 @PactBroker
 @IgnoreNoPactsToVerify(ignoreIoErrors = "true")


### PR DESCRIPTION
## Why

`SwiftMessagePactProviderVerificationTest` is double-disabled (`@Disabled` + a CI Gradle exclusion) with a reason that no longer holds: *"no consumer pact for openbank-swift-service yet; broker 404 hangs :test to the CI timeout"* (pre-split #2404). transaction-service publishes `pacts/openbank-transaction-service-openbank-swift-service.json` on every main push, and the `@PactVerifyProvider` method matches the pact's message description exactly (verified string-for-string).

Because **no swift version has ever verified that pact**, `can-i-deploy` blocks both transaction-service and swift-service on this edge — third of the three code fixes for the #1348 deadlock (with #1935, #1936).

## What

- drop `@Disabled` + the Gradle CI `exclude` for this class (comments refreshed with the history)
- the `@EnabledIfSystemProperty(pactbroker.url)` gate stays — the test runs only in the main-push lane

## Risk

If the pact ever disappears from the broker again, the historical hang could return on main-push — bounded by the job timeout, and `@IgnoreNoPactsToVerify(ignoreIoErrors=true)` remains in place. First live run is the post-merge main-push; watching it.

## Verification

`:openbank-swift-service:compileTestKotlin` + module ktlint green.

## Linked issues

Refs #1348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)