### PR TITLE
chore(swift): re-trigger the message-pact provider verification (#1348)

### DIFF
--- a/openbank-swift-service/build.gradle.kts
+++ b/openbank-swift-service/build.gradle.kts
@@ -85,6 +85,10 @@ tasks.withType<Test> {
     // gone — transaction-service publishes a consumer pact for openbank-swift-service on every
     // main push, so /for-verification returns content. The class stays
     // @EnabledIfSystemProperty(pactbroker.url)-gated, so it runs only in the main-push lane.
+    // Scan-scope fixed 2026-07-23 (#1948): the verification was crashing on a whole-classpath
+    // ClassGraph scan; the test now scopes MessageTestTarget to com.openbank.swift.contract. That
+    // fix touched only src/test, which does not rebuild this service on main-push, so this
+    // build-file note exists to re-trigger the provider verification (#1348 drain).
     if (System.getenv("CI") == "true") {
         exclude("**/SwiftBootSmokeIT*")
         // SwiftEventPactConsumerTest: PactConsumerTestExt auto-publishes the generated pact


### PR DESCRIPTION
## Why

#1948 fixed the ClassGraph whole-classpath scan crash in `SwiftMessagePactProviderVerificationTest`, but it changed only `src/test`. On this repo, a service's own build on main-push is **not** triggered by a `src/test`-only change, so swift-service never rebuilt and the fixed provider verification never re-published — the stale FAILED result (broker 9663, provider @6376c3fc) kept the `transaction <-> swift` `can-i-deploy` edge red, the last blocker in the #1348 drain.

## What

A comment in `build.gradle.kts` (a build-relevant path) to force swift-service to rebuild + re-run the now-fixed verification. `chore` type → no release cut.

Follow-up worth filing: a contract-test fix under `src/test` should re-run that service's provider verification on main-push; today it doesn't, so a broken-then-fixed verification needs a build-file nudge like this.

## Linked issues

Refs #1348, Refs #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)