### PR TITLE
feat(sca): pending-approvals list for decoupled/push SCA

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2061,6 +2061,23 @@ class CustomerEdgeResource(
         return upstream.get("$scaServiceUrl/api/v1/sca/challenges/$id", customer.partyId.toString())
     }
 
+    /**
+     * The caller's live SCA challenges awaiting a decision (#8 push/decoupled approval list). The
+     * edge scopes the sca-service query by the JWT partyId, so a customer only ever sees their own
+     * pending approvals — the path partyId is never taken from the client.
+     */
+    @GET
+    @Path("/sca/pending")
+    @Authorize(action = "customer.sca.challenge", resource = "")
+    @Blocking
+    fun listPendingSca(): Response {
+        val customer = customer()
+        return upstream.get(
+            "$scaServiceUrl/api/v1/sca/parties/${customer.partyId}/challenges/pending",
+            customer.partyId.toString(),
+        )
+    }
+
     @POST
     @Path("/sca/challenges/{id}/decision")
     @Authorize(action = "customer.sca.decision", resource = "#id")

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/port/in/ScaUseCases.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/port/in/ScaUseCases.kt
@@ -41,6 +41,9 @@ interface VerifyScaUseCase {
 
 interface GetScaUseCase {
     suspend fun getChallenge(challengeId: UUID): ScaChallenge
+
+    /** Live challenges awaiting a decision for [partyId] (decoupled/push approval list, ADR-0021). */
+    suspend fun listPendingByParty(partyId: UUID): List<ScaChallenge>
 }
 
 /** Enrol a device credential to a party so it can later sign decoupled approvals (ADR-0021). */

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/port/out/ScaPorts.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/port/out/ScaPorts.kt
@@ -17,6 +17,9 @@ interface ScaChallengeRepository {
 
     suspend fun findById(id: UUID): ScaChallenge?
 
+    /** Live (PENDING, not yet expired) challenges awaiting a decision for [partyId] — newest first. */
+    suspend fun findPendingByParty(partyId: UUID): List<ScaChallenge>
+
     /**
      * Atomically mark the challenge consumed (single-use gate). Returns true when THIS call
      * spent it; false when it was already consumed — the `consumed_at IS NULL` guard in the

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/application/usecase/ScaService.kt
@@ -327,6 +327,8 @@ class ScaService(
     override suspend fun getChallenge(challengeId: UUID): ScaChallenge =
         repository.findById(challengeId) ?: throw ScaChallengeNotFoundException(challengeId)
 
+    override suspend fun listPendingByParty(partyId: UUID): List<ScaChallenge> = repository.findPendingByParty(partyId)
+
     /**
      * Settlement gate (ADR-0021): spend an approved challenge on exactly the operation the
      * device signed. Order matters — every check happens BEFORE the atomic compare-and-consume,

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/persistence/repository/ScaChallengeRepositoryImpl.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/persistence/repository/ScaChallengeRepositoryImpl.kt
@@ -6,6 +6,7 @@ package com.openbank.sca.infrastructure.persistence.repository
 
 import com.openbank.sca.application.port.out.ScaChallengeRepository
 import com.openbank.sca.domain.model.ScaChallenge
+import com.openbank.sca.domain.model.ScaStatus
 import com.openbank.sca.infrastructure.persistence.entity.ScaChallengeEntity
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.hibernate.reactive.panache.PanacheRepository
@@ -34,6 +35,15 @@ class ScaChallengeRepositoryImpl :
 
     override suspend fun findById(id: UUID): ScaChallenge? =
         Panache.withSession { find("id", id).firstResult<ScaChallengeEntity>() }.awaitSuspending()?.toDomain()
+
+    override suspend fun findPendingByParty(partyId: UUID): List<ScaChallenge> = Panache.withSession {
+        find(
+            "partyId = ?1 and status = ?2 and expiresAt > ?3 order by createdAt desc",
+            partyId,
+            ScaStatus.PENDING,
+            OffsetDateTime.now(clock),
+        ).list<ScaChallengeEntity>()
+    }.awaitSuspending().map { it.toDomain() }
 
     override suspend fun markConsumed(id: UUID): Boolean = Panache.withTransaction {
         update("consumedAt = ?1 where id = ?2 and consumedAt is null", OffsetDateTime.now(clock), id)

--- a/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/rest/ScaResource.kt
+++ b/openbank-sca-service/src/main/kotlin/com/openbank/sca/infrastructure/rest/ScaResource.kt
@@ -126,6 +126,38 @@ data class ScaChallengeResponse(
 }
 
 /**
+ * A pending SCA challenge projected for the app's approval list (#8): the dynamic-linking data
+ * (amount, creditor) is surfaced so the customer sees WHAT they are approving before signing.
+ */
+data class PendingScaResponse(
+    val id: UUID,
+    val purpose: ScaPurpose,
+    val method: ScaMethod,
+    val amount: String?,
+    val currency: String?,
+    val creditorIban: String?,
+    val creditorName: String?,
+    val reference: String?,
+    val expiresAt: String,
+    val createdAt: String,
+) {
+    companion object {
+        fun from(c: ScaChallenge) = PendingScaResponse(
+            id = c.id,
+            purpose = c.purpose,
+            method = c.method,
+            amount = c.dynamicLinkingData?.amount,
+            currency = c.dynamicLinkingData?.currency,
+            creditorIban = c.dynamicLinkingData?.creditorIban,
+            creditorName = c.dynamicLinkingData?.creditorName,
+            reference = c.dynamicLinkingData?.reference,
+            expiresAt = c.expiresAt.toString(),
+            createdAt = c.createdAt.toString(),
+        )
+    }
+}
+
+/**
  * Compare-and-consume body (settlement gate): the caller states the operation it is about
  * to execute; the challenge is spent only when the device-signed dynamic-linking data
  * authorises exactly that operation. `creditor` is the creditor IBAN (SEPA) or the Czech
@@ -218,6 +250,19 @@ class ScaResource(
     @Authorize(action = "scaChallenge.read", resource = "#id")
     suspend fun get(@PathParam("id") id: UUID): ScaChallengeResponse =
         ScaChallengeResponse.from(getSca.getChallenge(id))
+
+    /**
+     * Live challenges awaiting a decision for a party — the "pending approvals" list behind the
+     * decoupled/push SCA flow (#8). Unlike [get] this projects the dynamic-linking data (amount,
+     * creditor) so the app can render WHAT is being approved. ROLE_CUSTOMER is allowed because the
+     * edge forwards the caller's own partyId (same stance as [listDevices]).
+     */
+    @GET
+    @Path("/parties/{partyId}/challenges/pending")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @Authorize(action = "scaChallenge.read", resource = "#partyId")
+    suspend fun listPending(@PathParam("partyId") partyId: UUID): List<PendingScaResponse> =
+        getSca.listPendingByParty(partyId).map { PendingScaResponse.from(it) }
 
     /**
      * List device credentials enrolled to a party (ADR-0021, ADR-0068 onboarding cockpit).


### PR DESCRIPTION
Backend for TOP-9 #8 (approve a payment on your phone via push). sca-service already pushes on PUSH_NOTIFICATION initiate and records device-key decisions; the missing piece was **discovering** a party's pending challenges.

## Adds
- `ScaChallengeRepository.findPendingByParty` (status=PENDING, not expired, newest-first)
- `GetScaUseCase.listPendingByParty` (ScaService impl)
- `GET /api/v1/sca/parties/{partyId}/challenges/pending` → `PendingScaResponse` projecting the **dynamic-linking amount/creditor** so the app can render what's being approved (the plain `ScaChallengeResponse` deliberately omits these)
- edge `GET /customer/v1/sca/pending` — scopes the query by the JWT partyId (a customer only ever sees their own approvals)

## Authz / netpol (lessons applied)
- `scaChallenge.read` is the same action the existing `/sca/challenges/{id}` edge route already uses → no rest.rego change
- `SCA_SERVICE_URL` is already in the edge gitops env → edge→sca NetworkPolicy already open

App screen (pending list + device-key approve/reject + push-tap routing) follows in the openbank-app PR.

Closes #1968

🤖 Generated with [Claude Code](https://claude.com/claude-code)