### PR TITLE
test(account): disable outbox dispatch in AccountOutboxClaimIT (#1855)

### DIFF
--- a/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountOutboxClaimIT.kt
+++ b/openbank-account-service/src/test/kotlin/com/openbank/account/integration/AccountOutboxClaimIT.kt
@@ -11,6 +11,8 @@ import com.openbank.libs.persistence.outbox.OutboxStatus
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.test.common.QuarkusTestResource
 import io.quarkus.test.junit.QuarkusTest
+import io.quarkus.test.junit.QuarkusTestProfile
+import io.quarkus.test.junit.TestProfile
 import io.quarkus.vertx.VertxContextSupport
 import io.smallrye.mutiny.coroutines.awaitSuspending
 import io.smallrye.mutiny.coroutines.uni
@@ -33,7 +35,20 @@ import java.time.Instant
  */
 @QuarkusTest
 @QuarkusTestResource(PostgresRedpandaRedisTestResource::class)
+@TestProfile(AccountOutboxClaimIT.NoDispatchProfile::class)
 class AccountOutboxClaimIT {
+
+    // This IT drives AccountOutboxRepositoryImpl.claimProcessable DIRECTLY to prove its
+    // concurrency/reclaim invariants (#1201). The real scheduled outbox dispatcher
+    // (openbank.outbox.dispatch-enabled defaults true in application.yaml) is pure
+    // interference here: running concurrently it claims + dispatches + removes the rows this
+    // test hand-seeds, so `a stale DISPATCHING row is reclaimed` intermittently found the row
+    // already gone (AssertionFailedError at the reclaim assertion) and the dispatch path's
+    // idempotency write collided (`pk_account_idempotency` duplicate key). Disabling dispatch
+    // for this class isolates it to exactly the repository method under test (issue #1855).
+    class NoDispatchProfile : QuarkusTestProfile {
+        override fun getConfigOverrides(): Map<String, String> = mapOf("openbank.outbox.dispatch-enabled" to "false")
+    }
 
     @Inject
     lateinit var repository: AccountOutboxRepositoryImpl


### PR DESCRIPTION
## Summary
Fixes the recurring **account-service** half of the flaky nightly full-fleet build.

`AccountOutboxClaimIT` drives `AccountOutboxRepositoryImpl.claimProcessable` **directly** to prove its concurrency/reclaim invariants (#1201) — but the service's real scheduled outbox dispatcher was left enabled (`openbank.outbox.dispatch-enabled` defaults `true` in `application.yaml`, and the account-service test config never overrode it). Running concurrently, the dispatcher claims + dispatches + removes the very rows the test hand-seeds, so:
- `a stale DISPATCHING row is reclaimed` intermittently found the row already gone → `AssertionFailedError` at the reclaim assertion (the `AccountOutboxClaimIT.kt:106` failure in the 2026-07-21 nightly), and
- the dispatch path's idempotency write collided → `duplicate key value violates unique constraint "pk_account_idempotency"`.

Adds a `@TestProfile` disabling dispatch **for this class only**, isolating it to exactly the repository method under test — the same reasoning `ConsentRevocationOutboxIT` already uses ("the scheduled dispatcher is disabled so it cannot mark the row SENT before the assertion observes it"). The test still exercises `claimProcessable` concurrency via its own two `async` calls, so the #1201 regression coverage is intact.

The **other** recurring nightly failure — `docs-truth-agent` `AdrTextScannerTest` / ADR-0039 — was already fixed by #1886 (merged 2026-07-22; the 2026-07-23 nightly passed). Together these two land the recurring causes; #1855 can close once a few nightlies stay green.

## Linked issues
Refs #1855 (the AdrTextScanner half is already merged via #1886; this covers the account-service half).

## Test plan
- [x] `:openbank-account-service:compileTestKotlin` + `:ktlintCheck` pass
- [x] `AccountOutboxClaimIT` runs **green** against real Postgres/Redpanda/Redis Testcontainers with dispatch disabled
- [x] Structural: with no background dispatcher, nothing can race the hand-seeded rows — the flake is now impossible, not merely less likely