### PR TITLE
feat(edge): revoke a registered device

### DIFF
--- a/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
+++ b/openbank-customer-edge/src/main/kotlin/com/openbank/customeredge/infrastructure/rest/CustomerEdgeResource.kt
@@ -2158,6 +2158,24 @@ class CustomerEdgeResource(
         )
     }
 
+    /**
+     * Revoke (deactivate) one of the caller's OWN registered devices (#3) — sign it out so it stops
+     * receiving push. The partyId is forced from the JWT onto the notification-service call, which
+     * scopes the deactivation to that party's tokens, so a customer can never sign out someone
+     * else's device even with a guessed device id.
+     */
+    @DELETE
+    @Path("/devices/{id}")
+    @Authorize(action = "customer.devices.delete", resource = "#id")
+    @Blocking
+    fun revokeDevice(@PathParam("id") id: UUID): Response {
+        val customer = customer()
+        return upstream.delete(
+            "$notificationServiceUrl/api/v1/devices/$id?partyId=${customer.partyId}",
+            customer.partyId.toString(),
+        )
+    }
+
     // --- Onboarding (ADR-0069) ---
 
     // NOTE: POST /onboarding/start lives in [OnboardingResource], a separate resource


### PR DESCRIPTION
TOP-10 #3. Edge `DELETE /customer/v1/devices/{id}` → notification-service device deactivate, partyId forced from the JWT (IDOR-safe). No new upstream/migration; `device.delete` covered by the edge-service-notification family, `customer.devices.delete` by the self-action rule.

Closes #2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)