### PR TITLE
fix(swift): scope the message-pact ClassGraph scan to the contract package (#1348)

### DIFF
--- a/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftMessagePactProviderVerificationTest.kt
+++ b/openbank-swift-service/src/test/kotlin/com/openbank/swift/contract/SwiftMessagePactProviderVerificationTest.kt
@@ -49,7 +49,12 @@ class SwiftMessagePactProviderVerificationTest {
 
     @BeforeEach
     fun configureTarget(context: PactVerificationContext?) {
-        context?.target = MessageTestTarget()
+        // Scope the ClassGraph scan to this package. The no-arg MessageTestTarget() scans the
+        // whole test classpath, and on swift-service that throws ClassGraphException ("Uncaught
+        // exception during scan"), failing verification with mismatches:[] (a harness crash, not a
+        // contract mismatch) — which kept the transaction<->swift edge red after #1938 re-enabled
+        // this class (#1348). Every working sibling (account/party/kyc/transaction) scopes the scan.
+        context?.target = MessageTestTarget(listOf("com.openbank.swift.contract"))
     }
 
     @TestTemplate


### PR DESCRIPTION
## Why

#1938 re-enabled `SwiftMessagePactProviderVerificationTest`, but it uses the no-arg `MessageTestTarget()`, which makes ClassGraph scan the **entire** test classpath. On swift-service that throws `ClassGraphException: Uncaught exception during scan`, so the verification fails with `mismatches: []` — a **harness crash, not a contract mismatch** (broker verification result 9663, provider @6376c3fc).

That kept the `transaction-service <-> swift-service` edge red in `can-i-deploy`, blocking both services' deploy — the last real blocker in the #1348 pact-deadlock chain after the balance/domestic-payment code fixes (#1935/#1936) landed.

## What

Scope the scan to `com.openbank.swift.contract`, exactly as every working sibling does — `account`, `party`, `kyc`, `transaction` all pass `MessageTestTarget(listOf("com.openbank.<svc>.contract"))`. swift was the only one on the no-arg form.

## Verification

Contract already satisfied (`mismatches: []`), so this is purely a scan-scope fix. `compileTestKotlin` + `ktlintTestSourceSetCheck` green locally; the test itself only runs on the main-push broker lane (`@EnabledIfSystemProperty pactbroker.url`), where the fresh verification going green is the real proof.

## Linked issues

Refs #1348, Refs #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)