### PR TITLE
feat(edge): self-service virtual card issuance

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2454,6 +2454,41 @@ class CustomerEdgeResource(
         return extractOwnerPartyId((resp.entity as? String).orEmpty()) == partyId.toString()
     }
 
+    /**
+     * Issue a VIRTUAL card on one of the caller's OWN accounts (self-service, #4b). The app sends
+     * only { "accountId": "..." }; the edge forces the partyId from the JWT, verifies the account
+     * belongs to the caller, and resolves the cardholder name from party-service — the customer can
+     * never mint a card on someone else's account or under someone else's name. Idempotent per
+     * (party, account): a re-tap replays the same card rather than issuing duplicates.
+     */
+    @POST
+    @Path("/cards")
+    @Authorize(action = "customer.cards.create", resource = "")
+    @Blocking
+    fun issueVirtualCard(body: String): Response {
+        val customer = customer()
+        val accountId = runCatching { objectMapper.readTree(body).get("accountId")?.asText() }.getOrNull()
+            ?: return badRequest("Missing accountId")
+        val acct = runCatching { UUID.fromString(accountId) }.getOrNull() ?: return badRequest("Invalid accountId")
+        if (!ownsAccount(acct, customer.partyId)) return forbidden("Account does not belong to caller")
+        val name = fetchPartyLegalName(customer.partyId) ?: "OpenBank Customer"
+        val req = objectMapper.createObjectNode()
+        req.put("partyId", customer.partyId.toString())
+        req.put("accountId", acct.toString())
+        req.put("productCode", "VIRTUAL_DEBIT")
+        req.put("cardType", "VIRTUAL")
+        req.put("network", "VISA")
+        req.put("cardholderName", name)
+        req.put("embossedName", name.uppercase())
+        req.put("currency", "CZK")
+        return upstream.post(
+            "$cardIssuanceServiceUrl/api/v1/cards",
+            customer.partyId.toString(),
+            req.toString(),
+            "vcard-${customer.partyId}-$acct",
+        )
+    }
+
     // --- Nearby payments (payment sessions, ADR-0087) ---
 
     /**


### PR DESCRIPTION
Exposes `POST /customer/v1/cards` so the app can issue a **virtual card** on the caller's own account (TOP-9 #4b).

## Flow
App sends `{ "accountId": "..." }` → edge:
1. forces `partyId` from the JWT
2. `ownsAccount(accountId, partyId)` — 403 if not the caller's
3. `fetchPartyLegalName(partyId)` → cardholder/embossed name
4. assembles IssueCardRequest (cardType=VIRTUAL, network=VISA, CZK, productCode=VIRTUAL_DEBIT) + Idempotency-Key `vcard-<party>-<account>` → card-issuance `POST /api/v1/cards`

## Authz / netpol (lessons applied)
- `customer.cards.create` is covered by the `customer.*` self-action edge OPA rule
- card-issuance is `AUTHZ_ENFORCE=false` + the edge M2M identity has ROLE_OPERATOR (satisfies `@RolesAllowed`), so no rest.rego change
- `CARD_ISSUANCE_SERVICE_URL` is already in the edge gitops env → edge→card-issuance NetworkPolicy already open (no netpol change — same service as the limits route)

Idempotent per (party, account): a re-tap replays the same card, no duplicates.

Closes #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)