### PR TITLE
fix(admin-ui): add react-is for the onboarding analytics board

### DIFF
--- a/openbank-admin-ui/package-lock.json
+++ b/openbank-admin-ui/package-lock.json
@@ -31,6 +31,7 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-hook-form": "7.82.0",
+        "react-is": "19.2.0",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
         "recharts": "3.9.2",
@@ -12379,11 +12380,10 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
+      "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/openbank-admin-ui/package.json
+++ b/openbank-admin-ui/package.json
@@ -41,6 +41,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-hook-form": "7.82.0",
+    "react-is": "19.2.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
     "recharts": "3.9.2",


### PR DESCRIPTION
recharts 3.x peer-depends on `react-is` (^19). The Turbopack production build (Docker deploy) resolves it as a direct import, so the onboarding funnel board's `page.tsx` failed the admin-ui image build with `Module not found: Can't resolve 'react-is'`. Adds `react-is@19.2.0` as a direct dependency (lock patched additively — no other deps pruned).

Unblocks the deploy of the `/onboarding/analytics` board added in #1974. Backend pipeline (edge `/onboarding/events` → Kafka → analytics-sink → ClickHouse gold views) is already live and verified e2e; this is the last hop so the board image builds and renders that data.

Closes part of #1982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)