### PR TITLE
chore(gitops): co-deploy sepa-payment/transaction/fraud at 6376c3fc to land #844

### DIFF
--- a/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
+++ b/openbank-infra/gitops/components/fraud-service/fraud-service.yaml
@@ -33,7 +33,7 @@ spec:
         seccompProfile: {type: RuntimeDefault}
       containers:
         - name: fraud-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-31e6692a
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-fraud-service:sandbox-6376c3fc
           imagePullPolicy: IfNotPresent
           ports:
             - {name: http, containerPort: 8133}

--- a/openbank-infra/gitops/components/payments/payments-services.yaml
+++ b/openbank-infra/gitops/components/payments/payments-services.yaml
@@ -53,7 +53,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: transaction-service
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-transaction-service:sandbox-e3a4c19d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-transaction-service:sandbox-6376c3fc
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -402,7 +402,7 @@ spec:
         - name: sepa-payment
 
 
-          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sepa-payment:sandbox-e3a4c19d
+          image: 265175468565.dkr.ecr.eu-north-1.amazonaws.com/openbank-sepa-payment:sandbox-6376c3fc
 
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
## Why

sepa-payment has run `sandbox-e3a4c19d` for ~12 days, **missing #844** (valueDate format fix). It could not deploy incrementally: the sandbox deploy graph is a **patchwork of different main shas** (deploy-freeze from the flaky pact-CLI download, fixed in #1947), so its pact — verified against its providers at `6376c3fc` — had no verified path against the older provider versions actually deployed (fraud@`31e6692a`, transaction@`e3a4c19d`). This is the **#1009 item-3 gap**: `can-i-deploy --to-environment` can't be satisfied incrementally from a tangled state; the connected component must deploy **together**.

## What

Pin sepa-payment + its providers **transaction** + **fraud** all to `sandbox-6376c3fc` — a main-push sha where all three published pacts **and are mutually verified**. Confirmed **deployable-together** against the live broker:

```
can-i-deploy {sepa,transaction,fraud}@6376c3fc --to sandbox
→ 'All required verification results are published and successful' (deployable=True)
```

- All three `sandbox-6376c3fc` images exist in ECR (verified) → no ImagePullBackOff.
- `6376c3fc` includes #844.
- **Only these 3 image tags change.** domestic-payment / settlement / sepa-instant in the same file stay on their current deployed versions — the `--to-environment` check accounted for them.

## Note

Deliberate **co-deploy that bypasses auto-deploy's incremental per-service can-i-deploy gate** (which structurally can't express deploy-together), validated manually against the broker instead. **Maintainer-authorized.** The systemic fix is #1009 item 3 (deploy-together orchestration in the pipeline).

Refs #1009, #1348, #844, #1947