### PR TITLE
ci(deploy): retire the GITOPS_PR_TOKEN user-PAT fallback rung (#1305)

### DIFF
--- a/.github/workflows/admin-ui-deploy.yml
+++ b/.github/workflows/admin-ui-deploy.yml
@@ -28,9 +28,9 @@
 #   - GitOps change lands via a PR (never direct push to main) — normal review gate.
 #   - A GitHub App installation token (GITOPS_APP_ID + GITOPS_APP_PRIVATE_KEY) opens the
 #     PR: it both triggers the required checks and gets its commit signed by GitHub, which
-#     required_signatures demands. Falls back to the GITOPS_PR_TOKEN user PAT (checks run,
-#     but the commit is unsigned → PR strands until re-signed by hand), then to
-#     GITHUB_TOKEN (manual-merge only — its PRs do not trigger workflows). See issue #1269.
+#     required_signatures demands. Falls back only to GITHUB_TOKEN (manual-merge only — its
+#     PRs do not trigger workflows); the GITOPS_PR_TOKEN user-PAT rung was retired in #1305
+#     (its commits were unsigned and stranded the PR anyway). See issue #1269.
 
 name: Admin-UI deploy
 
@@ -430,13 +430,13 @@ jobs:
           fi
 
       # GitHub signs API-created commits for GitHub *App* tokens (and the web UI's web-flow
-      # key) — never for a user PAT. GITOPS_PR_TOKEN is a user PAT, so `sign-commits: true`
-      # below faithfully routed the commit through the API and GitHub declined to sign it:
-      # every bot deploy commit since #806 came out `verified=false; reason=unsigned`, and
-      # required_signatures stranded the PR until a human re-signed it by hand (issue #1269).
-      # An App installation token is the only option that satisfies both constraints at once:
-      # it triggers the required checks (GITHUB_TOKEN does not) AND its commits get signed
-      # (a PAT's do not).
+      # key) — never for a user PAT. The old GITOPS_PR_TOKEN was a user PAT, so `sign-commits:
+      # true` below faithfully routed the commit through the API and GitHub declined to sign it:
+      # every bot deploy commit that fell to the PAT came out `verified=false; reason=unsigned`,
+      # and required_signatures stranded the PR until a human re-signed it by hand (issue #1269).
+      # That is exactly why the PAT was retired (#1305): an App installation token is the only
+      # option that satisfies both constraints at once — it triggers the required checks
+      # (GITHUB_TOKEN does not) AND its commits get signed (a PAT's do not).
       - name: Mint a GitHub App installation token
         id: app_token
         if: ${{ steps.rewrite.outputs.changed == 'true' && env.GITOPS_APP_ID != '' }}
@@ -452,13 +452,14 @@ jobs:
         with:
           # Preference order, and why each rung exists:
           #   1. App installation token — triggers required checks AND gets its commit signed.
-          #      The only rung that actually works end-to-end (issue #1269).
-          #   2. GITOPS_PR_TOKEN (user PAT) — triggers the required checks, but its commit is
-          #      unsigned, so the PR strands until a human re-signs. Kept as a fallback only
-          #      so the pipeline still opens a rescuable PR while the App is being set up.
-          #   3. GITHUB_TOKEN — a PR opened with it does NOT trigger workflows (anti-recursion),
-          #      so the required checks never run and there is nothing to auto-merge against.
-          token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          #      The only rung that actually works end-to-end (issue #1269). Proven on both
+          #      axes, so it is now the sole real path (the GITOPS_PR_TOKEN user PAT was retired
+          #      here, issue #1305 — its commits were unsigned and stranded the PR anyway).
+          #   2. GITHUB_TOKEN — last-resort only; a PR opened with it does NOT trigger workflows
+          #      (anti-recursion), so the required checks never run and there is nothing to
+          #      auto-merge against (an admin merges it by hand). Degraded fallback, not a
+          #      working path — it exists so a broken App-token mint still opens a rescuable PR.
+          token: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           # Route the commit through the GitHub API so GitHub can sign it. Necessary but NOT
           # sufficient on its own — the token above decides whether the signing actually
           # happens. The "Verify the deploy commit is signed" step below is what proves it did.
@@ -489,7 +490,7 @@ jobs:
         if: steps.gitops_pr.outputs.pull-request-number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
             const { data: pr } = await github.rest.pulls.get({
@@ -510,7 +511,7 @@ jobs:
                 await new Promise(r => setTimeout(r, 12000));
               }
             }
-            core.notice('could not enable auto-merge after retries — check the App token / GITOPS_PR_TOKEN / branch protection');
+            core.notice('could not enable auto-merge after retries — check the App token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY) / branch protection');
 
       # The failure this guards against is silent by construction: create-pull-request logs
       # "Commit verified: false; reason: unsigned" and exits 0, the PR opens with every check
@@ -526,7 +527,7 @@ jobs:
         if: ${{ always() && steps.gitops_pr.outputs.pull-request-number != '' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
             const { data: commits } = await github.rest.pulls.listCommits({
@@ -544,7 +545,9 @@ jobs:
               `PR #${pull_number} carries ${unsigned.length} unsigned commit(s); the main ruleset's ` +
               `required_signatures will block it and this deploy will never land. ` +
               `Most likely cause: no GitHub App token — GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY unset, so the ` +
-              `run fell back to the GITOPS_PR_TOKEN user PAT, whose API commits GitHub does not sign (issue #1269). ` +
-              `To rescue this PR by hand: amend the commit locally with a GPG signature and force-push — ` +
-              `auto-merge is already armed and fires on its own once the signature is valid.`
+              `run fell back to GITHUB_TOKEN, whose PR does not trigger the required checks (anti-recursion), ` +
+              `so auto-merge can never fire (the GITOPS_PR_TOKEN user-PAT fallback was retired in #1305). ` +
+              `To rescue this PR by hand: amend the commit locally with a GPG signature and force-push, then ` +
+              `re-run the required checks — auto-merge fires on its own once they pass and the signature is valid. ` +
+              `The durable fix is to restore the App token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY).`
             );

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -64,10 +64,11 @@ jobs:
     # — image-tag bump plus a regenerated derived catalog, ADR-0029 Layer B).
     #
     # The admin-ui-deploy skip is branch-pattern-based, not actor-based like the
-    # release-please one: that pipeline opens its PR via GITOPS_PR_TOKEN (a PAT
-    # under the repo owner's own account, so further workflows actually trigger),
-    # so `github.actor` here is the owner, not a bot — the actor check alone can't
-    # tell "automated deploy" apart from "a human's PR". Real-world cost of that
+    # release-please one: that pipeline opens its PR via the GitHub App token (the
+    # GITOPS_PR_TOKEN user-PAT rung was retired in #1305), whose actor is the App bot
+    # (`openbank-gitops-bot[bot]`, not `github-actions[bot]`) — so the actor check
+    # here still can't tell "automated deploy" apart from "a human's PR", and the
+    # branch pattern remains the reliable discriminator. Real-world cost of that
     # gap (2026-07-08): three deploy PRs (#596, #608, #609) piled up unmerged
     # because the reviewer kept flagging the SAME false positive on every one —
     # reviewing cluster-topology.json/infra-lifecycle.json (CI-regenerated

--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -840,13 +840,13 @@ jobs:
           persist-credentials: false
 
       # GitHub signs API-created commits for GitHub *App* tokens (and the web UI's web-flow
-      # key) — never for a user PAT. GITOPS_PR_TOKEN is a user PAT, so `sign-commits: true`
-      # below faithfully routed the commit through the API and GitHub declined to sign it:
-      # every bot deploy commit since #806 came out `verified=false; reason=unsigned`, and
-      # required_signatures stranded the PR until a human re-signed it by hand (issue #1269).
-      # An App installation token is the only option that satisfies both constraints at once:
-      # it triggers the required checks (GITHUB_TOKEN does not) AND its commits get signed
-      # (a PAT's do not).
+      # key) — never for a user PAT. The old GITOPS_PR_TOKEN was a user PAT, so `sign-commits:
+      # true` below faithfully routed the commit through the API and GitHub declined to sign it:
+      # every bot deploy commit that fell to the PAT came out `verified=false; reason=unsigned`,
+      # and required_signatures stranded the PR until a human re-signed it by hand (issue #1269).
+      # That is exactly why the PAT was retired (#1305): an App installation token is the only
+      # option that satisfies both constraints at once — it triggers the required checks
+      # (GITHUB_TOKEN does not) AND its commits get signed (a PAT's do not).
       - name: Mint a GitHub App installation token
         id: app_token
         if: env.GITOPS_APP_ID != ''
@@ -923,13 +923,15 @@ jobs:
         with:
           # Preference order, and why each rung exists:
           #   1. App installation token — triggers required checks AND gets its commit signed.
-          #      The only rung that actually works end-to-end (issue #1269).
-          #   2. GITOPS_PR_TOKEN (user PAT) — triggers the required checks, but its commit is
-          #      unsigned, so the PR strands until a human re-signs. Kept as a fallback only
-          #      so the pipeline still opens a rescuable PR while the App is being set up.
-          #   3. GITHUB_TOKEN — a PR opened with it does NOT trigger workflows (anti-recursion),
-          #      so the required checks never run and there is nothing to auto-merge against.
-          token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          #      The only rung that actually works end-to-end (issue #1269). Proven on both
+          #      axes, so it is now the sole real path (the GITOPS_PR_TOKEN user PAT was retired
+          #      here, issue #1305 — its commits were unsigned and stranded the PR anyway).
+          #   2. GITHUB_TOKEN — last-resort only; a PR opened with it does NOT trigger workflows
+          #      (anti-recursion), so the required checks never run and there is nothing to
+          #      auto-merge against (an admin merges it by hand). This is a degraded fallback,
+          #      not a working path — it exists so a broken App-token mint still opens a
+          #      rescuable PR rather than dropping the deploy silently.
+          token: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           # Route the commit through the GitHub API so GitHub can sign it. Necessary but NOT
           # sufficient on its own — the token above decides whether the signing actually
           # happens. The "Verify the deploy commit is signed" step below is what proves it did.
@@ -954,9 +956,9 @@ jobs:
             gitops
 
       # peter-evans/create-pull-request has no auto-merge input (the old `auto-merge: squash`
-      # was silently ignored). Enable it explicitly. Only effective when an App token or
-      # GITOPS_PR_TOKEN is set — otherwise the GITHUB_TOKEN PR's required checks never run and
-      # there is nothing to merge against (an admin merges it by hand, as today).
+      # was silently ignored). Enable it explicitly. Only effective when the App token is
+      # minted — otherwise the GITHUB_TOKEN PR's required checks never run and there is nothing
+      # to merge against (an admin merges it by hand, as today).
       # github-script (octokit), NOT gh — the openbank-build runner image has no gh CLI.
       # enablePullRequestAutoMerge is rejected ("Pull request is in clean status") until the
       # PR's required check runs register, which lags PR creation, so retry until it sticks.
@@ -966,7 +968,7 @@ jobs:
         if: steps.gitops_pr.outputs.pull-request-number != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
             const { data: pr } = await github.rest.pulls.get({
@@ -987,7 +989,7 @@ jobs:
                 await new Promise(r => setTimeout(r, 12000));
               }
             }
-            core.notice('could not enable auto-merge after retries — check the App token / GITOPS_PR_TOKEN / branch protection');
+            core.notice('could not enable auto-merge after retries — check the App token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY) / branch protection');
 
       # The failure this guards against is silent by construction: create-pull-request logs
       # "Commit verified: false; reason: unsigned" and exits 0, the PR opens with every check
@@ -1004,7 +1006,7 @@ jobs:
         if: ${{ always() && steps.gitops_pr.outputs.pull-request-number != '' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ steps.app_token.outputs.token || secrets.GITOPS_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app_token.outputs.token || secrets.GITHUB_TOKEN }}
           script: |
             const pull_number = Number('${{ steps.gitops_pr.outputs.pull-request-number }}');
             const { data: commits } = await github.rest.pulls.listCommits({
@@ -1022,9 +1024,11 @@ jobs:
               `PR #${pull_number} carries ${unsigned.length} unsigned commit(s); the main ruleset's ` +
               `required_signatures will block it and this deploy will never land. ` +
               `Most likely cause: no GitHub App token — GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY unset, so the ` +
-              `run fell back to the GITOPS_PR_TOKEN user PAT, whose API commits GitHub does not sign (issue #1269). ` +
-              `To rescue this PR by hand: amend the commit locally with a GPG signature and force-push — ` +
-              `auto-merge is already armed and fires on its own once the signature is valid.`
+              `run fell back to GITHUB_TOKEN, whose PR does not trigger the required checks (anti-recursion), ` +
+              `so auto-merge can never fire (the GITOPS_PR_TOKEN user-PAT fallback was retired in #1305). ` +
+              `To rescue this PR by hand: amend the commit locally with a GPG signature and force-push, then ` +
+              `re-run the required checks — auto-merge fires on its own once they pass and the signature is valid. ` +
+              `The durable fix is to restore the App token (GITOPS_APP_ID/GITOPS_APP_PRIVATE_KEY).`
             );
 
   # ── 4. Make a stranded deploy visible (issue #1332) ───────────────────────────

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,8 +61,8 @@ jobs:
       #
       # Deliberately ungated and unfallback'd. Every other identity available here is a dead
       # end: GITHUB_TOKEN opens PRs that trigger no workflows (anti-recursion), so the required
-      # checks never run and nothing can ever auto-merge; the GITOPS_PR_TOKEN user PAT works
-      # but is what this repo is retiring. So if the App credentials are missing or invalid,
+      # checks never run and nothing can ever auto-merge; the GITOPS_PR_TOKEN user PAT worked
+      # but has been retired (#1305). So if the App credentials are missing or invalid,
       # failing here loudly is the only honest outcome — a fallback would buy a green run that
       # quietly produces a release queue that can never drain.
       - name: Mint a GitHub App installation token


### PR DESCRIPTION
## Summary
The GitHub App token (`openbank-gitops-bot`) is proven on both axes — it triggers the required checks **and** its commits are signed — so it is now the sole real path. The `GITOPS_PR_TOKEN` user PAT was only ever a middle fallback rung whose commits GitHub refuses to sign (→ unsigned → stranded on `required_signatures` anyway, #1269), so it bought nothing.

Drops `|| secrets.GITOPS_PR_TOKEN` from all **6** token rungs — 3 in `auto-deploy.yml`, 3 in `admin-ui-deploy.yml` — leaving `app_token || GITHUB_TOKEN` (App-first; `GITHUB_TOKEN` as a degraded manual-merge-only last resort). Sweeps the now-stale comments + signature-guard diagnostic messages across `auto-deploy` / `admin-ui-deploy` / `agent-review` / `release-please`.

## Safety
- **This PR is the workflow-edit step only.** Leaving the `GITOPS_PR_TOKEN` secret in place is harmless (now unreferenced). The actual **secret deletion is the owner's final step, AFTER this merges** — deleting it before removing the references would fall through to `GITHUB_TOKEN` (whose PRs trigger no checks → auto-merge stalls), the exact hazard #1305 calls out.
- Confirmed the `agent-review` admin-ui-deploy skip is **branch-pattern**-based (`chore/admin-ui-deploy-`), not actor-based, so the App-bot actor change does not affect it (App bot is `openbank-gitops-bot[bot]`, not `github-actions[bot]`).
- **No auto-merge requested** — this is the deploy-critical signing path; owner should review + merge, then delete the secret.

## Linked issues
Closes #1305

## Test plan
- [x] All 4 workflows parse (YAML)
- [x] `actionlint` per-file introduces **zero new findings** vs `origin/main` (auto-deploy 4=4, admin-ui 0=0, agent-review 0=0, release-please 16=16 — all pre-existing baseline)
- [x] Functional diff is exactly the 6 rungs (3-rung → 2-rung, App-first preserved); everything else is comment/message text