### PR TITLE
docs(compliance): IPR/VoP position + ISO 20022 message catalog

### DIFF
--- a/docs/compliance/ipr-vop.md
+++ b/docs/compliance/ipr-vop.md
@@ -1,0 +1,79 @@
+# Instant Payments Regulation (IPR) — compliance position
+
+> Regulation (EU) 2024/886 of 13 March 2024 amending Regulations (EU) No 260/2012 and
+> (EU) 2021/1230 as regards instant credit transfers in euro ("the IPR").
+>
+> **This is technical positioning, not legal advice.** It maps selected IPR obligations to
+> the concrete services and code in this repository and is deliberately honest about what is
+> **not** yet implemented. Operators must run their own compliance review with qualified legal
+> counsel and the competent authority (CNB for the Czech jurisdiction). Verified against
+> `origin/main`; every service, ADR and config key cited below exists in the tree.
+
+## Scope of this note
+
+The IPR layers instant-payment obligations on top of the SEPA Regulation for PSPs that already
+offer standard SEPA Credit Transfers (SCT) in euro. This note covers the four obligations the
+platform touches in code today:
+
+1. Verification of Payee (VoP) on outbound credit transfers
+2. SCT Inst 10-second execution timing
+3. Charge parity between SCT Inst and standard SCT
+4. Sanctions-screening cadence
+
+It does **not** claim conformance for reachability mandates, the fraud-reimbursement /
+liability-shift regime, or the PSP self-attestation duties — see [Known gaps](#known-gaps-honest).
+
+## Requirement → implementation
+
+| IPR obligation | What the regulation requires | Implementation in this repo | Service / ADR | Status |
+|---|---|---|---|---|
+| **Verification of Payee** (Art. 5c) | Before a credit transfer is authorised, the payer's PSP must check the payee name against the account identifier (IBAN) and flag a mismatch to the payer. | `openbank-vop-service` runs a pure, deterministic name-match policy returning the four EPC outcomes `MATCH` / `CLOSE_MATCH` / `NO_MATCH` / `NO_DATA`. It **warns rather than blocks** and **fails open** as `NO_DATA` when data is unavailable. | `openbank-vop-service`, [ADR-0171](../adr/0171-verification-of-payee-for-outbound-credit-transfers.md) | Partial — service live; advisory-only |
+| **SCT Inst 10-second timing** (Art. 5a) | The payee's account must be credited (or the payer informed of rejection) within 10 seconds of the payment order, at any time of day. | `SctInstPaymentService` arms an execution deadline (`executionTimeoutAt = now + timeoutSeconds`) when the payment is cleared, and drives a dedicated `TIMEOUT` terminal state via `SctInstPaymentTimeout`. The window is `openbank.sct-inst.execution-timeout-seconds`, **default `10`**. | `openbank-sepa-instant` | Implemented (against the in-house scheme simulator; no live interbank leg) |
+| **Charge parity** (Art. 5b) | Charges for an instant credit transfer must not exceed the charges for a non-instant (standard) SCT. | Both rails build the pacs.008 with the same scheme-level charge bearer `ChargeBearer.SLEV` in their `SchemeGatewayAdapter`, so the network-side charging model is identical across SCT and SCT Inst. | `openbank-sepa-instant`, `openbank-sepa-payment` | Partial — charge-bearer parity is modelled; see gap note below |
+| **Sanctions screening** (Art. 5d) | PSPs must verify at least daily whether their own payment-service users are listed persons/entities, immediately after a listing change — rather than screening every individual instant transaction. | The sanctions list data is refreshed on an operator-configurable schedule (`SanctionsListService` holds `cronHour` / `cronMinute` / `cronDays`). Instant payments **additionally** call a synchronous per-payment screen (`POST /api/v1/sanctions/screen`) via `SanctionsScreeningPort`, which **fails closed** (`ADR-0032 §C`) — a stricter posture than the IPR baseline. | `openbank-sanctions-service`, `openbank-sepa-instant` | Implemented (both cadences present) |
+
+### Notes on the evidence
+
+- **VoP outcomes** are the EPC-standard set enumerated in the vop-service domain model
+  (`MATCH`, `CLOSE_MATCH`, `NO_MATCH`, `NO_DATA`). The fail-open-as-`NO_DATA` behaviour is a
+  deliberate contrast with the sanctions gate, which fails closed — VoP is designed to inform the
+  payer, not to hard-block a transfer.
+- **Timing** is enforced against the in-house scheme simulator (see
+  [ADR-0104](../adr/0104-production-faithful-payment-rails-iso-20022-and-scheme-simulator.md)); the
+  platform is production-faithful up to the network boundary but has no live interbank connection,
+  so real end-to-end sub-10-second SLA cannot be asserted here.
+- **Charge parity** is asserted only at the ISO 20022 charge-bearer level (`SLEV` on both rails).
+  This repository does **not** contain a per-rail tariff in `openbank-billing-service` that proves
+  the *priced* SCT Inst fee equals the SCT fee; that pricing parity is a billing-configuration and
+  operational control, not something enforced in code today.
+- **Sanctions cadence**: IPR Art. 5d deliberately moves the primary control to *daily screening of
+  the PSP's own client base* rather than per-transaction screening. This platform does both — a
+  scheduled list refresh plus a synchronous per-payment screen on the instant rail. The
+  per-transaction screen is an additional control, not a substitute for the daily client-base
+  screening obligation, which remains an operational duty.
+
+## Known gaps (honest) <a name="known-gaps-honest"></a>
+
+The following IPR obligations are **not** implemented in this repository and must not be presented
+as covered:
+
+- **Fraud reimbursement / liability shift.** The IPR's VoP regime carries a liability consequence:
+  where a PSP fails to provide a correct VoP result and the payer suffers loss, the PSP may be
+  liable to reimburse. No reimbursement, liability-shift, or VoP-result-linked refund workflow
+  exists in the codebase. VoP here is advisory only.
+- **Reachability (send + receive) mandate.** IPR requires PSPs already offering SCT to be reachable
+  for both sending and receiving SCT Inst by the regulatory deadlines. The platform settles against
+  an internal scheme simulator with no live interbank reachability, so this obligation is out of
+  scope for the current milestone.
+- **Priced charge parity in billing.** As above — parity is modelled at the scheme charge-bearer
+  level, not proven by a billing tariff.
+- **PSP self-attestation / competent-authority reporting** of IPR conformance is a process
+  obligation with no code artefact and is not addressed here.
+
+## References
+
+- [ADR-0171 — Verification of Payee for outbound credit transfers](../adr/0171-verification-of-payee-for-outbound-credit-transfers.md)
+- [ADR-0104 — Production-faithful payment rails: real ISO 20022 + scheme simulator](../adr/0104-production-faithful-payment-rails-iso-20022-and-scheme-simulator.md)
+- [ADR-0111 — SEPA R-Transaction returns via pacs.004](../adr/0111-payment-r-transaction-returns-pacs004.md)
+- [ISO 20022 message catalog](iso-20022-catalog.md)
+- [Compliance matrix](../strategy/07-compliance-matrix.md)

--- a/docs/compliance/iso-20022-catalog.md
+++ b/docs/compliance/iso-20022-catalog.md
@@ -1,0 +1,76 @@
+# ISO 20022 message catalog
+
+> Where each ISO 20022 (and legacy SWIFT MT) message type lives in this platform.
+>
+> **This catalog is derived from the code on `origin/main`**, not from a spec wish-list. Every
+> message type below was confirmed present in tracked source (`git grep`) before being listed;
+> types that are only *referenced* but not *modelled* are called out explicitly rather than
+> padded into the table. See [ADR-0104](../adr/0104-production-faithful-payment-rails-iso-20022-and-scheme-simulator.md)
+> for the production-faithful-rails decision that grounds this pipeline.
+
+## Shared ISO 20022 library
+
+The XSD-validated builders and readers are centralised in the domain library, package
+`com.openbank.libs.iso20022` (`openbank-libs-domain`), with bundled schemas under
+`src/main/resources/iso20022/schemas/`:
+
+| Schema shipped | File |
+|---|---|
+| `pacs.008.001.08` | `Pacs008Builder.kt` / `Pacs008Reader.kt` |
+| `pacs.002.001.10` | `Pacs002Builder.kt` / `Pacs002Reader.kt` |
+| `pacs.004.001.09` | `Pacs004Builder.kt` / `Pacs004Reader.kt` |
+| `camt.054.001.08` | `Camt054Builder.kt` |
+| `camt.056.001.08` | `Camt056Builder.kt` |
+
+Structural validation is performed by `Iso20022Validator.kt` against the bundled `.xsd` files.
+
+## Message → where it lives
+
+| Message | ISO 20022 / MT name | Role | Where it lives (services) |
+|---|---|---|---|
+| **pacs.008** | FI to FI Customer Credit Transfer | Outbound/inbound credit-transfer instruction | `openbank-libs-domain` (builder/reader), `openbank-clearing-simulator`, `openbank-domestic-payment`, `openbank-sepa-payment`, `openbank-sepa-instant`, `openbank-swift-service` |
+| **pacs.002** | FI to FI Payment Status Report | Accept/reject status for a submitted payment | `openbank-libs-domain`, `openbank-clearing-simulator`, `openbank-domestic-payment`, `openbank-sepa-payment`, `openbank-sepa-instant`, `openbank-swift-service` |
+| **pacs.004** | Payment Return | R-transaction return of a settled SCT | `openbank-libs-domain`, `openbank-clearing-simulator`, `openbank-sepa-payment` ([ADR-0111](../adr/0111-payment-r-transaction-returns-pacs004.md)) |
+| **camt.056** | FI to FI Payment Cancellation Request | Recall / cancellation request | `openbank-libs-domain` (`Camt056Builder`) |
+| **camt.053** | Bank to Customer Statement | End-of-day account statement | `openbank-statement-service`, `openbank-customer-edge` |
+| **camt.054** | Bank to Customer Debit/Credit Notification | Per-entry debit/credit advice | `openbank-libs-domain`, `openbank-clearing-simulator`, `openbank-transaction-service` |
+
+## Legacy SWIFT MT / MX (correspondent banking)
+
+`openbank-swift-service` models the correspondent-banking message set and emits both legacy MT and
+ISO 20022 MX (pacs) variants. The MT types enumerated in its domain model (`SwiftMessage.kt`) are:
+
+| MT | Purpose |
+|---|---|
+| **MT103** | Single customer credit transfer |
+| **MT199** | Free-format message (customer transfer group) |
+| **MT202** | General financial-institution transfer |
+| **MT900** | Confirmation of debit |
+| **MT910** | Confirmation of credit |
+| **MT940** | Customer statement message |
+| **MT950** | Statement message |
+
+On the MX side, swift-service builds `pacs.008` and reads `pacs.002.001.10`, i.e. the ISO 20022
+equivalents of the MT103/MT202 credit-transfer and status flows. Governing decisions:
+[ADR-0104](../adr/0104-production-faithful-payment-rails-iso-20022-and-scheme-simulator.md) (real
+ISO 20022 messages),
+[ADR-0108](../adr/0108-rail-settlement-via-transaction-service.md) (rail settlement path).
+
+## Referenced but not modelled (honest note)
+
+- **pain.001** (Customer Credit Transfer Initiation) is **not** implemented as an XML message in
+  this repository. It appears only as a documentation reference — a comment in
+  `openbank-customer-edge` noting the ISO 20022 `Max35Text` constraint on `endToEndId`, and a
+  mention in [ADR-0104](../adr/0104-production-faithful-payment-rails-iso-20022-and-scheme-simulator.md).
+  Payment initiation on this platform is a REST/JSON API at the customer edge, not a pain.001
+  submission. Do not list pain.001 as a supported message.
+- **camt.052** (intraday report) and **pain.002** (initiation status report) have **no**
+  occurrences in the codebase and are intentionally omitted.
+
+## References
+
+- [ADR-0104 — Production-faithful payment rails: real ISO 20022 + scheme simulator](../adr/0104-production-faithful-payment-rails-iso-20022-and-scheme-simulator.md)
+- [ADR-0108 — Rail settlement runs through transaction-service](../adr/0108-rail-settlement-via-transaction-service.md)
+- [ADR-0111 — SEPA R-Transaction returns via pacs.004](../adr/0111-payment-r-transaction-returns-pacs004.md)
+- [ADR-0103 — Transaction rail & instruction type captured at origination](../adr/0103-transaction-rail-and-instruction-type-at-origination.md)
+- [Instant Payments Regulation compliance position](ipr-vop.md)

--- a/docs/strategy/07-compliance-matrix.md
+++ b/docs/strategy/07-compliance-matrix.md
@@ -125,6 +125,13 @@ This document maps regulatory requirements to concrete technical capabilities an
 | CNB Act 21/1992 | 1 Jan 1993 | Ongoing | Czech national law; latest amendment 11 Jan 2026 |
 | eIDAS 2.0 (910/2014) | 27 Nov 2014 | 31 Dec 2026 | EUDI Wallet mandatory; implementing regs 2024/2977, 2024/2979, 2024/2982, 2024/2980 |
 
+## Related detailed positions
+
+Deep-dive compliance notes derived from the code on `origin/main`:
+
+- [Instant Payments Regulation (EU 2024/886) compliance position](../compliance/ipr-vop.md) — Verification of Payee, SCT Inst 10-second timing, charge parity, sanctions cadence, and an honest gap list.
+- [ISO 20022 message catalog](../compliance/iso-20022-catalog.md) — every pacs/camt/pain and SWIFT MT/MX message type mapped to the service it lives in.
+
 ## Sources
 
 - **PSD2**: Directive (EU) 2015/2366; RTS Regulation (EU) 2018/389 (amended by (EU) 2022/2360)


### PR DESCRIPTION
## What

Adds two regulator-facing positioning docs under a new `docs/compliance/` directory, both derived from and verified against `origin/main` (every service, ADR, config key and message type cited was confirmed present via `git grep` before listing).

### `docs/compliance/ipr-vop.md` — Instant Payments Regulation (EU 2024/886)
Requirement → implementation table:
- **Verification of Payee** — `openbank-vop-service`, [ADR-0171]; four EPC outcomes, advisory (warns, fails open `NO_DATA`).
- **SCT Inst 10-second timing** — `openbank-sepa-instant`; `openbank.sct-inst.execution-timeout-seconds` default `10`, dedicated `TIMEOUT` state.
- **Charge parity** — `ChargeBearer.SLEV` on both SCT and SCT Inst rails.
- **Sanctions cadence** — scheduled list refresh + synchronous per-payment screen (fails closed).

Honest **Known gaps** section: fraud reimbursement / liability shift, send+receive reachability, priced tariff parity in billing, and PSP self-attestation are **not** implemented and are called out as such.

### `docs/compliance/iso-20022-catalog.md` — message → service map
`pacs.008 / pacs.002 / pacs.004`, `camt.053 / camt.054 / camt.056`, and SWIFT `MT103/199/202/900/910/940/950` + MX `pacs` mapped to the services that own them, plus the shared `com.openbank.libs.iso20022` builder/reader library and bundled XSDs. `pain.001` is flagged as **referenced-only, not modelled**; `camt.052` / `pain.002` noted absent — rather than padded into the table.

## Where it's linked
From the compliance index [`docs/strategy/07-compliance-matrix.md`](../blob/main/docs/strategy/07-compliance-matrix.md) under a new "Related detailed positions" section.

## Verification
- All relative markdown links resolve (ADR targets, cross-doc links).
- No docs lint / link-check workflow exists in the repo, so none to run.
- `docs`-type commit touching only `docs/**` — no shipped-code path, so no release is cut (expected).

Closes #1929