### PR TITLE
docs(compliance): DORA evidence pack + FINOS CCC/AIGF control mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ The platform is designed with the following regulatory frameworks in mind. None 
 - **PCI DSS** — v4.0 (payment card industry)
 - **GDPR** — Regulation (EU) 2016/679 (data protection)
 
+Auditor-facing evidence and control mappings live under [`docs/compliance/`](docs/compliance/):
+the [DORA + supply-chain evidence pack](docs/compliance/evidence-pack.md) and the
+[FINOS CCC + AIGF control mapping](docs/compliance/finos-ccc-mapping.md).
+
 ---
 
 ## License

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,14 @@
+# Compliance index
+
+Regulator- and auditor-facing compliance documentation for OpenBank. None of this is legal advice;
+deploying OpenBank as a real bank requires your own licensing, compliance, and legal review.
+
+| Document | Covers |
+|----------|--------|
+| [`evidence-pack.md`](./evidence-pack.md) | DORA + supply-chain evidence pack: requirement → artifact → the command an auditor runs to verify it. |
+| [`finos-ccc-mapping.md`](./finos-ccc-mapping.md) | Mapping of platform controls to FINOS Common Cloud Controls (CCC) + AI Governance Framework (AIGF). |
+| [`eu-ai-act.md`](./eu-ai-act.md) | EU AI Act control mapping (tracked separately, issue #1918). |
+
+See also: [`docs/bcp/`](../bcp/) (BCP / DORA / incident response), the ADR set under
+[`docs/adr/`](../adr/), and the authoritative CI-enforced ruleset
+[`openbank-libs/governance/rules.yaml`](../../openbank-libs/governance/rules.yaml).

--- a/docs/compliance/evidence-pack.md
+++ b/docs/compliance/evidence-pack.md
@@ -70,11 +70,13 @@ Enforced authoritatively by [`openbank-libs/governance/rules.yaml`](../../openba
 
 ### Provenance gate rollout state (be precise with auditors)
 
-The deploy-time provenance gate is staged, not universally Enforce. The authoritative rollout state is
-`rules.yaml: provenance.gate` and the live Kyverno policy mode. As of this pack the
-`verify-openbank-image-sbom-attestation` ClusterPolicy is **Audit-only** (documented in-line in
-[`verify-sbom-attestation-policy.yaml`](../../openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml));
-the image-signature policy is Enforce. Verify the live mode before asserting either way:
+The deploy-time provenance gate graduated Audit → Enforce independently per rule. The authoritative
+rollout state is `rules.yaml: provenance.gate` and the live Kyverno policy mode. As of this pack the
+`verify-openbank-image-sbom-attestation` ClusterPolicy is **Enforce** (graduated from Audit on
+2026-07-12, ADR-0144; documented in-line in
+[`verify-sbom-attestation-policy.yaml`](../../openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml)) —
+an image lacking a cosign-signed SBOM attestation is REJECTED at admission; the image-signature
+policy has been Enforce since 2026-06-11. Verify the live mode before asserting either way:
 
 ```
 grep -nE 'validationFailureAction|Audit|Enforce' \
@@ -115,12 +117,12 @@ These are real, current limitations. Stating them is part of the evidence, not a
    (`WIRING INCOMPLETE`) rather than reporting a hollow PASS; `dr-test-log.md` currently records
    **table-top** exercises only. See [`automated-dr-restore.md`](../bcp/automated-dr-restore.md) for
    the remaining wiring.
-4. **Provenance gate is partially Audit-only.** The SBOM-attestation Kyverno policy is Audit, not
-   Enforce (§2 above); an unattested image would be surfaced, not blocked, at admission today.
-5. **DORA Art. 28/30 third-party controls are partial.** A vendor risk register and DORA Art. 30
+4. **DORA Art. 28/30 third-party controls are partial.** A vendor risk register and DORA Art. 30
    contractual clauses are backlog items (`dora-ictrm.md` follow-up; ADR-0174 `partial`), relevant
-   once the platform is commercially operated.
-6. **Escalation is single-maintainer (bus factor 1).** `incident-response.md` §4 documents no
+   once the platform is commercially operated. (Note: the supply-chain *technical* gate is NOT a gap —
+   both the image-signature and SBOM-attestation Kyverno policies are Enforce and reject
+   non-compliant images at admission, §2 above.)
+5. **Escalation is single-maintainer (bus factor 1).** `incident-response.md` §4 documents no
    secondary on-call — a deploying institution must fill this in before go-live.
 
 ---

--- a/docs/compliance/evidence-pack.md
+++ b/docs/compliance/evidence-pack.md
@@ -1,0 +1,134 @@
+# DORA + Supply-Chain Evidence Pack
+
+Date: 2026-07-23
+Regulation: EU 2022/2554 (DORA); EU SSDLC / supply-chain expectations (SLSA, CycloneDX, OpenVEX)
+Owner: CTO / Maintainer Lead
+Status: living document — regenerated when the underlying artifacts change
+
+---
+
+## How to read this pack
+
+Each row maps **a regulatory requirement → the artifact in this repo that satisfies it → a command an
+auditor can run to verify the artifact exists and is well-formed**. Every artifact and command is
+checkable against the state of `origin/main`; nothing here is aspirational. Where a control is
+partial or a gap, it is called out plainly in the [Honest gaps](#honest-gaps) section rather than
+dressed up as complete.
+
+Conventions:
+
+- `gh` commands assume the repository `JiRaska/open-bank-oss` and an authenticated `gh` CLI.
+- `cosign` commands assume cosign **v2.x** (pinned on purpose — see
+  [`openbank-infra/scripts/lib/cosign-attest.sh`](../../openbank-infra/scripts/lib/cosign-attest.sh)).
+- The cosign trust root is the AWS KMS key `awskms:///alias/openbank-cosign-signing`; its public key
+  is embedded (for offline verification) in
+  [`verify-sbom-attestation-policy.yaml`](../../openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml).
+
+---
+
+## 1. DORA ICT risk management (EU 2022/2554)
+
+The authoritative Article-by-Article mapping lives in
+[`docs/bcp/dora-ictrm.md`](../bcp/dora-ictrm.md); this pack points an auditor at the evidence and the
+verification command. Do not duplicate the Article table here — read it there.
+
+| DORA reference | Requirement | Evidence artifact | Auditor verification command |
+|---|---|---|---|
+| Art. 5–6 | ICT risk-management framework + risk system | [`docs/bcp/dora-ictrm.md`](../bcp/dora-ictrm.md) (Article map + risk register); threat models under [`docs/threat-models/`](../threat-models/) | `test -f docs/bcp/dora-ictrm.md && ls docs/threat-models/*.md \| wc -l` |
+| Art. 8 | Asset identification / register | per-service SBOMs (see §2); ICT third-party register [`docs/adr/0174-*.md`](../adr/0174-ict-third-party-dependencies-and-exit-strategy.md) | `test -f docs/adr/0174-ict-third-party-dependencies-and-exit-strategy.md` |
+| Art. 9 | Protection & prevention (access, encryption, patch) | OPA authz (ADR-0034), mTLS Kafka (ADR-0137), Keycloak OIDC, OpenBao secrets; PR-time CVE gate (see §2) | `grep -ni mtls docs/adr/0137-*.md; test -f docs/adr/0034-unified-opa-authz-mcp-and-rest.md` |
+| Art. 10, 17 | Detection + incident classification | [`docs/bcp/incident-response.md`](../bcp/incident-response.md) — P1–P4 tiers, declaration timing | `test -f docs/bcp/incident-response.md && grep -c '\*\*P' docs/bcp/incident-response.md` |
+| Art. 11 | Response & recovery (BCP/DRP, RTO/RPO) | [`docs/bcp/bcp-policy.md`](../bcp/bcp-policy.md) — T0–T3 RTO/RPO tiers | `grep -nE 'T0 — Payment' docs/bcp/bcp-policy.md` |
+| Art. 11(3)(c) | Documented, tested DR plan | [`docs/bcp/dr-test-log.md`](../bcp/dr-test-log.md); automated restore design [`docs/bcp/automated-dr-restore.md`](../bcp/automated-dr-restore.md) + [`.github/workflows/dr-restore-verify.yml`](../../.github/workflows/dr-restore-verify.yml) | `test -f docs/bcp/dr-test-log.md && test -f .github/workflows/dr-restore-verify.yml` |
+| Art. 12 | Backup policies (backup + restore) | CNPG S3 WAL archiving, 14-day retention, PITR (bcp-policy.md recovery-capabilities table) | `grep -nE 'WAL archiving\|Point-in-time' docs/bcp/bcp-policy.md` |
+| Art. 19–20 | Notification of major incidents to regulators | [`docs/bcp/incident-response.md`](../bcp/incident-response.md) §3 (register → 4 h notification) | `grep -n 'Art. 19' docs/bcp/incident-response.md` |
+| Art. 24–27 | Digital operational resilience testing (incl. TLPT) | DR table-top exercises in `dr-test-log.md`; deterministic simulation testing [`docs/adr/0100-*.md`](../adr/0100-deterministic-simulation-testing.md). **TLPT itself is planned-only** — see gaps | `grep -n TLPT docs/adr/0030-*.md docs/adr/0100-*.md` |
+| Art. 28, 30 | ICT third-party risk + contractual arrangements | ICT third-party register & exit strategy [`docs/adr/0174-*.md`](../adr/0174-ict-third-party-dependencies-and-exit-strategy.md); `dora-ictrm.md` Art. 28/30 backlog | `test -f docs/adr/0174-ict-third-party-dependencies-and-exit-strategy.md` |
+
+---
+
+## 2. Supply-chain / release provenance
+
+Enforced authoritatively by [`openbank-libs/governance/rules.yaml`](../../openbank-libs/governance/rules.yaml)
+(`provenance:` block, ADR-0029 D2 / ADR-0030 D4).
+
+| Control | Requirement | Evidence artifact | Auditor verification command |
+|---|---|---|---|
+| SBOM (per service) | CycloneDX SBOM generated per service | `./gradlew sbomAll` output; per-service SBOM job in [`security.yml`](../../.github/workflows/security.yml) | `grep -nE 'cyclonedx\|sbomAll' .github/workflows/security.yml` |
+| SBOM (aggregate) | Repo-level CycloneDX SBOM attached in CI | `anchore/sbom-action` (`format: cyclonedx-json`) in `security.yml` | `grep -nE 'cyclonedx-json' .github/workflows/security.yml` |
+| Image SBOM attestation | Every `openbank-*` image carries a cosign-signed CycloneDX attestation | [`cosign-attest.sh`](../../openbank-infra/scripts/lib/cosign-attest.sh); Kyverno `verify-openbank-image-sbom-attestation` policy | `cosign verify-attestation --key awskms:///alias/openbank-cosign-signing --type cyclonedx <ecr-image@sha256:...>` |
+| Image signing | Images cosign-signed, verified at admission | Kyverno `verify-openbank-image-signatures`; KMS key `alias/openbank-cosign-signing` | `cosign verify --key awskms:///alias/openbank-cosign-signing <ecr-image@sha256:...>` |
+| SLSA provenance | in-toto / SLSA provenance on releases | `rules.yaml: provenance.attestation: slsa`; release evidence bundle (below) | `grep -nE 'attestation: slsa' openbank-libs/governance/rules.yaml` |
+| Release evidence bundle | SBOM + SLSA provenance + coverage summary, cosign-signed, attached to the GitHub release | [`verify-release-evidence.yml`](../../.github/workflows/verify-release-evidence.yml) (verify side); [`backfill-release-evidence.yml`](../../.github/workflows/backfill-release-evidence.yml) | `gh api repos/JiRaska/open-bank-oss/releases/tags/<tag> --jq '.assets[].name'` |
+| Release-bundle signature verify | Each bundle document verified against the KMS cosign key + manifest digests | `verify-release-evidence.yml` (`cosign verify-blob --key awskms:///alias/openbank-cosign-signing`) | `gh workflow run verify-release-evidence.yml -f tag=<service>-v<x.y.z>` |
+| Fleet attestation gate | Every image declared in gitops is provably attested (catches admission gaps at review time) | [`fleet-attestation.yml`](../../.github/workflows/fleet-attestation.yml) + [`check-fleet-attestations.sh`](../../.github/scripts/check-fleet-attestations.sh) | `gh workflow run fleet-attestation.yml` then inspect the `fleet-attestation-report` artifact |
+| VEX (vuln exploitability) | Per-service OpenVEX statements to triage CVEs | [`openbank-libs/governance/vex/`](../../openbank-libs/governance/vex/) (`<service>.openvex.json`); [`vex-triage.yml`](../../.github/workflows/vex-triage.yml) | `ls openbank-libs/governance/vex/*.openvex.json \| wc -l` |
+| PR-time CVE gate | Dependency graph submitted + CVE-blocked at PR time | [`dependency-submission.yml`](../../.github/workflows/dependency-submission.yml) (keeps its `pull_request` trigger) + [`dependency-review.yml`](../../.github/workflows/dependency-review.yml); `rules.yaml: dependencies` | `grep -nE 'pull_request' .github/workflows/dependency-submission.yml` |
+| Threat models | Money-path services carry a threat model | [`docs/threat-models/<service>.md`](../threat-models/); `rules.yaml: money_path_services` (ADR-0030 D2) | `ls docs/threat-models/*.md \| wc -l` |
+| RTO/RPO tiers | Recovery targets bound to service tiers | [`docs/bcp/bcp-policy.md`](../bcp/bcp-policy.md) T0–T3 table | `grep -nE 'RTO target' docs/bcp/bcp-policy.md` |
+| OpenSSF posture | Independent supply-chain scorecard | [`scorecard.yml`](../../.github/workflows/scorecard.yml); [`docs/openssf-silver-assessment.md`](../openssf-silver-assessment.md) | `gh workflow view scorecard.yml` |
+
+### Provenance gate rollout state (be precise with auditors)
+
+The deploy-time provenance gate is staged, not universally Enforce. The authoritative rollout state is
+`rules.yaml: provenance.gate` and the live Kyverno policy mode. As of this pack the
+`verify-openbank-image-sbom-attestation` ClusterPolicy is **Audit-only** (documented in-line in
+[`verify-sbom-attestation-policy.yaml`](../../openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml));
+the image-signature policy is Enforce. Verify the live mode before asserting either way:
+
+```
+grep -nE 'validationFailureAction|Audit|Enforce' \
+  openbank-infra/gitops/components/kyverno/verify-sbom-attestation-policy.yaml
+```
+
+---
+
+## 3. AI-Act evidence (forward reference)
+
+DORA and the EU AI Act overlap on AI-system governance for the four AI agent services
+(ADR-0031 / ADR-0136). The AI-Act-specific control mapping is **owned by a separate document**,
+`docs/compliance/eu-ai-act.md` (issue #1918), and is **not duplicated here**. When that document
+lands, this pack's AI-Act row is: *see [`docs/compliance/eu-ai-act.md`](./eu-ai-act.md)*.
+
+Until then, the AI-governance substrate an auditor can already verify: agents-as-code + AI-attributed
+audit (ADR-0031), policy-gated MCP tool-calls via the shared OPA sidecar (ADR-0034), and agent
+charters as Markdown (ADR-0156).
+
+---
+
+## Honest gaps
+
+These are real, current limitations. Stating them is part of the evidence, not a failure of it.
+
+1. **ICT incident register has no purpose-built persistent store.** Declarations and resolutions are
+   recorded through the tamper-evident audit chain (ADR-0086 / ADR-0133) and the issue tracker per
+   [`incident-response.md`](../bcp/incident-response.md) §3. There is **no dedicated, queryable
+   incident-register service** — a real institution deploying OpenBank must provide one before
+   go-live. Treat any "register" reference as the audit-chain + issue-tracker composite, not a
+   standalone system.
+2. **TLPT (Threat-Led Penetration Testing, DORA Art. 24–27) is planned-only.** The repo documents the
+   requirement (ADR-0030, ADR-0100, `docs/strategy/`) and provides deterministic simulation testing as
+   partial "advanced testing" evidence, but no external TLPT engagement has been executed. It is an
+   external-provider activity, not a repo artifact.
+3. **Automated DR restore is a wired-once skeleton, not a passing quarterly control.**
+   [`dr-restore-verify.yml`](../../.github/workflows/dr-restore-verify.yml) intentionally hard-fails
+   (`WIRING INCOMPLETE`) rather than reporting a hollow PASS; `dr-test-log.md` currently records
+   **table-top** exercises only. See [`automated-dr-restore.md`](../bcp/automated-dr-restore.md) for
+   the remaining wiring.
+4. **Provenance gate is partially Audit-only.** The SBOM-attestation Kyverno policy is Audit, not
+   Enforce (§2 above); an unattested image would be surfaced, not blocked, at admission today.
+5. **DORA Art. 28/30 third-party controls are partial.** A vendor risk register and DORA Art. 30
+   contractual clauses are backlog items (`dora-ictrm.md` follow-up; ADR-0174 `partial`), relevant
+   once the platform is commercially operated.
+6. **Escalation is single-maintainer (bus factor 1).** `incident-response.md` §4 documents no
+   secondary on-call — a deploying institution must fill this in before go-live.
+
+---
+
+## Related
+
+- [`docs/compliance/finos-ccc-mapping.md`](./finos-ccc-mapping.md) — FINOS Common Cloud Controls + AI
+  Governance Framework mapping.
+- [`docs/bcp/`](../bcp/) — the BCP / DORA / incident-response source documents.
+- [`openbank-libs/governance/rules.yaml`](../../openbank-libs/governance/rules.yaml) — the authoritative,
+  CI-enforced governance ruleset.

--- a/docs/compliance/finos-ccc-mapping.md
+++ b/docs/compliance/finos-ccc-mapping.md
@@ -1,0 +1,84 @@
+# FINOS Common Cloud Controls (CCC) + AI Governance Framework (AIGF) mapping
+
+Date: 2026-07-23
+Frameworks: FINOS Common Cloud Controls (CCC); FINOS AI Governance Framework (AIGF)
+Owner: CTO / Maintainer Lead
+Status: living document — control statuses track `origin/main`
+
+---
+
+## Purpose
+
+Map this platform's implemented controls to the FINOS **Common Cloud Controls (CCC)** control families
+and the FINOS **AI Governance Framework (AIGF)**. Each row is
+**control family → our implementation (with the artifact that proves it) → status**. Status is one of:
+
+- **implemented** — the control exists and is enforced/checkable on `origin/main`.
+- **partial** — the control exists but is advisory-only, single-tier, or scoped narrower than the family.
+- **gap** — not yet built; called out honestly so the mapping is not misread as complete.
+
+The authoritative, CI-enforced source for most of these controls is
+[`openbank-libs/governance/rules.yaml`](../../openbank-libs/governance/rules.yaml); this document is a
+human-readable crosswalk, not a second source of truth.
+
+---
+
+## Part A — Common Cloud Controls (CCC)
+
+| CCC control family | Our implementation | Evidence artifact | Status |
+|---|---|---|---|
+| Identity & access management | Keycloak OIDC / OAuth2 for customer + operator auth; unified OPA authorization sidecar serving both REST and MCP tool-calls | ADR-0034; `AuthorizeInterceptor`; per-service Rego bundles from openbank-libs | partial — OPA enforce is staged; several services still advisory or lack a live PDP sidecar (issue #1797) |
+| Authorization / least privilege | Rego policies with principal-type vocabulary (`ANONYMOUS`/`AI_AGENT`/`HUMAN`); money-path action prefixes; four-eyes on money-path | ADR-0034; `rules.yaml: money_path_services`, `four_eyes`, `money_path_action_prefixes`; `check-no-service-principal-type.sh` | implemented |
+| Data encryption in transit | mTLS on Kafka (topic-scoped Strimzi tls listener + per-service KafkaUsers/ACLs); cert-manager PKI; TLS ingress | ADR-0137; External Secrets cert projection | partial — ADR-0137 enforces the `payment.scheme-accepted` boundary; the cluster-global allow-everyone gate stays on deliberately |
+| Data encryption at rest / secrets | OpenBao runtime secret injection; break-glass keys in AWS Secrets Manager; no secrets in-cluster at rest | `rules.yaml`; `incident-response.md` §5 key ceremonies | implemented |
+| Network security / segmentation | Kubernetes NetworkPolicies for east-west isolation per service | `dora-ictrm.md` (Availability/Confidentiality controls); gitops NetworkPolicies | partial — edge coverage gaps found by walking live paths (e.g. party 500 on missing edge) |
+| Logging & audit | Tamper-evident SHA-256 hash-chain audit trail with a verify endpoint; AI-attributed audit events | ADR-0086; ADR-0133; audit-service `AuditResource`/`AuditRepository` | implemented |
+| Monitoring & detection | Grafana + Pyrra SLOs; GoAlert on-call; Falco runtime; HolmesGPT RCA agent; GlitchTip errors | ADR-0088; ADR-0091; `dora-ictrm.md` Detection | implemented |
+| Configuration & change management | Governance-as-code: enforced conventional commits, per-service SemVer, release-please, generated catalog; GitOps via ArgoCD | ADR-0029; `rules.yaml`; release-please config | implemented |
+| Vulnerability & patch management | PR-time dependency-review CVE gate; per-service + aggregate CycloneDX SBOM; image rescan; OpenVEX triage | `dependency-submission.yml` + `dependency-review.yml`; `security.yml`; `image-rescan.yml`; `vex-triage.yml` | implemented |
+| Supply-chain integrity / provenance | Cosign image signing + KMS; CycloneDX SBOM attestation verified by Kyverno; SLSA provenance + signed release evidence bundle; fleet-attestation gate | ADR-0029/0030; `cosign-attest.sh`; `verify-sbom-attestation-policy.yaml`; `fleet-attestation.yml`; `verify-release-evidence.yml` | partial — SBOM-attestation Kyverno policy is Audit, not yet Enforce (`rules.yaml: provenance.gate`) |
+| Admission control / policy enforcement | Kyverno ClusterPolicies (image signature verify Enforce; SBOM attestation Audit); OPA bundles regenerated fleet-wide on any rules/rego change | `verify-images-policy.yaml`; `verify-sbom-attestation-policy.yaml`; `opa-policy.yml` | partial — signature Enforce, SBOM attestation Audit |
+| Resilience, backup & recovery | CNPG continuous S3 WAL archiving + 14-day retention + PITR; ArgoCD rollback; RTO/RPO tiers T0–T3; automated DR restore-verify skeleton | `bcp-policy.md`; `automated-dr-restore.md`; `dr-restore-verify.yml` | partial — backups implemented; automated restore-verify not yet wired (hard-fails by design) |
+| Incident management | Four-tier P1–P4 severity model; declaration timing; register tied to the audit chain; DORA Art. 19–20 reporting | ADR-0146; `incident-response.md` | partial — no dedicated persistent incident-register store; bus factor 1 (no secondary on-call) |
+| Third-party / ICT dependency risk | ICT third-party register of record with criticality + exit position per provider | ADR-0174; `dora-ictrm.md` Art. 28/30 backlog | partial — register exists; vendor risk register + Art. 30 clauses are backlog |
+
+---
+
+## Part B — AI Governance Framework (AIGF)
+
+Scope: the four AI agent services (agent-service, devops-agent, finops-agent, and the read-only
+observability/governance agents) governed under ADR-0031 / ADR-0136.
+
+| AIGF control area | Our implementation | Evidence artifact | Status |
+|---|---|---|---|
+| AI system inventory / agents-as-code | Agents declared as least-privilege workloads in `agents.yaml`, passing the same PR/CI/OPA gates as humans; Markdown charters with an id-parity gate | ADR-0031; ADR-0156; agent-charter-registry.yml | implemented |
+| Human oversight (model-proposes / bank-disposes) | Every agent output is a proposal, never auto-remediation; HolmesGPT read-only + on-demand only; DevOps/FinOps agents propose PRs a human must approve | ADR-0091; ADR-0119; ADR-0112; ADR-0102 | implemented |
+| Access control for AI tool-use | Policy-gated MCP `tools/call` through the same OPA sidecar as REST; principal type `AI_AGENT` distinct from `HUMAN` | ADR-0034; `authz-policy-auditor` (ADR-0167) | partial — OPA enforce staged; agent-service blanket-ROLE_OPERATOR priv-esc tracked as a draft advisory |
+| Attribution / auditability of AI actions | AI-attributed entries on the tamper-evident audit chain; agent charter identity threads into incident declarations | ADR-0031 D5; ADR-0133; `incident-response.md` §3 | implemented |
+| Model governance / lifecycle | ML decisioning platform: event-fed feature store, in-process ONNX serving, champion/challenger shadow-to-promote; deterministic rule layer kept as a permanent floor | ADR-0139 | partial — feature store + shadow shipped; ONNX serving adapter still a placeholder |
+| Independent review of AI-authored changes | Agent PR-review workflow submits a real approve/request-changes review from a different model family; sensitive scopes always deferred to humans | ADR-0154; agent-review.yml | implemented |
+| Policy-liveness / control assurance for AI | Read-only sentinel/auditor agents (control-liveness, governance-auditor, docs-truth, authz-policy, release-steward, flaky-test) re-check the fleet's own controls | ADR-0163–0168 | partial — most are advisory / not-yet-scheduled (`accepted/partial`) |
+| Third-party AI dependency posture | ADR-0174 states plainly that ADR-0031's LiteLLM/vLLM/Anthropic gateway topology is not deployed | ADR-0174 | gap — documented, not built |
+
+---
+
+## Honest gaps (summary)
+
+- **OPA enforce is not fleet-wide.** Several services run advisory or lack a live PDP sidecar
+  (issue #1797); enabling enforce without a sidecar fails closed (422). Do not read "OPA authz" as
+  universally enforcing.
+- **SBOM-attestation admission is Audit, not Enforce** (`rules.yaml: provenance.gate`).
+- **No persistent incident-register store; bus factor 1** — see `incident-response.md`.
+- **ML serving adapter is a placeholder** (ADR-0139 `partial`).
+- **AI gateway topology (ADR-0031) is not deployed** (ADR-0174).
+- **Automated DR restore-verify is a skeleton** that hard-fails rather than reporting a hollow pass.
+
+---
+
+## Related
+
+- [`docs/compliance/evidence-pack.md`](./evidence-pack.md) — DORA + supply-chain evidence pack with
+  auditor-runnable verification commands.
+- [`openbank-libs/governance/rules.yaml`](../../openbank-libs/governance/rules.yaml) — authoritative
+  CI-enforced controls.
+- [`docs/threat-models/`](../threat-models/) — per-service threat models.


### PR DESCRIPTION
## What

Two auditor/regulator-facing governance documents under `docs/compliance/`, plus a compliance index and README links.

### `docs/compliance/evidence-pack.md` (#1926)
DORA + supply-chain evidence pack: a table mapping **regulatory requirement → repo artifact → the command an auditor runs to verify it**.
- DORA Art. 5–30 rows point at `docs/bcp/*` (dora-ictrm, bcp-policy, incident-response, dr-test-log, automated-dr-restore) and ADR-0174 (ICT third-party register).
- Supply-chain rows: per-service + aggregate CycloneDX SBOM, cosign signing + CycloneDX attestation, SLSA provenance, signed release evidence bundle, fleet-attestation gate, OpenVEX, PR-time CVE gate, threat models, RTO/RPO tiers.
- Auditor one-liners verified against the actual workflows: `cosign verify-attestation --key awskms:///alias/openbank-cosign-signing --type cyclonedx …`, `gh api …/releases/tags/<tag>`, `gh workflow run verify-release-evidence.yml`, etc.

### `docs/compliance/finos-ccc-mapping.md` (#1928)
Maps platform controls to FINOS **Common Cloud Controls (CCC)** and the **AI Governance Framework (AIGF)** as *control family → our implementation → status (implemented / partial / gap)*, sourced from `rules.yaml`, threat-models, OPA/Kyverno/mTLS controls, and the relevant ADRs.

## Honest gaps flagged (accuracy over completeness)
- No purpose-built persistent ICT incident-register store (audit chain + issue tracker composite only).
- TLPT (DORA Art. 24–27) is planned-only — external engagement, not a repo artifact.
- Automated DR restore-verify is a wired-once skeleton that hard-fails rather than reporting a hollow PASS.
- SBOM-attestation Kyverno policy is still **Audit**, not Enforce.
- DORA Art. 28/30 third-party controls partial; bus factor 1 (no secondary on-call).
- ML serving adapter is a placeholder (ADR-0139); ADR-0031 AI gateway topology not deployed (ADR-0174).

The AI-Act row **forward-references** `docs/compliance/eu-ai-act.md` (#1918) rather than duplicating it.

## Scope note
The **OSTIF audit application** and the **OSFF CFP** (the other half of #1928) are external owner submissions, not part of this repo PR.

Refs #1926
Refs #1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
