### PR TITLE
ci(pact): force provider re-verify to re-publish on main push

### DIFF
--- a/.github/workflows/_service-ci.yml
+++ b/.github/workflows/_service-ci.yml
@@ -417,7 +417,23 @@ jobs:
           # provider build.gradle.kts copies these into the forked test JVM. Empty
           # pactbroker.url (var unset) → @PactBroker provider test skips (it is
           # @EnabledIfSystemProperty(named=pactbroker.url, matches=.+)-gated).
-          ./gradlew :${{ inputs.service }}:build --build-cache --console=plain --stacktrace \
+          #
+          # --rerun-tasks ONLY on the main-push publish path (#1965/#1964). Publishing the
+          # provider-verification result is a network SIDE-EFFECT (a POST to the Pact Broker)
+          # that Gradle's up-to-date / build-cache machinery cannot observe: when the `test`
+          # task is restored from cache — which happens in a fleet fan-out where THIS provider's
+          # source + SHA are unchanged (e.g. a consumer republishes a new pact and the provider
+          # must re-verify + re-publish against it) — the cached result is reused and the publish
+          # POST never fires. That is why #1964 needed a manual build.gradle.kts cache-key bust to
+          # force a re-publish. Forcing re-execution here makes the publish happen on every main
+          # push, deterministically. Gated on PUBLISH_RESULTS (main only) so PR builds and the
+          # PR-lane fleet keep their cache: they verify but never publish, so re-running them would
+          # only cost time with no side-effect to trigger. The later "Generate Kover XML report"
+          # step is NOT re-run (no --rerun-tasks): `test` is up-to-date from this step, so it stays
+          # cached and does not re-execute uncredentialed (the #1009 hazard documented below).
+          RERUN=""
+          if [ "${PUBLISH_RESULTS}" = "true" ]; then RERUN="--rerun-tasks"; fi
+          ./gradlew :${{ inputs.service }}:build ${RERUN} --build-cache --console=plain --stacktrace \
             -Dpactbroker.url="${PACT_BROKER_URL:-}" \
             -Dpactbroker.auth.username="${PACT_BROKER_USERNAME:-}" \
             -Dpactbroker.auth.password="${PACT_BROKER_PASSWORD:-}" \


### PR DESCRIPTION
## What & why

Corrected root cause of #1965. The issue's original framing (a `src/test/**/contract/**`
change doesn't trigger the fleet on push to main) is a **no-op**: `services-ci.yml` already
full-fleets on any non-inert path, so a contract-test change *does* build the fleet.

The real gap: publishing a provider-verification result to the Pact Broker is a **network
side-effect** (a `POST`) that Gradle's up-to-date / build-cache machinery cannot observe.
When the `test` task is cache-restored — which happens in a fleet fan-out where the
provider's own source + `GITHUB_SHA` are unchanged (e.g. a consumer republishes a pact the
provider must re-verify against) — the cached result is reused and the publish `POST` never
fires. That is exactly why #1964 needed a manual `build.gradle.kts` cache-key bust to force a
re-publish.

## The fix (one file, scoped)

`.github/workflows/_service-ci.yml` — add `--rerun-tasks` to the "Build + test" gradle
invocation **only on the main-push publish path** (gated on `PUBLISH_RESULTS`, which is
`github.ref == 'refs/heads/main'`):

- PR builds and the PR-lane fleet keep their cache untouched — they verify but never publish,
  so re-running them would only cost time with no side-effect to trigger.
- The later "Generate Kover XML report" step is **not** re-run, so `test` stays up-to-date
  from the build step and does not re-execute uncredentialed (the #1009 hazard).

## Validation

- `python3 yaml.safe_load` parses clean.
- `actionlint` on `origin/main` vs this branch: **zero findings on both, identical sets** (no
  new findings introduced).

Closes #1965
Refs #1964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
