### PR TITLE
test(settlement): serialize the postJournal pact body from the real factory (#1347)

### DIFF
--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapter.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/LedgerBookAdapter.kt
@@ -6,9 +6,7 @@ package com.openbank.settlement.infrastructure.adapter
 
 import com.openbank.settlement.application.port.out.LedgerPort
 import com.openbank.settlement.application.port.out.SettlementRepository
-import com.openbank.settlement.infrastructure.client.JournalLineRequest
 import com.openbank.settlement.infrastructure.client.LedgerRestClient
-import com.openbank.settlement.infrastructure.client.PostJournalRequest
 import jakarta.enterprise.context.ApplicationScoped
 import kotlinx.coroutines.future.await
 import org.eclipse.microprofile.config.inject.ConfigProperty
@@ -46,33 +44,18 @@ class LedgerBookAdapter(
         val today = LocalDate.now(clock).toString()
         log.infof("Booking settlement %s to ledger", settlementId)
         ledgerClient.postJournal(
-            PostJournalRequest(
-                idempotencyKey = "settlement-book-$settlementId",
-                transactionId = settlementId,
-                entryDate = today,
-                valueDate = today,
-                description = "Settlement booking $settlementId",
-                createdBy = SYSTEM_USER,
-                lines = listOf(
-                    JournalLineRequest(
-                        glAccountId = glDebitAccountId,
-                        side = "DEBIT",
-                        amount = settlement.amount,
-                        currencyCode = settlement.currency,
-                        baseAmount = settlement.amount,
-                        baseCurrencyCode = settlement.currency,
-                        subAccountId = settlement.payerAccountId,
-                    ),
-                    JournalLineRequest(
-                        glAccountId = glCreditAccountId,
-                        side = "CREDIT",
-                        amount = settlement.amount,
-                        currencyCode = settlement.currency,
-                        baseAmount = settlement.amount,
-                        baseCurrencyCode = settlement.currency,
-                        subAccountId = settlement.payeeAccountId,
-                    ),
+            SettlementJournalFactory.build(
+                posting = SettlementJournalFactory.Posting(
+                    settlementId = settlementId,
+                    amount = settlement.amount,
+                    currency = settlement.currency,
+                    payerAccountId = settlement.payerAccountId,
+                    payeeAccountId = settlement.payeeAccountId,
                 ),
+                glDebitAccountId = glDebitAccountId,
+                glCreditAccountId = glCreditAccountId,
+                date = today,
+                createdBy = SYSTEM_USER,
             ),
         ).subscribeAsCompletionStage().await()
     }

--- a/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/SettlementJournalFactory.kt
+++ b/openbank-settlement-service/src/main/kotlin/com/openbank/settlement/infrastructure/adapter/SettlementJournalFactory.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.settlement.infrastructure.adapter
+
+import com.openbank.settlement.infrastructure.client.JournalLineRequest
+import com.openbank.settlement.infrastructure.client.PostJournalRequest
+import java.math.BigDecimal
+import java.util.UUID
+
+/**
+ * Builds the ledger `PostJournalRequest` for a settlement booking. Shared by
+ * [LedgerBookAdapter.book] (production) and the settlement→ledger consumer pact
+ * (`SettlementLedgerPostJournalPactConsumerTest`) so the contract verifies the request THIS
+ * factory produces, not a hand-typed JSON literal that can silently drift from it (issue #1347).
+ * Mirrors the JournalFactory pattern billing/lending/transaction/interest already use for the same
+ * postJournal contract — and closes a concrete drift the literal had carried: it declared an
+ * `"fxRate": null` field per line that the real [JournalLineRequest] does not even have, so the
+ * old contract verified a body the adapter never sends.
+ */
+object SettlementJournalFactory {
+    /** The settlement-intrinsic inputs of a booking (grouped so [build] stays within the
+     * detekt LongParameterList threshold and reads as one cohesive posting). */
+    data class Posting(
+        val settlementId: UUID,
+        val amount: BigDecimal,
+        val currency: String,
+        val payerAccountId: UUID,
+        val payeeAccountId: UUID,
+    )
+
+    fun build(
+        posting: Posting,
+        glDebitAccountId: UUID,
+        glCreditAccountId: UUID,
+        date: String,
+        createdBy: UUID,
+    ): PostJournalRequest = PostJournalRequest(
+        idempotencyKey = "settlement-book-${posting.settlementId}",
+        transactionId = posting.settlementId,
+        entryDate = date,
+        valueDate = date,
+        description = "Settlement booking ${posting.settlementId}",
+        createdBy = createdBy,
+        lines = listOf(
+            JournalLineRequest(
+                glAccountId = glDebitAccountId,
+                side = "DEBIT",
+                amount = posting.amount,
+                currencyCode = posting.currency,
+                baseAmount = posting.amount,
+                baseCurrencyCode = posting.currency,
+                subAccountId = posting.payerAccountId,
+            ),
+            JournalLineRequest(
+                glAccountId = glCreditAccountId,
+                side = "CREDIT",
+                amount = posting.amount,
+                currencyCode = posting.currency,
+                baseAmount = posting.amount,
+                baseCurrencyCode = posting.currency,
+                subAccountId = posting.payeeAccountId,
+            ),
+        ),
+    )
+}

--- a/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
+++ b/openbank-settlement-service/src/test/kotlin/com/openbank/settlement/contract/SettlementLedgerPostJournalPactConsumerTest.kt
@@ -12,10 +12,14 @@ import au.com.dius.pact.consumer.junit5.PactTestFor
 import au.com.dius.pact.core.model.PactSpecVersion
 import au.com.dius.pact.core.model.RequestResponsePact
 import au.com.dius.pact.core.model.annotations.Pact
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.openbank.settlement.infrastructure.adapter.SettlementJournalFactory
 import io.restassured.RestAssured.given
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.util.UUID
 
 /**
  * Consumer-driven contract for the journal posting settlement-service makes when booking a
@@ -42,42 +46,34 @@ import org.junit.jupiter.api.extension.ExtendWith
 @PactTestFor(providerName = "openbank-ledger-service", pactVersion = PactSpecVersion.V3)
 class SettlementLedgerPostJournalPactConsumerTest {
 
-    private val transactionId = "55555555-5555-5555-5555-555555555555"
-    private val payerAccountId = "66666666-6666-6666-6666-666666666666"
-    private val payeeAccountId = "77777777-7777-7777-7777-777777777777"
+    private val transactionId = UUID.fromString("55555555-5555-5555-5555-555555555555")
+    private val payerAccountId = UUID.fromString("66666666-6666-6666-6666-666666666666")
+    private val payeeAccountId = UUID.fromString("77777777-7777-7777-7777-777777777777")
 
-    private val requestBody = """
-        {
-          "idempotencyKey": "settlement-book-$transactionId",
-          "transactionId": "$transactionId",
-          "entryDate": "2026-01-15",
-          "valueDate": "2026-01-15",
-          "description": "Settlement booking $transactionId",
-          "createdBy": "00000000-0000-0000-0000-000000005e77",
-          "lines": [
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000002",
-              "side": "DEBIT",
-              "amount": 750.00,
-              "currencyCode": "CZK",
-              "fxRate": null,
-              "baseAmount": 750.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": "$payerAccountId"
-            },
-            {
-              "glAccountId": "a0000000-0000-0000-0000-000000000002",
-              "side": "CREDIT",
-              "amount": 750.00,
-              "currencyCode": "CZK",
-              "fxRate": null,
-              "baseAmount": 750.00,
-              "baseCurrencyCode": "CZK",
-              "subAccountId": "$payeeAccountId"
-            }
-          ]
-        }
-    """.trimIndent()
+    // Both lines target the SAME GL account (...-002, 2100 Customer Deposit Control): a settlement
+    // moves money between two of the bank's own customer sub-accounts, so neither leg touches
+    // cash-clearing (see the class KDoc). The request body is SERIALIZED from the production
+    // [SettlementJournalFactory] — the same factory LedgerBookAdapter.book uses — so this contract
+    // verifies the request the adapter actually sends, not a hand-typed literal that can drift from
+    // the DTO (issue #1347: the old literal even carried an `fxRate` field JournalLineRequest lacks).
+    private val depositControlGlAccount = UUID.fromString("a0000000-0000-0000-0000-000000000002")
+    private val systemUser = UUID.fromString("00000000-0000-0000-0000-000000005e77")
+
+    private val requestBody = jacksonObjectMapper().writeValueAsString(
+        SettlementJournalFactory.build(
+            posting = SettlementJournalFactory.Posting(
+                settlementId = transactionId,
+                amount = BigDecimal("750.00"),
+                currency = "CZK",
+                payerAccountId = payerAccountId,
+                payeeAccountId = payeeAccountId,
+            ),
+            glDebitAccountId = depositControlGlAccount,
+            glCreditAccountId = depositControlGlAccount,
+            date = "2026-01-15",
+            createdBy = systemUser,
+        ),
+    )
 
     @Pact(consumer = "openbank-settlement-service", provider = "openbank-ledger-service")
     fun postSettlementJournalPact(builder: PactDslWithProvider): RequestResponsePact = builder

--- a/pacts/openbank-settlement-service-openbank-ledger-service.json
+++ b/pacts/openbank-settlement-service-openbank-ledger-service.json
@@ -22,7 +22,6 @@
               "baseAmount": 750.00,
               "baseCurrencyCode": "CZK",
               "currencyCode": "CZK",
-              "fxRate": null,
               "glAccountId": "a0000000-0000-0000-0000-000000000002",
               "side": "DEBIT",
               "subAccountId": "66666666-6666-6666-6666-666666666666"
@@ -32,7 +31,6 @@
               "baseAmount": 750.00,
               "baseCurrencyCode": "CZK",
               "currencyCode": "CZK",
-              "fxRate": null,
               "glAccountId": "a0000000-0000-0000-0000-000000000002",
               "side": "CREDIT",
               "subAccountId": "77777777-7777-7777-7777-777777777777"


### PR DESCRIPTION
## Summary
`SettlementLedgerPostJournalPactConsumerTest` hand-wrote its request body as a JSON string literal — so the contract verified a **literal**, not the request `LedgerBookAdapter.book` actually sends (the #1347 gap). The literal had even drifted: it declared an `"fxRate": null` field per line that the real `JournalLineRequest` DTO **does not have**, so the contract asserted a body the adapter never produces.

Extracts `SettlementJournalFactory` (mirroring the JournalFactory pattern billing/lending/transaction/interest already use for this same `postJournal` contract) and routes **both** `LedgerBookAdapter.book` (production) and the pact consumer test through it. The test now serializes the factory output as the pact body, so the contract is tied to the request type and drops the phantom `fxRate` field.

## Money-path note
settlement-service is a money-path service. The adapter change is **behavior-preserving** — `SettlementJournalFactory.build(...)` constructs the identical `PostJournalRequest` the adapter built inline, and `LedgerBookAdapterTest` (which captures the request and asserts every field: idempotencyKey, transactionId, dates, createdBy, both lines' glAccount/subAccount/amount) still passes unchanged. No auto-merge — leaving for review.

## Test plan
- [x] `SettlementLedgerPostJournalPactConsumerTest` green (mock-server round-trip)
- [x] `LedgerBookAdapterTest` green (behavior-preserving refactor)
- [x] `ktlintCheck` clean
- [ ] CI: **ledger-service Pact provider verification** replays this contract — since the adapter never sent `fxRate`, ledger already tolerates its absence, so dropping it aligns the contract with reality (the key gate to watch)

## Linked issues
Closes #1347 (the settlement literal was the last hand-written pact body; follow-ons — a governance `must-have-pact` rule + a `Money`-typed port — are separate).