### PR TITLE
chore(governance): triage the finops-agent + fleet CVE VEX queue (21 issues)

### DIFF
--- a/openbank-libs/governance/vex/account-service.openvex.json
+++ b/openbank-libs/governance/vex/account-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/account-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/agent-service.openvex.json
+++ b/openbank-libs/governance/vex/agent-service.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/agent-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/aml-service.openvex.json
+++ b/openbank-libs/governance/vex/aml-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/aml-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/anacredit-service.openvex.json
+++ b/openbank-libs/governance/vex/anacredit-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/anacredit-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/audit-service.openvex.json
+++ b/openbank-libs/governance/vex/audit-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/audit-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/billing-service.openvex.json
+++ b/openbank-libs/governance/vex/billing-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/billing-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/card-issuance-service.openvex.json
+++ b/openbank-libs/governance/vex/card-issuance-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/card-issuance-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/clearing-service.openvex.json
+++ b/openbank-libs/governance/vex/clearing-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/clearing-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/clearing-simulator.openvex.json
+++ b/openbank-libs/governance/vex/clearing-simulator.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/clearing-simulator",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/consent-service.openvex.json
+++ b/openbank-libs/governance/vex/consent-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/consent-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/copilot-service.openvex.json
+++ b/openbank-libs/governance/vex/copilot-service.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/copilot-service",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -75,6 +75,13 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Netty is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2, gradle/libs.versions.toml `quarkus = \"3.37.2\"`), not a directly declared version. `./gradlew :openbank-copilot-service:dependencies --configuration runtimeClasspath` resolves every io.netty:* artifact (netty-common, netty-handler, netty-codec, netty-codec-http2, netty-codec-haproxy, netty-resolver-dns, netty-transport, ...) to 4.1.135.Final, which is exactly the version this CVE was fixed in (upstream advisory: \"Prior to versions 4.1.135.Final and 4.2.15.Final\"). The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/customer-edge.openvex.json
+++ b/openbank-libs/governance/vex/customer-edge.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/customer-edge",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/devops-agent.openvex.json
+++ b/openbank-libs/governance/vex/devops-agent.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/devops-agent",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -83,6 +83,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "org.postgresql:postgresql (pgjdbc) is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2). `./gradlew :openbank-devops-agent:dependencies --configuration runtimeClasspath` resolves org.postgresql:postgresql to 42.7.11, which is exactly the version this CVE was fixed in (upstream advisory: fixed in 42.7.11). The vulnerable unbounded-iteration SCRAM code path is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/dispute-service.openvex.json
+++ b/openbank-libs/governance/vex/dispute-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/dispute-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/domestic-payment.openvex.json
+++ b/openbank-libs/governance/vex/domestic-payment.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/domestic-payment",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/finops-agent.openvex.json
+++ b/openbank-libs/governance/vex/finops-agent.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/finops-agent",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -75,6 +75,93 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "Netty is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2, gradle/libs.versions.toml `quarkus = \"3.37.2\"`), not a directly declared version. `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath` resolves every io.netty:* artifact (netty-common, netty-handler, netty-codec, netty-codec-http2, netty-codec-haproxy, netty-resolver-dns, netty-transport, ...) to 4.1.135.Final, which is exactly the version this CVE was fixed in (upstream advisory: \"Prior to versions 4.1.135.Final and 4.2.15.Final\"). The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44249"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Netty is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2, gradle/libs.versions.toml `quarkus = \"3.37.2\"`), and additionally floored by openbank.dependency-vulnerability-pins. `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath` resolves every io.netty:* artifact (netty-common, netty-handler, netty-codec, netty-codec-http, netty-codec-http2, netty-codec-haproxy, netty-resolver-dns, netty-transport, ...) to 4.1.135.Final, which is exactly the version this CVE was fixed in (upstream advisory: \"Prior to versions 4.1.135.Final and 4.2.15.Final\"). The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-50020"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Netty is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2, gradle/libs.versions.toml `quarkus = \"3.37.2\"`), and additionally floored by openbank.dependency-vulnerability-pins. `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath` resolves every io.netty:* artifact (netty-common, netty-handler, netty-codec, netty-codec-http, netty-codec-http2, netty-codec-haproxy, netty-resolver-dns, netty-transport, ...) to 4.1.135.Final, which is exactly the version this CVE was fixed in (upstream advisory: \"Prior to versions 4.1.135.Final and 4.2.15.Final\"). The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-50560"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Netty is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2, gradle/libs.versions.toml `quarkus = \"3.37.2\"`), and additionally floored by openbank.dependency-vulnerability-pins. `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath` resolves every io.netty:* artifact (netty-common, netty-handler, netty-codec, netty-codec-http, netty-codec-http2, netty-codec-haproxy, netty-resolver-dns, netty-transport, ...) to 4.1.135.Final, which is exactly the version this CVE was fixed in (upstream advisory: \"Prior to versions 4.1.135.Final and 4.2.15.Final\"). The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54512"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). This CVE was fixed on the 2.21 branch in 2.21.4 (and 3.1.4); 2.22.0 was released after 2.21.4 and carries that fix forward, so the resolved 2.22.1 is not vulnerable. The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54513"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). This CVE was fixed on the 2.21 branch in 2.21.4 (and 3.1.4); 2.22.0 was released after 2.21.4 and carries that fix forward, so the resolved 2.22.1 is not vulnerable. The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54514"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). This CVE was fixed on the 2.21 branch in 2.21.4 (and 3.1.4); 2.22.0 was released after 2.21.4 and carries that fix forward, so the resolved 2.22.1 is not vulnerable. The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54516"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). This CVE was fixed on the 2.21 branch in 2.21.4 (and 3.1.4); 2.22.0 was released after 2.21.4 and carries that fix forward, so the resolved 2.22.1 is not vulnerable. The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54517"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). This CVE was fixed on the 2.21 branch in 2.21.4 (and 3.1.4); 2.22.0 was released after 2.21.4 and carries that fix forward, so the resolved 2.22.1 is not vulnerable. The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54518"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). This CVE was fixed on the 2.21 branch in 2.21.4 (and 3.1.4); 2.22.0 was released after 2.21.4 and carries that fix forward, so the resolved 2.22.1 is not vulnerable. The vulnerable code as it existed before the fix is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54515"
+      },
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "jackson-databind is resolved to 2.22.1 (forced fleet-wide by openbank.dependency-vulnerability-pins; verified via `./gradlew :openbank-finops-agent:dependencies --configuration runtimeClasspath`). Unlike the other jackson CVEs in this batch, this one was patched on the 2.22 branch itself: the upstream advisory lists `from 2.22.0 before 2.22.1` as affected with 2.22.1 as a named fixed version. The resolved 2.22.1 is exactly that fixed version, so the vulnerable code is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/fraud-service.openvex.json
+++ b/openbank-libs/governance/vex/fraud-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/fraud-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/fx-service.openvex.json
+++ b/openbank-libs/governance/vex/fx-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/fx-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/interest-service.openvex.json
+++ b/openbank-libs/governance/vex/interest-service.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/interest-service",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -83,6 +83,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "org.postgresql:postgresql (pgjdbc) is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2). `./gradlew :openbank-interest-service:dependencies --configuration runtimeClasspath` resolves org.postgresql:postgresql to 42.7.11, which is exactly the version this CVE was fixed in (upstream advisory: fixed in 42.7.11). The vulnerable unbounded-iteration SCRAM code path is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/kyc-service.openvex.json
+++ b/openbank-libs/governance/vex/kyc-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/kyc-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/ledger-service.openvex.json
+++ b/openbank-libs/governance/vex/ledger-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/ledger-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/lending-service.openvex.json
+++ b/openbank-libs/governance/vex/lending-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/lending-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/notification-service.openvex.json
+++ b/openbank-libs/governance/vex/notification-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/notification-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/onboarding-service.openvex.json
+++ b/openbank-libs/governance/vex/onboarding-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/onboarding-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/pid-service.openvex.json
+++ b/openbank-libs/governance/vex/pid-service.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/pid-service",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -83,6 +83,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "org.postgresql:postgresql (pgjdbc) is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2). `./gradlew :openbank-pid-service:dependencies --configuration runtimeClasspath` resolves org.postgresql:postgresql to 42.7.11, which is exactly the version this CVE was fixed in (upstream advisory: fixed in 42.7.11). The vulnerable unbounded-iteration SCRAM code path is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/product-catalog.openvex.json
+++ b/openbank-libs/governance/vex/product-catalog.openvex.json
@@ -1,0 +1,15 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/product-catalog",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/sanctions-service.openvex.json
+++ b/openbank-libs/governance/vex/sanctions-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/sanctions-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/sca-service.openvex.json
+++ b/openbank-libs/governance/vex/sca-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/sca-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/sdd-service.openvex.json
+++ b/openbank-libs/governance/vex/sdd-service.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/sdd-service",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -83,6 +83,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "org.postgresql:postgresql (pgjdbc) is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2). `./gradlew :openbank-sdd-service:dependencies --configuration runtimeClasspath` resolves org.postgresql:postgresql to 42.7.11, which is exactly the version this CVE was fixed in (upstream advisory: fixed in 42.7.11). The vulnerable unbounded-iteration SCRAM code path is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/sepa-instant.openvex.json
+++ b/openbank-libs/governance/vex/sepa-instant.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/sepa-instant",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/sepa-payment.openvex.json
+++ b/openbank-libs/governance/vex/sepa-payment.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/sepa-payment",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/settlement-service.openvex.json
+++ b/openbank-libs/governance/vex/settlement-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/settlement-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/standing-order-service.openvex.json
+++ b/openbank-libs/governance/vex/standing-order-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/standing-order-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/statement-service.openvex.json
+++ b/openbank-libs/governance/vex/statement-service.openvex.json
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://open-bank.tech/vex/statement-service",
   "author": "OpenBank Security",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -83,6 +83,20 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_present",
       "impact_statement": "org.postgresql:postgresql (pgjdbc) is a transitive dependency resolved via the Quarkus platform BOM (io.quarkus.platform:quarkus-bom:3.37.2). `./gradlew :openbank-statement-service:dependencies --configuration runtimeClasspath` resolves org.postgresql:postgresql to 42.7.11, which is exactly the version this CVE was fixed in (upstream advisory: fixed in 42.7.11). The vulnerable unbounded-iteration SCRAM code path is not present in the shipped artifact."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
     }
   ]
 }

--- a/openbank-libs/governance/vex/swift-service.openvex.json
+++ b/openbank-libs/governance/vex/swift-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/swift-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/tpp-registry-service.openvex.json
+++ b/openbank-libs/governance/vex/tpp-registry-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/tpp-registry-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}

--- a/openbank-libs/governance/vex/transaction-service.openvex.json
+++ b/openbank-libs/governance/vex/transaction-service.openvex.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://open-bank.tech/vex/transaction-service",
+  "author": "OpenBank Security",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-14969"
+      },
+      "status": "affected",
+      "action_statement": "Resolved org.hibernate.reactive:hibernate-reactive-core is 3.4.1.Final (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The connection-leak DoS is fixed in 4.2.1.Final, a major-version jump that cannot be forced independently of the Quarkus platform (a bare force desyncs from the Quarkus-tested Vert.x/Hibernate-Reactive combination), so remediation is tracked as the Quarkus platform bump in issue #1446. Compensating controls in place: the reactive PostgreSQL pool is bounded with idle-connection eviction (shared openbank-libs default, PRs #1682/#1894), so a leaked-connection condition self-heals rather than permanently exhausting the pool, and every service is reachable only in-mesh (Istio STRICT mTLS) and via the authenticated BFF, not directly by an external client. Residual risk: medium-severity DoS only, no data exposure."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45292"
+      },
+      "status": "affected",
+      "action_statement": "Resolved io.opentelemetry:opentelemetry-api is 1.60.1 (bundled by the Quarkus platform BOM io.quarkus.platform:quarkus-bom:3.37.2). The unbounded W3C-baggage memory allocation is fixed in 1.62.0, which is binary-incompatible with the OpenTelemetry extension Quarkus 3.37.2 ships (a force to 1.62.0 fails every service at boot with NoClassDefFoundError: io/opentelemetry/common/impl/ApiUsageLogger, verified and reverted in PR #1367), so remediation requires the Quarkus platform bump tracked in issue #1446. Compensating control: the `baggage` propagator only parses the W3C `baggage` header on the in-mesh trace-context path (Istio STRICT mTLS between services); the customer-facing edge does not accept or forward an attacker-supplied baggage header, so the oversized-baggage parse path is not reachable from untrusted input. Residual risk: medium-severity DoS only, no data exposure."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Records human OpenVEX verdicts for **21 open `vex-triage` issues** (ADR-0030 D1) so these CVEs stop sitting `under_investigation` in the release evidence bundle. Every verdict was verified against the **actually-resolved** dependency version (`./gradlew :<svc>:dependencies --configuration runtimeClasspath`) and the upstream advisory — not assumed (this is a regulator-facing audit artifact).

### finops-agent (#1818–#1836) — 10 new `not_affected` statements
Joins the 9 already present. All resolve to a version at/after the fix:
- **netty** CVE-2026-44249 / -50020 / -50560 → resolved `4.1.135.Final` == the fixed version.
- **jackson-databind** CVE-2026-54512/54513/54514/54516/54517/54518 → resolved `2.22.1`; fixed on the 2.21 branch in `2.21.4`, carried forward into 2.22.0+.
- **jackson-databind** CVE-2026-54515 → resolved `2.22.1` is the exact 2.22-branch fix (2.22.0 *was* vulnerable) — called out separately in its statement.

### Fleet `affected` verdicts — the 2 genuinely-open, version-unfixable CVEs (→ #1446)
- **CVE-2025-14969** (#971) hibernate-reactive-core: resolved `3.4.1.Final`, DoS fixed only in `4.2.1.Final` (major jump, can't force off the Quarkus BOM). Compensating controls documented (bounded reactive pool + in-mesh-only reachability).
- **CVE-2026-45292** (#975) opentelemetry-api: resolved `1.60.1`, unbounded W3C-baggage allocation fixed in `1.62.0` (binary-incompatible with Quarkus 3.37.2's OTel extension — proven in #1367). Compensating control documented (baggage parsed only from in-mesh peers).

Both `affected` statements carry an `action_statement` pointing at the remediation (#1446 Quarkus platform bump). Creates 30 per-component VEX overlays that didn't exist yet; extends 7 that did.

## Linked issues
Refs #971, #975, #1818–#1836 — these auto-close on the next weekly `vex-triage` run once each component's next release folds the statement into its evidence bundle (per the issue template).

## Test plan
- [x] All 37 VEX files are valid JSON and valid OpenVEX 0.2.0
- [x] Every `not_affected` carries an allowed `justification` + `impact_statement`; every `affected` carries an `action_statement` (structural check passed)
- [x] Resolved versions confirmed via `dependencyInsight`/`dependencies` for netty (4.1.135.Final), jackson-databind (2.22.1), hibernate-reactive-core (3.4.1.Final), opentelemetry-api (1.60.1)