### PR TITLE
feat(cards): channel controls (contactless / online / ATM / abroad)

### DIFF
--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/in/CardPorts.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/port/in/CardPorts.kt
@@ -31,6 +31,16 @@ data class UpdateLimitsCommand(
     val changedBy: String,
 )
 
+data class UpdateControlsCommand(
+    val cardId: UUID,
+    val contactlessEnabled: Boolean,
+    val onlineEnabled: Boolean,
+    val atmEnabled: Boolean,
+    val abroadEnabled: Boolean,
+    val changedBy: String,
+)
+
+@Suppress("TooManyFunctions") // one use-case method per card operation (hexagonal)
 interface CardUseCase {
     suspend fun issueCard(cmd: IssueCardCommand): Card
     suspend fun activateCard(cmd: CardStatusCommand): Card
@@ -38,6 +48,7 @@ interface CardUseCase {
     suspend fun suspendCard(cmd: CardStatusCommand): Card
     suspend fun resumeCard(cmd: CardStatusCommand): Card
     suspend fun updateLimits(cmd: UpdateLimitsCommand): Card
+    suspend fun updateControls(cmd: UpdateControlsCommand): Card
     suspend fun getCard(id: UUID): Card?
     suspend fun listAll(): List<Card>
     suspend fun listByAccount(accountId: UUID): List<Card>

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardService.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/application/usecase/CardService.kt
@@ -80,6 +80,27 @@ class CardService(private val repo: CardRepository, private val mapper: ObjectMa
         return repo.save(updated, outboxMessage(updated.id, EVENT_CARD_LIMITS_CHANGED, event))
     }
 
+    override suspend fun updateControls(cmd: UpdateControlsCommand): Card {
+        val card = repo.findById(cmd.cardId) ?: error("Card not found: ${cmd.cardId}")
+        val updated = card.withControls(
+            cmd.contactlessEnabled,
+            cmd.onlineEnabled,
+            cmd.atmEnabled,
+            cmd.abroadEnabled,
+            Instant.now(clock),
+        )
+        val event = CardControlsChanged(
+            updated.id,
+            updated.contactlessEnabled,
+            updated.onlineEnabled,
+            updated.atmEnabled,
+            updated.abroadEnabled,
+            cmd.changedBy,
+            updated.updatedAt,
+        )
+        return repo.save(updated, outboxMessage(updated.id, EVENT_CARD_CONTROLS_CHANGED, event))
+    }
+
     /**
      * Shared status-transition path: load the card, apply [transition], then persist the updated
      * aggregate and its CardStatusChanged event in one transaction (ADR-0050).
@@ -114,5 +135,6 @@ class CardService(private val repo: CardRepository, private val mapper: ObjectMa
         const val EVENT_CARD_ISSUED = "card.issued.v1"
         const val EVENT_CARD_STATUS_CHANGED = "card.status_changed.v1"
         const val EVENT_CARD_LIMITS_CHANGED = "card.limits_changed.v1"
+        const val EVENT_CARD_CONTROLS_CHANGED = "card.controls_changed.v1"
     }
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/event/CardEvents.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/event/CardEvents.kt
@@ -36,3 +36,12 @@ data class CardLimitsChanged(
     val changedBy: String,
     override val occurredAt: Instant = Instant.EPOCH,
 ) : CardEvent()
+data class CardControlsChanged(
+    override val cardId: UUID,
+    val contactlessEnabled: Boolean,
+    val onlineEnabled: Boolean,
+    val atmEnabled: Boolean,
+    val abroadEnabled: Boolean,
+    val changedBy: String,
+    override val occurredAt: Instant = Instant.EPOCH,
+) : CardEvent()

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/domain/model/Card.kt
@@ -34,6 +34,11 @@ data class Card(
     val blockedReason: String?,
     val createdAt: Instant,
     val updatedAt: Instant,
+    // Customer channel controls (#1): which rails the card may transact on. Default all-on.
+    val contactlessEnabled: Boolean = true,
+    val onlineEnabled: Boolean = true,
+    val atmEnabled: Boolean = true,
+    val abroadEnabled: Boolean = true,
 ) {
     fun activate(now: Instant = Instant.EPOCH) = also {
         require(status == CardStatus.PENDING) { "Only PENDING cards can be activated, current: $status" }
@@ -63,4 +68,26 @@ data class Card(
         require(dailyMinor >= 0 && monthlyMinor >= 0) { "Limits must be non-negative" }
         require(dailyMinor <= monthlyMinor) { "Daily limit ($dailyMinor) cannot exceed monthly ($monthlyMinor)" }
     }.copy(dailyLimitMinorUnits = dailyMinor, monthlyLimitMinorUnits = monthlyMinor, updatedAt = now)
+
+    /**
+     * Customer channel controls (#1): turn contactless / online (e-commerce) / ATM / abroad usage
+     * on or off. Only a live card may be re-controlled — a terminal card has no usage to gate.
+     */
+    fun withControls(
+        contactless: Boolean,
+        online: Boolean,
+        atm: Boolean,
+        abroad: Boolean,
+        now: Instant = Instant.EPOCH,
+    ) = also {
+        require(status in setOf(CardStatus.ACTIVE, CardStatus.SUSPENDED, CardStatus.PENDING)) {
+            "Cannot change controls on a card in status $status"
+        }
+    }.copy(
+        contactlessEnabled = contactless,
+        onlineEnabled = online,
+        atmEnabled = atm,
+        abroadEnabled = abroad,
+        updatedAt = now,
+    )
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardEntity.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/entity/CardEntity.kt
@@ -58,6 +58,18 @@ class CardEntity {
     @Column(name = "monthly_limit_minor_units", nullable = false)
     var monthlyLimitMinorUnits: Long = 0
 
+    @Column(name = "contactless_enabled", nullable = false)
+    var contactlessEnabled: Boolean = true
+
+    @Column(name = "online_enabled", nullable = false)
+    var onlineEnabled: Boolean = true
+
+    @Column(name = "atm_enabled", nullable = false)
+    var atmEnabled: Boolean = true
+
+    @Column(name = "abroad_enabled", nullable = false)
+    var abroadEnabled: Boolean = true
+
     @Column(name = "currency", nullable = false)
     lateinit var currency: String
 

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/mapper/CardMapper.kt
@@ -16,6 +16,8 @@ fun CardEntity.toDomain() = Card(
     currency = currency, deliveryAddress = deliveryAddress,
     activatedAt = activatedAt, blockedAt = blockedAt, blockedReason = blockedReason,
     createdAt = createdAt, updatedAt = updatedAt,
+    contactlessEnabled = contactlessEnabled, onlineEnabled = onlineEnabled,
+    atmEnabled = atmEnabled, abroadEnabled = abroadEnabled,
 )
 
 fun Card.toEntity() = CardEntity().also { e ->
@@ -33,6 +35,10 @@ fun Card.toEntity() = CardEntity().also { e ->
     e.status = status.name
     e.dailyLimitMinorUnits = dailyLimitMinorUnits
     e.monthlyLimitMinorUnits = monthlyLimitMinorUnits
+    e.contactlessEnabled = contactlessEnabled
+    e.onlineEnabled = onlineEnabled
+    e.atmEnabled = atmEnabled
+    e.abroadEnabled = abroadEnabled
     e.currency = currency
     e.deliveryAddress = deliveryAddress
     e.activatedAt = activatedAt

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/persistence/repository/CardRepositoryImpl.kt
@@ -83,6 +83,10 @@ class CardRepositoryImpl(private val outboxRepository: CardOutboxRepositoryImpl)
         expiryDate = card.expiryDate
         dailyLimitMinorUnits = card.dailyLimitMinorUnits
         monthlyLimitMinorUnits = card.monthlyLimitMinorUnits
+        contactlessEnabled = card.contactlessEnabled
+        onlineEnabled = card.onlineEnabled
+        atmEnabled = card.atmEnabled
+        abroadEnabled = card.abroadEnabled
         currency = card.currency
         deliveryAddress = card.deliveryAddress
         activatedAt = card.activatedAt

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardResource.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/CardResource.kt
@@ -6,9 +6,11 @@ package com.openbank.cardissuance.infrastructure.rest
 
 import com.openbank.cardissuance.application.port.`in`.CardStatusCommand
 import com.openbank.cardissuance.application.port.`in`.CardUseCase
+import com.openbank.cardissuance.application.port.`in`.UpdateControlsCommand
 import com.openbank.cardissuance.application.port.`in`.UpdateLimitsCommand
 import com.openbank.cardissuance.infrastructure.rest.dto.CardStatusRequest
 import com.openbank.cardissuance.infrastructure.rest.dto.IssueCardRequest
+import com.openbank.cardissuance.infrastructure.rest.dto.UpdateControlsRequest
 import com.openbank.cardissuance.infrastructure.rest.dto.UpdateLimitsRequest
 import com.openbank.cardissuance.infrastructure.rest.dto.toResponse
 import com.openbank.libs.authz.Authorize
@@ -32,6 +34,7 @@ import java.util.UUID
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Cards", description = "Card issuance and lifecycle management — PCI DSS compliant")
+@Suppress("TooManyFunctions") // one REST handler per card operation (issue/lifecycle/limits/controls)
 class CardResource(private val cardUseCase: CardUseCase) {
 
     @POST
@@ -123,6 +126,29 @@ class CardResource(private val cardUseCase: CardUseCase) {
     ): Response = Response.ok(
         cardUseCase.updateLimits(
             UpdateLimitsCommand(id, req.dailyLimitMinorUnits, req.monthlyLimitMinorUnits, operatorId),
+        ).toResponse(),
+    ).build()
+
+    @PUT
+    @Path("/{id}/controls")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RolesAllowed("ROLE_OPERATOR", "ROLE_ADMIN")
+    @Authorize(action = "card.controls.update", resource = "#id")
+    @Operation(summary = "Set a card's channel controls (contactless / online / ATM / abroad)")
+    suspend fun updateControls(
+        @PathParam("id") id: UUID,
+        req: UpdateControlsRequest,
+        @HeaderParam("X-Operator-Id") operatorId: String,
+    ): Response = Response.ok(
+        cardUseCase.updateControls(
+            UpdateControlsCommand(
+                id,
+                req.contactlessEnabled,
+                req.onlineEnabled,
+                req.atmEnabled,
+                req.abroadEnabled,
+                operatorId,
+            ),
         ).toResponse(),
     ).build()
 }

--- a/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/dto/CardDtos.kt
+++ b/openbank-card-issuance-service/src/main/kotlin/com/openbank/cardissuance/infrastructure/rest/dto/CardDtos.kt
@@ -52,6 +52,10 @@ data class CardResponse(
     val blockedReason: String?,
     val createdAt: Instant,
     val updatedAt: Instant,
+    val contactlessEnabled: Boolean = true,
+    val onlineEnabled: Boolean = true,
+    val atmEnabled: Boolean = true,
+    val abroadEnabled: Boolean = true,
 )
 
 fun Card.toResponse() = CardResponse(
@@ -59,7 +63,16 @@ fun Card.toResponse() = CardResponse(
     cardholderName, embossedName, expiryDate, status,
     dailyLimitMinorUnits, monthlyLimitMinorUnits, currency, deliveryAddress,
     activatedAt, blockedAt, blockedReason, createdAt, updatedAt,
+    contactlessEnabled, onlineEnabled, atmEnabled, abroadEnabled,
 )
 
 /** Customer/operator request to set a card's spending limits (minor units). */
 data class UpdateLimitsRequest(val dailyLimitMinorUnits: Long, val monthlyLimitMinorUnits: Long)
+
+/** Customer/operator request to set a card's channel controls (which rails may transact). */
+data class UpdateControlsRequest(
+    val contactlessEnabled: Boolean,
+    val onlineEnabled: Boolean,
+    val atmEnabled: Boolean,
+    val abroadEnabled: Boolean,
+)

--- a/openbank-card-issuance-service/src/main/resources/db/migration/V5__card_channel_controls.sql
+++ b/openbank-card-issuance-service/src/main/resources/db/migration/V5__card_channel_controls.sql
@@ -1,0 +1,6 @@
+-- Customer channel controls (#1): which rails a card may transact on. Default all-on so every
+-- existing card keeps working exactly as before this migration.
+ALTER TABLE cards ADD COLUMN contactless_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE cards ADD COLUMN online_enabled      BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE cards ADD COLUMN atm_enabled         BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE cards ADD COLUMN abroad_enabled      BOOLEAN NOT NULL DEFAULT TRUE;

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardServiceTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/application/usecase/CardServiceTest.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import com.openbank.cardissuance.application.port.`in`.CardStatusCommand
 import com.openbank.cardissuance.application.port.`in`.IssueCardCommand
+import com.openbank.cardissuance.application.port.`in`.UpdateControlsCommand
 import com.openbank.cardissuance.application.port.out.CardRepository
 import com.openbank.cardissuance.domain.model.Card
 import com.openbank.cardissuance.domain.model.CardNetwork
@@ -94,6 +95,30 @@ class CardServiceTest {
                         it.payload.contains("ops-user")
                 },
             )
+        }
+    }
+
+    @Test fun `updateControls applies the flags and emits a controls-changed event`(): Unit = runBlocking {
+        val active = card(status = CardStatus.ACTIVE)
+        coEvery { repo.findById(active.id) } returns active
+        coEvery { repo.save(any(), any()) } answers { firstArg() }
+
+        val result = service.updateControls(
+            UpdateControlsCommand(
+                cardId = active.id,
+                contactlessEnabled = false,
+                onlineEnabled = true,
+                atmEnabled = false,
+                abroadEnabled = true,
+                changedBy = "customer:${active.partyId}",
+            ),
+        )
+
+        assertThat(result.contactlessEnabled).isFalse()
+        assertThat(result.atmEnabled).isFalse()
+        assertThat(result.abroadEnabled).isTrue()
+        coVerify(exactly = 1) {
+            repo.save(any(), match { it.eventType == CardService.EVENT_CARD_CONTROLS_CHANGED })
         }
     }
 

--- a/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/CardTest.kt
+++ b/openbank-card-issuance-service/src/test/kotlin/com/openbank/cardissuance/domain/model/CardTest.kt
@@ -95,6 +95,33 @@ class CardTest {
             .hasMessageContaining("Only SUSPENDED cards can be resumed")
     }
 
+    @Test fun `withControls flips all four channel flags and stamps updatedAt`() {
+        val now = Instant.parse("2026-02-02T09:00:00Z")
+        val card = card(status = CardStatus.ACTIVE)
+
+        val updated = card.withControls(contactless = false, online = true, atm = false, abroad = true, now = now)
+
+        assertThat(updated.contactlessEnabled).isFalse()
+        assertThat(updated.onlineEnabled).isTrue()
+        assertThat(updated.atmEnabled).isFalse()
+        assertThat(updated.abroadEnabled).isTrue()
+        assertThat(updated.updatedAt).isEqualTo(now)
+    }
+
+    @Test fun `withControls is allowed on a suspended card`() {
+        val updated = card(status = CardStatus.SUSPENDED)
+            .withControls(contactless = true, online = false, atm = true, abroad = false)
+        assertThat(updated.onlineEnabled).isFalse()
+    }
+
+    @Test fun `withControls rejects a terminal card`() {
+        assertThatThrownBy {
+            card(status = CardStatus.BLOCKED).withControls(true, true, true, true)
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cannot change controls")
+    }
+
     private fun card(status: CardStatus) = Card(
         id = UUID.fromString("11111111-1111-1111-1111-111111111111"),
         idempotencyKey = "idem-key",

--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2465,6 +2465,24 @@ class CustomerEdgeResource(
         )
     }
 
+    /** Set channel controls on one of the caller's OWN cards. Body:
+     *  {"contactlessEnabled":bool,"onlineEnabled":bool,"atmEnabled":bool,"abroadEnabled":bool}. */
+    @PUT
+    @Path("/cards/{id}/controls")
+    @Authorize(action = "customer.cards.update", resource = "#id")
+    @Blocking
+    fun updateCardControls(@PathParam("id") id: UUID, body: String): Response {
+        val customer = customer()
+        if (!ownsCard(id, customer.partyId)) return forbidden("Card does not belong to caller")
+        return upstream.put(
+            "$cardIssuanceServiceUrl/api/v1/cards/$id/controls",
+            customer.partyId.toString(),
+            body,
+            null,
+            mapOf("X-Operator-Id" to "customer:${customer.partyId}"),
+        )
+    }
+
     private fun ownsCard(id: UUID, partyId: UUID): Boolean {
         val resp = upstream.get("$cardIssuanceServiceUrl/api/v1/cards/$id", partyId.toString())
         if (resp.status != 200) return false


### PR DESCRIPTION
TOP-10 #1. Adds per-channel on/off to a card (the freeze/limits slice, one level deeper). App PR follows.

## Adds
- Card aggregate: 4 flags (contactless/online/atm/abroad, default all-on) + `withControls` + `CardControlsChanged` event
- `PUT /api/v1/cards/{id}/controls` (mirrors /limits) + CardResponse now returns the flags
- Flyway **V5** — 4 BOOLEAN columns DEFAULT TRUE (existing cards unaffected)
- edge `PUT /customer/v1/cards/{id}/controls` (ownership-checked)

## Authz / netpol (lessons applied)
- `customer.cards.update` already covered by the customer.* self-action edge rule
- card-issuance AUTHZ_ENFORCE=false + edge M2M has ROLE_OPERATOR → no rego change
- CARD_ISSUANCE_SERVICE_URL already in edge gitops env → netpol already open

Closes #1980

🤖 Generated with [Claude Code](https://claude.com/claude-code)