### PR TITLE
feat(notifications): per-party push preferences with category opt-out

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2002,6 +2002,33 @@ class CustomerEdgeResource(
         return Response.ok(out).type(MediaType.APPLICATION_JSON).build()
     }
 
+    /** The caller's push-notification preferences (#2). Party is taken from the JWT, never the client. */
+    @GET
+    @Path("/notification-preferences")
+    @Authorize(action = "customer.notifications.read", resource = "")
+    @Blocking
+    fun getNotificationPreferences(): Response {
+        val customer = customer()
+        return upstream.get(
+            "$notificationServiceUrl/api/v1/preferences/party/${customer.partyId}",
+            customer.partyId.toString(),
+        )
+    }
+
+    /** Set the caller's push-notification preferences (#2). Body: {paymentsPush,productPush,marketingPush}. */
+    @PUT
+    @Path("/notification-preferences")
+    @Authorize(action = "customer.notifications.update", resource = "")
+    @Blocking
+    fun setNotificationPreferences(body: String): Response {
+        val customer = customer()
+        return upstream.put(
+            "$notificationServiceUrl/api/v1/preferences/party/${customer.partyId}",
+            customer.partyId.toString(),
+            body,
+        )
+    }
+
     // --- SCA device enrollment (ADR-0021) ---
 
     @POST

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/application/NotificationConsumer.kt
@@ -13,6 +13,7 @@ import com.openbank.notification.application.port.out.OversightWebhookPublisher
 import com.openbank.notification.application.port.out.PushMessage
 import com.openbank.notification.application.port.out.PushSender
 import com.openbank.notification.domain.HtmlEscape
+import com.openbank.notification.domain.model.NotificationCategory
 import com.openbank.notification.domain.model.NotificationChannel
 import com.openbank.notification.domain.model.NotificationRequest
 import com.openbank.notification.domain.model.NotificationStatus
@@ -21,6 +22,7 @@ import com.openbank.notification.domain.model.PushPlatform
 import com.openbank.notification.domain.model.TemplateSensitivity
 import com.openbank.notification.infrastructure.persistence.entity.NotificationEntity
 import com.openbank.notification.infrastructure.persistence.repository.DeviceTokenRepository
+import com.openbank.notification.infrastructure.persistence.repository.NotificationPreferenceRepository
 import com.openbank.notification.infrastructure.persistence.repository.NotificationRepository
 import io.quarkus.hibernate.reactive.panache.Panache
 import io.quarkus.mailer.Mail
@@ -38,6 +40,7 @@ import java.time.Instant
 import java.util.concurrent.Executor
 
 @ApplicationScoped
+@Suppress("TooManyFunctions") // one delivery path per channel + shared helpers; grows with channels
 class NotificationConsumer {
 
     @Inject lateinit var mailer: ReactiveMailer
@@ -47,6 +50,8 @@ class NotificationConsumer {
     @Inject lateinit var notificationRepo: NotificationRepository
 
     @Inject lateinit var deviceTokenRepo: DeviceTokenRepository
+
+    @Inject lateinit var preferenceRepo: NotificationPreferenceRepository
 
     @Inject lateinit var pushSender: PushSender
 
@@ -151,7 +156,7 @@ class NotificationConsumer {
                         log.infof("SMS stub: to=%s template=%s", req.recipient, req.template)
                         Uni.createFrom().voidItem()
                     }
-                    NotificationChannel.PUSH -> sendPush(req, subject, body, entity)
+                    NotificationChannel.PUSH -> maybeSendPush(req, subject, body, entity)
                     NotificationChannel.IN_APP -> {
                         log.infof("IN_APP stub: to=%s template=%s", req.recipient, req.template)
                         Uni.createFrom().voidItem()
@@ -285,6 +290,35 @@ class NotificationConsumer {
             )
         }
         .onFailure().recoverWithUni { _ -> Uni.createFrom().voidItem() }
+
+    /**
+     * Gate a PUSH by the party's preferences (#2). SECURITY-category notifications (OTP, SCA, KYC,
+     * account freeze) always send. For a togglable category, a missing preference row means "on";
+     * a muted category records the notification as SUPPRESSED and skips egress.
+     */
+    private fun maybeSendPush(
+        req: NotificationRequest,
+        subject: String,
+        body: String,
+        entity: NotificationEntity,
+    ): Uni<Void> {
+        val category = req.template.category
+        if (category == NotificationCategory.SECURITY) return sendPush(req, subject, body, entity)
+        return Panache.withTransaction { preferenceRepo.findByParty(req.partyId) }.chain { pref ->
+            val enabled = when (category) {
+                NotificationCategory.PAYMENTS -> pref?.paymentsPush ?: true
+                NotificationCategory.PRODUCT -> pref?.productPush ?: true
+                NotificationCategory.MARKETING -> pref?.marketingPush ?: true
+                NotificationCategory.SECURITY -> true
+            }
+            if (enabled) {
+                sendPush(req, subject, body, entity)
+            } else {
+                log.infof("PUSH suppressed by preference: party=%s category=%s", req.partyId, category)
+                markStatus(entity, "SUPPRESSED")
+            }
+        }
+    }
 
     /**
      * Deliver a PUSH notification by fanning out to every ACTIVE device token registered for

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/domain/model/Notification.kt
@@ -45,7 +45,25 @@ enum class NotificationTemplate(val variables: Set<String>) {
 
     /** Keys in [vars] that this template does not accept. Empty = the request is well-formed. */
     fun unknownVariables(vars: Map<String, String>): Set<String> = vars.keys - variables
+
+    /**
+     * The customer-facing category a template belongs to (#2). SECURITY is deliberately un-mutable:
+     * a customer can never silence OTP / SCA / KYC / account-freeze pushes, so those are always sent
+     * regardless of preferences. Everything else maps to a togglable category.
+     */
+    val category: NotificationCategory
+        get() = when (this) {
+            OTP_CODE, PASSWORD_RESET, ACCOUNT_FROZEN,
+            KYC_APPROVED, KYC_REJECTED, KYC_DOCUMENT_REQUIRED,
+            CONSENT_GRANTED, CONSENT_REVOKED,
+            -> NotificationCategory.SECURITY
+            TRANSACTION_COMPLETED, TRANSACTION_FAILED -> NotificationCategory.PAYMENTS
+            ACCOUNT_OPENED, ACCOUNT_CLOSED, WELCOME -> NotificationCategory.PRODUCT
+        }
 }
+
+/** Customer-facing notification categories for push preferences (#2). */
+enum class NotificationCategory { SECURITY, PAYMENTS, PRODUCT, MARKETING }
 
 data class Notification(
     val id: UUID,

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/entity/NotificationPreferenceEntity.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/entity/NotificationPreferenceEntity.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.persistence.entity
+
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * A party's push-notification preferences (#2). One row per party; a missing row means "all on"
+ * (the app never has to seed defaults). Security-critical notifications (OTP, SCA, KYC, account
+ * freeze) are NOT represented here — they are always delivered regardless of these flags.
+ */
+@Entity
+@Table(name = "notification_preferences")
+class NotificationPreferenceEntity : PanacheEntity() {
+    @Column(name = "party_id", nullable = false, unique = true)
+    lateinit var partyId: UUID
+
+    @Column(name = "payments_push", nullable = false)
+    var paymentsPush: Boolean = true
+
+    @Column(name = "product_push", nullable = false)
+    var productPush: Boolean = true
+
+    @Column(name = "marketing_push", nullable = false)
+    var marketingPush: Boolean = true
+
+    @Column(name = "updated_at", nullable = false)
+    lateinit var updatedAt: Instant
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationPreferenceRepository.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/persistence/repository/NotificationPreferenceRepository.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.persistence.repository
+
+import com.openbank.notification.infrastructure.persistence.entity.NotificationPreferenceEntity
+import io.quarkus.hibernate.reactive.panache.Panache
+import io.quarkus.hibernate.reactive.panache.kotlin.PanacheRepository
+import io.smallrye.mutiny.Uni
+import io.smallrye.mutiny.coroutines.awaitSuspending
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.inject.Inject
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+@ApplicationScoped
+class NotificationPreferenceRepository : PanacheRepository<NotificationPreferenceEntity> {
+    @Inject
+    lateinit var clock: Clock
+
+    /**
+     * The party's preferences as a `Uni` (not `suspend`) so it composes inside the consumer's
+     * reactive `Panache.withTransaction { }` chain, which avoids `suspend` on the Kafka polling
+     * thread. Emits null when the party has never set preferences (⇒ all channels on).
+     */
+    fun findByParty(partyId: UUID): Uni<NotificationPreferenceEntity?> = find("partyId", partyId).firstResult()
+
+    /** Read for the REST layer (coroutine world). */
+    suspend fun getByParty(partyId: UUID): NotificationPreferenceEntity? =
+        Panache.withSession { findByParty(partyId) }.awaitSuspending()
+
+    /** Upsert the party's preferences and return the persisted row (REST layer). */
+    suspend fun upsert(
+        partyId: UUID,
+        payments: Boolean,
+        product: Boolean,
+        marketing: Boolean,
+    ): NotificationPreferenceEntity = Panache.withTransaction {
+        findByParty(partyId).chain { existing ->
+            val row = existing ?: NotificationPreferenceEntity().also { it.partyId = partyId }
+            row.paymentsPush = payments
+            row.productPush = product
+            row.marketingPush = marketing
+            row.updatedAt = Instant.now(clock)
+            if (existing == null) persist(row).map { row } else Uni.createFrom().item(row)
+        }
+    }.awaitSuspending()
+}

--- a/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationPreferenceResource.kt
+++ b/openbank-notification-service/src/main/kotlin/com/openbank/notification/infrastructure/rest/NotificationPreferenceResource.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) OpenBank contributors. Licensed under the Apache License, Version 2.0.
+// See LICENSE in the repository root or https://www.apache.org/licenses/LICENSE-2.0 for details.
+
+package com.openbank.notification.infrastructure.rest
+
+import com.openbank.libs.authz.Authorize
+import com.openbank.notification.infrastructure.persistence.repository.NotificationPreferenceRepository
+import jakarta.annotation.security.RolesAllowed
+import jakarta.inject.Inject
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.GET
+import jakarta.ws.rs.PUT
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.PathParam
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.eclipse.microprofile.openapi.annotations.Operation
+import org.eclipse.microprofile.openapi.annotations.tags.Tag
+import java.util.UUID
+
+/** A party's push preferences; a party with no stored row is treated as all-on. */
+data class NotificationPreferenceDto(
+    val paymentsPush: Boolean = true,
+    val productPush: Boolean = true,
+    val marketingPush: Boolean = true,
+)
+
+@Path("/api/v1/preferences")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Preferences", description = "Per-party push-notification preferences (#2)")
+class NotificationPreferenceResource {
+
+    @Inject
+    lateinit var repo: NotificationPreferenceRepository
+
+    @GET
+    @Path("/party/{partyId}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @Authorize(action = "notification.preferences.read", resource = "#partyId")
+    @Operation(summary = "Get a party's push preferences (all-on when never set)")
+    suspend fun get(@PathParam("partyId") partyId: UUID): NotificationPreferenceDto {
+        val row = repo.getByParty(partyId) ?: return NotificationPreferenceDto()
+        return NotificationPreferenceDto(row.paymentsPush, row.productPush, row.marketingPush)
+    }
+
+    @PUT
+    @Path("/party/{partyId}")
+    @RolesAllowed("ROLE_SERVICE", "ROLE_OPERATOR", "ROLE_ADMIN", "ROLE_CUSTOMER")
+    @Authorize(action = "notification.preferences.update", resource = "#partyId")
+    @Operation(summary = "Set a party's push preferences")
+    suspend fun set(@PathParam("partyId") partyId: UUID, req: NotificationPreferenceDto): NotificationPreferenceDto {
+        val row = repo.upsert(partyId, req.paymentsPush, req.productPush, req.marketingPush)
+        return NotificationPreferenceDto(row.paymentsPush, row.productPush, row.marketingPush)
+    }
+}

--- a/openbank-notification-service/src/main/resources/db/migration/V11__notification_preferences.sql
+++ b/openbank-notification-service/src/main/resources/db/migration/V11__notification_preferences.sql
@@ -1,0 +1,20 @@
+-- Per-party push preferences (#2). A missing row means "all on", so no backfill is needed and
+-- existing customers keep receiving every push until they opt out. Security-critical categories
+-- (OTP / SCA / KYC / account freeze) are never gated by these flags.
+CREATE TABLE notification_preferences (
+    id             BIGSERIAL PRIMARY KEY,
+    party_id       UUID        NOT NULL UNIQUE,
+    payments_push  BOOLEAN     NOT NULL DEFAULT TRUE,
+    product_push   BOOLEAN     NOT NULL DEFAULT TRUE,
+    marketing_push BOOLEAN     NOT NULL DEFAULT TRUE,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Hibernate Reactive + Kotlin PanacheEntity allocate the id from a sequence named
+-- "<table>_seq" (default allocationSize 50); BIGSERIAL alone only yields "<table>_id_seq".
+-- Enforced by HibernateSequenceGuardTest. Rollback: DROP TABLE notification_preferences;
+-- DROP SEQUENCE notification_preferences_seq;
+CREATE SEQUENCE IF NOT EXISTS notification_preferences_seq INCREMENT BY 50;
+
+GRANT ALL ON ALL TABLES IN SCHEMA public TO openbank;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO openbank;


### PR DESCRIPTION
TOP-10 #2. Lets a customer silence non-critical push categories; SECURITY (OTP/SCA/KYC/account-freeze) is always delivered.

## Adds
- `NotificationCategory` + `NotificationTemplate.category` mapping
- `NotificationPreferenceEntity` + repository + Flyway **V11** (with the `<table>_seq` PanacheEntity convention). Missing row = all-on → no backfill, existing customers unaffected
- consumer `dispatch()` gates PUSH via `maybeSendPush`: muted category → recorded SUPPRESSED, no egress; SECURITY bypasses
- `GET/PUT /api/v1/preferences/party/{partyId}` + edge `GET/PUT /customer/v1/notification-preferences`

## Authz / netpol (lessons applied)
- edge `customer.notifications.*` covered by the customer.* self-action rule
- notification-service `notification.preferences.*` covered by the edge-service-notification family → no rest.rego change
- NOTIFICATION_SERVICE_URL already in edge gitops env → netpol already open

Closes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)