### PR TITLE
fix(edge): open edge->consent NetworkPolicy for PSD2 consents

### DIFF
--- a/openbank-infra/gitops/components/consent/network-policies.yaml
+++ b/openbank-infra/gitops/components/consent/network-policies.yaml
@@ -38,6 +38,9 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: customer-edge
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: psd2
         - namespaceSelector:
             matchLabels:

--- a/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
+++ b/openbank-infra/gitops/components/customer-edge/customer-edge.yaml
@@ -169,6 +169,11 @@ spec:
             # edge->sdd ingress allow. sdd-service is KEDA scale-to-zero — first call cold-starts it.
             - name: SDD_SERVICE_URL
               value: http://sdd-service.sdd.svc:8129
+            # PSD2 third-party consents (ADR-0126) for the customer app (#1880): GET/DELETE
+            # /customer/v1/consents. Declared here so gen-network-policies.py opens the
+            # edge->consent ingress allow (consent-service enforces OPA, so the call must land).
+            - name: CONSENT_SERVICE_URL
+              value: http://consent-service.consent.svc:8106
             - name: SCA_SERVICE_URL
               value: http://sca-service.sca.svc:8110
             # Bind management interface to all interfaces so kubelet probes (from node IP)


### PR DESCRIPTION
The PSD2 consent routes (#1880) 502 at the edge because consent-service's derived ingress allow-list (ADR-0081) never included customer-edge — `CONSENT_SERVICE_URL` lived only in the edge's in-jar `application.yaml` default, so `gen-network-policies.py` (which derives edges from Deployment env URLs) couldn't see edge→consent.

## Fix
- Declare `CONSENT_SERVICE_URL=http://consent-service.consent.svc:8106` in the customer-edge Deployment env (mirrors SDD_SERVICE_URL etc.)
- Regenerate network policies → consent ingress allow-list now includes the customer-edge ns (only diff: +customer-edge namespaceSelector on 8106)

## Why route probes missed it
The edge swallows the upstream 502 into an empty list, so `GET /customer/v1/consents` returned 200 [] and only DELETE surfaced the 502. Caught by an **end-to-end test with a real customer token** (password-grant on the openbank-app client), not a 401 route probe.

Closes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)